### PR TITLE
Create the directory where the default datadir volume is mounted and make it writable

### DIFF
--- a/services/catalog/Dockerfile
+++ b/services/catalog/Dockerfile
@@ -20,9 +20,9 @@ LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
 COPY --from=builder /usr/share/fonts/truetype/* /usr/share/fonts/truetype/
 
-VOLUME /opt/app/data_directory
-
 RUN mkdir -p /opt/app/bin
+RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
+VOLUME /opt/app/data_directory
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=

--- a/services/restconfig/Dockerfile
+++ b/services/restconfig/Dockerfile
@@ -20,9 +20,9 @@ LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
 COPY --from=builder /usr/share/fonts/truetype/* /usr/share/fonts/truetype/
 
-VOLUME /opt/app/data_directory
-
 RUN mkdir -p /opt/app/bin
+RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
+VOLUME /opt/app/data_directory
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=

--- a/services/wcs/Dockerfile
+++ b/services/wcs/Dockerfile
@@ -10,9 +10,9 @@ FROM adoptopenjdk:11-jre-openj9
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
-VOLUME /opt/app/data_directory
-
 RUN mkdir -p /opt/app/bin
+RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
+VOLUME /opt/app/data_directory
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=

--- a/services/web-ui/Dockerfile
+++ b/services/web-ui/Dockerfile
@@ -20,9 +20,9 @@ LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
 COPY --from=builder /usr/share/fonts/truetype/* /usr/share/fonts/truetype/
 
-VOLUME /opt/app/data_directory
-
 RUN mkdir -p /opt/app/bin
+RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
+VOLUME /opt/app/data_directory
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=

--- a/services/wfs/Dockerfile
+++ b/services/wfs/Dockerfile
@@ -10,9 +10,9 @@ FROM adoptopenjdk:11-jre-openj9
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
-VOLUME /opt/app/data_directory
-
 RUN mkdir -p /opt/app/bin
+RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
+VOLUME /opt/app/data_directory
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=

--- a/services/wms/Dockerfile
+++ b/services/wms/Dockerfile
@@ -20,9 +20,9 @@ LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
 COPY --from=builder /usr/share/fonts/truetype/* /usr/share/fonts/truetype/
 
-VOLUME /opt/app/data_directory
-
 RUN mkdir -p /opt/app/bin
+RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
+VOLUME /opt/app/data_directory
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=

--- a/services/wps/Dockerfile
+++ b/services/wps/Dockerfile
@@ -10,9 +10,9 @@ FROM adoptopenjdk:11-jre-openj9
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
-VOLUME /opt/app/data_directory
-
 RUN mkdir -p /opt/app/bin
+RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
+VOLUME /opt/app/data_directory
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=


### PR DESCRIPTION
When running on docker as a non-root user, the /opt/app/data_directory
directory was not writable as it belongs to root.