### PR TITLE
Manage webmvc transitive dependency from geoserver

### DIFF
--- a/catalog-support/pluggable-catalog-support/pom.xml
+++ b/catalog-support/pluggable-catalog-support/pom.xml
@@ -15,12 +15,21 @@
       <artifactId>gs-main</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <!-- provided scope, so its added explicitly where needed. GeoServer's Dispatcher should really get rid of servlet 
+        and webmvc apis, and/or the Dispatcher.REQUEST ThreadLocal -->
+      <artifactId>spring-webmvc</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <!-- for CatalogImplConformanceTest, this dep is excluded from gs-main in the root pom -->
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>

--- a/starters/catalog-backend-starter/pom.xml
+++ b/starters/catalog-backend-starter/pom.xml
@@ -11,6 +11,16 @@
   <description>Catalog backends starter</description>
   <dependencies>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-webmvc</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
     </dependency>


### PR DESCRIPTION
Due to https://github.com/geoserver/geoserver/pull/4884,
excluding spring-webmvc from gs-main results in a
`NoClassDefFoundError: org/springframework/web/servlet/mvc/AbstractController`. 

Before it was coming as transitive of gs-ows anyways.

Yet webmvc can't be included in the reactive projects, so adding it in
provided scope where required.