### PR TITLE
Match OWS service query parameters in case-insensitively

### DIFF
--- a/config/gateway-service.yml
+++ b/config/gateway-service.yml
@@ -32,7 +32,7 @@ spring:
         uri: lb://wfs-service
         predicates:
         - Path=/ows,/{segment}/ows
-        - Query=SERVICE, (?i:WFS)
+        - RegExpQuery=(?i:service),(?i:wfs) # match service=wfs case insensitively 
 # WMS routes
       - id: wms # proxies requests to gateway-service:/wms to wms-service:/wms
         uri: lb://wms-service #load balanced to the wms-service instances
@@ -42,7 +42,7 @@ spring:
         uri: lb://wms-service
         predicates:
         - Path=/ows,/{segment}/ows
-        - Query=SERVICE, (?i:WMS)
+        - RegExpQuery=(?i:service),(?i:wms) # match service=wms case insensitively 
 # WCS routes
       - id: wcs # proxies requests to gateway-service:/wcs to wcs-service:/wcs
         uri: lb://wcs-service #load balanced to the wps-service instances
@@ -52,7 +52,7 @@ spring:
         uri: lb://wcs-service
         predicates:
         - Path=/ows,/{segment}/ows
-        - Query=SERVICE, (?i:WCS)
+        - RegExpQuery=(?i:service),(?i:wcs) # match service=wcs case insensitively 
 # WPS routes
       - id: wps # proxies requests to gateway-service:/wps to wfs-service:/wps
         uri: lb://wps-service #load balanced to the wps-service instances
@@ -62,7 +62,7 @@ spring:
         uri: lb://wps-service
         predicates:
         - Path=/ows,/{segment}/ows
-        - Query=SERVICE, (?i:WPS)
+        - RegExpQuery=(?i:service),(?i:wps) # match service=wps case insensitively 
 # REST configuration routes
       - id: restconfig
         uri: lb://restconfig-v1 #load balanced to the restconfig-v1 instances
@@ -79,10 +79,3 @@ logging:
 #    root: ERROR
     com.netflix.discovery: WARN
     com.netflix.eureka: WARN
-# ----------------
-# ----------------
-# Orphan comments:
-# ----------------
-# Was at begin of line:78 :# Orphan comments:
-# Was at begin of line:79 :# ----------------
-# Was at begin of line:80 :# Was at begin of line:78 :#         - RewritePath=/rest/(?<segment>.*), /rest/$\{segment}

--- a/support-services/api-gateway/pom.xml
+++ b/support-services/api-gateway/pom.xml
@@ -51,6 +51,10 @@
       <artifactId>spring-cloud-starter-gateway</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/support-services/api-gateway/src/main/java/org/geoserver/cloud/gateway/GatewayApplication.java
+++ b/support-services/api-gateway/src/main/java/org/geoserver/cloud/gateway/GatewayApplication.java
@@ -1,18 +1,17 @@
-/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
- * This code is licensed under the GPL 2.0 license, available at the root
- * application directory.
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
  */
 package org.geoserver.cloud.gateway;
 
+import org.geoserver.cloud.gateway.predicate.RegExpQueryRoutePredicateFactory;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 @SpringBootApplication
-@Configuration
 public class GatewayApplication {
 
     public static void main(String[] args) {
@@ -21,5 +20,13 @@ public class GatewayApplication {
 
     public @Bean RouteLocator customRouteLocator(RouteLocatorBuilder builder) {
         return builder.routes().build();
+    }
+
+    /**
+     * Custom gateway predicate factory to support matching by regular expressions on both name and
+     * value of query parameters
+     */
+    public @Bean RegExpQueryRoutePredicateFactory regExpQueryRoutePredicateFactory() {
+        return new RegExpQueryRoutePredicateFactory();
     }
 }

--- a/support-services/api-gateway/src/main/java/org/geoserver/cloud/gateway/predicate/RegExpQueryRoutePredicateFactory.java
+++ b/support-services/api-gateway/src/main/java/org/geoserver/cloud/gateway/predicate/RegExpQueryRoutePredicateFactory.java
@@ -1,0 +1,120 @@
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.gateway.predicate;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import javax.validation.constraints.NotEmpty;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+import org.springframework.cloud.gateway.handler.predicate.AbstractRoutePredicateFactory;
+import org.springframework.cloud.gateway.handler.predicate.GatewayPredicate;
+import org.springframework.cloud.gateway.handler.predicate.QueryRoutePredicateFactory;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.server.ServerWebExchange;
+
+/**
+ * Gateway predicate factory that allows matching by HTTP request query string parameters using
+ * {@link Pattern Java regular expressions} for both parameter name and value.
+ *
+ * <p>This predicate factory is similar to the {@link QueryRoutePredicateFactory} but besides
+ * allowing regular expressions to match a parameter value, also allows to match the parameter name
+ * through a regex.
+ *
+ * <p>Just like with {@link QueryRoutePredicateFactory}, the "value" regular expression is optional.
+ * If not given, the test will be performed only against the query parameter names. If a value
+ * regular expression is present, though, the evaluation will be performed against the values of the
+ * first parameter that matches the name regex.
+ *
+ * <p>Sample usage: the following route configuration example uses a {@code RegExpQuery} predicate
+ * to match the {@code service} query parameter name and {@code wfs} value in a case insensitive
+ * fashion.
+ *
+ * <pre>
+ * <code>
+ * spring:
+ *  cloud:
+ *   gateway:
+ *    routes:
+ *     - id: wfs_ows
+ *       uri: lb://wfs-service
+ *       predicates:
+ *       - RegExpQuery=(?i:service),(?i:wfs)
+ * </code>
+ * </pre>
+ */
+public class RegExpQueryRoutePredicateFactory
+        extends AbstractRoutePredicateFactory<RegExpQueryRoutePredicateFactory.Config> {
+
+    /** HTTP request query parameter regexp key. */
+    public static final String PARAM_KEY = "paramRegexp";
+
+    /** HTTP request query parameter value regexp key. */
+    public static final String VALUE_KEY = "valueRegexp";
+
+    public RegExpQueryRoutePredicateFactory() {
+        super(Config.class);
+    }
+
+    public @Override List<String> shortcutFieldOrder() {
+        return Arrays.asList(PARAM_KEY, VALUE_KEY);
+    }
+
+    public @Override Predicate<ServerWebExchange> apply(Config config) {
+        return new RegExpQueryRoutePredicate(config);
+    }
+
+    @RequiredArgsConstructor
+    private static class RegExpQueryRoutePredicate implements GatewayPredicate {
+        private final @NonNull Config config;
+
+        public @Override boolean test(ServerWebExchange exchange) {
+            final String paramRegexp = config.getParamRegexp();
+            final String valueRegexp = config.getValueRegexp();
+
+            boolean matchNameOnly = !StringUtils.hasText(config.getValueRegexp());
+            Optional<String> paramName = findParameterName(paramRegexp, exchange);
+            boolean paramNameMatches = paramName.isPresent();
+            if (matchNameOnly) {
+                return paramNameMatches;
+            }
+            return paramNameMatches && paramValueMatches(paramName.get(), valueRegexp, exchange);
+        }
+
+        public @Override String toString() {
+            return String.format(
+                    "Query: param regexp='%s' value regexp='%s'",
+                    config.getParamRegexp(), config.getValueRegexp());
+        }
+    }
+
+    static Optional<String> findParameterName(@NonNull String regex, ServerWebExchange exchange) {
+        Set<String> parameterNames = exchange.getRequest().getQueryParams().keySet();
+        return parameterNames.stream().filter(name -> name.matches(regex)).findFirst();
+    }
+
+    static boolean paramValueMatches(
+            @NonNull String paramName, @NonNull String valueRegEx, ServerWebExchange exchange) {
+        List<String> values = exchange.getRequest().getQueryParams().get(paramName);
+        return values != null && values.stream().anyMatch(v -> v != null && v.matches(valueRegEx));
+    }
+
+    @Data
+    @Accessors(chain = true)
+    @Validated
+    public static class Config {
+
+        @NotEmpty private String paramRegexp;
+
+        private String valueRegexp;
+    }
+}


### PR DESCRIPTION
Fix #15 

Add a gateway predicate factory to match query parameters
using regular expressions for both the query parameter name and value,
and configure the gateway OWS routes to match the `service=<ows name>`
query parameter in a case insensitive fashion using regular expressions.