### PR TITLE
GeoServerSecurityManager startup configuration improvements

### DIFF
--- a/services/catalog/src/main/resources/bootstrap.yml
+++ b/services/catalog/src/main/resources/bootstrap.yml
@@ -36,9 +36,9 @@ spring:
       indent-output: true
   main:
     banner-mode: off
-    web-application-type: REACTIVE
     allow-bean-definition-overriding: true
     allow-circular-references: true # false by default since spring-boot 2.6.0, breaks geoserver initialization
+    web-application-type: reactive
   application:
     name: catalog-service
   cloud:

--- a/services/restconfig/src/main/resources/bootstrap.yml
+++ b/services/restconfig/src/main/resources/bootstrap.yml
@@ -13,6 +13,7 @@ spring:
     banner-mode: off
     allow-bean-definition-overriding: true
     allow-circular-references: true # false by default since spring-boot 2.6.0, breaks geoserver initialization
+    web-application-type: servlet
   application:
     name: restconfig-v1
   cloud:

--- a/services/wcs/src/main/resources/bootstrap.yml
+++ b/services/wcs/src/main/resources/bootstrap.yml
@@ -12,6 +12,7 @@ spring:
     banner-mode: off
     allow-bean-definition-overriding: true
     allow-circular-references: true # false by default since spring-boot 2.6.0, breaks geoserver initialization
+    web-application-type: servlet
   application:
     name: wcs-service
   cloud:

--- a/services/web-ui/src/main/resources/bootstrap.yml
+++ b/services/web-ui/src/main/resources/bootstrap.yml
@@ -14,6 +14,7 @@ spring:
     banner-mode: off
     allow-bean-definition-overriding: true
     allow-circular-references: true # false by default since spring-boot 2.6.0, breaks geoserver initialization
+    web-application-type: servlet
   application:
     name: web-ui
   cloud:

--- a/services/wfs/src/main/resources/bootstrap.yml
+++ b/services/wfs/src/main/resources/bootstrap.yml
@@ -12,10 +12,10 @@ spring:
   banner:
     charset: UTF-8 # https://patorjk.com/software/taag/#p=display&f=Marquee&t=GeoServer%20WFS
   main:
-    banner-mode: console
+    banner-mode: off
     allow-bean-definition-overriding: true
     allow-circular-references: true # false by default since spring-boot 2.6.0, breaks geoserver initialization
-    web-application-type: SERVLET
+    web-application-type: servlet
   application:
     name: wfs-service
   cloud:

--- a/services/wms/src/main/resources/bootstrap.yml
+++ b/services/wms/src/main/resources/bootstrap.yml
@@ -12,6 +12,7 @@ spring:
     banner-mode: off
     allow-bean-definition-overriding: true
     allow-circular-references: true # false by default since spring-boot 2.6.0, breaks geoserver initialization
+    web-application-type: servlet
   application:
     name: wms-service
   cloud:

--- a/services/wps/src/main/resources/bootstrap.yml
+++ b/services/wps/src/main/resources/bootstrap.yml
@@ -12,6 +12,7 @@ spring:
     banner-mode: off
     allow-bean-definition-overriding: true
     allow-circular-references: true # false by default since spring-boot 2.6.0, breaks geoserver initialization
+    web-application-type: servlet
   application:
     name: wps-service
   cloud:

--- a/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/security/CloudGeoServerSecurityManager.java
+++ b/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/security/CloudGeoServerSecurityManager.java
@@ -54,18 +54,25 @@ public class CloudGeoServerSecurityManager extends GeoServerSecurityManager {
      */
     @EventListener(GeoServerSecurityConfigChangeEvent.class)
     public void onRemoteSecurityConfigChangeEvent(GeoServerSecurityConfigChangeEvent event) {
-        if (!isFromSelf(event)) {
+        if (isFromSelf(event)) {
+            return;
+        }
+        if (!isInitialized()) {
             log.info(
-                    "Reloading security configuration due to change from {}, reason: {}",
+                    "Ignoring security config change event from {}, security subsystem not yet initialized.",
+                    event.getOriginService());
+            return;
+        }
+        log.info(
+                "Reloading security configuration due to change from {}, reason: {}",
+                event.getOriginService(),
+                event.getReason());
+        synchronized (this) {
+            super.reload();
+            log.debug(
+                    "Security configuration reloaded due to change from {}, reason: {}",
                     event.getOriginService(),
                     event.getReason());
-            synchronized (this) {
-                super.reload();
-                log.debug(
-                        "Security configuration reloaded due to change from {}, reason: {}",
-                        event.getOriginService(),
-                        event.getReason());
-            }
         }
     }
 

--- a/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/security/CloudGeoServerSecurityManager.java
+++ b/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/security/CloudGeoServerSecurityManager.java
@@ -24,9 +24,9 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 
 /**
- * Extends {@link GeoServerSecurityManager} to {@link #fireChanged(String) notify} other services of
- * changes to the security configuration happened on the currently running service, and to {@link
- * #onRemoteSecurityConfigChangeEvent listen to} those events to {@link
+ * Extends {@link GeoServerSecurityManager} to {@link #fireRemoteChangedEvent(String) notify} other
+ * services of changes to the security configuration happened on the currently running service, and
+ * to {@link #onRemoteSecurityConfigChangeEvent listen to} those events to {@link
  * GeoServerSecurityManager#reload() reload} the security config when other serice made a change.
  */
 @Slf4j(topic = "org.geoserver.cloud.security")
@@ -36,16 +36,36 @@ public class CloudGeoServerSecurityManager extends GeoServerSecurityManager {
 
     private @Autowired ApplicationEventPublisher eventPublisher;
 
+    private boolean reloading = false;
+    private boolean changedDuringReload = false;
+
     public CloudGeoServerSecurityManager(GeoServerDataDirectory dataDir) throws Exception {
         super(dataDir);
+    }
+
+    public @Override void reload() {
+        reloading = true;
+        changedDuringReload = false;
+        try {
+            super.reload();
+        } finally {
+            reloading = false;
+        }
+        if (changedDuringReload) {
+            fireRemoteChangedEvent("Changed during reload");
+        }
     }
 
     /**
      * Fires a {@link GeoServerSecurityConfigChangeEvent} for other services to react accordingly.
      */
-    public void fireChanged(@NonNull String reason) {
-        log.debug("Publishing remote security event due to {}", reason);
-        eventPublisher.publishEvent(event(reason));
+    public void fireRemoteChangedEvent(@NonNull String reason) {
+        if (reloading) {
+            changedDuringReload = true;
+        } else {
+            log.debug("Publishing remote security event due to {}", reason);
+            eventPublisher.publishEvent(event(reason));
+        }
     }
 
     /**
@@ -80,41 +100,41 @@ public class CloudGeoServerSecurityManager extends GeoServerSecurityManager {
     public @Override void saveRoleService(SecurityRoleServiceConfig config)
             throws IOException, SecurityConfigException {
         super.saveRoleService(config);
-        fireChanged("SecurityRoleServiceConfig changed");
+        fireRemoteChangedEvent("SecurityRoleServiceConfig changed");
     }
 
     /** Override to {@link #fireChanged fire} a remote {@link GeoServerSecurityConfigChangeEvent} */
     public @Override void savePasswordPolicy(PasswordPolicyConfig config)
             throws IOException, SecurityConfigException {
         super.savePasswordPolicy(config);
-        fireChanged("PasswordPolicyConfig changed");
+        fireRemoteChangedEvent("PasswordPolicyConfig changed");
     }
 
     /** Override to {@link #fireChanged fire} a remote {@link GeoServerSecurityConfigChangeEvent} */
     public @Override void saveUserGroupService(SecurityUserGroupServiceConfig config)
             throws IOException, SecurityConfigException {
         super.saveUserGroupService(config);
-        fireChanged("SecurityUserGroupServiceConfig changed");
+        fireRemoteChangedEvent("SecurityUserGroupServiceConfig changed");
     }
 
     /** Override to {@link #fireChanged fire} a remote {@link GeoServerSecurityConfigChangeEvent} */
     public @Override void saveAuthenticationProvider(SecurityAuthProviderConfig config)
             throws IOException, SecurityConfigException {
         super.saveAuthenticationProvider(config);
-        fireChanged("SecurityAuthProviderConfig changed");
+        fireRemoteChangedEvent("SecurityAuthProviderConfig changed");
     }
 
     /** Override to {@link #fireChanged fire} a remote {@link GeoServerSecurityConfigChangeEvent} */
     public @Override void saveFilter(SecurityNamedServiceConfig config)
             throws IOException, SecurityConfigException {
         super.saveFilter(config);
-        fireChanged("SecurityNamedServiceConfig changed");
+        fireRemoteChangedEvent("SecurityNamedServiceConfig changed");
     }
 
     /** Override to {@link #fireChanged fire} a remote {@link GeoServerSecurityConfigChangeEvent} */
     public @Override void saveSecurityConfig(SecurityManagerConfig config) throws Exception {
         super.saveSecurityConfig(config);
-        fireChanged("SecurityManagerConfig changed");
+        fireRemoteChangedEvent("SecurityManagerConfig changed");
     }
 
     /** Override to {@link #fireChanged fire} a remote {@link GeoServerSecurityConfigChangeEvent} */
@@ -125,20 +145,20 @@ public class CloudGeoServerSecurityManager extends GeoServerSecurityManager {
             char[] newPasswdConfirm)
             throws Exception {
         super.saveMasterPasswordConfig(config, currPasswd, newPasswd, newPasswdConfirm);
-        fireChanged("MasterPasswordConfig changed");
+        fireRemoteChangedEvent("MasterPasswordConfig changed");
     }
 
     /** Override to {@link #fireChanged fire} a remote {@link GeoServerSecurityConfigChangeEvent} */
     public @Override void saveMasterPasswordConfig(MasterPasswordConfig config) throws IOException {
         super.saveMasterPasswordConfig(config);
-        fireChanged("MasterPasswordConfig changed");
+        fireRemoteChangedEvent("MasterPasswordConfig changed");
     }
 
     /** Override to {@link #fireChanged fire} a remote {@link GeoServerSecurityConfigChangeEvent} */
     public @Override void saveMasterPasswordProviderConfig(MasterPasswordProviderConfig config)
             throws IOException, SecurityConfigException {
         super.saveMasterPasswordProviderConfig(config);
-        fireChanged("MasterPasswordProviderConfig changed");
+        fireRemoteChangedEvent("MasterPasswordProviderConfig changed");
     }
 
     protected GeoServerSecurityConfigChangeEvent event(String reason) {


### PR DESCRIPTION
*  Send a single security config remote change event during reload
   
 If the security config changes during CloudGeoServerSecurityManager.reload()
 (e.g. when starting up off an empty or old data directory), fire
 a single remote event instead of multiple.

*  Do not try to initialize the security subsystem upon remote events while uninitialized
    
 CloudGeoServerSecurityManager listens to remote security config
 change events and reloads the security configuration.
    
 This may happen while waiting to acquire the lock at startup
 to load the config for the first time. If so, ignore the event.
