### PR TITLE
Switch to adoptopenjdk:11-jre-openj9 as base docker image

### DIFF
--- a/config/application.yml
+++ b/config/application.yml
@@ -115,6 +115,8 @@ logging:
     org.springframework: ERROR
     org.springframework.cloud.bus: INFO
     org.springframework.retry: INFO
+    org.springframework.jdbc.support: INFO
+    com.zaxxer.hikari.pool: OFF
     # geoserver roots
     org.geoserver: INFO
     org.geoserver.catalog.plugin: INFO

--- a/docker-healthcheck/pom.xml
+++ b/docker-healthcheck/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.geoserver.cloud</groupId>
+    <artifactId>gs-cloud-parent</artifactId>
+    <version>${revision}</version>
+  </parent>
+  <artifactId>gs-cloud-docker-healthcheck</artifactId>
+  <packaging>jar</packaging>
+  <description>Docker support utilities like custom health check</description>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-json</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <attach>true</attach>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/docker-healthcheck/src/main/java/org/geoserver/cloud/healthchek/ActuatorHealthCheck.java
+++ b/docker-healthcheck/src/main/java/org/geoserver/cloud/healthchek/ActuatorHealthCheck.java
@@ -1,0 +1,107 @@
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.healthchek;
+
+import ch.qos.logback.classic.Level;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Map;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.Banner.Mode;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.ExitCodeGenerator;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Standalone, command line application to be used as a docker healthcheck over a Spring-boot
+ * actuator health end point.
+ *
+ * <p>Command line arguments can be an unnamed port number of full URL, and a (logback) log {@link
+ * Level}: {@code log=<level>}
+ *
+ * <p>If no port number or target URI is given, defaults to {@literal
+ * http://localhost:8080/actuator/health}
+ *
+ * <p>Examples:
+ *
+ * <pre>{@code
+ * java -Dlog.level=debug -jar gs-cloud-docker-support-<version>-bin.jar
+ * java -Dlog.level=debug -jar gs-cloud-docker-support-<version>-bin.jar 9090
+ * java -jar gs-cloud-docker-support-<version>-bin.jar 9090
+ * java -jar gs-cloud-docker-support-<version>-bin.jar http://localhost:9100/geoserver/actuator/health
+ * }</pre>
+ */
+@Slf4j(topic = "org.geoserver.cloud.healthchek")
+@SpringBootApplication
+public class ActuatorHealthCheck implements CommandLineRunner, ExitCodeGenerator {
+
+    private static final int DEFAULT_PORT = 8080;
+
+    @Getter(onMethod = @__(@Override))
+    private int exitCode = 1;
+
+    public static void main(String[] args) {
+        SpringApplication app =
+                new SpringApplicationBuilder(ActuatorHealthCheck.class)
+                        .logStartupInfo(false)
+                        .headless(true)
+                        .web(WebApplicationType.NONE)
+                        .bannerMode(Mode.OFF)
+                        .build();
+        System.exit(SpringApplication.exit(app.run(args)));
+    }
+
+    @Override
+    public void run(String... args) {
+        final URI url = buildUrl(args);
+        try {
+            @SuppressWarnings("rawtypes")
+            ResponseEntity<Map> response = new RestTemplate().getForEntity(url, Map.class);
+            HttpStatus statusCode = response.getStatusCode();
+            if (statusCode.is2xxSuccessful()) {
+                exitCode = 0;
+                if (log.isDebugEnabled()) {
+                    log.debug("healthy ({}): {}: {}", statusCode.value(), url, response.getBody());
+                } else if (log.isInfoEnabled()) {
+                    log.info("healthy ({}): {}", statusCode.value(), url);
+                }
+            } else {
+                log.info("Not healthy ({}): {}", statusCode, url);
+                exitCode = statusCode.value();
+            }
+        } catch (RestClientException e) {
+            log.info("Not healthy ({}): {}", url, e.getMessage());
+        } catch (RuntimeException e) {
+            log.error("Unexpected error running health check: {}", e.getMessage());
+        }
+    }
+
+    private static URI buildUrl(String... args) {
+        args = Arrays.stream(args).filter(arg -> !arg.startsWith("log=")).toArray(String[]::new);
+        int port = DEFAULT_PORT;
+        if (args != null && args.length > 0) {
+            try {
+                log.trace("trying command line argument '{}' as port number...", args[0]);
+                port = Integer.parseInt(args[0]);
+            } catch (NumberFormatException invalidPort) {
+                log.trace("trying command line argument '{}' as full URL...", args[0]);
+                try {
+                    return URI.create(args[0]);
+                } catch (IllegalArgumentException invalidURI) {
+
+                }
+            }
+        }
+        return URI.create("http://localhost:" + port + "/actuator/health");
+    }
+}

--- a/docker-healthcheck/src/main/resources/application.yml
+++ b/docker-healthcheck/src/main/resources/application.yml
@@ -1,0 +1,4 @@
+logging:
+  level:
+    root: off
+    org.geoserver.cloud.healthchek: ${log.level:info}

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
   <!-- See https://maven.apache.org/maven-ci-friendly.html -->
   <packaging>pom</packaging>
   <modules>
+    <module>docker-healthcheck</module>
     <module>support-services</module>
     <module>catalog-support</module>
     <module>starters</module>
@@ -70,6 +71,12 @@
         <groupId>com.playtika.reactivefeign</groupId>
         <artifactId>feign-reactor-webclient</artifactId>
         <version>${feign-reactor.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.cloud</groupId>
+        <artifactId>gs-cloud-docker-healthcheck</artifactId>
+        <version>${project.version}</version>
+        <classifier>bin</classifier>
       </dependency>
       <dependency>
         <groupId>org.geoserver.cloud</groupId>

--- a/services/catalog/Dockerfile
+++ b/services/catalog/Dockerfile
@@ -1,39 +1,39 @@
-FROM bellsoft/liberica-openjdk-alpine-musl:11 as builder
+FROM adoptopenjdk:11-jre-openj9 as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
-COPY ${JAR_FILE} application.jar
+RUN apt update && \ 
+apt install -y fonts-deva \
+fonts-font-awesome \
+fonts-freefont-ttf \
+fonts-material-design-icons-iconfont \
+fonts-materialdesignicons-webfont \
+fonts-roboto
 
-# see https://github.com/Eficode/wait-for
-RUN wget -q https://raw.githubusercontent.com/eficode/wait-for/master/wait-for -O /usr/local/bin/wait-for \
-    && chmod +x /usr/local/bin/wait-for
+COPY ${JAR_FILE} application.jar
 
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM bellsoft/liberica-openjdk-alpine-musl:11
+FROM adoptopenjdk:11-jre-openj9
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
-COPY --from=builder /usr/local/bin/wait-for /usr/local/bin/wait-for
+COPY --from=builder /usr/share/fonts/truetype/* /usr/share/fonts/truetype/
 
 RUN mkdir -p /opt/app/bin \
     && mkdir -p /opt/app/data_directory \ 
-    && addgroup -S -g 630 geo \
-    && adduser -s /bin/sh -h /opt/app/bin -D -u 630 -G geo geo \
+    && groupadd --system -g 630 geo \
+    && useradd -u 630 -g geo --home-dir /opt/app/bin geo \
     && chown geo:geo /opt/app -R
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
-HEALTHCHECK CMD wait-for -t 0 http://localhost:8080/actuator/health || exit 1
-RUN apk add fontconfig ttf-dejavu
 
 USER geo:geo
-COPY --from=builder /usr/local/bin/wait-for /usr/local/bin/wait-for
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./
 COPY --from=builder application/ ./
 
-#ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]
-CMD exec wait-for -t 120 http://config:8080/catalog-service/default -- java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "org.springframework.boot.loader.JarLauncher"]

--- a/services/catalog/Dockerfile
+++ b/services/catalog/Dockerfile
@@ -36,4 +36,11 @@ COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./
 COPY --from=builder application/ ./
 
-CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "org.springframework.boot.loader.JarLauncher"]
+HEALTHCHECK \
+--interval=10s \
+--timeout=5s \
+--start-period=30s \
+--retries=5 \
+CMD java -Xms4M -Xmx16M -jar BOOT-INF/lib/gs-cloud-docker-healthcheck-*-bin.jar || exit 1
+
+CMD exec java $JAVA_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/catalog/src/main/resources/bootstrap.yml
+++ b/services/catalog/src/main/resources/bootstrap.yml
@@ -38,7 +38,7 @@ spring:
   cloud:
     loadbalancer.ribbon.enabled: false # ribbon is in maintenance mode and should be replaced by spring-cloud-loadbalancer
     config:
-      fail-fast: false
+      fail-fast: true
       retry:
         max-attempts: 20
       discovery:

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -25,6 +25,14 @@
       <classifier>bin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.springframework.retry</groupId>
+      <artifactId>spring-retry</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-aop</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -20,6 +20,11 @@
   </modules>
   <dependencies>
     <dependency>
+      <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-docker-healthcheck</artifactId>
+      <classifier>bin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/services/restconfig/Dockerfile
+++ b/services/restconfig/Dockerfile
@@ -36,4 +36,11 @@ COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./
 COPY --from=builder application/ ./
 
-CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "org.springframework.boot.loader.JarLauncher"]
+HEALTHCHECK \
+--interval=10s \
+--timeout=5s \
+--start-period=30s \
+--retries=5 \
+CMD java -Xms4M -Xmx16M -jar BOOT-INF/lib/gs-cloud-docker-healthcheck-*-bin.jar || exit 1
+
+CMD exec java $JAVA_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/restconfig/Dockerfile
+++ b/services/restconfig/Dockerfile
@@ -1,39 +1,39 @@
-FROM bellsoft/liberica-openjdk-alpine-musl:11 as builder
+FROM adoptopenjdk:11-jre-openj9 as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
-COPY ${JAR_FILE} application.jar
+RUN apt update && \ 
+apt install -y fonts-deva \
+fonts-font-awesome \
+fonts-freefont-ttf \
+fonts-material-design-icons-iconfont \
+fonts-materialdesignicons-webfont \
+fonts-roboto
 
-# see https://github.com/Eficode/wait-for
-RUN wget -q https://raw.githubusercontent.com/eficode/wait-for/master/wait-for -O /usr/local/bin/wait-for \
-    && chmod +x /usr/local/bin/wait-for
+COPY ${JAR_FILE} application.jar
 
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM bellsoft/liberica-openjdk-alpine-musl:11
+FROM adoptopenjdk:11-jre-openj9
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
-COPY --from=builder /usr/local/bin/wait-for /usr/local/bin/wait-for
+COPY --from=builder /usr/share/fonts/truetype/* /usr/share/fonts/truetype/
 
 RUN mkdir -p /opt/app/bin \
     && mkdir -p /opt/app/data_directory \ 
-    && addgroup -S -g 630 geo \
-    && adduser -s /bin/sh -h /opt/app/bin -D -u 630 -G geo geo \
+    && groupadd --system -g 630 geo \
+    && useradd -u 630 -g geo --home-dir /opt/app/bin geo \
     && chown geo:geo /opt/app -R
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
-HEALTHCHECK CMD wait-for -t 0 http://localhost:8080/actuator/health || exit 1
-RUN apk add fontconfig ttf-dejavu
 
 USER geo:geo
-COPY --from=builder /usr/local/bin/wait-for /usr/local/bin/wait-for
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./
 COPY --from=builder application/ ./
 
-#ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]
-CMD exec wait-for -t 120 http://config:8080/restconfig-v1/default -- java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "org.springframework.boot.loader.JarLauncher"]

--- a/services/restconfig/src/main/java/org/geoserver/cloud/restconfig/RestConfigApplication.java
+++ b/services/restconfig/src/main/java/org/geoserver/cloud/restconfig/RestConfigApplication.java
@@ -10,10 +10,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.util.unit.DataSize;
 
 @Slf4j
 @SpringBootApplication
+@EnableRetry
 public class RestConfigApplication {
 
     public static void main(String[] args) {

--- a/services/restconfig/src/main/resources/bootstrap.yml
+++ b/services/restconfig/src/main/resources/bootstrap.yml
@@ -12,7 +12,7 @@ spring:
   cloud:
     loadbalancer.ribbon.enabled: false # ribbon is in maintenance mode and should be replaced by spring-cloud-loadbalancer
     config:
-      fail-fast: false
+      fail-fast: true
       retry:
         max-attempts: 20
       discovery:
@@ -44,9 +44,8 @@ eureka:
     healthcheck:
       enabled: false
 
-logging:
-  level:
-    org.springframework.retry: DEBUG
+logging.level:
+    '[org.springframework.retry]': debug
 
 ---
 spring.profiles: local

--- a/services/wcs/Dockerfile
+++ b/services/wcs/Dockerfile
@@ -26,4 +26,11 @@ COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./
 COPY --from=builder application/ ./
 
-CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "org.springframework.boot.loader.JarLauncher"]
+HEALTHCHECK \
+--interval=10s \
+--timeout=5s \
+--start-period=30s \
+--retries=5 \
+CMD java -Xms4M -Xmx16M -jar BOOT-INF/lib/gs-cloud-docker-healthcheck-*-bin.jar || exit 1
+
+CMD exec java $JAVA_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/wcs/Dockerfile
+++ b/services/wcs/Dockerfile
@@ -1,32 +1,24 @@
-FROM bellsoft/liberica-openjdk-alpine-musl:11 as builder
+FROM adoptopenjdk:11-jre-openj9 as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 COPY ${JAR_FILE} application.jar
 
-# see https://github.com/Eficode/wait-for
-RUN wget -q https://raw.githubusercontent.com/eficode/wait-for/master/wait-for -O /usr/local/bin/wait-for \
-    && chmod +x /usr/local/bin/wait-for
-
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM bellsoft/liberica-openjdk-alpine-musl:11
+FROM adoptopenjdk:11-jre-openj9
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
-COPY --from=builder /usr/local/bin/wait-for /usr/local/bin/wait-for
-
 RUN mkdir -p /opt/app/bin \
     && mkdir -p /opt/app/data_directory \ 
-    && addgroup -S -g 630 geo \
-    && adduser -s /bin/sh -h /opt/app/bin -D -u 630 -G geo geo \
+    && groupadd --system -g 630 geo \
+    && useradd -u 630 -g geo --home-dir /opt/app/bin geo \
     && chown geo:geo /opt/app -R
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
-HEALTHCHECK CMD wait-for -t 0 http://localhost:8080/actuator/health || exit 1
-#RUN apk add fontconfig ttf-dejavu
 
 USER geo:geo
 COPY --from=builder dependencies/ ./
@@ -34,5 +26,4 @@ COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./
 COPY --from=builder application/ ./
 
-#ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]
-CMD exec wait-for -t 120 http://config:8080/wcs-service/default -- java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "org.springframework.boot.loader.JarLauncher"]

--- a/services/wcs/src/main/java/org/geoserver/cloud/wcs/WcsApplication.java
+++ b/services/wcs/src/main/java/org/geoserver/cloud/wcs/WcsApplication.java
@@ -10,10 +10,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.util.unit.DataSize;
 
 @Slf4j
 @SpringBootApplication
+@EnableRetry
 public class WcsApplication {
 
     public static void main(String[] args) {

--- a/services/wcs/src/main/resources/bootstrap.yml
+++ b/services/wcs/src/main/resources/bootstrap.yml
@@ -12,7 +12,7 @@ spring:
   cloud:
     loadbalancer.ribbon.enabled: false # ribbon is in maintenance mode and should be replaced by spring-cloud-loadbalancer
     config:
-      fail-fast: false
+      fail-fast: true
       retry:
         max-attempts: 20
       discovery:
@@ -43,9 +43,8 @@ eureka:
     healthcheck:
       enabled: false
 
-logging:
-  level:
-    org.springframework.retry: DEBUG
+logging.level:
+    '[org.springframework.retry]': debug
 
 ---
 spring.profiles: local

--- a/services/web-ui/Dockerfile
+++ b/services/web-ui/Dockerfile
@@ -36,4 +36,11 @@ COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./
 COPY --from=builder application/ ./
 
-CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "org.springframework.boot.loader.JarLauncher"]
+HEALTHCHECK \
+--interval=10s \
+--timeout=5s \
+--start-period=30s \
+--retries=5 \
+CMD java -Xms4M -Xmx16M -jar BOOT-INF/lib/gs-cloud-docker-healthcheck-*-bin.jar || exit 1
+
+CMD exec java $JAVA_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/web-ui/Dockerfile
+++ b/services/web-ui/Dockerfile
@@ -1,32 +1,34 @@
-FROM bellsoft/liberica-openjdk-alpine-musl:11 as builder
+FROM adoptopenjdk:11-jre-openj9 as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
-COPY ${JAR_FILE} application.jar
+RUN apt update && \ 
+apt install -y fonts-deva \
+fonts-font-awesome \
+fonts-freefont-ttf \
+fonts-material-design-icons-iconfont \
+fonts-materialdesignicons-webfont \
+fonts-roboto
 
-# see https://github.com/Eficode/wait-for
-RUN wget -q https://raw.githubusercontent.com/eficode/wait-for/master/wait-for -O /usr/local/bin/wait-for \
-    && chmod +x /usr/local/bin/wait-for
+COPY ${JAR_FILE} application.jar
 
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM bellsoft/liberica-openjdk-alpine-musl:11
+FROM adoptopenjdk:11-jre-openj9
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
-COPY --from=builder /usr/local/bin/wait-for /usr/local/bin/wait-for
+COPY --from=builder /usr/share/fonts/truetype/* /usr/share/fonts/truetype/
 
 RUN mkdir -p /opt/app/bin \
     && mkdir -p /opt/app/data_directory \ 
-    && addgroup -S -g 630 geo \
-    && adduser -s /bin/sh -h /opt/app/bin -D -u 630 -G geo geo \
+    && groupadd --system -g 630 geo \
+    && useradd -u 630 -g geo --home-dir /opt/app/bin geo \
     && chown geo:geo /opt/app -R
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
-HEALTHCHECK CMD wait-for -t 0 http://localhost:8080/actuator/health || exit 1
-RUN apk add fontconfig ttf-dejavu
 
 USER geo:geo
 COPY --from=builder dependencies/ ./
@@ -34,5 +36,4 @@ COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./
 COPY --from=builder application/ ./
 
-#ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]
-CMD exec wait-for -t 120 http://config:8080/web-ui/default -- java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "org.springframework.boot.loader.JarLauncher"]

--- a/services/web-ui/src/main/java/org/geoserver/cloud/web/app/WebUIApplication.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/web/app/WebUIApplication.java
@@ -10,10 +10,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.util.unit.DataSize;
 
 @Slf4j
 @SpringBootApplication
+@EnableRetry
 public class WebUIApplication {
 
     public static void main(String[] args) {

--- a/services/web-ui/src/main/resources/bootstrap.yml
+++ b/services/web-ui/src/main/resources/bootstrap.yml
@@ -15,7 +15,7 @@ spring:
   cloud:
     loadbalancer.ribbon.enabled: false # ribbon is in maintenance mode and should be replaced by spring-cloud-loadbalancer
     config:
-      fail-fast: false
+      fail-fast: true
       retry:
         max-attempts: 20
       discovery:
@@ -47,9 +47,8 @@ eureka:
     healthcheck:
       enabled: false
 
-logging:
-  level:
-    org.springframework.retry: DEBUG
+logging.level:
+    '[org.springframework.retry]': debug
 
 ---
 spring.profiles: local

--- a/services/wfs/Dockerfile
+++ b/services/wfs/Dockerfile
@@ -26,4 +26,11 @@ COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./
 COPY --from=builder application/ ./
 
-CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "org.springframework.boot.loader.JarLauncher"]
+HEALTHCHECK \
+--interval=10s \
+--timeout=5s \
+--start-period=30s \
+--retries=5 \
+CMD java -Xms4M -Xmx16M -jar BOOT-INF/lib/gs-cloud-docker-healthcheck-*-bin.jar || exit 1
+
+CMD exec java $JAVA_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/wfs/Dockerfile
+++ b/services/wfs/Dockerfile
@@ -1,32 +1,24 @@
-FROM bellsoft/liberica-openjdk-alpine-musl:11 as builder
+FROM adoptopenjdk:11-jre-openj9 as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 COPY ${JAR_FILE} application.jar
 
-# see https://github.com/Eficode/wait-for
-RUN wget -q https://raw.githubusercontent.com/eficode/wait-for/master/wait-for -O /usr/local/bin/wait-for \
-    && chmod +x /usr/local/bin/wait-for
-
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM bellsoft/liberica-openjdk-alpine-musl:11
+FROM adoptopenjdk:11-jre-openj9
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
-COPY --from=builder /usr/local/bin/wait-for /usr/local/bin/wait-for
-
 RUN mkdir -p /opt/app/bin \
     && mkdir -p /opt/app/data_directory \ 
-    && addgroup -S -g 630 geo \
-    && adduser -s /bin/sh -h /opt/app/bin -D -u 630 -G geo geo \
+    && groupadd --system -g 630 geo \
+    && useradd -u 630 -g geo --home-dir /opt/app/bin geo \
     && chown geo:geo /opt/app -R
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
-HEALTHCHECK CMD wait-for -t 0 http://localhost:8080/actuator/health || exit 1
-#RUN apk add fontconfig ttf-dejavu
 
 USER geo:geo
 COPY --from=builder dependencies/ ./
@@ -34,5 +26,4 @@ COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./
 COPY --from=builder application/ ./
 
-#ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]
-CMD exec wait-for -t 120 http://config:8080/wfs-service/default -- java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "org.springframework.boot.loader.JarLauncher"]

--- a/services/wfs/src/main/java/org/geoserver/cloud/wfs/app/WfsApplication.java
+++ b/services/wfs/src/main/java/org/geoserver/cloud/wfs/app/WfsApplication.java
@@ -10,10 +10,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.util.unit.DataSize;
 
 @Slf4j
 @SpringBootApplication
+@EnableRetry
 public class WfsApplication {
 
     public static void main(String[] args) {

--- a/services/wfs/src/main/resources/bootstrap.yml
+++ b/services/wfs/src/main/resources/bootstrap.yml
@@ -14,7 +14,7 @@ spring:
   cloud:
     loadbalancer.ribbon.enabled: false # ribbon is in maintenance mode and should be replaced by spring-cloud-loadbalancer
     config:
-      fail-fast: false
+      fail-fast: true
       retry:
         max-attempts: 20
       discovery:
@@ -46,11 +46,8 @@ eureka:
     healthcheck:
       enabled: false
 
-logging:
-  level:
-    org.springframework.retry: DEBUG
-
-
+logging.level:
+    '[org.springframework.retry]': debug
 ---
 spring.profiles: local
 eureka.server.url: http://localhost:8761/eureka

--- a/services/wms/Dockerfile
+++ b/services/wms/Dockerfile
@@ -1,32 +1,34 @@
-FROM bellsoft/liberica-openjdk-alpine-musl:11 as builder
+FROM adoptopenjdk:11-jre-openj9 as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
-COPY ${JAR_FILE} application.jar
+RUN apt update && \ 
+apt install -y fonts-deva \
+fonts-font-awesome \
+fonts-freefont-ttf \
+fonts-material-design-icons-iconfont \
+fonts-materialdesignicons-webfont \
+fonts-roboto
 
-# see https://github.com/Eficode/wait-for
-RUN wget -q https://raw.githubusercontent.com/eficode/wait-for/master/wait-for -O /usr/local/bin/wait-for \
-    && chmod +x /usr/local/bin/wait-for
+COPY ${JAR_FILE} application.jar
 
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM bellsoft/liberica-openjdk-alpine-musl:11
+FROM adoptopenjdk:11-jre-openj9
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
-COPY --from=builder /usr/local/bin/wait-for /usr/local/bin/wait-for
+COPY --from=builder /usr/share/fonts/truetype/* /usr/share/fonts/truetype/
 
 RUN mkdir -p /opt/app/bin \
     && mkdir -p /opt/app/data_directory \ 
-    && addgroup -S -g 630 geo \
-    && adduser -s /bin/sh -h /opt/app/bin -D -u 630 -G geo geo \
+    && groupadd --system -g 630 geo \
+    && useradd -u 630 -g geo --home-dir /opt/app/bin geo \
     && chown geo:geo /opt/app -R
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
-HEALTHCHECK CMD wait-for -t 0 http://localhost:8080/actuator/health || exit 1
-RUN apk add fontconfig ttf-dejavu
 
 USER geo:geo
 COPY --from=builder dependencies/ ./
@@ -34,5 +36,5 @@ COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./
 COPY --from=builder application/ ./
 
-#ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]
-CMD exec wait-for -t 120 http://config:8080/wms-service/default -- java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "org.springframework.boot.loader.JarLauncher"]
+

--- a/services/wms/Dockerfile
+++ b/services/wms/Dockerfile
@@ -36,5 +36,12 @@ COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./
 COPY --from=builder application/ ./
 
-CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "org.springframework.boot.loader.JarLauncher"]
+HEALTHCHECK \
+--interval=10s \
+--timeout=5s \
+--start-period=30s \
+--retries=5 \
+CMD java -Xms4M -Xmx16M -jar BOOT-INF/lib/gs-cloud-docker-healthcheck-*-bin.jar || exit 1
+
+CMD exec java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
 

--- a/services/wms/src/main/java/org/geoserver/cloud/wms/WmsApplication.java
+++ b/services/wms/src/main/java/org/geoserver/cloud/wms/WmsApplication.java
@@ -1,6 +1,6 @@
-/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
- * This code is licensed under the GPL 2.0 license, available at the root
- * application directory.
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
  */
 package org.geoserver.cloud.wms;
 
@@ -10,10 +10,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.util.unit.DataSize;
 
 @Slf4j
 @SpringBootApplication
+@EnableRetry
 public class WmsApplication {
 
     public static void main(String[] args) {

--- a/services/wms/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/services/wms/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,5 @@
+{"properties": [{
+  "name": "eureka.server.url",
+  "type": "java.lang.String",
+  "description": "User provided shortcut for 'eureka.client.serviceUrl.defaultZone'"
+}]}

--- a/services/wms/src/main/resources/bootstrap.yml
+++ b/services/wms/src/main/resources/bootstrap.yml
@@ -12,7 +12,7 @@ spring:
   cloud:
     loadbalancer.ribbon.enabled: false # ribbon is in maintenance mode and should be replaced by spring-cloud-loadbalancer
     config:
-      fail-fast: false
+      fail-fast: true
       retry:
         max-attempts: 20
       discovery:
@@ -41,12 +41,10 @@ eureka:
     serviceUrl:
       defaultZone: ${eureka.server.url:http://discovery:8761/eureka}
     healthcheck:
-      enabled: false
+      enabled: true
 
-logging:
-  level:
-    org.springframework.retry: DEBUG
-
+logging.level:
+    '[org.springframework.retry]': debug
 ---
 spring.profiles: local
 eureka.server.url: http://localhost:8761/eureka

--- a/services/wps/Dockerfile
+++ b/services/wps/Dockerfile
@@ -26,4 +26,11 @@ COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./
 COPY --from=builder application/ ./
 
-CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "org.springframework.boot.loader.JarLauncher"]
+HEALTHCHECK \
+--interval=10s \
+--timeout=5s \
+--start-period=30s \
+--retries=5 \
+CMD java -Xms4M -Xmx16M -jar BOOT-INF/lib/gs-cloud-docker-healthcheck-*-bin.jar || exit 1
+
+CMD exec java $JAVA_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/wps/Dockerfile
+++ b/services/wps/Dockerfile
@@ -1,32 +1,24 @@
-FROM bellsoft/liberica-openjdk-alpine-musl:11 as builder
+FROM adoptopenjdk:11-jre-openj9 as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 COPY ${JAR_FILE} application.jar
 
-# see https://github.com/Eficode/wait-for
-RUN wget -q https://raw.githubusercontent.com/eficode/wait-for/master/wait-for -O /usr/local/bin/wait-for \
-    && chmod +x /usr/local/bin/wait-for
-
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM bellsoft/liberica-openjdk-alpine-musl:11
+FROM adoptopenjdk:11-jre-openj9
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
-COPY --from=builder /usr/local/bin/wait-for /usr/local/bin/wait-for
-
 RUN mkdir -p /opt/app/bin \
     && mkdir -p /opt/app/data_directory \ 
-    && addgroup -S -g 630 geo \
-    && adduser -s /bin/sh -h /opt/app/bin -D -u 630 -G geo geo \
+    && groupadd --system -g 630 geo \
+    && useradd -u 630 -g geo --home-dir /opt/app/bin geo \
     && chown geo:geo /opt/app -R
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
-HEALTHCHECK CMD wait-for -t 0 http://localhost:8080/actuator/health || exit 1
-RUN apk add fontconfig ttf-dejavu
 
 USER geo:geo
 COPY --from=builder dependencies/ ./
@@ -34,5 +26,4 @@ COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./
 COPY --from=builder application/ ./
 
-#ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]
-CMD exec wait-for -t 120 http://config:8080/wps-service/default -- java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "org.springframework.boot.loader.JarLauncher"]

--- a/services/wps/src/main/java/org/geoserver/cloud/wps/WpsApplication.java
+++ b/services/wps/src/main/java/org/geoserver/cloud/wps/WpsApplication.java
@@ -10,10 +10,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.util.unit.DataSize;
 
 @Slf4j
 @SpringBootApplication
+@EnableRetry
 public class WpsApplication {
 
     public static void main(String[] args) {

--- a/services/wps/src/main/resources/bootstrap.yml
+++ b/services/wps/src/main/resources/bootstrap.yml
@@ -12,7 +12,7 @@ spring:
   cloud:
     loadbalancer.ribbon.enabled: false # ribbon is in maintenance mode and should be replaced by spring-cloud-loadbalancer
     config:
-      fail-fast: false
+      fail-fast: true
       retry:
         max-attempts: 20
       discovery:
@@ -43,9 +43,8 @@ eureka:
     healthcheck:
       enabled: false
 
-logging:
-  level:
-    org.springframework.retry: DEBUG
+logging.level:
+    '[org.springframework.retry]': debug
 
 ---
 spring.profiles: local

--- a/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/config/jdbcconfig/JDBCConfigBackendConfigurer.java
+++ b/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/config/jdbcconfig/JDBCConfigBackendConfigurer.java
@@ -106,6 +106,7 @@ public class JDBCConfigBackendConfigurer implements GeoServerBackendConfigurer {
                 JDBCConfigBackendConfigurer.class.getSimpleName());
     }
 
+    @DependsOn("jdbcConfigDataSourceStartupValidator")
     @ConfigurationProperties(prefix = "geoserver.backend.jdbcconfig")
     public @Bean("JDBCConfigProperties") JDBCConfigProperties jdbcConfigProperties() {
         CloudJdbcConfigProperties configProperties = new CloudJdbcConfigProperties(dataSource);
@@ -114,11 +115,13 @@ public class JDBCConfigBackendConfigurer implements GeoServerBackendConfigurer {
         return configProperties;
     }
 
+    @DependsOn("jdbcConfigDataSourceStartupValidator")
     @ConfigurationProperties(prefix = "geoserver.backend.jdbcconfig")
     public @Bean CloudJdbcStoreProperties jdbcStoreProperties() {
         return new CloudJdbcStoreProperties(dataSource);
     }
 
+    @DependsOn("jdbcConfigDataSourceStartupValidator")
     public @Override @Bean GeoServerResourceLoader resourceLoader() {
         Path path = configProperties.getDataDirectory().getLocation();
         File dataDirectory = path.toFile();
@@ -128,7 +131,7 @@ public class JDBCConfigBackendConfigurer implements GeoServerBackendConfigurer {
         return loader;
     }
 
-    @DependsOn("JDBCConfigDB")
+    @DependsOn({"JDBCConfigDB", "jdbcConfigDataSourceStartupValidator"})
     public @Override @Bean @NonNull ResourceStore resourceStoreImpl() {
         final JDBCConfigProperties jdbcConfigProperties = jdbcConfigProperties();
         final CloudJdbcStoreProperties jdbcStoreProperties = jdbcStoreProperties();
@@ -149,14 +152,17 @@ public class JDBCConfigBackendConfigurer implements GeoServerBackendConfigurer {
         }
     }
 
+    @DependsOn("jdbcConfigDataSourceStartupValidator")
     public @Bean LockRegistryAdapter jdbcStoreLockProvider() {
         return new LockRegistryAdapter(jdbcLockRegistry());
     }
 
+    @DependsOn("jdbcConfigDataSourceStartupValidator")
     public @Bean JdbcLockRegistry jdbcLockRegistry() {
         return new JdbcLockRegistry(jdbcLockRepository());
     }
 
+    @DependsOn("jdbcConfigDataSourceStartupValidator")
     public @Bean DefaultLockRepository jdbcLockRepository() {
         String id = this.instanceId;
         DefaultLockRepository lockRepository;
@@ -173,6 +179,7 @@ public class JDBCConfigBackendConfigurer implements GeoServerBackendConfigurer {
         return lockRepository;
     }
 
+    @DependsOn("jdbcConfigDataSourceStartupValidator")
     @Bean(name = {"catalogFacade", "JDBCCatalogFacade"})
     public @Override ExtendedCatalogFacade catalogFacade() {
         ConfigDatabase configDB = jdbcConfigDB();
@@ -191,6 +198,7 @@ public class JDBCConfigBackendConfigurer implements GeoServerBackendConfigurer {
         return new CatalogFacadeExtensionAdapter(legacyFacade);
     }
 
+    @DependsOn("jdbcConfigDataSourceStartupValidator")
     @Bean(name = {"geoserverFacade", "JDBCGeoServerFacade"})
     public @Override GeoServerFacade geoserverFacade() {
         initDbSchema(jdbcConfigProperties(), jdbcStoreProperties(), jdbcConfigDB());
@@ -223,10 +231,12 @@ public class JDBCConfigBackendConfigurer implements GeoServerBackendConfigurer {
         return new JdbcConfigRemoteEventProcessor();
     }
 
+    @DependsOn("jdbcConfigDataSourceStartupValidator")
     public @Bean XStreamInfoSerialBinding jdbcPersistenceBinding() {
         return new XStreamInfoSerialBinding(xstreamPersisterFactory);
     }
 
+    @DependsOn("jdbcConfigDataSourceStartupValidator")
     public @Bean(name = "JDBCConfigDB") ConfigDatabase jdbcConfigDB() {
         ConfigDatabase configDb = new CloudJdbcConfigDatabase(dataSource, jdbcPersistenceBinding());
         return configDb;
@@ -275,6 +285,7 @@ public class JDBCConfigBackendConfigurer implements GeoServerBackendConfigurer {
 
     // <bean id="JDBCConfigXStreamPersisterInitializer"
     // class="org.geoserver.jdbcconfig.internal.JDBCConfigXStreamPersisterInitializer"/>
+    @DependsOn("jdbcConfigDataSourceStartupValidator")
     public @Bean("JDBCConfigXStreamPersisterInitializer") JDBCConfigXStreamPersisterInitializer
             jdbcConfigXStreamPersisterInitializer() {
         return new JDBCConfigXStreamPersisterInitializer();

--- a/support-services/api-gateway/Dockerfile
+++ b/support-services/api-gateway/Dockerfile
@@ -1,30 +1,23 @@
-FROM bellsoft/liberica-openjdk-alpine-musl:11 as builder
+FROM adoptopenjdk:11-jre-openj9 as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 COPY ${JAR_FILE} application.jar
 
-# see https://github.com/Eficode/wait-for
-RUN wget -q https://raw.githubusercontent.com/eficode/wait-for/master/wait-for -O /usr/local/bin/wait-for \
-    && chmod +x /usr/local/bin/wait-for
-
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM bellsoft/liberica-openjdk-alpine-musl:11
+FROM adoptopenjdk:11-jre-openj9
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
-COPY --from=builder /usr/local/bin/wait-for /usr/local/bin/wait-for
-
 RUN mkdir -p /opt/app \ 
-    && addgroup -S -g 630 geo \
-    && adduser -s /bin/sh -h /opt/app/bin -D -u 630 -G geo geo \
+    && groupadd --system -g 630 geo \
+    && useradd -u 630 -g geo --home-dir /opt/app/bin geo \
     && chown geo:geo /opt/app
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
-HEALTHCHECK CMD wait-for -t 0 http://localhost:8080/actuator/health || exit 1
 
 USER geo:geo
 COPY --from=builder dependencies/ ./
@@ -32,5 +25,4 @@ COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./
 COPY --from=builder application/ ./
 
-#ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]
-CMD exec wait-for -t 120 http://config:8080/gateway-service/default -- java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "org.springframework.boot.loader.JarLauncher"]

--- a/support-services/api-gateway/Dockerfile
+++ b/support-services/api-gateway/Dockerfile
@@ -25,4 +25,11 @@ COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./
 COPY --from=builder application/ ./
 
-CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "org.springframework.boot.loader.JarLauncher"]
+HEALTHCHECK \
+--interval=10s \
+--timeout=5s \
+--start-period=30s \
+--retries=5 \
+CMD java -Xms4M -Xmx16M -jar BOOT-INF/lib/gs-cloud-docker-healthcheck-*-bin.jar || exit 1
+
+CMD exec java $JAVA_OPTS org.springframework.boot.loader.JarLauncher

--- a/support-services/api-gateway/pom.xml
+++ b/support-services/api-gateway/pom.xml
@@ -53,6 +53,11 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-docker-healthcheck</artifactId>
+      <classifier>bin</classifier>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/support-services/api-gateway/src/main/resources/bootstrap.yml
+++ b/support-services/api-gateway/src/main/resources/bootstrap.yml
@@ -9,7 +9,7 @@ spring:
   cloud:
     loadbalancer.ribbon.enabled: false # ribbon is in maintenance mode and should be replaced by spring-cloud-loadbalancer
     config:
-      fail-fast: false
+      fail-fast: true
       retry:
         max-attempts: 20
       discovery:

--- a/support-services/config/Dockerfile
+++ b/support-services/config/Dockerfile
@@ -25,5 +25,12 @@ COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./
 COPY --from=builder application/ ./
 
-CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "org.springframework.boot.loader.JarLauncher"]
+HEALTHCHECK \
+--interval=10s \
+--timeout=5s \
+--start-period=30s \
+--retries=5 \
+CMD java -Xms4M -Xmx16M -jar BOOT-INF/lib/gs-cloud-docker-healthcheck-*-bin.jar || exit 1
+
+CMD exec java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
 

--- a/support-services/config/Dockerfile
+++ b/support-services/config/Dockerfile
@@ -1,30 +1,23 @@
-FROM bellsoft/liberica-openjdk-alpine-musl:11 as builder
+FROM adoptopenjdk:11-jre-openj9 as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 COPY ${JAR_FILE} application.jar
 
-# see https://github.com/Eficode/wait-for
-RUN wget -q https://raw.githubusercontent.com/eficode/wait-for/master/wait-for -O /usr/local/bin/wait-for \
-    && chmod +x /usr/local/bin/wait-for
-
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM bellsoft/liberica-openjdk-alpine-musl:11
+FROM adoptopenjdk:11-jre-openj9
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
-COPY --from=builder /usr/local/bin/wait-for /usr/local/bin/wait-for
-
 RUN mkdir -p /opt/app \ 
-    && addgroup -S -g 630 geo \
-    && adduser -s /bin/sh -h /opt/app/bin -D -u 630 -G geo geo \
+    && groupadd --system -g 630 geo \
+    && useradd -u 630 -g geo --home-dir /opt/app/bin geo \
     && chown geo:geo /opt/app
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
-HEALTHCHECK CMD wait-for -t 0 http://localhost:8080/actuator/health || exit 1
 
 USER geo:geo
 COPY --from=builder dependencies/ ./
@@ -32,6 +25,5 @@ COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./
 COPY --from=builder application/ ./
 
-#ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]
-CMD exec wait-for -t 60 http://discovery:8761/actuator/health -- java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "org.springframework.boot.loader.JarLauncher"]
 

--- a/support-services/config/pom.xml
+++ b/support-services/config/pom.xml
@@ -46,6 +46,11 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-aop</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-docker-healthcheck</artifactId>
+      <classifier>bin</classifier>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/support-services/config/src/main/java/org/geoserver/cloud/config/ConfigApplication.java
+++ b/support-services/config/src/main/java/org/geoserver/cloud/config/ConfigApplication.java
@@ -1,6 +1,6 @@
-/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
- * This code is licensed under the GPL 2.0 license, available at the root
- * application directory.
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
  */
 package org.geoserver.cloud.config;
 
@@ -11,11 +11,13 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.cloud.config.server.EnableConfigServer;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.util.unit.DataSize;
 
 @Slf4j
 @SpringBootApplication
 @EnableConfigServer
+@EnableRetry
 public class ConfigApplication {
 
     public static void main(String[] args) {

--- a/support-services/config/src/main/resources/bootstrap.yml
+++ b/support-services/config/src/main/resources/bootstrap.yml
@@ -37,9 +37,8 @@ eureka:
 
 logging:
   level:
-    org.springframework.retry: DEBUG
     # Avoid log flooding with "INFO Adding property source: file:<...>/application.yml" triggered by the actuator health check
-    org.springframework.cloud.config.server.environment.NativeEnvironmentRepository: WARN
+    '[org.springframework.cloud.config.server.environment.NativeEnvironmentRepository]': warn
 
 ---
 spring.profiles: local

--- a/support-services/database/Dockerfile
+++ b/support-services/database/Dockerfile
@@ -7,4 +7,4 @@ ADD ./postgresql_initdb /docker-entrypoint-initdb.d
 
 COPY --chown=postgres ./postgresql_initdb/* /docker-entrypoint-initdb.d/
 
-HEALTHCHECK --interval=5s --timeout=1s CMD pg_isready -d $POSTGRES_DB -U $POSTGRES_USER
+HEALTHCHECK --interval=10s --timeout=1s --retries=5 CMD pg_isready -d $POSTGRES_DB -U $POSTGRES_USER

--- a/support-services/discovery/Dockerfile
+++ b/support-services/discovery/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir -p /opt/app \
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
-EXPOSE 8080
+EXPOSE 8761
 
 USER geo:geo
 COPY --from=builder dependencies/ ./
@@ -25,5 +25,11 @@ COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./
 COPY --from=builder application/ ./
 
-#ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]
+HEALTHCHECK \
+--interval=10s \
+--timeout=5s \
+--start-period=30s \
+--retries=5 \
+CMD java -Xms4M -Xmx16M -jar BOOT-INF/lib/gs-cloud-docker-healthcheck-*-bin.jar 8761|| exit 1
+
 CMD exec java $JAVA_OPTS org.springframework.boot.loader.JarLauncher

--- a/support-services/discovery/Dockerfile
+++ b/support-services/discovery/Dockerfile
@@ -1,30 +1,23 @@
-FROM bellsoft/liberica-openjdk-alpine-musl:11 as builder
+FROM adoptopenjdk:11-jre-openj9 as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 COPY ${JAR_FILE} application.jar
 
-# see https://github.com/Eficode/wait-for
-RUN wget -q https://raw.githubusercontent.com/eficode/wait-for/master/wait-for -O /usr/local/bin/wait-for \
-    && chmod +x /usr/local/bin/wait-for
-
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM bellsoft/liberica-openjdk-alpine-musl:11
+FROM adoptopenjdk:11-jre-openj9
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
-COPY --from=builder /usr/local/bin/wait-for /usr/local/bin/wait-for
-
 RUN mkdir -p /opt/app \ 
-    && addgroup -S -g 630 geo \
-    && adduser -s /bin/sh -h /opt/app/bin -D -u 630 -G geo geo \
+    && groupadd --system -g 630 geo \
+    && useradd -u 630 -g geo --home-dir /opt/app/bin geo \
     && chown geo:geo /opt/app
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
-HEALTHCHECK CMD wait-for -t 0 http://localhost:8761/actuator/health || exit 1
 
 USER geo:geo
 COPY --from=builder dependencies/ ./

--- a/support-services/discovery/pom.xml
+++ b/support-services/discovery/pom.xml
@@ -37,6 +37,11 @@
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-docker-healthcheck</artifactId>
+      <classifier>bin</classifier>
+    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
- Use adoptopenjdk:11-jre-openj9 as base docker image as it passes Trivy vulnerability scans with no critical or high alerts at the Operating system level, whilst the previous base image (`bellsoft/liberica-openjdk-alpine-musl:11`) has 3 critical and 20 high vulnerabilities.
- jdbcconfig: wait for database before continuing spring initialization without requiring any external tool. Using a `DatabaseStartupValidator` bean
- Use a custom healthcheck application to decouple from base image tools like `curl`, `wait-for`, `dockerize`, etc.
- Wait for discovery and config services to be ready without external tools
    Properly configure spring-retry and `spring.cloud.config.fail-fast: true`
    for service startup to wait for the discovery and config services to be
    ready without requiring any external tool like `wait-for`.

---

<p style="margin: 0px; padding: 0px; color: rgb(23, 43, 77); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(244, 245, 247); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Trivy vulnerability scans.</p><p style="margin: 10px 0px 0px; padding: 0px; color: rgb(23, 43, 77); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(244, 245, 247); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Compare version 1.0-RC1 as scanned in<span> </span><a href="https://jira.camptocamp.com/browse/GSFLI-6" title="Analyse GeoServer Security Requirements" class="issue-link" data-issue-key="GSFLI-6" style="color: rgb(122, 122, 122); text-decoration: none; cursor: pointer;"><del>GSFLI-6</del></a><span> </span>vs 1.0-SNAPSHOT after switching to the adoptopenjdk:11-jre-openj9 base image.</p><p style="margin: 10px 0px 0px; padding: 0px; color: rgb(23, 43, 77); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(244, 245, 247); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"> </p><div class="table-wrap" style="margin: 0px; padding: 0px; color: rgb(23, 43, 77); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(244, 245, 247); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">

Image | Tag | OS total | Library total | OS critical | OS high | Library critical | Library high)
-- | -- | -- | -- | -- | -- | -- | --
geoserver-cloud-config | 1.0-RC1 / 1.0-SNAPSHOT (OpenJ9) | 27 / 60 | 37 / 37 | 3 / 0 | 20 / 0 | 7 / 7 | 23 / 23
geoserver-cloud-discovery | 1.0-RC1 / 1.0-SNAPSHOT (OpenJ9) | 27 / 60 | 37 / 37 | 3 / 0 | 20 / 0 | 7 / 7 | 23 / 23
geoserver-cloud-gateway | 1.0-RC1 / 1.0-SNAPSHOT (OpenJ9) | 27 / 60 | 37 / 37 | 3 / 0 | 20 / 0 | 7 / 7 | 22 / 22
geoserver-cloud-rest | 1.0-RC1 / 1.0-SNAPSHOT (OpenJ9) | 27 / 60 | 48 / 48 | 3 / 0 | 20 / 0 | 8 / 8 | 28 / 28
geoserver-cloud-wcs | 1.0-RC1 / 1.0-SNAPSHOT (OpenJ9) | 27 / 60 | 46 / 46 | 3 / 0 | 20 / 0 | 7 / 7 | 28 / 28
geoserver-cloud-webui | 1.0-RC1 / 1.0-SNAPSHOT (OpenJ9) | 27 / 60 | 50 / 50 | 3 / 0 | 20 / 0 | 2 / 9 | 28 / 28
geoserver-cloud-wfs | 1.0-RC1 / 1.0-SNAPSHOT (OpenJ9) | 27 / 60 | 50 / 50 | 3 / 0 | 20 / 0 | 9 / 9 | 29 / 29
geoserver-cloud-wms | 1.0-RC1 / 1.0-SNAPSHOT (OpenJ9) | 27 / 60 | 48 / 48 | 3 / 0 | 20 / 0 | 8 / 8 | 28 / 28

</div>
 