### PR TITLE
Rename docker images based on feedback

### DIFF
--- a/docker-base-java/pom.xml
+++ b/docker-base-java/pom.xml
@@ -11,6 +11,7 @@
   <packaging>pom</packaging>
   <name>Docker base image for Spring Boot apps</name>
   <properties>
+    <dockerfile.skip>false</dockerfile.skip>
     <docker.image.name>docker-base-java</docker.image.name>
   </properties>
   <profiles>

--- a/docker-compose-discovery-ha.yml
+++ b/docker-compose-discovery-ha.yml
@@ -13,7 +13,7 @@ services:
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://discovery-2:8761/eureka
 
   discovery2:
-    image: geoservercloud/gs-cloud-discovery-service:${TAG}
+    image: geoservercloud/geoserver-cloud-discovery:${TAG}
     container_name: discovery-2
     environment:
       SERVER_PORT: 8761
@@ -26,7 +26,7 @@ services:
       - gs-cloud-network
 
   config:
-    image: geoservercloud/gs-cloud-config-service:${TAG}
+    image: geoservercloud/geoserver-cloud-config:${TAG}
     depends_on:
       - discovery
       - discovery2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
           memory: 1G
 
   database:
-    image: geoservercloud/jdbcconfig-database:${TAG}
+    image: geoservercloud/geoserver-cloud-postgres-jdbcconfig:${TAG}
     environment:
       POSTGRES_DB: "${JDBCCONFIG_DBNAME}"
       POSTGRES_USER: "${JDBCCONFIG_USERNAME}"
@@ -51,7 +51,7 @@ services:
   # Browse to http://localhost:8761 to check all services are registered.
   # Run docker-compose -f docker-compose.yml -f docker-compose-discovery-ha.yml to run extra discovery service instances for HA
   discovery:
-    image: geoservercloud/discovery-service:${TAG}
+    image: geoservercloud/geoserver-cloud-discovery:${TAG}
     environment:
       SERVER_PORT: 8761
       EUREKA_INSTANCE_HOSTNAME: discovery
@@ -75,7 +75,7 @@ services:
   # microservices. Being a Discovery First Bootstrap configuration, it'll
   # register itself with the Eureka discovery service and can be scaled
   config:
-    image: geoservercloud/config-service:${TAG}
+    image: geoservercloud/geoserver-cloud-config:${TAG}
     depends_on:
       - discovery
     environment:
@@ -111,7 +111,7 @@ services:
   # Application facade, provides a single entry point routing to all
   # microservices (e.g. http://localhost:9090/geoserver/wms, http://localhost:9090/geoserver/wfs, etc)
   gateway:
-    image: geoservercloud/gateway-service:${TAG}
+    image: geoservercloud/geoserver-cloud-gateway:${TAG}
     depends_on:
       - discovery
       - config
@@ -134,7 +134,7 @@ services:
 
   # catalog microservice, provides a unified catalog backend to all services
   catalog:
-    image: geoservercloud/catalog-service:${TAG}
+    image: geoservercloud/geoserver-cloud-catalog:${TAG}
     depends_on:
       - discovery
       - config
@@ -166,7 +166,7 @@ services:
 
   # WFS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wfs=5)
   wfs:
-    image: geoservercloud/wfs-service:${TAG}
+    image: geoservercloud/geoserver-cloud-wfs:${TAG}
     depends_on:
       - catalog
     environment:
@@ -188,7 +188,7 @@ services:
 
   # WMS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wms=5)
   wms:
-    image: geoservercloud/wms-service:${TAG}
+    image: geoservercloud/geoserver-cloud-wms:${TAG}
     depends_on:
       - catalog
     environment:
@@ -208,7 +208,7 @@ services:
 
   # WCS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wcs=5)
   wcs:
-    image: geoservercloud/wcs-service:${TAG}
+    image: geoservercloud/geoserver-cloud-wcs:${TAG}
     depends_on:
       - catalog
     environment:
@@ -228,7 +228,7 @@ services:
 
 #  # WPS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wps=5)
 #  wps:
-#    image: geoservercloud/wps-service:${TAG}
+#    image: geoservercloud/geoserver-cloud-wps:${TAG}
 #    depends_on:
 #      - rabbitmq
 #      - catalog
@@ -243,7 +243,7 @@ services:
 
   # REST config microservice, port dynamically allocated to allow scaling (e.g docker-compose scale rest=5)
   rest:
-    image: geoservercloud/rest-service:${TAG}
+    image: geoservercloud/geoserver-cloud-rest:${TAG}
     depends_on:
       - rabbitmq
       - catalog
@@ -266,7 +266,7 @@ services:
 
   # WEB UI microservice
   webui:
-    image: geoservercloud/webui-service:${TAG}
+    image: geoservercloud/geoserver-cloud-webui:${TAG}
     depends_on:
       - rabbitmq
       - catalog

--- a/docs/deploy/docker-compose/stable/docker-compose.yml
+++ b/docs/deploy/docker-compose/stable/docker-compose.yml
@@ -32,7 +32,7 @@ services:
           memory: 1G
 
   database:
-    image: geoservercloud/jdbcconfig-database:1.0-M1
+    image: geoservercloud/geoserver-cloud-postgres-jdbcconfig:1.0-M1
     environment:
       POSTGRES_DB: "geoserver_config"
       POSTGRES_USER: "geoserver"
@@ -54,7 +54,7 @@ services:
   # Browse to http://localhost:8761 to check all services are registered.
   # Run docker-compose -f docker-compose.yml -f docker-compose-discovery-ha.yml to run extra discovery service instances for HA
   discovery:
-    image: geoservercloud/discovery-service:1.0-M1
+    image: geoservercloud/geoserver-cloud-discovery:1.0-M1
     environment:
       SERVER_PORT: 8761
       EUREKA_INSTANCE_HOSTNAME: discovery
@@ -78,7 +78,7 @@ services:
   # microservices. Being a Discovery First Bootstrap configuration, it'll
   # register itself with the Eureka discovery service and can be scaled
   config:
-    image: geoservercloud/config-service:1.0-M1
+    image: geoservercloud/geoserver-cloud-config:1.0-M1
     depends_on:
       - discovery
     environment:
@@ -113,7 +113,7 @@ services:
   # Application facade, provides a single entry point routing to all
   # microservices (e.g. http://localhost:9090/geoserver/wms, http://localhost:9090/geoserver/wfs, etc)
   gateway:
-    image: geoservercloud/gateway-service:1.0-M1
+    image: geoservercloud/geoserver-cloud-gateway:1.0-M1
     depends_on:
       - discovery
       - config
@@ -137,7 +137,7 @@ services:
 
   # catalog microservice, provides a unified catalog backend to all services
   catalog:
-    image: geoservercloud/catalog-service:1.0-M1
+    image: geoservercloud/geoserver-cloud-catalog:1.0-M1
     depends_on:
       - discovery
       - config
@@ -165,7 +165,7 @@ services:
 
   # WFS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wfs=5)
   wfs:
-    image: geoservercloud/wfs-service:1.0-M1
+    image: geoservercloud/geoserver-cloud-wfs:1.0-M1
     depends_on:
       - rabbitmq
       - catalog
@@ -186,7 +186,7 @@ services:
 
   # WMS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wms=5)
   wms:
-    image: geoservercloud/wms-service:1.0-M1
+    image: geoservercloud/geoserver-cloud-wms:1.0-M1
     depends_on:
       - rabbitmq
       - catalog
@@ -208,7 +208,7 @@ services:
 
   # WCS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wcs=5)
   wcs:
-    image: geoservercloud/wcs-service:1.0-M1
+    image: geoservercloud/geoserver-cloud-wcs:1.0-M1
     depends_on:
       - rabbitmq
       - catalog
@@ -230,7 +230,7 @@ services:
 
   # REST config microservice, port dynamically allocated to allow scaling (e.g docker-compose scale rest=5)
   rest:
-    image: geoservercloud/rest-service:1.0-M1
+    image: geoservercloud/geoserver-cloud-rest:1.0-M1
     depends_on:
       - rabbitmq
       - catalog
@@ -252,7 +252,7 @@ services:
 
   # WEB UI microservice
   webui:
-    image: geoservercloud/webui-service:1.0-M1
+    image: geoservercloud/geoserver-cloud-webui:1.0-M1
     depends_on:
       - rabbitmq
       - catalog

--- a/pom.xml
+++ b/pom.xml
@@ -28,9 +28,13 @@
     <fmt.skip>false</fmt.skip>
     <fork.javac>true</fork.javac>
     <javac.maxHeapSize>256M</javac.maxHeapSize>
+    <!-- docker.image.prefix: dockerhub organization name -->
     <docker.image.prefix>geoservercloud</docker.image.prefix>
-    <docker.image.name>${project.artifactId}</docker.image.name>
+    <!-- Set docker.image.name on each service pom -->
+    <docker.image.name>change_me</docker.image.name>
     <docker.repository>${docker.image.prefix}/${docker.image.name}</docker.repository>
+    <!-- set dockerfile.skip to false in service projects to we can run mvn dockerfile:build from the root directory -->
+    <dockerfile.skip>true</dockerfile.skip>
     <dockerfile.build.pullNewerImage>false</dockerfile.build.pullNewerImage>
     <dockerfile.push.skip>true</dockerfile.push.skip>
   </properties>

--- a/services/catalog/pom.xml
+++ b/services/catalog/pom.xml
@@ -10,7 +10,8 @@
   <packaging>jar</packaging>
   <name>Catalog microservice</name>
   <properties>
-    <docker.image.name>catalog-service</docker.image.name>
+    <dockerfile.skip>false</dockerfile.skip>
+    <docker.image.name>geoserver-cloud-catalog</docker.image.name>
     <start-class>org.geoserver.cloud.catalog.app.CatalogServiceApplication</start-class>
   </properties>
   <dependencies>

--- a/services/restconfig/pom.xml
+++ b/services/restconfig/pom.xml
@@ -10,7 +10,8 @@
   <packaging>jar</packaging>
   <name>restconfig-service</name>
   <properties>
-    <docker.image.name>rest-service</docker.image.name>
+    <dockerfile.skip>false</dockerfile.skip>
+    <docker.image.name>geoserver-cloud-rest</docker.image.name>
     <start-class>org.geoserver.cloud.restconfig.RestConfigApplication</start-class>
   </properties>
   <dependencies>

--- a/services/wcs/pom.xml
+++ b/services/wcs/pom.xml
@@ -10,7 +10,8 @@
   <packaging>jar</packaging>
   <name>wcs-service</name>
   <properties>
-    <docker.image.name>wcs-service</docker.image.name>
+    <dockerfile.skip>false</dockerfile.skip>
+    <docker.image.name>geoserver-cloud-wcs</docker.image.name>
     <start-class>org.geoserver.cloud.wcs.WcsApplication</start-class>
   </properties>
   <dependencies>

--- a/services/web-ui/pom.xml
+++ b/services/web-ui/pom.xml
@@ -10,7 +10,8 @@
   <packaging>jar</packaging>
   <name>web-ui-service</name>
   <properties>
-    <docker.image.name>webui-service</docker.image.name>
+    <dockerfile.skip>false</dockerfile.skip>
+    <docker.image.name>geoserver-cloud-webui</docker.image.name>
     <start-class>org.geoserver.cloud.web.app.WebUIApplication</start-class>
     <!-- The following properties control whether all gs-wms,gs-wfs,gs-wcs,gs-wps, and gs-gwc transitive dependencies are 
       excluded. Those jars need to be on the classpath even if the respective profiles are disabled, because they each provide 

--- a/services/wfs/pom.xml
+++ b/services/wfs/pom.xml
@@ -10,7 +10,8 @@
   <packaging>jar</packaging>
   <name>wfs-service</name>
   <properties>
-    <docker.image.name>wfs-service</docker.image.name>
+    <dockerfile.skip>false</dockerfile.skip>
+    <docker.image.name>geoserver-cloud-wfs</docker.image.name>
     <start-class>org.geoserver.cloud.wfs.WfsApplication</start-class>
   </properties>
   <dependencies>

--- a/services/wms/pom.xml
+++ b/services/wms/pom.xml
@@ -10,7 +10,8 @@
   <packaging>jar</packaging>
   <name>wms-service</name>
   <properties>
-    <docker.image.name>wms-service</docker.image.name>
+    <dockerfile.skip>false</dockerfile.skip>
+    <docker.image.name>geoserver-cloud-wms</docker.image.name>
     <start-class>org.geoserver.cloud.wms.WmsApplication</start-class>
   </properties>
   <dependencies>

--- a/services/wps/pom.xml
+++ b/services/wps/pom.xml
@@ -10,7 +10,8 @@
   <packaging>jar</packaging>
   <name>wps-service</name>
   <properties>
-    <docker.image.name>wps-service</docker.image.name>
+    <dockerfile.skip>false</dockerfile.skip>
+    <docker.image.name>geoserver-cloud-wps</docker.image.name>
     <start-class>org.geoserver.cloud.wps.WpsApplication</start-class>
   </properties>
   <dependencies>

--- a/support-services/api-gateway/pom.xml
+++ b/support-services/api-gateway/pom.xml
@@ -10,7 +10,8 @@
   <packaging>jar</packaging>
   <name>API gateway service</name>
   <properties>
-    <docker.image.name>gateway-service</docker.image.name>
+    <dockerfile.skip>false</dockerfile.skip>
+    <docker.image.name>geoserver-cloud-gateway</docker.image.name>
   </properties>
   <dependencies>
     <dependency>

--- a/support-services/config/pom.xml
+++ b/support-services/config/pom.xml
@@ -10,7 +10,8 @@
   <packaging>jar</packaging>
   <name>Cloud config service</name>
   <properties>
-    <docker.image.name>config-service</docker.image.name>
+    <dockerfile.skip>false</dockerfile.skip>
+    <docker.image.name>geoserver-cloud-config</docker.image.name>
     <start-class>org.geoserver.cloud.config.ConfigApplication</start-class>
   </properties>
   <dependencies>

--- a/support-services/database/pom.xml
+++ b/support-services/database/pom.xml
@@ -10,7 +10,8 @@
   <packaging>pom</packaging>
   <name>Database service</name>
   <properties>
-    <docker.image.name>jdbcconfig-database</docker.image.name>
+    <dockerfile.skip>false</dockerfile.skip>
+    <docker.image.name>geoserver-cloud-postgres-jdbcconfig</docker.image.name>
   </properties>
   <profiles>
     <profile>

--- a/support-services/discovery/pom.xml
+++ b/support-services/discovery/pom.xml
@@ -10,7 +10,8 @@
   <packaging>jar</packaging>
   <name>Discovery service</name>
   <properties>
-    <docker.image.name>discovery-service</docker.image.name>
+    <dockerfile.skip>false</dockerfile.skip>
+    <docker.image.name>geoserver-cloud-discovery</docker.image.name>
     <start-class>org.geoserver.cloud.discovery.DiscoveryApplication</start-class>
   </properties>
   <dependencies>


### PR DESCRIPTION
Docker images renamed as follow, since based on devops feedback, they
can be pushed to other dockerhub users/organizations, deployed to
environment with several other images, and the current names are not
indicative enough to see at a quick glance which ones are
geoserver-cloud images and which aren't.

```
geoservercloud/geoserver-cloud-webui
geoservercloud/geoserver-cloud-rest
geoservercloud/geoserver-cloud-wps
geoservercloud/geoserver-cloud-wcs
geoservercloud/geoserver-cloud-wms
geoservercloud/geoserver-cloud-wfs
geoservercloud/geoserver-cloud-catalog
geoservercloud/geoserver-cloud-postgres-jdbcconfig
geoservercloud/geoserver-cloud-gateway
geoservercloud/geoserver-cloud-config
geoservercloud/geoserver-cloud-discovery
```