### PR TITLE
Use maven CI friendly versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ webapp
 # https://bugs.openjdk.java.net/browse/JDK-8214300
 .attach_pid*
 
+.flattened-pom.xml

--- a/catalog-support/catalog-cache/pom.xml
+++ b/catalog-support/catalog-cache/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-catalog-support</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-catalog-cache</artifactId>
   <packaging>jar</packaging>

--- a/catalog-support/catalog-client/pom.xml
+++ b/catalog-support/catalog-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-catalog-support</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-catalog-client</artifactId>
   <packaging>jar</packaging>

--- a/catalog-support/catalog-event-bus-amqp/pom.xml
+++ b/catalog-support/catalog-event-bus-amqp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-catalog-support</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-event-bus-amqp</artifactId>
   <packaging>jar</packaging>

--- a/catalog-support/catalog-event-bus/pom.xml
+++ b/catalog-support/catalog-event-bus/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-catalog-support</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-event-bus</artifactId>
   <packaging>jar</packaging>

--- a/catalog-support/geoserver-jackson-bindings/pom.xml
+++ b/catalog-support/geoserver-jackson-bindings/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-catalog-support</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-jackson-bindings</artifactId>
   <packaging>jar</packaging>

--- a/catalog-support/geotools-jackson-bindings/pom.xml
+++ b/catalog-support/geotools-jackson-bindings/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-catalog-support</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gt-jackson-bindings</artifactId>
   <packaging>jar</packaging>

--- a/catalog-support/pluggable-catalog-support/pom.xml
+++ b/catalog-support/pluggable-catalog-support/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-catalog-support</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-pluggable-catalog-support</artifactId>
   <packaging>jar</packaging>

--- a/catalog-support/pom.xml
+++ b/catalog-support/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-catalog-support</artifactId>
   <packaging>pom</packaging>

--- a/integration-tests/catalog-service-it/pom.xml
+++ b/integration-tests/catalog-service-it/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>integration-tests</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-catalog-service-it</artifactId>
   <packaging>jar</packaging>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>integration-tests</artifactId>
   <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,8 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.geoserver.cloud</groupId>
   <artifactId>gs-cloud-parent</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>${revision}</version>
+  <!-- See https://maven.apache.org/maven-ci-friendly.html -->
   <packaging>pom</packaging>
   <modules>
     <module>support-services</module>
@@ -13,6 +14,7 @@
     <module>integration-tests</module>
   </modules>
   <properties>
+    <revision>1.0-SNAPSHOT</revision>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <spring-cloud.version>Hoxton.SR8</spring-cloud.version>
@@ -692,6 +694,11 @@
           </configuration>
         </plugin>
         <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>flatten-maven-plugin</artifactId>
+          <version>1.2.2</version>
+        </plugin>
+        <plugin>
           <groupId>com.coveo</groupId>
           <artifactId>fmt-maven-plugin</artifactId>
           <version>2.4.0</version>
@@ -778,6 +785,11 @@
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>3.2.0</version>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>2.8.1</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -834,6 +846,31 @@
           <encoding>UTF-8</encoding>
           <fork>${fork.javac}</fork>
           <maxmem>${javac.maxHeapSize}</maxmem>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <updatePomFile>true</updatePomFile>
+          <!--flattenMode>resolveCiFriendliesOnly</flattenMode-->
+          <flattenMode>oss</flattenMode>
         </configuration>
       </plugin>
       <plugin>

--- a/services/catalog/pom.xml
+++ b/services/catalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-services-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-catalog</artifactId>
   <packaging>jar</packaging>

--- a/services/catalog/src/main/resources/bootstrap.yml
+++ b/services/catalog/src/main/resources/bootstrap.yml
@@ -25,9 +25,9 @@ server:
   port: 8080
   instance-id: ${spring.application.name}:${spring.application.instance_id:${spring.cloud.client.ip-address}}:${server.port}
   # one of never, always, on_trace_param (deprecated), on_param
-  error.includeStacktrace: on_trace_param
+  error.includeStacktrace: on-trace-param
 spring:
-  jackson.default-property-inclusion: non_empty
+  jackson.default-property-inclusion: non-empty
   jackson.serialization.indent_output: true
   main:
     banner-mode: off
@@ -38,7 +38,7 @@ spring:
   cloud:
     loadbalancer.ribbon.enabled: false # ribbon is in maintenance mode and should be replaced by spring-cloud-loadbalancer
     config:
-      fail-fast: true
+      fail-fast: false
       retry:
         max-attempts: 20
       discovery:

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-services-parent</artifactId>
   <packaging>pom</packaging>

--- a/services/restconfig/pom.xml
+++ b/services/restconfig/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-services-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-restconfig-v1</artifactId>
   <packaging>jar</packaging>

--- a/services/restconfig/src/main/resources/bootstrap.yml
+++ b/services/restconfig/src/main/resources/bootstrap.yml
@@ -12,7 +12,7 @@ spring:
   cloud:
     loadbalancer.ribbon.enabled: false # ribbon is in maintenance mode and should be replaced by spring-cloud-loadbalancer
     config:
-      fail-fast: true
+      fail-fast: false
       retry:
         max-attempts: 20
       discovery:

--- a/services/wcs/pom.xml
+++ b/services/wcs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-services-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-wcs</artifactId>
   <packaging>jar</packaging>

--- a/services/wcs/src/main/resources/bootstrap.yml
+++ b/services/wcs/src/main/resources/bootstrap.yml
@@ -12,7 +12,7 @@ spring:
   cloud:
     loadbalancer.ribbon.enabled: false # ribbon is in maintenance mode and should be replaced by spring-cloud-loadbalancer
     config:
-      fail-fast: true
+      fail-fast: false
       retry:
         max-attempts: 20
       discovery:

--- a/services/web-ui/pom.xml
+++ b/services/web-ui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-services-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-web-ui</artifactId>
   <packaging>jar</packaging>

--- a/services/web-ui/src/main/resources/bootstrap.yml
+++ b/services/web-ui/src/main/resources/bootstrap.yml
@@ -15,7 +15,7 @@ spring:
   cloud:
     loadbalancer.ribbon.enabled: false # ribbon is in maintenance mode and should be replaced by spring-cloud-loadbalancer
     config:
-      fail-fast: true
+      fail-fast: false
       retry:
         max-attempts: 20
       discovery:

--- a/services/wfs/pom.xml
+++ b/services/wfs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-services-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-wfs</artifactId>
   <packaging>jar</packaging>

--- a/services/wfs/src/main/resources/bootstrap.yml
+++ b/services/wfs/src/main/resources/bootstrap.yml
@@ -14,7 +14,7 @@ spring:
   cloud:
     loadbalancer.ribbon.enabled: false # ribbon is in maintenance mode and should be replaced by spring-cloud-loadbalancer
     config:
-      fail-fast: true
+      fail-fast: false
       retry:
         max-attempts: 20
       discovery:

--- a/services/wms/pom.xml
+++ b/services/wms/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-services-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-wms</artifactId>
   <packaging>jar</packaging>

--- a/services/wms/src/main/resources/bootstrap.yml
+++ b/services/wms/src/main/resources/bootstrap.yml
@@ -12,7 +12,7 @@ spring:
   cloud:
     loadbalancer.ribbon.enabled: false # ribbon is in maintenance mode and should be replaced by spring-cloud-loadbalancer
     config:
-      fail-fast: true
+      fail-fast: false
       retry:
         max-attempts: 20
       discovery:

--- a/services/wps/pom.xml
+++ b/services/wps/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-services-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-wps</artifactId>
   <packaging>jar</packaging>

--- a/services/wps/src/main/resources/bootstrap.yml
+++ b/services/wps/src/main/resources/bootstrap.yml
@@ -12,7 +12,7 @@ spring:
   cloud:
     loadbalancer.ribbon.enabled: false # ribbon is in maintenance mode and should be replaced by spring-cloud-loadbalancer
     config:
-      fail-fast: true
+      fail-fast: false
       retry:
         max-attempts: 20
       discovery:

--- a/starters/catalog-backend-starter/pom.xml
+++ b/starters/catalog-backend-starter/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-starters</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-catalog-backend-starter</artifactId>
   <packaging>jar</packaging>

--- a/starters/pom.xml
+++ b/starters/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-starters</artifactId>
   <packaging>pom</packaging>

--- a/starters/starter-jackson/pom.xml
+++ b/starters/starter-jackson/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-starters</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-starter-jackson</artifactId>
   <packaging>jar</packaging>

--- a/starters/starter-raster-formats/pom.xml
+++ b/starters/starter-raster-formats/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-starters</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-starter-raster-formats</artifactId>
   <packaging>jar</packaging>

--- a/starters/starter-reactive/pom.xml
+++ b/starters/starter-reactive/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-starters</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-starter-reactive</artifactId>
   <packaging>jar</packaging>

--- a/starters/starter-vector-formats/pom.xml
+++ b/starters/starter-vector-formats/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-starters</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-starter-vector-formats</artifactId>
   <packaging>jar</packaging>

--- a/starters/starter-webmvc/pom.xml
+++ b/starters/starter-webmvc/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-starters</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-starter-webmvc</artifactId>
   <packaging>jar</packaging>

--- a/support-services/api-gateway/pom.xml
+++ b/support-services/api-gateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-support-services</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-gateway</artifactId>
   <packaging>jar</packaging>

--- a/support-services/api-gateway/src/main/resources/bootstrap.yml
+++ b/support-services/api-gateway/src/main/resources/bootstrap.yml
@@ -9,7 +9,7 @@ spring:
   cloud:
     loadbalancer.ribbon.enabled: false # ribbon is in maintenance mode and should be replaced by spring-cloud-loadbalancer
     config:
-      fail-fast: true
+      fail-fast: false
       retry:
         max-attempts: 20
       discovery:

--- a/support-services/config/pom.xml
+++ b/support-services/config/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-support-services</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-config-service</artifactId>
   <packaging>jar</packaging>

--- a/support-services/database/pom.xml
+++ b/support-services/database/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-support-services</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-database</artifactId>
   <packaging>pom</packaging>

--- a/support-services/discovery/pom.xml
+++ b/support-services/discovery/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-support-services</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-cloud-discovery-service</artifactId>
   <packaging>jar</packaging>

--- a/support-services/pom.xml
+++ b/support-services/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.geoserver.cloud</groupId>
     <artifactId>gs-cloud-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>gs-support-services</artifactId>
   <packaging>pom</packaging>


### PR DESCRIPTION
Use Maven CI Friendly Versions
   
Use a maven property `revision` in the root pom as the single definition
of the project version for all modules.
    
This way, child maven modules don't need to specify parent project version.
    
This has two main advantages:
    
- Changing the project version is achieved by modifying only the root
pom (the `revision` property).
- Modules in feature branches created in a version prior to the latest
in the upstream branch don't get outdated when rebased/merged.
    
And one drawback: `mvn versions:set` will still modify all the poms,
despite it asking "Enter the new version to set ${revision}:".
So just change the revision property manually, not a big deal.
    
See https://maven.apache.org/maven-ci-friendly.html for more information.
