### PR TITLE
Remove custom user:group from Dockerfile

### DIFF
--- a/services/catalog/Dockerfile
+++ b/services/catalog/Dockerfile
@@ -20,17 +20,14 @@ LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
 COPY --from=builder /usr/share/fonts/truetype/* /usr/share/fonts/truetype/
 
-RUN mkdir -p /opt/app/bin \
-    && mkdir -p /opt/app/data_directory \ 
-    && groupadd --system -g 630 geo \
-    && useradd -u 630 -g geo --home-dir /opt/app/bin geo \
-    && chown geo:geo /opt/app -R
+VOLUME /opt/app/data_directory
+
+RUN mkdir -p /opt/app/bin
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
 
-USER geo:geo
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/services/restconfig/Dockerfile
+++ b/services/restconfig/Dockerfile
@@ -20,17 +20,14 @@ LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
 COPY --from=builder /usr/share/fonts/truetype/* /usr/share/fonts/truetype/
 
-RUN mkdir -p /opt/app/bin \
-    && mkdir -p /opt/app/data_directory \ 
-    && groupadd --system -g 630 geo \
-    && useradd -u 630 -g geo --home-dir /opt/app/bin geo \
-    && chown geo:geo /opt/app -R
+VOLUME /opt/app/data_directory
+
+RUN mkdir -p /opt/app/bin
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
 
-USER geo:geo
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/services/wcs/Dockerfile
+++ b/services/wcs/Dockerfile
@@ -10,17 +10,14 @@ FROM adoptopenjdk:11-jre-openj9
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
-RUN mkdir -p /opt/app/bin \
-    && mkdir -p /opt/app/data_directory \ 
-    && groupadd --system -g 630 geo \
-    && useradd -u 630 -g geo --home-dir /opt/app/bin geo \
-    && chown geo:geo /opt/app -R
+VOLUME /opt/app/data_directory
+
+RUN mkdir -p /opt/app/bin
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
 
-USER geo:geo
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/services/web-ui/Dockerfile
+++ b/services/web-ui/Dockerfile
@@ -20,17 +20,14 @@ LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
 COPY --from=builder /usr/share/fonts/truetype/* /usr/share/fonts/truetype/
 
-RUN mkdir -p /opt/app/bin \
-    && mkdir -p /opt/app/data_directory \ 
-    && groupadd --system -g 630 geo \
-    && useradd -u 630 -g geo --home-dir /opt/app/bin geo \
-    && chown geo:geo /opt/app -R
+VOLUME /opt/app/data_directory
+
+RUN mkdir -p /opt/app/bin
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
 
-USER geo:geo
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/services/wfs/Dockerfile
+++ b/services/wfs/Dockerfile
@@ -10,17 +10,14 @@ FROM adoptopenjdk:11-jre-openj9
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
-RUN mkdir -p /opt/app/bin \
-    && mkdir -p /opt/app/data_directory \ 
-    && groupadd --system -g 630 geo \
-    && useradd -u 630 -g geo --home-dir /opt/app/bin geo \
-    && chown geo:geo /opt/app -R
+VOLUME /opt/app/data_directory
+
+RUN mkdir -p /opt/app/bin
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
 
-USER geo:geo
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/services/wms/Dockerfile
+++ b/services/wms/Dockerfile
@@ -20,17 +20,14 @@ LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
 COPY --from=builder /usr/share/fonts/truetype/* /usr/share/fonts/truetype/
 
-RUN mkdir -p /opt/app/bin \
-    && mkdir -p /opt/app/data_directory \ 
-    && groupadd --system -g 630 geo \
-    && useradd -u 630 -g geo --home-dir /opt/app/bin geo \
-    && chown geo:geo /opt/app -R
+VOLUME /opt/app/data_directory
+
+RUN mkdir -p /opt/app/bin
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
 
-USER geo:geo
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/services/wps/Dockerfile
+++ b/services/wps/Dockerfile
@@ -10,17 +10,14 @@ FROM adoptopenjdk:11-jre-openj9
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
-RUN mkdir -p /opt/app/bin \
-    && mkdir -p /opt/app/data_directory \ 
-    && groupadd --system -g 630 geo \
-    && useradd -u 630 -g geo --home-dir /opt/app/bin geo \
-    && chown geo:geo /opt/app -R
+VOLUME /opt/app/data_directory
+
+RUN mkdir -p /opt/app/bin
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
 
-USER geo:geo
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/support-services/admin/Dockerfile
+++ b/support-services/admin/Dockerfile
@@ -19,7 +19,6 @@ WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8761
 
-USER geo:geo
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/support-services/api-gateway/Dockerfile
+++ b/support-services/api-gateway/Dockerfile
@@ -19,7 +19,6 @@ WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
 
-USER geo:geo
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/support-services/config/Dockerfile
+++ b/support-services/config/Dockerfile
@@ -19,7 +19,6 @@ WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
 
-USER geo:geo
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/support-services/discovery/Dockerfile
+++ b/support-services/discovery/Dockerfile
@@ -19,7 +19,6 @@ WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8761
 
-USER geo:geo
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./


### PR DESCRIPTION
Let the deployment strategy/platform specify the user
the containers run as.

With podman, they can run as the current host user with

```
podman run --userns=keep-id
```

The user can also be specified with docker and kubernetes.