### PR TITLE
Fix use of cloud-bus over a `gscloud` topic for catalog events

### DIFF
--- a/config/restconfig-v1.yml
+++ b/config/restconfig-v1.yml
@@ -21,11 +21,10 @@ spring:
     stream:
       bindings:
         springCloudBusOutput:
-          destination: geoserver
+          destination: gscatalog
         springCloudBusInput:
-          destination: geoserver
-          group: catalog-event-queue
-
+          destination: gscatalog
+ 
 logging:
   level:
 #      org.springframework: ERROR

--- a/config/wcs-service.yml
+++ b/config/wcs-service.yml
@@ -21,10 +21,9 @@ spring:
     stream:
       bindings:
         springCloudBusOutput:
-          destination: geoserver
+          destination: gscatalog
         springCloudBusInput:
-          destination: geoserver
-          group: catalog-event-queue
+          destination: gscatalog
 
 logging:
   level:

--- a/config/web-ui.yml
+++ b/config/web-ui.yml
@@ -21,10 +21,9 @@ spring:
     stream:
       bindings:
         springCloudBusOutput:
-          destination: geoserver
+          destination: gscatalog
         springCloudBusInput:
-          destination: geoserver
-          group: catalog-event-queue
+          destination: gscatalog
 
 logging:
   level:

--- a/config/wfs-service.yml
+++ b/config/wfs-service.yml
@@ -21,10 +21,9 @@ spring:
     stream:
       bindings:
         springCloudBusOutput:
-          destination: geoserver
+          destination: gscatalog
         springCloudBusInput:
-          destination: geoserver
-          group: catalog-event-queue
+          destination: gscatalog
 
 logging:
   level:

--- a/config/wms-service.yml
+++ b/config/wms-service.yml
@@ -21,10 +21,9 @@ spring:
     stream:
       bindings:
         springCloudBusOutput:
-          destination: geoserver
+          destination: gscatalog
         springCloudBusInput:
-          destination: geoserver
-          group: catalog-event-queue
+          destination: gscatalog
 
 logging:
   level:

--- a/config/wps-service.yml
+++ b/config/wps-service.yml
@@ -21,10 +21,9 @@ spring:
     stream:
       bindings:
         springCloudBusOutput:
-          destination: geoserver
+          destination: gscatalog
         springCloudBusInput:
-          destination: geoserver
-          group: catalog-event-queue
+          destination: gscatalog
 
 logging:
   level:

--- a/services/catalog/src/main/java/org/geoserver/cloud/autoconfigure/EnableBusEventHandling.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/autoconfigure/EnableBusEventHandling.java
@@ -9,8 +9,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.geoserver.cloud.catalog.bus.BusDisabledLogger;
-import org.geoserver.cloud.catalog.bus.CatalogBusAutoConfiguration;
+import org.geoserver.cloud.bus.catalog.BusDisabledLogger;
+import org.geoserver.cloud.bus.catalog.CatalogBusAutoConfiguration;
 import org.springframework.context.annotation.Import;
 
 @Retention(RetentionPolicy.RUNTIME)

--- a/services/catalog/src/main/java/org/geoserver/cloud/autoconfigure/jdbcconfig/JDBCConfigAutoConfiguration.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/autoconfigure/jdbcconfig/JDBCConfigAutoConfiguration.java
@@ -1,6 +1,6 @@
-/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
- * This code is licensed under the GPL 2.0 license, available at the root
- * application directory.
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
  */
 package org.geoserver.cloud.autoconfigure.jdbcconfig;
 
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.bus.ConditionalOnBusEnabled;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -29,6 +30,12 @@ import org.springframework.context.annotation.Import;
 @ConditionalOnProperty(prefix = "geoserver.jdbcconfig", name = "enabled", matchIfMissing = true)
 @Import({JDBCDataSourceConfiguration.class, JDBCConfigWebAutoConfiguration.class})
 public class JDBCConfigAutoConfiguration {
+
+    @Bean
+    @ConditionalOnBusEnabled
+    public JdbcConfigRemoteEventProcessor jdbcConfigRemoteEventProcessor() {
+        return new JdbcConfigRemoteEventProcessor();
+    }
 
     // <!-- main configuration, loaded via factory bean -->
     // <bean id="jdbcConfigProperties"

--- a/services/catalog/src/main/java/org/geoserver/cloud/autoconfigure/jdbcconfig/JdbcConfigRemoteEventProcessor.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/autoconfigure/jdbcconfig/JdbcConfigRemoteEventProcessor.java
@@ -1,0 +1,48 @@
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.jdbcconfig;
+
+import lombok.extern.slf4j.Slf4j;
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.cloud.bus.catalog.CatalogRemoteEvent;
+import org.geoserver.cloud.bus.catalog.CatalogRemoteModifyEvent;
+import org.geoserver.cloud.bus.catalog.CatalogRemoteRemoveEvent;
+import org.geoserver.jdbcconfig.internal.ConfigDatabase;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.bus.ServiceMatcher;
+import org.springframework.context.event.EventListener;
+
+/**
+ * Listens to {@link CatalogRemoteEvent}s and evicts the modified or deleted {@link CatalogInfo }
+ * from the {@link ConfigDatabase} cache
+ */
+@Slf4j
+public class JdbcConfigRemoteEventProcessor {
+    private @Autowired ServiceMatcher busServiceMatcher;
+
+    private @Autowired ConfigDatabase jdbcConfigDatabase;
+
+    @EventListener(CatalogRemoteRemoveEvent.class)
+    public void onCatalogRemoteRemoveEvent(CatalogRemoteRemoveEvent event) {
+        if (!busServiceMatcher.isFromSelf(event)) {
+            evictConfigDatabaseEntry(event);
+        }
+    }
+
+    @EventListener(CatalogRemoteModifyEvent.class)
+    public void onCatalogRemoteModifyEvent(CatalogRemoteModifyEvent event) {
+        if (!busServiceMatcher.isFromSelf(event)) {
+            evictConfigDatabaseEntry(event);
+        }
+    }
+
+    private void evictConfigDatabaseEntry(CatalogRemoteEvent event) {
+        if (!busServiceMatcher.isFromSelf(event)) {
+            log.debug("Evict JDBCConfig cache for {}", event);
+            String catalogInfoId = event.getCatalogInfoId();
+            jdbcConfigDatabase.clearCacheIfPresent(catalogInfoId);
+        }
+    }
+}

--- a/services/catalog/src/main/java/org/geoserver/cloud/bus/catalog/BusDisabledLogger.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/bus/catalog/BusDisabledLogger.java
@@ -2,7 +2,7 @@
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
-package org.geoserver.cloud.catalog.bus;
+package org.geoserver.cloud.bus.catalog;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;

--- a/services/catalog/src/main/java/org/geoserver/cloud/bus/catalog/CatalogBusAutoConfiguration.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/bus/catalog/CatalogBusAutoConfiguration.java
@@ -2,13 +2,12 @@
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
-package org.geoserver.cloud.catalog.bus;
+package org.geoserver.cloud.bus.catalog;
 
 import javax.annotation.PostConstruct;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.geoserver.catalog.Catalog;
-import org.geoserver.cloud.catalog.bus.events.CatalogRemoteEvent;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.cloud.bus.BusAutoConfiguration;
@@ -38,8 +37,8 @@ public class CatalogBusAutoConfiguration {
         return broadcaster;
     }
 
-    public @Bean CatalogRemoteEventProcessor catalogRemoteEventProcessor(
+    public @Bean ResourcePoolRemoteEventProcessor catalogRemoteEventProcessor(
             @Qualifier("rawCatalog") Catalog rawCatalog) {
-        return new CatalogRemoteEventProcessor(rawCatalog);
+        return new ResourcePoolRemoteEventProcessor(rawCatalog);
     }
 }

--- a/services/catalog/src/main/java/org/geoserver/cloud/bus/catalog/CatalogRemoteAddEvent.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/bus/catalog/CatalogRemoteAddEvent.java
@@ -2,24 +2,21 @@
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
-package org.geoserver.cloud.catalog.bus.events;
+package org.geoserver.cloud.bus.catalog;
 
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
-import lombok.ToString;
 import org.geoserver.catalog.impl.ClassMappings;
 
 @EqualsAndHashCode(callSuper = true)
-@ToString(callSuper = true)
-public class CatalogRemoteModifyEvent extends CatalogRemoteEvent {
+public class CatalogRemoteAddEvent extends CatalogRemoteEvent {
     private static final long serialVersionUID = 1L;
 
-    /** default constructor, needed for deserialization */
-    protected CatalogRemoteModifyEvent() {
-        //
+    protected CatalogRemoteAddEvent() {
+        // default constructor, needed for deserialization
     }
 
-    public CatalogRemoteModifyEvent(
+    public CatalogRemoteAddEvent(
             Object source,
             String originService,
             String destinationService,

--- a/services/catalog/src/main/java/org/geoserver/cloud/bus/catalog/CatalogRemoteEvent.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/bus/catalog/CatalogRemoteEvent.java
@@ -1,19 +1,17 @@
-/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
- * This code is licensed under the GPL 2.0 license, available at the root
- * application directory.
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
  */
-package org.geoserver.cloud.catalog.bus.events;
+package org.geoserver.cloud.bus.catalog;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.ToString;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.impl.ClassMappings;
 import org.springframework.cloud.bus.event.RemoteApplicationEvent;
 
 @EqualsAndHashCode(callSuper = true)
-@ToString(callSuper = true)
 public abstract class CatalogRemoteEvent extends RemoteApplicationEvent {
     private static final long serialVersionUID = 1L;
 
@@ -35,5 +33,26 @@ public abstract class CatalogRemoteEvent extends RemoteApplicationEvent {
         super(source, originService, destinationService);
         this.catalogInfoId = catalogInfoId;
         this.catalogInfoEnumType = catalogInfoEnumType;
+    }
+
+    public @Override String toString() {
+        return String.format(
+                "%s(%s: %s)[event id: %s, from: %s, to: %s, ts: %d]",
+                getClass().getSimpleName(),
+                this.getCatalogInfoEnumType(),
+                this.getCatalogInfoId(),
+                super.getId(),
+                super.getOriginService(),
+                super.getDestinationService(),
+                super.getTimestamp());
+    }
+
+    public static @FunctionalInterface interface CatalogRemoteEventFactory {
+        CatalogRemoteEvent create(
+                Object source,
+                String originService,
+                String destinationService,
+                @NonNull String catalogInfoId,
+                @NonNull ClassMappings catalogInfoEnumType);
     }
 }

--- a/services/catalog/src/main/java/org/geoserver/cloud/bus/catalog/CatalogRemoteModifyEvent.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/bus/catalog/CatalogRemoteModifyEvent.java
@@ -2,23 +2,22 @@
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
-package org.geoserver.cloud.catalog.bus.events;
+package org.geoserver.cloud.bus.catalog;
 
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
-import lombok.ToString;
 import org.geoserver.catalog.impl.ClassMappings;
 
 @EqualsAndHashCode(callSuper = true)
-@ToString(callSuper = true)
-public class CatalogRemoteAddEvent extends CatalogRemoteEvent {
+public class CatalogRemoteModifyEvent extends CatalogRemoteEvent {
     private static final long serialVersionUID = 1L;
 
-    protected CatalogRemoteAddEvent() {
-        // default constructor, needed for deserialization
+    /** default constructor, needed for deserialization */
+    protected CatalogRemoteModifyEvent() {
+        //
     }
 
-    public CatalogRemoteAddEvent(
+    public CatalogRemoteModifyEvent(
             Object source,
             String originService,
             String destinationService,

--- a/services/catalog/src/main/java/org/geoserver/cloud/bus/catalog/CatalogRemoteRemoveEvent.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/bus/catalog/CatalogRemoteRemoveEvent.java
@@ -2,15 +2,13 @@
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
-package org.geoserver.cloud.catalog.bus.events;
+package org.geoserver.cloud.bus.catalog;
 
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
-import lombok.ToString;
 import org.geoserver.catalog.impl.ClassMappings;
 
 @EqualsAndHashCode(callSuper = true)
-@ToString(callSuper = true)
 public class CatalogRemoteRemoveEvent extends CatalogRemoteEvent {
     private static final long serialVersionUID = 1L;
 

--- a/services/catalog/src/main/resources/spring.factories
+++ b/services/catalog/src/main/resources/spring.factories
@@ -1,5 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.geoserver.cloud.autoconfigure.jdbcconfig.JDBCConfigAutoConfiguration,\
 org.geoserver.cloud.autoconfigure.jdbcconfig.JDBCStoreAutoConfiguration,\
-org.geoserver.cloud.catalog.bus.CatalogBusAutoConfiguration,\
-org.geoserver.cloud.catalog.bus.BusDisabledLogger
+org.geoserver.cloud.bus.catalog.CatalogBusAutoConfiguration,\
+org.geoserver.cloud.bus.catalog.BusDisabledLogger


### PR DESCRIPTION
Fix Catalog side of the fence handling for remote events using `spring-cloud-bus`

- Listener on remote events to clear entries from the resource pool
- Listener on remote events to evit entries from the jdbcconfig cache

Partial fix for #19, remains to handle resource change events in order to clear local resource caches
