### PR TITLE
Re-enable jdbcconfig internal cache

### DIFF
--- a/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/integration/jdbcconfig/JDBCConfigCatalogConformanceTest.java
+++ b/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/integration/jdbcconfig/JDBCConfigCatalogConformanceTest.java
@@ -10,12 +10,14 @@ import org.geoserver.catalog.plugin.CatalogPlugin;
 import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
 import org.geoserver.cloud.testconfiguration.IntegrationTestConfiguration;
 import org.geoserver.platform.GeoServerResourceLoader;
-import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @SpringBootTest(
@@ -23,6 +25,7 @@ import org.springframework.test.context.junit4.SpringRunner;
     properties = {"geoserver.backend.jdbcconfig.enabled=true"}
 )
 @RunWith(SpringRunner.class)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 public class JDBCConfigCatalogConformanceTest extends CatalogConformanceTest {
 
     private @Autowired @Qualifier("catalogFacade") ExtendedCatalogFacade jdbcCatalogFacade;
@@ -35,10 +38,15 @@ public class JDBCConfigCatalogConformanceTest extends CatalogConformanceTest {
         return catalog;
     }
 
-    public @After void deleteAll() {
+    public @Before void prepare() {
         data.deleteAll(rawCatalog);
-        jdbcCatalogFacade.dispose();
+        jdbcCatalogFacade.dispose(); // disposes internal caches
     }
+
+    //    public @After void deleteAll() {
+    //        data.deleteAll(rawCatalog);
+    //        jdbcCatalogFacade.dispose();
+    //    }
 
     // @Ignore("equals fails with jdbcfacade, not worth fixing right now")
     public @Override @Test void testDataStoreEvents() {

--- a/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/config/jdbcconfig/CloudJdbcConfigDatabase.java
+++ b/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/config/jdbcconfig/CloudJdbcConfigDatabase.java
@@ -11,12 +11,9 @@ import static org.geoserver.jdbcconfig.internal.DbUtils.logStatement;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Stopwatch;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import java.io.IOException;
-import java.io.Serializable;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collections;
@@ -29,8 +26,8 @@ import javax.annotation.Nullable;
 import javax.sql.DataSource;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.Info;
-import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.impl.CatalogImpl;
+import org.geoserver.catalog.impl.ModificationProxy;
 import org.geoserver.catalog.util.CapabilitiesFilterSplitterFix;
 import org.geoserver.catalog.util.CloseableIterator;
 import org.geoserver.catalog.util.CloseableIteratorAdapter;
@@ -41,7 +38,6 @@ import org.geoserver.jdbcconfig.internal.FilterToCatalogSQL;
 import org.geoserver.jdbcconfig.internal.PropertyType;
 import org.geoserver.jdbcconfig.internal.XStreamInfoSerialBinding;
 import org.geoserver.platform.resource.Resource;
-import org.geoserver.util.CacheProvider;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.Capabilities;
 import org.geotools.filter.visitor.CapabilitiesFilterSplitter;
@@ -75,40 +71,43 @@ class CloudJdbcConfigDatabase extends ConfigDatabase {
     private DbMappings dbMappings;
     private ConfigDatabase transactionalConfigDatabase;
 
-    /**
-     * Cache provider that returns no-op caches, where all tests will be cache misses. We use this
-     * here because GeoServer's jdbcconfig's {@link ConfigDatabase} has serious concurrency issues.
-     * For example, if querying WMS capabilities concurrently, will always get the exception below,
-     * since it's updating a {@link LayerInfo}'s styles list while other threads are reading it to
-     * produce the capabilities document.
-     *
-     * <pre>
-     * <code>
-     *   java.util.ConcurrentModificationException: null
-     *   at java.base/java.util.LinkedHashMap$LinkedHashIterator.nextNode(Unknown Source) ~[na:na]
-     *   at java.base/java.util.LinkedHashMap$LinkedKeyIterator.next(Unknown Source) ~[na:na]
-     *   at org.geoserver.jdbcconfig.internal.ConfigDatabase$CatalogReferenceUpdater.visit(ConfigDatabase.java:1795) ~[gs-jdbcconfig-2.19-SNAPSHOT.jar!/:2.19-SNAPSHOT]
-     *   at org.geoserver.catalog.impl.LayerInfoImpl.accept(LayerInfoImpl.java:272) ~[gs-main-2.19-SNAPSHOT.jar!/:2.19-SNAPSHOT]
-     *   ...
-     * </code>
-     * </pre>
-     *
-     * By doing this, we remove all the hassle of caching from jdbcconfig and use our caching module
-     * instead.
-     */
-    private static final CacheProvider NULL_CACHE_PROVIDER =
-            new CacheProvider() {
-                public @Override <K extends Serializable, V extends Serializable>
-                        Cache<K, V> getCache(String cacheName) {
-                    return CacheBuilder.newBuilder().maximumSize(0).build();
-                }
-            };
-
     public CloudJdbcConfigDatabase(
             final DataSource dataSource, final XStreamInfoSerialBinding binding) {
-        super(dataSource, binding, NULL_CACHE_PROVIDER);
+        super(dataSource, binding);
         this.dataSource = dataSource;
         this.template = new NamedParameterJdbcTemplate(dataSource);
+    }
+
+    /**
+     * Override to dispose the internal cache for both the {@link ModificationProxy} wrapped object
+     * (as it may contain identity references to other objects) and the provided {@code info} (which
+     * can contain new references to other objects like workspace)
+     */
+    @Override
+    @Transactional(
+        transactionManager = "jdbcConfigTransactionManager",
+        propagation = Propagation.REQUIRED,
+        rollbackFor = Exception.class
+    )
+    public <T extends Info> T save(T info) {
+        clearCache(ModificationProxy.unwrap(info));
+        T saved = super.save(info);
+        clearCache(saved);
+        return saved;
+    }
+
+    /**
+     * Override to dispose the internal cache for both the {@link ModificationProxy} wrapped object
+     */
+    @Override
+    @Transactional(
+        transactionManager = "jdbcConfigTransactionManager",
+        propagation = Propagation.REQUIRED,
+        rollbackFor = Exception.class
+    )
+    public void remove(Info info) {
+        clearCache(ModificationProxy.unwrap(info));
+        super.remove(info);
     }
 
     /**


### PR DESCRIPTION
After upstream concurrency fixes in jdbcconfig, we can re-enable its
internal cache, which also leads to less jdbc connection timeout
exceptions.