### PR TITLE
Change GeoServer microservices management port to 8081

### DIFF
--- a/services/catalog/Dockerfile
+++ b/services/catalog/Dockerfile
@@ -27,6 +27,7 @@ RUN mkdir -p /opt/app/bin
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
+EXPOSE 8081
 
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
@@ -38,6 +39,6 @@ HEALTHCHECK \
 --timeout=5s \
 --start-period=30s \
 --retries=5 \
-CMD curl -f -s -o /dev/null localhost:8080/actuator/health || exit 1
+CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
 CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/catalog/src/main/resources/bootstrap.yml
+++ b/services/catalog/src/main/resources/bootstrap.yml
@@ -55,6 +55,10 @@ spring:
       - org.springframework.boot.autoconfigure.security.reactive.ReactiveUserDetailsServiceAutoConfiguration
       - org.springframework.boot.actuate.autoconfigure.security.reactive.ReactiveManagementWebSecurityAutoConfiguration
 
+management:
+  server.port: 8081
+  endpoint.health.probes.enabled: true
+
 eureka:
   instance:
     hostname: ${spring.application.name}

--- a/services/restconfig/Dockerfile
+++ b/services/restconfig/Dockerfile
@@ -27,6 +27,7 @@ RUN mkdir -p /opt/app/bin
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
+EXPOSE 8081
 
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
@@ -38,6 +39,6 @@ HEALTHCHECK \
 --timeout=5s \
 --start-period=30s \
 --retries=5 \
-CMD curl -f -s -o /dev/null localhost:8080/actuator/health || exit 1
+CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
 CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/restconfig/src/main/resources/bootstrap.yml
+++ b/services/restconfig/src/main/resources/bootstrap.yml
@@ -32,6 +32,10 @@ spring:
       - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
       - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
 
+management:
+  server.port: 8081
+  endpoint.health.probes.enabled: true
+    
 eureka:
   instance:
     hostname: ${spring.application.name}

--- a/services/wcs/Dockerfile
+++ b/services/wcs/Dockerfile
@@ -17,6 +17,7 @@ RUN mkdir -p /opt/app/bin
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
+EXPOSE 8081
 
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
@@ -28,6 +29,6 @@ HEALTHCHECK \
 --timeout=5s \
 --start-period=30s \
 --retries=5 \
-CMD curl -f -s -o /dev/null localhost:8080/actuator/health || exit 1
+CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
 CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/wcs/src/main/resources/bootstrap.yml
+++ b/services/wcs/src/main/resources/bootstrap.yml
@@ -30,6 +30,11 @@ spring:
       - org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
       - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
       - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
+
+management:
+  server.port: 8081
+  endpoint.health.probes.enabled: true
+
 eureka:
   instance:
     hostname: ${spring.application.name}

--- a/services/web-ui/Dockerfile
+++ b/services/web-ui/Dockerfile
@@ -27,6 +27,7 @@ RUN mkdir -p /opt/app/bin
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
+EXPOSE 8081
 
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
@@ -38,6 +39,6 @@ HEALTHCHECK \
 --timeout=5s \
 --start-period=30s \
 --retries=5 \
-CMD curl -f -s -o /dev/null localhost:8080/actuator/health || exit 1
+CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
 CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/web-ui/src/main/resources/bootstrap.yml
+++ b/services/web-ui/src/main/resources/bootstrap.yml
@@ -33,6 +33,11 @@ spring:
       - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
       - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
       - org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration
+
+management:
+  server.port: 8081
+  endpoint.health.probes.enabled: true
+
 eureka:
   instance:
     hostname: ${spring.application.name}

--- a/services/wfs/Dockerfile
+++ b/services/wfs/Dockerfile
@@ -18,6 +18,7 @@ WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 
 EXPOSE 8080
+EXPOSE 8081
 
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
@@ -29,6 +30,6 @@ HEALTHCHECK \
 --timeout=5s \
 --start-period=30s \
 --retries=5 \
-CMD curl -f -s -o /dev/null localhost:8080/actuator/health || exit 1
+CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
 CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/wfs/src/main/resources/bootstrap.yml
+++ b/services/wfs/src/main/resources/bootstrap.yml
@@ -35,6 +35,10 @@ spring:
       - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
       - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
 
+management:
+  server.port: 8081
+  endpoint.health.probes.enabled: true
+
 eureka:
   instance:
     hostname: ${spring.application.name}

--- a/services/wms/Dockerfile
+++ b/services/wms/Dockerfile
@@ -27,6 +27,7 @@ RUN mkdir -p /opt/app/bin
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
+EXPOSE 8081
 
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
@@ -38,7 +39,7 @@ HEALTHCHECK \
 --timeout=5s \
 --start-period=30s \
 --retries=5 \
-CMD curl -f -s -o /dev/null localhost:8080/actuator/health || exit 1
+CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
 CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
 

--- a/services/wms/src/main/resources/bootstrap.yml
+++ b/services/wms/src/main/resources/bootstrap.yml
@@ -30,6 +30,11 @@ spring:
       - org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
       - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
       - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
+
+management:
+  server.port: 8081
+  endpoint.health.probes.enabled: true
+
 eureka:
   instance:
     hostname: ${spring.application.name}

--- a/services/wps/Dockerfile
+++ b/services/wps/Dockerfile
@@ -17,6 +17,7 @@ RUN mkdir -p /opt/app/bin
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
+EXPOSE 8081
 
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
@@ -28,6 +29,6 @@ HEALTHCHECK \
 --timeout=5s \
 --start-period=30s \
 --retries=5 \
-CMD curl -f -s -o /dev/null localhost:8080/actuator/health || exit 1
+CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
 CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/wps/src/main/resources/bootstrap.yml
+++ b/services/wps/src/main/resources/bootstrap.yml
@@ -30,6 +30,11 @@ spring:
       - org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
       - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
       - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
+
+management:
+  server.port: 8081
+  endpoint.health.probes.enabled: true
+
 eureka:
   instance:
     hostname: ${spring.application.name}

--- a/support-services/admin/src/main/resources/bootstrap.yml
+++ b/support-services/admin/src/main/resources/bootstrap.yml
@@ -30,6 +30,10 @@ spring:
 #      - org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
 #      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
 #      - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
+
+management:
+  endpoint.health.probes.enabled: true
+
 eureka:
   instance:
     hostname: ${spring.application.name}

--- a/support-services/api-gateway/src/main/resources/bootstrap.yml
+++ b/support-services/api-gateway/src/main/resources/bootstrap.yml
@@ -18,6 +18,10 @@ spring:
       discovery:
         enabled: true
         service-id: config-service
+
+management:
+  endpoint.health.probes.enabled: true
+
 eureka:
   instance:
     hostname: ${spring.application.name}

--- a/support-services/config/src/main/resources/application.yml
+++ b/support-services/config/src/main/resources/application.yml
@@ -69,6 +69,7 @@ management:
     shutdown.enabled: true
     health:
       enabled: true
+      probes.enabled: true
       show-details: always
   metrics:
     enable:

--- a/support-services/discovery/src/main/resources/application.yml
+++ b/support-services/discovery/src/main/resources/application.yml
@@ -41,6 +41,7 @@ management:
     shutdown.enabled: true
     health:
       enabled: true
+      probes.enabled: true
       show-details: always
   metrics:
     enable:


### PR DESCRIPTION
Having the actuator endpoints (/actuator/health, etc.)
on the same context/port than the main application causes
trouble as some GeoServer servlet filters are called
while still uninitialized leading to NullPointerExceptions.

Change the management port to 8081 for the following services:
catalog, restconfig, wcs, web-ui, wfs, wms, wps.