### PR TITLE
Shared data directory remote events processing and improved configuration

### DIFF
--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/reactivefeign/ReactiveConfigClient.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/reactivefeign/ReactiveConfigClient.java
@@ -36,8 +36,12 @@ public interface ReactiveConfigClient {
     @PutMapping("/global")
     Mono<Void> setGlobal(@RequestBody GeoServerInfo global);
 
+    /** The settings configuration by its id, or <code>null</code> if not exists. */
+    @GetMapping("/workspaces/settings/{id}")
+    Mono<SettingsInfo> getSettingsById(@PathVariable("id") String id);
+
     /**
-     * The settings configuration for the specified workspace, or <code>null</code> if non exists.
+     * The settings configuration for the specified workspace, or <code>null</code> if not exists.
      */
     @GetMapping("/workspaces/{workspaceId}/settings")
     Mono<SettingsInfo> getSettingsByWorkspace(@PathVariable("workspaceId") String workspaceId);

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientConfigRepository.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientConfigRepository.java
@@ -56,6 +56,10 @@ public class CatalogClientConfigRepository implements ConfigRepository {
         blockAndReturn(client.setGlobal(global));
     }
 
+    public @Override Optional<SettingsInfo> getSettingsById(String id) {
+        return blockAndReturn(client.getSettingsById(id));
+    }
+
     public @Override Optional<SettingsInfo> getSettingsByWorkspace(WorkspaceInfo workspace) {
         return blockAndReturn(client.getSettingsByWorkspace(workspace.getId()));
     }

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/RemoteModifyEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/RemoteModifyEvent.java
@@ -36,11 +36,7 @@ public abstract class RemoteModifyEvent<S, I extends Info> extends RemoteInfoEve
             String destinationService) {
         super(source, objectId, type, originService, destinationService);
         this.patch = patch;
-        this.changedProperties =
-                patch.getPatches()
-                        .stream()
-                        .map(Patch.Property::getName)
-                        .collect(Collectors.toList());
+        this.changedProperties = patch.getPropertyNames();
     }
 
     public @Override String toString() {

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/CatalogInfoLookup.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/CatalogInfoLookup.java
@@ -378,7 +378,7 @@ abstract class CatalogInfoLookup<T extends CatalogInfo> implements CatalogInfoRe
 
     /** Looks up a CatalogInfo by class and identifier */
     public @Override <U extends T> Optional<U> findById(String id, Class<U> clazz) {
-        requireNonNull(id);
+        requireNonNull(id, () -> "id is null, class: " + clazz);
         requireNonNull(clazz);
         for (Class<? extends T> key : idMultiMap.keySet()) {
             if (clazz.isAssignableFrom(key)) {

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/Patch.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/Patch.java
@@ -66,6 +66,10 @@ public @Value class Patch implements Serializable {
         return p;
     }
 
+    public List<String> getPropertyNames() {
+        return new ArrayList<>(patches.keySet());
+    }
+
     public Optional<Property> get(String propertyName) {
         Property property = this.patches.get(propertyName);
         return Optional.ofNullable(property);

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/RepositoryCatalogFacadeImpl.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/RepositoryCatalogFacadeImpl.java
@@ -318,7 +318,8 @@ public class RepositoryCatalogFacadeImpl extends CatalogInfoRepositoryHolderImpl
     }
 
     public @Override void remove(NamespaceInfo namespace) {
-        if (namespace.equals(getDefaultNamespace())) {
+        NamespaceInfo defaultNamespace = getDefaultNamespace();
+        if (defaultNamespace != null && namespace.getId().equals(defaultNamespace.getId())) {
             setDefaultNamespace(null);
         }
         namespaces.remove(namespace);
@@ -362,7 +363,8 @@ public class RepositoryCatalogFacadeImpl extends CatalogInfoRepositoryHolderImpl
     }
 
     public @Override void remove(WorkspaceInfo workspace) {
-        if (workspace.equals(getDefaultWorkspace())) {
+        WorkspaceInfo defaultWorkspace = getDefaultWorkspace();
+        if (defaultWorkspace != null && workspace.getId().equals(defaultWorkspace.getId())) {
             workspaces.unsetDefaultWorkspace();
         }
         workspaces.remove(workspace);

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/config/plugin/ConfigRepository.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/config/plugin/ConfigRepository.java
@@ -45,6 +45,8 @@ public interface ConfigRepository {
      */
     Optional<SettingsInfo> getSettingsByWorkspace(WorkspaceInfo workspace);
 
+    Optional<SettingsInfo> getSettingsById(String id);
+
     /** Adds a settings configuration for the specified workspace. */
     void add(SettingsInfo settings);
 

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/config/plugin/MemoryConfigRepository.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/config/plugin/MemoryConfigRepository.java
@@ -47,6 +47,10 @@ public class MemoryConfigRepository implements ConfigRepository {
         this.global = global;
     }
 
+    public @Override Optional<SettingsInfo> getSettingsById(String id) {
+        return Optional.ofNullable(settings.get(id));
+    }
+
     public @Override Optional<SettingsInfo> getSettingsByWorkspace(WorkspaceInfo workspace) {
         requireNonNull(workspace);
         requireNonNull(workspace.getId());

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/config/plugin/RepositoryGeoServerFacade.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/config/plugin/RepositoryGeoServerFacade.java
@@ -5,7 +5,11 @@
 package org.geoserver.config.plugin;
 
 import org.geoserver.config.GeoServerFacade;
+import org.geoserver.config.SettingsInfo;
 
 public interface RepositoryGeoServerFacade extends GeoServerFacade {
+
+    SettingsInfo getSettings(String id);
+
     void setRepository(ConfigRepository repository);
 }

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/config/plugin/RepositoryGeoServerFacadeImpl.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/config/plugin/RepositoryGeoServerFacadeImpl.java
@@ -317,4 +317,9 @@ public class RepositoryGeoServerFacadeImpl implements RepositoryGeoServerFacade 
         }
         return settings;
     }
+
+    @Override
+    public SettingsInfo getSettings(String id) {
+        return repository.getSettingsById(id).orElse(null);
+    }
 }

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/config/plugin/forwarding/ForwardingGeoServerFacade.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/config/plugin/forwarding/ForwardingGeoServerFacade.java
@@ -131,4 +131,11 @@ public class ForwardingGeoServerFacade implements RepositoryGeoServerFacade {
     public @Override void dispose() {
         facade.dispose();
     }
+
+    public @Override SettingsInfo getSettings(String id) {
+        if (facade instanceof RepositoryGeoServerFacade)
+            ((RepositoryGeoServerFacade) facade).getSettings(id);
+
+        throw new UnsupportedOperationException();
+    }
 }

--- a/catalog-support/pluggable-catalog-support/src/test/java/org/geoserver/config/plugin/XmlSerializedConfigRepository.java
+++ b/catalog-support/pluggable-catalog-support/src/test/java/org/geoserver/config/plugin/XmlSerializedConfigRepository.java
@@ -89,6 +89,10 @@ class XmlSerializedConfigRepository implements ConfigRepository {
         this.global = serialize(global);
     }
 
+    public @Override Optional<SettingsInfo> getSettingsById(String id) {
+        return Optional.ofNullable(toSettings(settings.get(id)));
+    }
+
     public @Override Optional<SettingsInfo> getSettingsByWorkspace(WorkspaceInfo workspace) {
         return settings.values()
                 .stream()

--- a/config/application.yml
+++ b/config/application.yml
@@ -14,26 +14,26 @@ geoserver:
     send-events: true
     # whether to send the object (CatalogInfo/config info) as payload with the event. Set to false, 
     # not all possible payload types are propertly tested, and full object payload is not needed.
-    send-object: false
+    send-object: ${geoserver.backend.data-directory.enabled}
     # whether to send a diff of changes as payload with the event. Set to false, not all possible payload types are propertly tested nor needed.
-    send-diff: false
+    send-diff: ${geoserver.backend.data-directory.enabled}
   backend:
     # configure catalog backends and decide which backend to use on this service.
     # All backends are disabled, enable the required one on each service. For example, the catalog microservice 
     # will enable one backend type, and the front services the catalog-service backend.
     # revisit: Could be split into profiles
     catalog-service:
-      enabled: false
+      enabled: ${backend.catalog:false}
       # Base URI of the catalog service. If not set, will be automatically determined using the discovery service, looking for "catalog-service"
       # This allows to explicitly set a fixed location for the catalog service.
       # uri: http://catalog:8080
       cache-directory: ${java.io.tmpdir}/cngs/catalog-client/resource_store
       fallback-resource-directory: ${java.io.tmpdir}/cngs/catalog-client/fallback_resource_store
     data-directory:
-      enabled: false
+      enabled: ${backend.data-directory:false}
       location: ${GEOSERVER_DATA_DIR:${java.io.tmpdir}/cngs/data_directory} 
     jdbcconfig:
-      enabled: false
+      enabled: ${backend.jdbcconfig:false}
       initdb: false
       web.enabled: false
       cache-directory: ${jdbcconfig.cachedir:${java.io.tmpdir}/cngs/jdbcconfig/cache}
@@ -43,9 +43,9 @@ geoserver:
         password: ${jdbcconfig.password:geo$erver}
         driverClassname: ${jdbcconfig.driverClassname:org.postgresql.Driver}
         # optional:
-        schema: public
-        minimumIdle: 2
-        maximumPoolSize: 8
+        schema: ${jdbcconfig.schema:public}
+        minimumIdle: ${jdbcconfig.minConnections:2}
+        maximumPoolSize: ${jdbcconfig.maxConnections:8}
 
 management:
   endpoint:

--- a/config/catalog-service.yml
+++ b/config/catalog-service.yml
@@ -14,17 +14,15 @@ geoserver:
       # Number of back-end threads to hit the actual catalog with. Defaults 4 * number of cores if unset.
       # If using jdbcconfig, let io-threads be about half the size of geoserver.backend.jdbcconfig.datasource.maximumPoolSize, 
       # it has the tendency to use more than one jdbc connection for some requests.
-      max-size: 16
+      max-size: ${catalog.io.threads:8}
       # maximum number of queued requests per worker thread before rejecting new requests 
-      max-queued: 10000
+      max-queued: ${catalog.io.maxQueued:10000}
   bus:
     # receive events but don't publish, it's the front catalogs that publish events to better track where the changes come from
     send-events: false
   backend:
-    # decide which catalog backend to use on this service.
-    jdbcconfig.enabled: true
-    jdbcconfig.datasource.minimumIdle: 2
-    jdbcconfig.datasource.maximumPoolSize: 32
+    # decide which catalog backend to use on this service, default to using jdbcconfig
+    jdbcconfig.enabled: ${backend.jdbcconfig:true}
 
 #spring:
 #  error.includeStacktrace: on_trace_param

--- a/config/gateway-service.yml
+++ b/config/gateway-service.yml
@@ -2,26 +2,27 @@ server:
   compression:
     enabled: true
 # Configure routes to services. See https://cloud.spring.io/spring-cloud-gateway/single/spring-cloud-gateway.html
+
 management:
-  endpoint:
-    gateway:
-      enabled: true # default value
-    info:
-      enabled: true
-    health:
-      enabled: true
+  endpoint.gateway.enabled: true # default value
   endpoints:
-    web:
-      exposure:
-        include: gateway, info, health
+    enabled-by-default: true
+    web.exposure.include: "*"
+    #web.exposure.include: gateway, info, health
+    
 spring:
   cloud:
-#    loadbalancer.ribbon.enabled: false # ribbon is in maintenance mode and should be replaced by spring-cloud-loadbalancer
     gateway:
       actuator:
         verbose:
           enabled: true
       routes:
+      - id: catalog
+        uri: lb://catalog-service
+        predicates:
+        - Path=/api/v1/**
+        filters: # Expose the catalog and configuration API only if the dev profile is active
+        - RouteProfile=dev,403
 # WFS routes
       - id: wfs # proxies requests to gateway-service:/wfs to wfs-service:/wfs
         uri: lb://wfs-service #load balanced to the wfs-service instances
@@ -79,3 +80,4 @@ logging:
     root: WARN
     com.netflix.discovery: WARN
     com.netflix.eureka: WARN
+

--- a/config/restconfig-v1.yml
+++ b/config/restconfig-v1.yml
@@ -1,5 +1,5 @@
 geoserver:
-  backend.catalog-service.enabled: true
+  backend.catalog-service.enabled: ${backend.catalog:true}
 ---
 spring.profiles: local
 server.port: 9105

--- a/config/wcs-service.yml
+++ b/config/wcs-service.yml
@@ -1,5 +1,5 @@
 geoserver:
-  backend.catalog-service.enabled: true
+  backend.catalog-service.enabled: ${backend.catalog:true}
 ---
 spring.profiles: local
 server.port: 9103

--- a/config/web-ui.yml
+++ b/config/web-ui.yml
@@ -1,5 +1,5 @@
 geoserver:
-  backend.catalog-service.enabled: true
+  backend.catalog-service.enabled: ${backend.catalog:true}
   web-ui:
     # Theese are all default values, here just for reference. You can omit them and add only the ones to disable or further configure
     security.enabled: true

--- a/config/wfs-service.yml
+++ b/config/wfs-service.yml
@@ -1,5 +1,5 @@
 geoserver:
-  backend.catalog-service.enabled: true
+  backend.catalog-service.enabled: ${backend.catalog:true}
 ---
 spring.profiles: local
 server.port: 9101

--- a/config/wms-service.yml
+++ b/config/wms-service.yml
@@ -1,5 +1,5 @@
 geoserver:
-  backend.catalog-service.enabled: true
+  backend.catalog-service.enabled: ${backend.catalog:true}
 ---
 spring.profiles: local
 server.port: 9102

--- a/config/wps-service.yml
+++ b/config/wps-service.yml
@@ -1,5 +1,5 @@
 geoserver:
-  backend.catalog-service.enabled: true
+  backend.catalog-service.enabled: ${backend.catalog:true}
 ---
 spring.profiles: local
 server.port: 9104

--- a/docker-compose-shared_datadir.yml
+++ b/docker-compose-shared_datadir.yml
@@ -1,0 +1,72 @@
+version: "3.8"
+
+#
+# Configures all geoserver services to use a shared data directory as catalog backend.
+# Run with `docker-compose --compatibility -f docker-compose.yml -f docker-compose-shared_datadir.yml up -d`
+# NOTE: Not ready for direct usage until deciding on a strategy to easily set up the shared data directory.
+#
+
+volumes:
+  shared_data_directory:
+    driver_opts:
+      type: none
+      o: bind
+      device: $PWD/docker-compose_datadir
+  
+services:
+  database:
+    entrypoint: echo "database-service disabled."
+
+  catalog:
+    environment:
+      BACKEND_JDBCCONFIG: "false"
+      BACKEND_DATA_DIRECTORY: "true"
+      GEOSERVER_DATA_DIR: /tmp/data_directory
+    volumes:
+      - shared_data_directory:/tmp/data_directory
+    command: echo "catalog-service disabled."
+
+  wfs:
+    environment:
+      BACKEND_CATALOG: "false"
+      BACKEND_DATA_DIRECTORY: "true"
+      GEOSERVER_DATA_DIR: /tmp/data_directory
+    volumes:
+      - shared_data_directory:/tmp/data_directory
+    command: sh -c "exec dockerize --timeout 120s -wait http://config:8080/wfs-service/default java $$JAVA_OPTS -jar /opt/app/wfs-service.jar"
+
+  wms:
+    environment:
+      BACKEND_CATALOG: "false"
+      BACKEND_DATA_DIRECTORY: "true"
+      GEOSERVER_DATA_DIR: /tmp/data_directory
+    volumes:
+      - shared_data_directory:/tmp/data_directory
+    command: sh -c "exec dockerize --timeout 120s -wait http://config:8080/wms-service/default java $$JAVA_OPTS -jar /opt/app/wms-service.jar"
+
+  wcs:
+    environment:
+      BACKEND_CATALOG: "false"
+      BACKEND_DATA_DIRECTORY: "true"
+      GEOSERVER_DATA_DIR: /tmp/data_directory
+    volumes:
+      - shared_data_directory:/tmp/data_directory
+    command: sh -c "exec dockerize --timeout 120s -wait http://config:8080/wcs-service/default java $$JAVA_OPTS -jar /opt/app/wcs-service.jar"
+
+  rest:
+    environment:
+      BACKEND_CATALOG: "false"
+      BACKEND_DATA_DIRECTORY: "true"
+      GEOSERVER_DATA_DIR: /tmp/data_directory
+    volumes:
+      - shared_data_directory:/tmp/data_directory
+    command: sh -c "exec dockerize --timeout 120s -wait http://config:8080/restconfig-v1/default java $$JAVA_OPTS -jar /opt/app/restconfig-service.jar"
+
+  webui:
+    environment:
+      BACKEND_CATALOG: "false"
+      BACKEND_DATA_DIRECTORY: "true"
+      GEOSERVER_DATA_DIR: /tmp/data_directory
+    volumes:
+      - shared_data_directory:/tmp/data_directory
+    command: sh -c "exec dockerize --timeout 120s -wait http://config:8080/web-ui/default java $$JAVA_OPTS -jar /opt/app/web-ui-service.jar"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ volumes:
   
 networks:
   gs-cloud-network:
-    driver: bridge
+#    driver: bridge
         
 services:
   rabbitmq:
@@ -97,8 +97,8 @@ services:
       - ./config:/opt/app/config
     healthcheck:
       test: ["CMD", "curl", "-f", "-m", "1", "http://localhost:8080/actuator/health"]
-      interval: 1s
-      timeout: 1s
+      interval: 5s
+      timeout: 2s
       retries: 15
     deploy:
       resources:
@@ -118,6 +118,7 @@ services:
     environment:
       EUREKA_SERVER_URL: ${EUREKA_SERVER_URL}
       JAVA_OPTS: ${GATEWAY_JAVA_OPTS}
+      SPRING_PROFILES_ACTIVE: dev #exposes the catalog and config API at /api/v1/**
     ports:
       - 9090:8080
     networks:
@@ -129,6 +130,7 @@ services:
         limits:
           cpus: '4.0'
           memory: 512M
+    command: sh -c "exec dockerize -wait http://config:8080/gateway-service/default --timeout 120s java $$JAVA_OPTS -jar /opt/app/gateway-service.jar"
 
   # catalog microservice, provides a unified catalog backend to all services
   catalog:
@@ -139,25 +141,28 @@ services:
       - database
       - rabbitmq
     environment:
-      EUREKA_SERVER_URL: ${EUREKA_SERVER_URL}
       # Force the max RAM (-XX:MaxRAM) seen by the JVM in case --compatibility wasn't used to launch the composition
       JAVA_OPTS: "${CATALOG_JAVA_OPTS}"
+      EUREKA_SERVER_URL: ${EUREKA_SERVER_URL}
       RABBITMQ_HOST: rabbitmq
+      CATALOG_IO_THREADS: 8
+      CATALOG_IO_MAX_QUEUED: 10000
+      BACKEND_JDBCCONFIG: "true"
       JDBCCONFIG_URL: "${JDBCCONFIG_URL}"
       JDBCCONFIG_USERNAME: "${JDBCCONFIG_USERNAME}"
       JDBCCONFIG_PASSWORD: "${JDBCCONFIG_PASSWORD}"
+      JDBCCONFIG_MIN_CONNECTIONS: 2
+      JDBCCONFIG_MAX_CONNECTIONS: 16 # 2 x CATALOG_IO_THREADS
     networks:
       - gs-cloud-network
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
-    # expose port only to be able of running local instances, not necessary in production, just for testing
-    #ports:
-    #  - "9100:8080"
     deploy:
       resources:
         limits:
           cpus: '2.0'
           memory: 512M
+    command: sh -c "exec dockerize -wait http://config:8080/catalog-service/default --timeout 120s java $$JAVA_OPTS -jar /opt/app/catalog-service.jar"
 
   # WFS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wfs=5)
   wfs:
@@ -178,7 +183,8 @@ services:
       resources:
         limits:
           cpus: '2.0'
-          memory: 512M
+          memory: 2G
+    command: sh -c "exec dockerize --timeout 120s -wait http://config:8080/wfs-service/default -wait http://catalog:8080/api/v1/catalog/workspaces java $$JAVA_OPTS -jar /opt/app/wfs-service.jar"
 
   # WMS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wms=5)
   wms:
@@ -198,6 +204,7 @@ services:
         limits:
           cpus: '2.0'
           memory: 1G
+    command: sh -c "exec dockerize -wait http://config:8080/wms-service/default -wait http://catalog:8080/api/v1/catalog/workspaces --timeout 120s java $$JAVA_OPTS -jar /opt/app/wms-service.jar"
 
   # WCS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wcs=5)
   wcs:
@@ -217,6 +224,7 @@ services:
         limits:
           cpus: '2.0'
           memory: 1G
+    command: sh -c "exec dockerize -wait http://config:8080/wcs-service/default -wait http://catalog:8080/api/v1/catalog/workspaces --timeout 120s java $$JAVA_OPTS -jar /opt/app/wcs-service.jar"
 
 #  # WPS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wps=5)
 #  wps:
@@ -254,6 +262,7 @@ services:
         limits:
           cpus: '1.5'
           memory: 512M
+    command: sh -c "exec dockerize -wait http://config:8080/restconfig-v1/default -wait http://catalog:8080/api/v1/catalog/workspaces --timeout 120s java $$JAVA_OPTS -jar /opt/app/restconfig-service.jar"
 
   # WEB UI microservice
   webui:
@@ -274,3 +283,4 @@ services:
         limits:
           cpus: '2.0'
           memory: 1G
+    command: sh -c "exec dockerize -wait http://config:8080/web-ui/default -wait http://catalog:8080/api/v1/catalog/workspaces --timeout 120s java $$JAVA_OPTS -jar /opt/app/web-ui-service.jar"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,7 +183,7 @@ services:
       resources:
         limits:
           cpus: '2.0'
-          memory: 2G
+          memory: 1G
     command: sh -c "exec dockerize --timeout 120s -wait http://config:8080/wfs-service/default -wait http://catalog:8080/api/v1/catalog/workspaces java $$JAVA_OPTS -jar /opt/app/wfs-service.jar"
 
   # WMS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wms=5)

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/api/v1/ReactiveConfigController.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/api/v1/ReactiveConfigController.java
@@ -53,6 +53,12 @@ public class ReactiveConfigController {
         return config.setGlobal(global);
     }
 
+    /** The settings configuration by its id, or <code>null</code> if not exists. */
+    @GetMapping("/workspaces/settings/{id}")
+    public Mono<SettingsInfo> getSettingsById(@PathVariable("id") String id) {
+        return config.getSettingsById(id);
+    }
+
     /**
      * The settings configuration for the specified workspace, or <code>null</code> if non exists.
      */

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/service/ReactiveGeoServer.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/service/ReactiveGeoServer.java
@@ -4,6 +4,8 @@
  */
 package org.geoserver.cloud.catalog.service;
 
+import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.Patch;
@@ -136,6 +138,21 @@ public class ReactiveGeoServer {
                     patch.applyTo(service, serviceType);
                     blockingConfig.save(service);
                     return service;
+                });
+    }
+
+    public Mono<SettingsInfo> getSettingsById(String id) {
+        // TODO: improve
+        return async(
+                () -> {
+                    List<WorkspaceInfo> workspaces = blockingConfig.getCatalog().getWorkspaces();
+                    for (WorkspaceInfo w : workspaces) {
+                        SettingsInfo settings = blockingConfig.getSettings(w);
+                        if (settings != null && Objects.equals(id, settings.getId())) {
+                            return settings;
+                        }
+                    }
+                    return null;
                 });
     }
 

--- a/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/config/datadirectory/DataDirectoryBackendConfigurer.java
+++ b/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/config/datadirectory/DataDirectoryBackendConfigurer.java
@@ -9,12 +9,13 @@ import java.nio.file.Path;
 import javax.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
+import org.geoserver.catalog.plugin.DefaultMemoryCatalogFacade;
+import org.geoserver.cloud.autoconfigure.bus.ConditionalOnGeoServerRemoteEventsEnabled;
 import org.geoserver.cloud.config.catalog.GeoServerBackendConfigurer;
 import org.geoserver.cloud.config.catalog.GeoServerBackendProperties;
 import org.geoserver.config.DefaultGeoServerLoader;
-import org.geoserver.config.GeoServerFacade;
 import org.geoserver.config.GeoServerLoader;
+import org.geoserver.config.plugin.RepositoryGeoServerFacade;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.platform.resource.ResourceStore;
 import org.geoserver.wcs.WCSXStreamLoader;
@@ -39,11 +40,16 @@ public class DataDirectoryBackendConfigurer implements GeoServerBackendConfigure
         log.info("Loading geoserver config backend with {}", getClass().getSimpleName());
     }
 
-    public @Override @Bean ExtendedCatalogFacade catalogFacade() {
+    @ConditionalOnGeoServerRemoteEventsEnabled
+    public @Bean DataDirectoryRemoteEventProcessor dataDirectoryRemoteEventProcessor() {
+        return new DataDirectoryRemoteEventProcessor();
+    }
+
+    public @Override @Bean DefaultMemoryCatalogFacade catalogFacade() {
         return new org.geoserver.catalog.plugin.DefaultMemoryCatalogFacade();
     }
 
-    public @Override @Bean GeoServerFacade geoserverFacade() {
+    public @Override @Bean RepositoryGeoServerFacade geoserverFacade() {
         return new org.geoserver.config.plugin.RepositoryGeoServerFacadeImpl();
     }
 

--- a/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/config/datadirectory/DataDirectoryRemoteEventProcessor.java
+++ b/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/config/datadirectory/DataDirectoryRemoteEventProcessor.java
@@ -1,0 +1,276 @@
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.config.datadirectory;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.Info;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StoreInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.catalog.plugin.DefaultMemoryCatalogFacade;
+import org.geoserver.catalog.plugin.Patch;
+import org.geoserver.cloud.bus.event.RemoteAddEvent;
+import org.geoserver.cloud.bus.event.RemoteModifyEvent;
+import org.geoserver.cloud.bus.event.RemoteRemoveEvent;
+import org.geoserver.cloud.bus.event.catalog.RemoteCatalogEvent;
+import org.geoserver.cloud.bus.event.catalog.RemoteDefaultDataStoreEvent;
+import org.geoserver.cloud.bus.event.catalog.RemoteDefaultNamespaceEvent;
+import org.geoserver.cloud.bus.event.catalog.RemoteDefaultWorkspaceEvent;
+import org.geoserver.cloud.event.ConfigInfoInfoType;
+import org.geoserver.config.ServiceInfo;
+import org.geoserver.config.SettingsInfo;
+import org.geoserver.config.plugin.RepositoryGeoServerFacade;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+
+/** Listens to {@link RemoteCatalogEvent}s and updates the local catalog */
+@Slf4j(topic = "org.geoserver.cloud.bus.incoming.datadirectory")
+public class DataDirectoryRemoteEventProcessor {
+    private @Autowired RepositoryGeoServerFacade configFacade;
+
+    private @Autowired DefaultMemoryCatalogFacade catalogFacade;
+
+    @EventListener(RemoteRemoveEvent.class)
+    public void onRemoteRemoveEvent(RemoteRemoveEvent<?, ? extends Info> event) {
+        if (event.isFromSelf()) {
+            return;
+        }
+        final ConfigInfoInfoType type = event.getInfoType();
+        final String objectId = event.getObjectId();
+        switch (type) {
+            case NamespaceInfo:
+                remove(objectId, catalogFacade::getNamespace, catalogFacade::remove);
+                break;
+            case WorkspaceInfo:
+                remove(objectId, catalogFacade::getWorkspace, catalogFacade::remove);
+                break;
+            case CoverageInfo:
+            case FeatureTypeInfo:
+            case WmsLayerInfo:
+            case WmtsLayerInfo:
+                remove(
+                        objectId,
+                        id -> catalogFacade.getResource(id, ResourceInfo.class),
+                        catalogFacade::remove);
+                break;
+            case CoverageStoreInfo:
+            case DataStoreInfo:
+            case WmsStoreInfo:
+            case WmtsStoreInfo:
+                remove(
+                        objectId,
+                        id -> catalogFacade.getStore(id, StoreInfo.class),
+                        catalogFacade::remove);
+                break;
+            case LayerGroupInfo:
+                remove(objectId, catalogFacade::getLayerGroup, catalogFacade::remove);
+                break;
+            case LayerInfo:
+                remove(objectId, catalogFacade::getLayer, catalogFacade::remove);
+                break;
+            case StyleInfo:
+                remove(objectId, catalogFacade::getStyle, catalogFacade::remove);
+                break;
+            case ServiceInfo:
+                remove(
+                        objectId,
+                        id -> configFacade.getService(id, ServiceInfo.class),
+                        configFacade::remove);
+                break;
+            case SettingsInfo:
+                remove(objectId, configFacade::getSettings, configFacade::remove);
+                break;
+            default:
+                log.warn(
+                        "Don't know how to handle remote remove envent for {}({})", type, objectId);
+                break;
+        }
+    }
+
+    @EventListener(RemoteAddEvent.class)
+    public void onRemoteAddEvent(RemoteAddEvent<?, ? extends Info> event) {
+        if (event.isFromSelf()) {
+            return;
+        }
+        final String objectId = event.getObjectId();
+        final ConfigInfoInfoType type = event.getInfoType();
+        log.debug("Handling remote add event {}({})", type, objectId);
+        final Info object = event.getObject();
+        if (object == null) {
+            log.error("Remote add event didn't send the object payload for {}({})", type, objectId);
+            return;
+        }
+        switch (type) {
+            case NamespaceInfo:
+                catalogFacade.add((NamespaceInfo) object);
+                break;
+            case WorkspaceInfo:
+                catalogFacade.add((WorkspaceInfo) object);
+                break;
+            case CoverageInfo:
+            case FeatureTypeInfo:
+            case WmsLayerInfo:
+            case WmtsLayerInfo:
+                catalogFacade.add((ResourceInfo) object);
+                break;
+            case CoverageStoreInfo:
+            case DataStoreInfo:
+            case WmsStoreInfo:
+            case WmtsStoreInfo:
+                catalogFacade.add((StoreInfo) object);
+                break;
+            case LayerGroupInfo:
+                catalogFacade.add((LayerGroupInfo) object);
+                break;
+            case LayerInfo:
+                catalogFacade.add((LayerInfo) object);
+                break;
+            case StyleInfo:
+                catalogFacade.add((StyleInfo) object);
+                break;
+            case ServiceInfo:
+                configFacade.add((ServiceInfo) object);
+                break;
+            case SettingsInfo:
+                configFacade.add((SettingsInfo) object);
+                break;
+            default:
+                log.warn("Don't know how to handle remote add envent for {}({})", type, objectId);
+                break;
+        }
+    }
+
+    @EventListener(RemoteDefaultWorkspaceEvent.class)
+    public void onRemoteDefaultWorkspaceEvent(RemoteDefaultWorkspaceEvent event) {
+        if (event.isFromSelf()) {
+            return;
+        }
+        String newId = event.getNewWorkspaceId();
+        WorkspaceInfo newDefault = newId == null ? null : catalogFacade.getWorkspace(newId);
+        catalogFacade.setDefaultWorkspace(newDefault);
+    }
+
+    @EventListener(RemoteDefaultNamespaceEvent.class)
+    public void onRemoteDefaultNamespaceEvent(RemoteDefaultNamespaceEvent event) {
+        if (event.isFromSelf()) {
+            return;
+        }
+        String newId = event.getNewNamespaceId();
+        NamespaceInfo namespace = newId == null ? null : catalogFacade.getNamespace(newId);
+        catalogFacade.setDefaultNamespace(namespace);
+    }
+
+    @EventListener(RemoteDefaultDataStoreEvent.class)
+    public void onRemoteDefaultDataStoreEvent(RemoteDefaultDataStoreEvent event) {
+        if (event.isFromSelf()) {
+            return;
+        }
+        String workspaceId = event.getWorkspaceId();
+        WorkspaceInfo workspace = catalogFacade.getWorkspace(workspaceId);
+        String storeId = event.getDefaultDataStoreId();
+        DataStoreInfo store =
+                storeId == null ? null : catalogFacade.getStore(storeId, DataStoreInfo.class);
+        catalogFacade.setDefaultDataStore(workspace, store);
+    }
+
+    @EventListener(RemoteModifyEvent.class)
+    public void onRemoteModifyEvent(RemoteModifyEvent<?, ? extends Info> event) {
+        if (event.isFromSelf()) {
+            return;
+        }
+        final String objectId = event.getObjectId();
+        final ConfigInfoInfoType type = event.getInfoType();
+        if (type == ConfigInfoInfoType.Catalog) {
+            log.trace(
+                    "remote catalog modify events handled by RemoteDefaultWorkspace/Namespace/Store event handlers");
+            return;
+        }
+        log.debug("Handling remote modify event {}({})", type, objectId);
+        final Patch patch = event.getPatch();
+        if (patch == null) {
+            log.error("Remote add event didn't send the patch payload for {}({})", type, objectId);
+            return;
+        }
+        Info info = null;
+        switch (type) {
+            case NamespaceInfo:
+                info = catalogFacade.getNamespace(objectId);
+                break;
+            case WorkspaceInfo:
+                info = catalogFacade.getWorkspace(objectId);
+                break;
+            case CoverageInfo:
+            case FeatureTypeInfo:
+            case WmsLayerInfo:
+            case WmtsLayerInfo:
+                info = catalogFacade.getResource(objectId, ResourceInfo.class);
+                break;
+            case CoverageStoreInfo:
+            case DataStoreInfo:
+            case WmsStoreInfo:
+            case WmtsStoreInfo:
+                info = catalogFacade.getStore(objectId, StoreInfo.class);
+                break;
+            case LayerGroupInfo:
+                info = catalogFacade.getLayerGroup(objectId);
+                break;
+            case LayerInfo:
+                info = catalogFacade.getLayer(objectId);
+                break;
+            case StyleInfo:
+                info = catalogFacade.getStyle(objectId);
+                break;
+            case GeoServerInfo:
+                info = configFacade.getGlobal();
+                info = ModificationProxy.unwrap(info);
+                break;
+            case ServiceInfo:
+                info = configFacade.getService(objectId, ServiceInfo.class);
+                info = ModificationProxy.unwrap(info);
+                break;
+            case SettingsInfo:
+                info = configFacade.getSettings(objectId);
+                info = ModificationProxy.unwrap(info);
+                break;
+            default:
+                log.warn(
+                        "Don't know how to handle remote modify envent for {}({})", type, objectId);
+                return;
+        }
+        if (info == null) {
+            log.warn(
+                    "Object not found, can't update upon remote modify event {}({})",
+                    type,
+                    objectId);
+        } else {
+            patch.applyTo(info);
+            log.debug(
+                    "Object updated: {}({}). Properties: {}",
+                    type,
+                    objectId,
+                    event.getChangedProperties().stream().collect(Collectors.joining(",")));
+        }
+    }
+
+    private <T extends Info> void remove(
+            String id, Function<String, T> supplier, Consumer<? super T> remover) {
+        T info = supplier.apply(id);
+        if (info == null) {
+            log.warn("Can't remove {}, not present in local catalog", id);
+        } else {
+            remover.accept(info);
+            log.debug("Removed {}", id);
+        }
+    }
+}

--- a/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/config/jdbcconfig/JDBCConfigBackendConfigurer.java
+++ b/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/config/jdbcconfig/JDBCConfigBackendConfigurer.java
@@ -14,6 +14,7 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.geoserver.catalog.plugin.CatalogFacadeExtensionAdapter;
 import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
+import org.geoserver.cloud.autoconfigure.bus.ConditionalOnGeoServerRemoteEventsEnabled;
 import org.geoserver.cloud.config.catalog.GeoServerBackendConfigurer;
 import org.geoserver.cloud.config.jdbcconfig.bus.JdbcConfigRemoteEventProcessor;
 import org.geoserver.config.GeoServerFacade;
@@ -43,7 +44,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cloud.bus.ConditionalOnBusEnabled;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -177,7 +177,7 @@ public class JDBCConfigBackendConfigurer implements GeoServerBackendConfigurer {
     }
 
     @Bean
-    @ConditionalOnBusEnabled
+    @ConditionalOnGeoServerRemoteEventsEnabled
     public JdbcConfigRemoteEventProcessor jdbcConfigRemoteEventProcessor() {
         return new JdbcConfigRemoteEventProcessor();
     }

--- a/starters/catalog-backend-starter/src/test/java/org/geoserver/cloud/bus/incoming/caching/RemoteEventCacheEvictorTest.java
+++ b/starters/catalog-backend-starter/src/test/java/org/geoserver/cloud/bus/incoming/caching/RemoteEventCacheEvictorTest.java
@@ -186,8 +186,8 @@ public class RemoteEventCacheEvictorTest {
         assertNull(
                 "expected key evicted after setting null default datastore", catalogCache.get(key));
 
-        catalog.getDefaultDataStore(data.workspaceA);
-        assertNotNull(catalogCache.get(key));
+        assertNull(catalog.getDefaultDataStore(data.workspaceA));
+        assertNull(catalogCache.get(key));
 
         publish(
                 RemoteDefaultDataStoreEvent.class,
@@ -197,6 +197,8 @@ public class RemoteEventCacheEvictorTest {
                 originService,
                 destinationService);
         assertNull(catalogCache.get(key));
+        assertNotNull(catalog.getDefaultDataStore(data.workspaceA));
+        assertNotNull(catalogCache.get(key));
     }
 
     public @Test void testCatalogInfoEvictingEvents() {

--- a/support-services/api-gateway/src/main/java/org/geoserver/cloud/gateway/GatewayApplication.java
+++ b/support-services/api-gateway/src/main/java/org/geoserver/cloud/gateway/GatewayApplication.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.gateway;
 
 import lombok.extern.slf4j.Slf4j;
+import org.geoserver.cloud.gateway.filter.RouteProfileGatewayFilterFactory;
 import org.geoserver.cloud.gateway.predicate.RegExpQueryRoutePredicateFactory;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -34,6 +35,11 @@ public class GatewayApplication {
      */
     public @Bean RegExpQueryRoutePredicateFactory regExpQueryRoutePredicateFactory() {
         return new RegExpQueryRoutePredicateFactory();
+    }
+
+    /** Allows to enable routes only if a given spring profile is enabled */
+    public @Bean RouteProfileGatewayFilterFactory routeProfileGatewayFilterFactory() {
+        return new RouteProfileGatewayFilterFactory();
     }
 
     @EventListener(ApplicationReadyEvent.class)

--- a/support-services/api-gateway/src/main/java/org/geoserver/cloud/gateway/filter/RouteProfileGatewayFilterFactory.java
+++ b/support-services/api-gateway/src/main/java/org/geoserver/cloud/gateway/filter/RouteProfileGatewayFilterFactory.java
@@ -1,0 +1,107 @@
+/*
+ * (c) 2021 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.gateway.filter;
+
+import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.validation.constraints.NotEmpty;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/** Allows to enable routes only if a given spring profile is enabled */
+public class RouteProfileGatewayFilterFactory
+        extends AbstractGatewayFilterFactory<RouteProfileGatewayFilterFactory.Config> {
+
+    private static final List<String> SHORTCUT_FIELD_ORDER =
+            Collections.unmodifiableList(Arrays.asList(Config.PROFILE_KEY, Config.HTTPSTATUS_KEY));
+
+    @Autowired private Environment environment;
+
+    public RouteProfileGatewayFilterFactory() {
+        super(Config.class);
+    }
+
+    @Override
+    public List<String> shortcutFieldOrder() {
+        return SHORTCUT_FIELD_ORDER;
+    }
+
+    @Override
+    public GatewayFilter apply(Config config) {
+        return new RouteProfileGatewayFilter(environment, config);
+    }
+
+    @RequiredArgsConstructor
+    private static class RouteProfileGatewayFilter implements GatewayFilter {
+
+        private final @NonNull Environment environment;
+        private final @NonNull Config config;
+
+        @Override
+        public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+            final List<String> activeProfiles = Arrays.asList(environment.getActiveProfiles());
+            String profile = config.getProfile();
+            if (StringUtils.hasText(profile)) {
+                final boolean exclude = profile.startsWith("!");
+                profile = exclude ? profile.substring(1) : profile;
+
+                boolean profileMatch = activeProfiles.contains(profile);
+                boolean proceed = (profileMatch && !exclude) || (!profileMatch && exclude);
+                if (proceed) {
+                    // continue...
+                    return chain.filter(exchange);
+                }
+            }
+
+            int status = config.getStatusCode();
+            exchange.getResponse().setRawStatusCode(status);
+            return exchange.getResponse().setComplete();
+        }
+
+        @Override
+        public String toString() {
+            return filterToStringCreator(this)
+                    .append(Config.PROFILE_KEY, config.getProfile())
+                    .append(Config.HTTPSTATUS_KEY, config.getStatusCode())
+                    .toString();
+        }
+    }
+
+    @Data
+    @Accessors(chain = true)
+    @Validated
+    public static class Config {
+
+        /**
+         * Profiles key, indicates which profiles must be enabled to allow the request to proceed
+         */
+        public static final String PROFILE_KEY = "profile";
+
+        /**
+         * Status code key. HTTP status code to return when the request is not allowed to proceed
+         * because the required profiles are not active
+         */
+        public static final String HTTPSTATUS_KEY = "statusCode";
+
+        @NotEmpty private String profile;
+
+        private int statusCode = HttpStatus.NOT_FOUND.value();
+    }
+}


### PR DESCRIPTION
Add `DataDirectoryRemoteEventProcessor` to handle incoming events when
the config backend is `data-directory`, and patch the catalog facade
objects directly without any configuration reload.