### PR TITLE
specify user:group in docker-compose.yml for each service

### DIFF
--- a/.env
+++ b/.env
@@ -6,7 +6,7 @@ EUREKA_SERVER_URL=http://discovery:8761/eureka
 JDBCCONFIG_DBNAME=geoserver_config
 JDBCCONFIG_URL=jdbc:postgresql://database:5432/${JDBCCONFIG_DBNAME}
 JDBCCONFIG_USERNAME=geoserver
-JDBCCONFIG_PASSWORD='geo5erver'
+JDBCCONFIG_PASSWORD=geo5erver
 
 # Force the max RAM (-XX:MaxRAM) seen by the JVM in case --compatibility 
 # wasn't used to launch the composition. Make sure the value is consistent

--- a/.env
+++ b/.env
@@ -1,6 +1,7 @@
 # docker-compose default environment variable values
 COMPOSE_PROJECT_NAME=gscloud
 TAG=1.0-SNAPSHOT
+GS_USER="1000:1000"
 EUREKA_SERVER_URL=http://discovery:8761/eureka
 JDBCCONFIG_DBNAME=geoserver_config
 JDBCCONFIG_URL=jdbc:postgresql://database:5432/${JDBCCONFIG_DBNAME}

--- a/catalog-support/catalog-client/src/test/resources/application-test.yml
+++ b/catalog-support/catalog-client/src/test/resources/application-test.yml
@@ -35,7 +35,7 @@ geoserver:
       cache-directory: ${java.io.tmpdir}/gscloud_tests/jdbcconfig_cache_${random.uuid}
       datasource:
         driverClassname: org.h2.Driver
-        jdbcUrl: jdbc:h2:mem:test;
+        url: jdbc:h2:mem:test;
         username: sa
         password:
 

--- a/catalog-support/geoserver-jackson-bindings/src/test/resources/bootstrap-test.yml
+++ b/catalog-support/geoserver-jackson-bindings/src/test/resources/bootstrap-test.yml
@@ -15,7 +15,7 @@ geoserver:
       cache-directory: ${java.io.tmpdir}/gscloud_tests/jdbcconfig_cache_${random.uuid}
       datasource:
         driverClassname: org.h2.Driver
-        jdbcUrl: jdbc:h2:mem:test;
+        url: jdbc:h2:mem:test;
         username: sa
         password:
 

--- a/contrib/chart/templates/config/configmap.yaml
+++ b/contrib/chart/templates/config/configmap.yaml
@@ -115,7 +115,7 @@ data:
           web.enabled: false
           cache-directory: ${jdbcconfig.cachedir:${java.io.tmpdir}/geoserver-jdbcconfig-cache}
           datasource:
-            jdbcUrl: {{ .Values.jdbcconfig.url }}
+            url: {{ .Values.jdbcconfig.url }}
             username: {{ .Values.jdbcconfig.username }}
             password: {{ .Values.jdbcconfig.password }}
             driverClassname: org.postgresql.Driver

--- a/docker-compose-jdbcconfig.yml
+++ b/docker-compose-jdbcconfig.yml
@@ -7,11 +7,6 @@ version: "3.8"
 
 services:
   catalog:
-    environment:
-      SPRING_PROFILES_ACTIVE: "jdbcconfig"
-      JDBCCONFIG_URL: "${JDBCCONFIG_URL}"
-      JDBCCONFIG_USERNAME: "${JDBCCONFIG_USERNAME}"
-      JDBCCONFIG_PASSWORD: "${JDBCCONFIG_PASSWORD}"
     command: echo "catalog-service disabled."
 
   wfs:

--- a/docker-compose-shared_datadir.yml
+++ b/docker-compose-shared_datadir.yml
@@ -4,7 +4,8 @@ version: "3.8"
 # Configures all geoserver services to use a shared data directory as catalog backend.
 # Run with `docker-compose --compatibility -f docker-compose.yml -f docker-compose-shared_datadir.yml up -d`
 # NOTE: Not ready for direct usage until deciding on a strategy to easily set up the shared data directory.
-#
+# Note the default data directory locatio is /opt/app/data_directory
+# To set it to a different path, change the mount point and add the following env variable: GEOSERVER_DATA_DIR: </path/to/data_directory>
 
 volumes:
   test_shared_data_directory:
@@ -18,44 +19,34 @@ services:
     entrypoint: echo "database-service disabled."
 
   catalog:
-    environment:
-      SPRING_PROFILES_ACTIVE: "datadir"
-      GEOSERVER_DATA_DIR: /tmp/data_directory
-    volumes:
-      - test_shared_data_directory:/tmp/data_directory
     command: echo "catalog-service disabled."
 
   wfs:
     environment:
       SPRING_PROFILES_ACTIVE: "datadir"
-      GEOSERVER_DATA_DIR: /tmp/data_directory
     volumes:
-      - test_shared_data_directory:/tmp/data_directory
+      - test_shared_data_directory:/opt/app/data_directory
 
   wms:
     environment:
       SPRING_PROFILES_ACTIVE: "datadir"
-      GEOSERVER_DATA_DIR: /tmp/data_directory
     volumes:
-      - test_shared_data_directory:/tmp/data_directory
+      - test_shared_data_directory:/opt/app/data_directory
 
   wcs:
     environment:
       SPRING_PROFILES_ACTIVE: "datadir"
-      GEOSERVER_DATA_DIR: /tmp/data_directory
     volumes:
-      - test_shared_data_directory:/tmp/data_directory
+      - test_shared_data_directory:/opt/app/data_directory
 
   rest:
     environment:
       SPRING_PROFILES_ACTIVE: "datadir"
-      GEOSERVER_DATA_DIR: /tmp/data_directory
     volumes:
-      - test_shared_data_directory:/tmp/data_directory
+      - test_shared_data_directory:/opt/app/data_directory
 
   webui:
     environment:
       SPRING_PROFILES_ACTIVE: "datadir"
-      GEOSERVER_DATA_DIR: /tmp/data_directory
     volumes:
-      - test_shared_data_directory:/tmp/data_directory
+      - test_shared_data_directory:/opt/app/data_directory

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     
   rabbitmq:
     image: rabbitmq:3.9-management
+    user: ${GS_USER}
     restart: always
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
@@ -69,6 +70,7 @@ services:
   # Run docker-compose -f docker-compose.yml -f docker-compose-discovery-ha.yml to run extra discovery service instances for HA
   discovery:
     image: geoservercloud/geoserver-cloud-discovery:${TAG}
+    user: ${GS_USER}
     environment:
       JAVA_OPTS: "${DISCOVERY_JAVA_OPTS}"
     ports:
@@ -87,6 +89,7 @@ services:
   config:
     image: geoservercloud/geoserver-cloud-config:${TAG}
     #image: geoservercloud/geoserver-cloud-config:${TAG}-native
+    user: ${GS_USER}
     depends_on:
       - discovery
     environment:
@@ -114,6 +117,7 @@ services:
 
   admin:
     image: geoservercloud/geoserver-cloud-admin-server:${TAG}
+    user: ${GS_USER}
     depends_on:
       - config
     ports:
@@ -130,6 +134,7 @@ services:
   # microservices (e.g. http://localhost:9090/geoserver/wms, http://localhost:9090/geoserver/wfs, etc)
   gateway:
     image: geoservercloud/geoserver-cloud-gateway:${TAG}
+    user: ${GS_USER}
     depends_on:
       - config
     environment:
@@ -149,6 +154,7 @@ services:
   # catalog microservice, provides a unified catalog backend to all services
   catalog:
     image: geoservercloud/geoserver-cloud-catalog:${TAG}
+    user: ${GS_USER}
     depends_on:
       - config
       - database
@@ -176,6 +182,7 @@ services:
   # WFS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wfs=5)
   wfs:
     image: geoservercloud/geoserver-cloud-wfs:${TAG}
+    user: ${GS_USER}
     depends_on:
       - catalog
     environment:
@@ -194,6 +201,7 @@ services:
   # WMS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wms=5)
   wms:
     image: geoservercloud/geoserver-cloud-wms:${TAG}
+    user: ${GS_USER}
     depends_on:
       - catalog
     environment:
@@ -210,6 +218,7 @@ services:
   # WCS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wcs=5)
   wcs:
     image: geoservercloud/geoserver-cloud-wcs:${TAG}
+    user: ${GS_USER}
     depends_on:
       - catalog
     environment:
@@ -237,6 +246,7 @@ services:
   # REST config microservice, port dynamically allocated to allow scaling (e.g docker-compose scale rest=5)
   rest:
     image: geoservercloud/geoserver-cloud-rest:${TAG}
+    user: ${GS_USER}
     depends_on:
       - rabbitmq
       - catalog
@@ -256,6 +266,7 @@ services:
   # WEB UI microservice
   webui:
     image: geoservercloud/geoserver-cloud-webui:${TAG}
+    user: ${GS_USER}
     depends_on:
       - rabbitmq
       - catalog

--- a/docs/deploy/docker-compose/docker-compose.md
+++ b/docs/deploy/docker-compose/docker-compose.md
@@ -20,6 +20,8 @@ Open a terminal and enter the directory where you just downloaded that file,
 and run `docker-compose pull` to fetch the docker images from 
 [Dockerhub](https://hub.docker.com/u/geoservercloud/):
 
+> Note in order to run the containers as a non root user, all service definitions specify a `user: 1000:1000`,
+> which you should change to the appropriate user id and group id especially if using bind volumes.
 
 ```bash
 $ docker-compose pull

--- a/docs/deploy/docker-compose/stable/jdbcconfig/docker-compose.yml
+++ b/docs/deploy/docker-compose/stable/jdbcconfig/docker-compose.yml
@@ -10,6 +10,7 @@ networks:
 services:
   rabbitmq:
     image: rabbitmq:3.9-management
+    user: 1000:1000 # set the userid:groupid the container runs as
     restart: always
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
@@ -24,6 +25,7 @@ services:
   database:
     # be sure geoserver.backend.jdbcconfig.initdb is set to true in application.yml at lease for the first app run
     image: postgres:13-alpine
+    user: 1000:1000 # set the userid:groupid the container runs as
     environment:
       POSTGRES_DB: geoserver_config
       POSTGRES_USER: geoserver
@@ -44,6 +46,7 @@ services:
   # Run docker-compose -f docker-compose.yml -f docker-compose-discovery-ha.yml to run extra discovery service instances for HA
   discovery:
     image: geoservercloud/geoserver-cloud-discovery:1.0-RC5
+    user: 1000:1000 # set the userid:groupid the container runs as
     ports:
       - 8761:8761
     networks:
@@ -60,6 +63,7 @@ services:
   # register itself with the Eureka discovery service and can be scaled
   config:
     image: geoservercloud/geoserver-cloud-config:1.0-RC5
+    user: 1000:1000 # set the userid:groupid the container runs as
     depends_on:
       - discovery
       - rabbitmq
@@ -90,6 +94,7 @@ services:
 
   admin:
     image: geoservercloud/geoserver-cloud-admin-server:1.0-RC5
+    user: 1000:1000 # set the userid:groupid the container runs as
     depends_on:
       - config
     ports:
@@ -106,6 +111,7 @@ services:
   # microservices (e.g. http://localhost:9090/geoserver/wms, http://localhost:9090/geoserver/wfs, etc)
   gateway:
     image: geoservercloud/geoserver-cloud-gateway:1.0-RC5
+    user: 1000:1000 # set the userid:groupid the container runs as
     depends_on:
       - config
     environment:
@@ -123,6 +129,7 @@ services:
   # WFS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wfs=5)
   wfs:
     image: geoservercloud/geoserver-cloud-wfs:1.0-RC5
+    user: 1000:1000 # set the userid:groupid the container runs as
     depends_on:
       - config
     environment:
@@ -138,6 +145,7 @@ services:
   # WMS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wms=5)
   wms:
     image: geoservercloud/geoserver-cloud-wms:1.0-RC5
+    user: 1000:1000 # set the userid:groupid the container runs as
     depends_on:
       - config
     environment:
@@ -153,6 +161,7 @@ services:
   # WCS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wcs=5)
   wcs:
     image: geoservercloud/geoserver-cloud-wcs:1.0-RC5
+    user: 1000:1000 # set the userid:groupid the container runs as
     depends_on:
       - config
     environment:
@@ -168,6 +177,7 @@ services:
   # REST config microservice, port dynamically allocated to allow scaling (e.g docker-compose scale rest=5)
   rest:
     image: geoservercloud/geoserver-cloud-rest:1.0-RC5
+    user: 1000:1000 # set the userid:groupid the container runs as
     depends_on:
       - config
     environment:
@@ -185,6 +195,7 @@ services:
   # WEB UI microservice
   webui:
     image: geoservercloud/geoserver-cloud-webui:1.0-RC5
+    user: 1000:1000 # set the userid:groupid the container runs as
     depends_on:
       - rabbitmq
     environment:

--- a/docs/deploy/docker-compose/stable/shared_datadir/docker-compose.yml
+++ b/docs/deploy/docker-compose/stable/shared_datadir/docker-compose.yml
@@ -18,6 +18,7 @@ networks:
 services:
   rabbitmq:
     image: rabbitmq:3.9-management
+    user: 1000:1000 # set the userid:groupid the container runs as
     restart: always
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
@@ -35,6 +36,7 @@ services:
   # Run docker-compose -f docker-compose.yml -f docker-compose-discovery-ha.yml to run extra discovery service instances for HA
   discovery:
     image: geoservercloud/geoserver-cloud-discovery:1.0-RC5
+    user: 1000:1000 # set the userid:groupid the container runs as
     ports:
       - 8761:8761
     networks:
@@ -51,6 +53,7 @@ services:
   # register itself with the Eureka discovery service and can be scaled
   config:
     image: geoservercloud/geoserver-cloud-config:1.0-RC5
+    user: 1000:1000 # set the userid:groupid the container runs as
     depends_on:
       - discovery
       - rabbitmq
@@ -80,6 +83,7 @@ services:
 
   admin:
     image: geoservercloud/geoserver-cloud-admin-server:1.0-RC5
+    user: 1000:1000 # set the userid:groupid the container runs as
     depends_on:
       - config
     ports:
@@ -96,6 +100,7 @@ services:
   # microservices (e.g. http://localhost:9090/geoserver/wms, http://localhost:9090/geoserver/wfs, etc)
   gateway:
     image: geoservercloud/geoserver-cloud-gateway:1.0-RC5
+    user: 1000:1000 # set the userid:groupid the container runs as
     depends_on:
       - config
     environment:
@@ -113,6 +118,7 @@ services:
   # WFS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wfs=5)
   wfs:
     image: geoservercloud/geoserver-cloud-wfs:1.0-RC5
+    user: 1000:1000 # set the userid:groupid the container runs as
     depends_on:
       - config
     environment:
@@ -131,6 +137,7 @@ services:
   # WMS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wms=5)
   wms:
     image: geoservercloud/geoserver-cloud-wms:1.0-RC5
+    user: 1000:1000 # set the userid:groupid the container runs as
     depends_on:
       - config
     environment:
@@ -149,6 +156,7 @@ services:
   # WCS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wcs=5)
   wcs:
     image: geoservercloud/geoserver-cloud-wcs:1.0-RC5
+    user: 1000:1000 # set the userid:groupid the container runs as
     depends_on:
       - config
     environment:
@@ -167,6 +175,7 @@ services:
   # REST config microservice, port dynamically allocated to allow scaling (e.g docker-compose scale rest=5)
   rest:
     image: geoservercloud/geoserver-cloud-rest:1.0-RC5
+    user: 1000:1000 # set the userid:groupid the container runs as
     depends_on:
       - config
     environment:
@@ -187,6 +196,7 @@ services:
   # WEB UI microservice
   webui:
     image: geoservercloud/geoserver-cloud-webui:1.0-RC5
+    user: 1000:1000 # set the userid:groupid the container runs as
     depends_on:
       - config
     environment:

--- a/services/catalog/src/main/resources/bootstrap-standalone.yml
+++ b/services/catalog/src/main/resources/bootstrap-standalone.yml
@@ -12,7 +12,7 @@ geoserver:
       cache-directory: ${java.io.tmpdir}/geoserver-jdbcconfig-cache
       datasource:
         driverClassname: org.h2.Driver
-        jdbcUrl: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+        url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
         username: sa
         password:
 

--- a/services/catalog/src/test/resources/bootstrap-test.yml
+++ b/services/catalog/src/test/resources/bootstrap-test.yml
@@ -25,7 +25,7 @@ geoserver:
       cache-directory: ${java.io.tmpdir}/geoserver-jdbcconfig-cache
       datasource:
         driverClassname: org.h2.Driver
-        jdbcUrl: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+        url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
         username: sa
         password:
 

--- a/services/restconfig/src/test/resources/bootstrap-test.yml
+++ b/services/restconfig/src/test/resources/bootstrap-test.yml
@@ -20,7 +20,7 @@ geoserver:
       cache-directory: ${java.io.tmpdir}/geoserver-jdbcconfig-cache
       datasource:
         driverClassname: org.h2.Driver
-        jdbcUrl: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+        url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
         username: sa
         password:
 

--- a/services/wcs/src/test/resources/bootstrap-test.yml
+++ b/services/wcs/src/test/resources/bootstrap-test.yml
@@ -20,7 +20,7 @@ geoserver:
       cache-directory: ${java.io.tmpdir}/geoserver-jdbcconfig-cache
       datasource:
         driverClassname: org.h2.Driver
-        jdbcUrl: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+        url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
         username: sa
         password:
 

--- a/services/web-ui/src/test/resources/bootstrap-test.yml
+++ b/services/web-ui/src/test/resources/bootstrap-test.yml
@@ -20,7 +20,7 @@ geoserver:
       cache-directory: ${java.io.tmpdir}/geoserver-jdbcconfig-cache
       datasource:
         driverClassname: org.h2.Driver
-        jdbcUrl: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+        url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
         username: sa
         password:
 

--- a/services/wfs/src/test/resources/bootstrap-test.yml
+++ b/services/wfs/src/test/resources/bootstrap-test.yml
@@ -16,7 +16,7 @@ geoserver:
       cache-directory: ${java.io.tmpdir}/geoserver-jdbcconfig-cache
       datasource:
         driverClassname: org.h2.Driver
-        jdbcUrl: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+        url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
         username: sa
         password:
 

--- a/services/wms/src/test/resources/bootstrap-test.yml
+++ b/services/wms/src/test/resources/bootstrap-test.yml
@@ -20,7 +20,7 @@ geoserver:
       cache-directory: ${java.io.tmpdir}/geoserver-jdbcconfig-cache
       datasource:
         driverClassname: org.h2.Driver
-        jdbcUrl: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+        url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
         username: sa
         password:
 

--- a/services/wps/src/test/resources/bootstrap-test.yml
+++ b/services/wps/src/test/resources/bootstrap-test.yml
@@ -20,7 +20,7 @@ geoserver:
       cache-directory: ${java.io.tmpdir}/geoserver-jdbcconfig-cache
       datasource:
         driverClassname: org.h2.Driver
-        jdbcUrl: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+        url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
         username: sa
         password:
 

--- a/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/autoconfigure/security/GeoServerSecurityEnabledAutoConfiguration.java
+++ b/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/autoconfigure/security/GeoServerSecurityEnabledAutoConfiguration.java
@@ -6,13 +6,16 @@ package org.geoserver.cloud.autoconfigure.security;
 
 import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+import org.geoserver.cloud.autoconfigure.bus.RemoteApplicationEventsAutoConfiguration;
 import org.geoserver.cloud.config.security.GeoServerSecurityConfiguration;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 @ConditionalOnGeoServerSecurityEnabled
 @Import(GeoServerSecurityConfiguration.class)
+@AutoConfigureAfter(RemoteApplicationEventsAutoConfiguration.class)
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.security")
 public @Configuration class GeoServerSecurityEnabledAutoConfiguration {
 

--- a/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/config/datadirectory/DataDirectoryBackendConfigurer.java
+++ b/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/config/datadirectory/DataDirectoryBackendConfigurer.java
@@ -18,7 +18,6 @@ import org.geoserver.cloud.config.catalog.GeoServerBackendProperties;
 import org.geoserver.config.GeoServerLoader;
 import org.geoserver.config.plugin.RepositoryGeoServerFacade;
 import org.geoserver.platform.GeoServerResourceLoader;
-import org.geoserver.platform.resource.FileLockProvider;
 import org.geoserver.platform.resource.ResourceStore;
 import org.geoserver.wcs.WCSXStreamLoader;
 import org.geoserver.wfs.WFSXStreamLoader;
@@ -79,7 +78,7 @@ public class DataDirectoryBackendConfigurer implements GeoServerBackendConfigure
         final @NonNull File dataDirectory = dataDirectoryFile().toFile();
         NoServletContextDataDirectoryResourceStore store =
                 new NoServletContextDataDirectoryResourceStore(dataDirectory);
-        store.setLockProvider(new FileLockProvider(dataDirectory));
+        store.setLockProvider(new NoServletContextFileLockProvider(dataDirectory));
         return store;
     }
 

--- a/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/config/datadirectory/NoServletContextFileLockProvider.java
+++ b/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/config/datadirectory/NoServletContextFileLockProvider.java
@@ -1,0 +1,28 @@
+/*
+ * (c) 2021 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.config.datadirectory;
+
+import java.io.File;
+import javax.servlet.ServletContext;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.geoserver.platform.resource.FileLockProvider;
+
+/**
+ * {@link FileLockProvider} that expects the data directory file at its constructor, overriding
+ * {@link #setServletContext} to be ignored.
+ */
+@Slf4j
+public class NoServletContextFileLockProvider extends FileLockProvider {
+
+    public NoServletContextFileLockProvider(@NonNull File dataDirectory) {
+        super(dataDirectory);
+    }
+
+    @Override
+    public void setServletContext(ServletContext servletContext) {
+        log.debug("setServletContext(ServletContext) ignored, data directory explicitly provided.");
+    }
+}

--- a/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/config/jdbcconfig/JDBCConfigBackendConfigurer.java
+++ b/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/config/jdbcconfig/JDBCConfigBackendConfigurer.java
@@ -68,7 +68,7 @@ import org.springframework.util.StringUtils;
  *   <li>{@code geoserver.backend.jdbcconfig.web.enabled}: whether to enable jdbc-config wicket
  *       components, provided {@code jdbcconfig} is enabled and the geoserver web-ui is in the
  *       classpath. Defaults to {@code true}.
- *   <li>{@code geoserver.backend.jdbcconfig.datasource.jdbcUrl}: connection URL (e.g. {@code
+ *   <li>{@code geoserver.backend.jdbcconfig.datasource.url}: connection URL (e.g. {@code
  *       jdbc:postgresql://localhost:5432/gsconfigdb})
  *   <li>{@code geoserver.backend.jdbcconfig.datasource.username}:
  *   <li>{@code geoserver.backend.jdbcconfig.datasource.password}:

--- a/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/security/CloudGeoServerSecurityManager.java
+++ b/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/security/CloudGeoServerSecurityManager.java
@@ -136,9 +136,7 @@ public class CloudGeoServerSecurityManager extends GeoServerSecurityManager {
 
     protected GeoServerSecurityConfigChangeEvent event(String reason) {
         final String originService = busServiceMatcher.getBusId();
-        GeoServerSecurityConfigChangeEvent event =
-                new GeoServerSecurityConfigChangeEvent(this, originService, reason);
-        return event;
+        return new GeoServerSecurityConfigChangeEvent(this, originService, reason);
     }
 
     private boolean isFromSelf(GeoServerSecurityConfigChangeEvent event) {

--- a/starters/catalog-backend-starter/src/test/java/org/geoserver/cloud/autoconfigure/test/backend/JDBCConfigAutoConfigurationTest.java
+++ b/starters/catalog-backend-starter/src/test/java/org/geoserver/cloud/autoconfigure/test/backend/JDBCConfigAutoConfigurationTest.java
@@ -34,7 +34,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  */
 @SpringBootTest(
     classes = AutoConfigurationTestConfiguration.class,
-    properties = {"geoserver.backend.jdbcconfig.enabled=true"}
+    properties = "geoserver.backend.jdbcconfig.enabled=true"
 )
 @RunWith(SpringRunner.class)
 public class JDBCConfigAutoConfigurationTest extends JDBCConfigTest {

--- a/starters/catalog-backend-starter/src/test/resources/application.yml
+++ b/starters/catalog-backend-starter/src/test/resources/application.yml
@@ -11,6 +11,9 @@ spring:
     exclude:
     - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 
+
+eureka.client.enabled: false
+
 geoserver:
   backend:
     catalog-service:

--- a/starters/starter-webmvc/src/main/java/org/geoserver/cloud/config/main/GeoServerMainModuleConfiguration.java
+++ b/starters/starter-webmvc/src/main/java/org/geoserver/cloud/config/main/GeoServerMainModuleConfiguration.java
@@ -64,7 +64,8 @@ import org.springframework.context.annotation.ImportResource;
 public class GeoServerMainModuleConfiguration {
 
     private static final String UNUSED_BEAN_NAMES =
-            "proxyfierHeaderCollector|proxyfierHeaderTransfer|proxyfier" + "|logsPage";
+            "proxyfierHeaderCollector|proxyfierHeaderTransfer|proxyfier" //
+                    + "|fileLockProvider|memoryLockProvider|nullLockProvider|lockProviderInitializer";
 
     private static final String OVERRIDDEN_BEAN_NAMES =
             "rawCatalog|secureCatalog|localWorkspaceCatalog|catalog|advertisedCatalog|accessRulesDao|catalogFacade|dataDirectory|extensions|geoServer|geoserverFacade|geoServerLoader|geoServerSecurityManager|resourceLoader|resourceStoreImpl|secureCatalog|xstreamPersisterFactory";

--- a/starters/starter-webmvc/src/main/java/org/geoserver/cloud/config/servlet/GeoServerServletContextConfiguration.java
+++ b/starters/starter-webmvc/src/main/java/org/geoserver/cloud/config/servlet/GeoServerServletContextConfiguration.java
@@ -21,7 +21,6 @@ import org.springframework.web.context.request.RequestContextListener;
 @Configuration
 public class GeoServerServletContextConfiguration {
 
-    private static final int FORWARDED_HEADER_FILTER_ORDER = 0;
     private static final int FLUSH_SAFE_FILTER_ORDER = 1;
     private static final int SESSION_DEBUG_FILTER_ORDER = 2;
     private static final int SPRING_DELEGATING_FILTER_ORDER = 3;

--- a/starters/starter-webmvc/src/test/resources/application.yml
+++ b/starters/starter-webmvc/src/test/resources/application.yml
@@ -21,7 +21,7 @@ geoserver:
       cache-directory: ${java.io.tmpdir}/geoserver-jdbcconfig-cache}
       datasource:
         driverClassname: org.h2.Driver
-        jdbcUrl: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+        url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
         username: sa
         password:
 


### PR DESCRIPTION
In order to run services as a non-root user when running with
docker-compose (this is the default behavior with podman),
set a `user: <uid>:<guid>` config to each service definition
in docker-compose.yml.

Fix too early and double initialization of GeoServerSecurityManager
    
GeoServerServletInitializer: Instead of implementing `ServletContextInitializer`,
listen to `ContextRefreshedEvent`, since servlet context initialization happens
too early during application context initialization and some things like
the event bus may not be ready.
    
Also prevent double initialization by checking the ApplicationContext
subject of the ContextRefreshEvent is the actual application context
and not another one (e.g. the bootstrap context).