### PR TITLE
[geoserver-jackson-bindings] Add mapping for new InternationalString properties

### DIFF
--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModule.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModule.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;
 import org.geoserver.catalog.AuthorityURLInfo;
@@ -51,6 +52,7 @@ import org.geotools.util.NumberRange;
 import org.mapstruct.factory.Mappers;
 import org.opengis.coverage.grid.GridGeometry;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.util.InternationalString;
 
 /**
  * Jackson {@link com.fasterxml.jackson.databind.Module} to handle GeoServer {@link CatalogInfo}
@@ -200,6 +202,12 @@ public class GeoServerCatalogModule extends SimpleModule {
 
         addMapperSerializer(
                 Query.class, VALUE_MAPPER::queryToDto, QueryDto.class, VALUE_MAPPER::dtoToQuery);
+
+        addMapperSerializer(
+                InternationalString.class,
+                VALUE_MAPPER::internationalStringToDto,
+                Map.class,
+                VALUE_MAPPER::dtoToInternationalString);
     }
 
     private void registerSharedMappers() {

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/LayerGroup.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/LayerGroup.java
@@ -5,6 +5,8 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -30,4 +32,8 @@ public class LayerGroup extends Published {
     protected List<MetadataLink> metadataLinks;
     protected Envelope bounds;
     private List<Keyword> keywords;
+    /** @since geoserver 2.20.0 */
+    private Map<Locale, String> internationalTitle;
+    /** @since geoserver 2.20.0 */
+    private Map<Locale, String> internationalAbstract;
 }

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Resource.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Resource.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -50,4 +51,9 @@ public abstract class Resource extends CatalogInfoDto {
     private boolean serviceConfiguration;
     private List<String> disabledServices;
     private Boolean simpleConversionEnabled;
+
+    /** @since geoserver 2.20.0 */
+    private Map<Locale, String> internationalTitle;
+    /** @since geoserver 2.20.0 */
+    private Map<Locale, String> internationalAbstract;
 }

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/mapper/PublishedMapper.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/mapper/PublishedMapper.java
@@ -40,6 +40,8 @@ public interface PublishedMapper {
     @Mapping(target = "abstract", ignore = true)
     @Mapping(target = "enabled", ignore = true)
     @Mapping(target = "advertised", ignore = true)
+    @Mapping(target = "internationalTitle", ignore = true)
+    @Mapping(target = "internationalAbstract", ignore = true)
     LayerInfo map(Layer o);
 
     Layer map(LayerInfo o);

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/Service.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/Service.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import lombok.Data;
@@ -62,6 +63,13 @@ public abstract @Data class Service extends ConfigInfoDto {
     // not used
     // Map<Object, Object> clientProperties;
 
+    /** @since geoserver 2.20.0 */
+    private Locale defaultLocale;
+    /** @since geoserver 2.20.0 */
+    private Map<Locale, String> internationalTitle;
+    /** @since geoserver 2.20.0 */
+    private Map<Locale, String> internationalAbstract;
+
     @EqualsAndHashCode(callSuper = true)
     public static @Data class WmsService extends Service {
         // Works well as POJO, no need to create a separate DTO
@@ -92,6 +100,11 @@ public abstract @Data class Service extends ConfigInfoDto {
 
         /** @since geoserver 2.19.2 */
         private boolean defaultGroupStyleEnabled;
+
+        /** @since geoserver 2.20.0 */
+        private Map<Locale, String> internationalRootLayerTitle;
+        /** @since geoserver 2.20.0 */
+        private Map<Locale, String> internationalRootLayerAbstract;
     }
 
     @EqualsAndHashCode(callSuper = true)

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/Settings.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/Settings.java
@@ -5,6 +5,7 @@
 package org.geoserver.jackson.databind.config.dto;
 
 import java.io.Serializable;
+import java.util.Locale;
 import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -30,4 +31,7 @@ public @Data class Settings extends ConfigInfoDto {
     private boolean localWorkspaceIncludesPrefix;
     private boolean showCreatedTimeColumnsInAdminList;
     private boolean showModifiedTimeColumnsInAdminList;
+
+    /** @since geoserver 2.20.0 */
+    private Locale defaultLocale;
 }

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/ConfigInfoMapperConfig.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/ConfigInfoMapperConfig.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.jackson.databind.config.dto.mapper;
 
+import org.geoserver.jackson.databind.catalog.mapper.ValueMappers;
 import org.geoserver.jackson.databind.mapper.SharedMappers;
 import org.mapstruct.MapperConfig;
 import org.mapstruct.ReportingPolicy;
@@ -11,6 +12,6 @@ import org.mapstruct.ReportingPolicy;
 @MapperConfig(
     componentModel = "default",
     unmappedTargetPolicy = ReportingPolicy.ERROR,
-    uses = {SharedMappers.class, ObjectFacotries.class, WPSMapper.class}
+    uses = {SharedMappers.class, ObjectFacotries.class, WPSMapper.class, ValueMappers.class}
 )
 public class ConfigInfoMapperConfig {}

--- a/catalog-support/geoserver-jackson-bindings/src/test/java/org/geoserver/jackson/databind/config/GeoServerConfigModuleTest.java
+++ b/catalog-support/geoserver-jackson-bindings/src/test/java/org/geoserver/jackson/databind/config/GeoServerConfigModuleTest.java
@@ -66,7 +66,7 @@ public class GeoServerConfigModuleTest {
         ObjectWriter writer = objectMapper.writer();
         writer = writer.withDefaultPrettyPrinter();
         String encoded = writer.writeValueAsString(orig);
-        System.out.println(encoded);
+
         @SuppressWarnings("unchecked")
         Class<T> type = (Class<T>) ClassMappings.fromImpl(orig.getClass()).getInterface();
 
@@ -78,6 +78,7 @@ public class GeoServerConfigModuleTest {
         OwsUtils.resolveCollections(orig);
         OwsUtils.resolveCollections(decoded);
         assertEquals(orig, decoded);
+        testData.assertInternationalStringPropertiesEqual(orig, decoded);
         if (orig instanceof SettingsInfo) {
             // SettingsInfoImpl's equals() doesn't check workspace
             assertEquals(
@@ -114,7 +115,7 @@ public class GeoServerConfigModuleTest {
     }
 
     public @Test void wmtsServiceInfo() throws Exception {
-        WMTSInfo wmtsService = new WMTSInfoImpl();
+        WMTSInfo wmtsService = testData.createService("wmts", WMTSInfoImpl::new);
         roundtripTest(wmtsService);
     }
 }


### PR DESCRIPTION
Catalog and config objects [got new internationalized](https://github.com/geoserver/geoserver/pull/5122) title and abstract properties. Support them in our Jackson databind mappings.