### PR TITLE
jdbc resource store cache causes startup failures due to stale resource metadata

### DIFF
--- a/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/config/security/GeoServerSecurityConfiguration.java
+++ b/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/config/security/GeoServerSecurityConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServic
 import org.springframework.cloud.bus.jackson.RemoteApplicationEventScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.ImportResource;
 
 /**
@@ -64,6 +65,7 @@ public class GeoServerSecurityConfiguration {
      * @return {@link CloudGeoServerSecurityManager}
      */
     @Bean(name = {"authenticationManager", "geoServerSecurityManager"})
+    @DependsOn({"extensions"})
     @ConditionalOnGeoServerRemoteEventsEnabled
     public CloudGeoServerSecurityManager cloudAuthenticationManager(GeoServerDataDirectory dataDir)
             throws Exception {


### PR DESCRIPTION
Use a null-cache provider for jdbc resource store.

JbcResourceStore Resource's rely on cached JDBCDirectoryStructure.Entry
objects, and result in startup errors as these cached
entries metadata incorrectly inform resources don't exist
once another service have created them.