### PR TITLE
Cascaded OWS Stores with HTTP proxy externalized configuration

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1,0 +1,91 @@
+# Cloud Native GeoServer externalized configuration guide
+
+## Contents
+{:.no_toc}
+
+* Will be replaced with the ToC, excluding the "Contents" header
+{:toc}
+
+## Introduction
+
+TBD
+
+## GeoServer configuration properties
+
+## HTTP proxy for cascaded OWS (WMS/WMTS/WFS) Stores
+
+Cascaded OWS stores make use of a SPI (Service Provider Interface)
+extension point to configure the appropriate GeoTools `HTTPClientFactory`.
+
+We provide a Spring Boot Auto-configuration that can be configured
+through regular spring-boot externalized properties and only affects 
+GeoTools HTTP clients instead of the whole JVM.
+
+The usual way to set an http proxy is through the `http.proxyHost`, `http.proxyPort`,
+`http.proxyUser`, `http.proxyPassword` Java System Properties.
+
+In the context of Cloud Native GeoServer containerized applications,
+this presents a number of drawbacks:
+
+* Standard Java proxy parameters only work with System properties,
+  not OS environment variables, and setting system properties is more
+  cumbersome than env variables (you have to modify the container run command).
+* `http.proxyUser/Password` are not standard properties, though commonly used, it's kind of
+JDK implementation dependent.
+* Setting `-Dhttp.proxy* System properties affects all HTTP clients in the container, meaning
+requests to the config-service, discovery-service, etc., will also try to go through the proxy,
+or you need to go through the extra burden of figuring out how to ignore them.
+* If the proxy is secured, and since the http client used may not respect the
+http.proxyUser/Password parameters, the apps won't start since they'll get
+HTTP 407 "Proxy Authentication Required".
+
+The following externalized configuration properties apply, with these suggested default values:
+
+```yaml
+# GeoTools HTTP Client proxy configuration, allows configuring cascaded WMS/WMTS/WFS stores
+# that need to go through an HTTP proxy without affecting all the http clients at the JVM level
+# These are default settings. The enabled property can be set to false to disable the custom
+# HTTPClientFactory altogether.
+# The following OS environment variables can be set for easier configuration:
+# HTTP(S)_PROXYHOST, HTTP(S)_PROXYPORT, HTTP(S)_PROXYUSER, HTTP(S)_PROXYPASSWORD, HTTP(S)_NONPROXYHOSTS
+geotools:
+  httpclient:
+    proxy:
+      enabled: true
+      http:
+        host: ${http.proxyHost:}
+        port: ${http.proxyPort:}
+        user: ${http.proxyUser:}
+        password: ${http.proxyPassword:}
+        nonProxyHosts: ${http.nonProxyHosts:localhost.*}
+        # comma separated list of Java regular expressions, e.g.: nonProxyHosts: localhost, example.*
+      https:
+        host: ${https.proxyHost:${geotools.httpclient.proxy.http.host}}
+        port: ${https.proxyPort:${geotools.httpclient.proxy.http.port}}
+        user: ${https.proxyUser:${geotools.httpclient.proxy.http.user}}
+        password: ${https.proxyPassword:${geotools.httpclient.proxy.http.password}}
+        nonProxyHosts: ${https.nonProxyHosts:${geotools.httpclient.proxy.http.nonProxyHosts}}
+```
+
+### Configure HTTP proxy with environment variables in docker-compose.yml
+
+As mentioned above, regular JVM proxy configuration works with Java System properties
+but not with Operating System environment variables.
+
+The above `geotools.httpclient.proxy` config properties though allow to do so
+easily as in the following `docker-compose.yml` snippet:
+
+```yaml
+version: "3.8"
+...
+services:
+...
+  wms:
+    image: geoservercloud/geoserver-cloud-wms:<version>
+    environment:
+      HTTP_PROXYHOST: 192.168.86.26
+      HTTP_PROXYPORT: 80
+      HTTP_PROXYUSER: jack
+      HTTP_PROXYPASSWORD: insecure
+...
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -213,3 +213,7 @@ Things to mention
 
 ** Gateway: custom filter to adhere to OWS case-insensitive parameter names
 -->
+
+# Configuration guide
+
+Check out the [Externalized configuration guide](configuration/index.md) to learn about fine tuning GeoServer-Cloud applications.

--- a/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/autoconfigure/catalog/GeoServerBackendAutoConfiguration.java
+++ b/starters/catalog-backend-starter/src/main/java/org/geoserver/cloud/autoconfigure/catalog/GeoServerBackendAutoConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.autoconfigure.catalog;
 
 import org.geoserver.cloud.config.catalog.CoreBackendConfiguration;
+import org.geotools.autoconfigure.httpclient.GeoToolsHttpClientAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -19,6 +20,7 @@ import org.springframework.context.annotation.Import;
  * (provided their configs are included in this class' {@code @Import} list)
  */
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(GeoToolsHttpClientAutoConfiguration.class)
 @Import({ //
     CoreBackendConfiguration.class, //
     DataDirectoryAutoConfiguration.class, //

--- a/starters/catalog-backend-starter/src/main/java/org/geotools/autoconfigure/httpclient/GeoToolsHttpClientAutoConfiguration.java
+++ b/starters/catalog-backend-starter/src/main/java/org/geotools/autoconfigure/httpclient/GeoToolsHttpClientAutoConfiguration.java
@@ -1,0 +1,114 @@
+/*
+ * (c) 2021 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geotools.autoconfigure.httpclient;
+
+import lombok.extern.slf4j.Slf4j;
+import org.geotools.autoconfigure.httpclient.ProxyConfig.ProxyHostConfig;
+import org.geotools.http.HTTPClientFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@link EnableAutoConfiguration @EnableAutoConfiguration} auto configuration for a GeoTools {@link
+ * HTTPClientFactory} that can be configured through spring-boot externalized properties and only
+ * affects GeoTools http clients instead of the whole JVM.
+ *
+ * <p>The usual way to set an http proxy is through the {@literal http.proxyHost}, {@literal
+ * http.proxyPort}, {@literal http.proxyUser}, {@literal http.proxyPassword} Java System Properties.
+ *
+ * <p>In the context of Cloud Native GeoServer containerized applications, this has a number of
+ * drawbacks:
+ *
+ * <ul>
+ *   <li>Standard java proxy parameters only work with System properties, not env variables (at
+ *       least with the apache http client), and setting system properties is more cumbersome than
+ *       env variables (you have to modify the container run command)
+ *   <li>{@literal http.proxyUser/Password} are not standard properties, though commonly used, it's
+ *       kind of JDK implementation dependent.
+ *   <li>Setting {@literal -Dhtt.proxy*} System properties affects all HTTP clients in the
+ *       container, meaning requests to the {@literal config-service}, {@literal discovery-service},
+ *       etc., will also try to go through the proxy, or you need to go through the extra burden of
+ *       figuring out how to ignore them.
+ *   <li>If the proxy is secured, and since the http client used may not respect the {@literal
+ *       http.proxyUser/Password} parameters, the apps won't start since they'll get HTTP 407 "Proxy
+ *       Authentication Required".
+ * </ul>
+ *
+ * <p>The following externalized configuration properties apply:
+ *
+ * <pre>
+ * <code>
+ * geotools:
+ *   httpclient:
+ *     proxy:
+ *       # defaults to true, false disables the autoconfiguration and falls back to standard GeoServer behavior
+ *       enabled: true
+ *       http:
+ *         host:
+ *         port:
+ *         user:
+ *         password:
+ *         nonProxyHosts:
+ *         # comma separated list of Java regular expressions, e.g.: nonProxyHosts: localhost, example.*
+ *       https:
+ *         host:
+ *         port:
+ *         user:
+ *         password:
+ *         nonProxyHosts:
+ * </code>
+ * </pre>
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties
+@ConditionalOnProperty(
+    prefix = "geotools.httpclient.proxy",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true
+)
+@Slf4j(topic = "org.geotools.autoconfigure.httpclient")
+public class GeoToolsHttpClientAutoConfiguration {
+
+    @ConfigurationProperties(prefix = "geotools.httpclient.proxy")
+    public @Bean ProxyConfig geoToolsHttpProxyConfiguration() {
+        System.setProperty(
+                "HTTP_CLIENT_FACTORY",
+                SpringEnvironmentAwareGeoToolsHttpClientFactory.class.getCanonicalName());
+        return new ProxyConfig();
+    }
+
+    public @Bean SpringEnvironmentAwareGeoToolsHttpClientFactory
+            springEnvironmentAwareGeoToolsHttpClientFactory(@Autowired ProxyConfig proxyConfig) {
+
+        log.info("Using spring environment aware GeoTools HTTPClientFactory");
+        log(proxyConfig.getHttp(), "HTTP");
+        log(proxyConfig.getHttps(), "HTTPS");
+        SpringEnvironmentAwareGeoToolsHttpClientFactory.setProxyConfig(proxyConfig);
+
+        return new SpringEnvironmentAwareGeoToolsHttpClientFactory();
+    }
+
+    private void log(ProxyHostConfig config, String protocol) {
+        config.host()
+                .ifPresentOrElse(
+                        host ->
+                                log.info(
+                                        "{} proxy configured for GeoTools cascaded OWS stores: {}:{}, secured: {}",
+                                        protocol,
+                                        host,
+                                        config.port(),
+                                        config.isSecured()),
+                        () ->
+                                log.info(
+                                        "No {} proxy configured for GeoTools cascaded OWS stores",
+                                        protocol));
+    }
+}

--- a/starters/catalog-backend-starter/src/main/java/org/geotools/autoconfigure/httpclient/ProxyConfig.java
+++ b/starters/catalog-backend-starter/src/main/java/org/geotools/autoconfigure/httpclient/ProxyConfig.java
@@ -1,0 +1,64 @@
+/*
+ * (c) 2021 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geotools.autoconfigure.httpclient;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import lombok.Data;
+import lombok.NonNull;
+import org.springframework.util.StringUtils;
+
+/** */
+public @Data class ProxyConfig {
+
+    private boolean enabled = true;
+    private ProxyHostConfig http = new ProxyHostConfig();
+    private ProxyHostConfig https = new ProxyHostConfig();
+
+    public static @Data class ProxyHostConfig {
+        private String host;
+        private Integer port;
+        private String user;
+        private String password;
+        private List<Pattern> nonProxyHosts;
+
+        public Optional<ProxyHostConfig> forHost(@NonNull String targetHostname) {
+            if (host().isEmpty()) {
+                return Optional.empty();
+            }
+            for (Pattern p : nonProxyHosts()) {
+                if (p.matcher(targetHostname).matches()) {
+                    return Optional.empty();
+                }
+            }
+            return Optional.of(this);
+        }
+
+        public List<Pattern> nonProxyHosts() {
+            return this.nonProxyHosts == null ? List.of() : this.nonProxyHosts;
+        }
+
+        public Optional<String> host() {
+            return StringUtils.hasLength(this.host) ? Optional.of(this.host) : Optional.empty();
+        }
+
+        public int port() {
+            return port == null ? 80 : port.intValue();
+        }
+
+        public boolean isSecured() {
+            return StringUtils.hasLength(host)
+                    && StringUtils.hasLength(user)
+                    && StringUtils.hasLength(password);
+        }
+    }
+
+    public ProxyHostConfig ofProtocol(@NonNull String protocol) {
+        if ("http".equals(protocol)) return http == null ? new ProxyHostConfig() : http;
+        if ("https".equals(protocol)) return https == null ? new ProxyHostConfig() : https;
+        throw new IllegalArgumentException("Uknown protocol " + protocol + ". Expected http(s)");
+    }
+}

--- a/starters/catalog-backend-starter/src/main/java/org/geotools/autoconfigure/httpclient/SpringEnvironmentAwareGeoToolsHttpClient.java
+++ b/starters/catalog-backend-starter/src/main/java/org/geotools/autoconfigure/httpclient/SpringEnvironmentAwareGeoToolsHttpClient.java
@@ -1,0 +1,390 @@
+/*
+ * GeoTools - The Open Source Java GIS Toolkit http://geotools.org
+ *
+ * (C) 2004-2011, Open Source Geospatial Foundation (OSGeo)
+ *
+ * This library is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation; version 2.1 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ */
+/*
+ * (c) 2021 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geotools.autoconfigure.httpclient;
+
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofSeconds;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
+import lombok.NonNull;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.geotools.autoconfigure.httpclient.ProxyConfig.ProxyHostConfig;
+import org.geotools.http.HTTPClient;
+import org.geotools.http.HTTPConnectionPooling;
+import org.geotools.http.HTTPProxy;
+import org.geotools.http.HTTPResponse;
+import org.geotools.util.factory.GeoTools;
+import org.springframework.core.env.PropertyResolver;
+
+/**
+ * Copy of GeoTools' {@link org.geotools.http.commons.MultithreadedHttpClient} due to its lack of
+ * extensibility, adding the ability to set up the Apache HTTPClient's proxy configuration from
+ * Spring {@link PropertyResolver}'s properties.
+ */
+class SpringEnvironmentAwareGeoToolsHttpClient
+        implements HTTPClient, HTTPConnectionPooling, HTTPProxy {
+
+    private final PoolingHttpClientConnectionManager connectionManager;
+
+    private HttpClient client;
+
+    private String user;
+
+    private String password;
+
+    private boolean tryGzip = true;
+
+    private RequestConfig connectionConfig;
+
+    private BasicCredentialsProvider credsProvider = null;
+
+    private ProxyConfig proxyConfig;
+
+    public SpringEnvironmentAwareGeoToolsHttpClient(@NonNull ProxyConfig proxyConfig) {
+        this.proxyConfig = proxyConfig;
+        connectionManager = new PoolingHttpClientConnectionManager();
+        connectionManager.setMaxTotal(6);
+        connectionManager.setDefaultMaxPerRoute(6);
+        connectionConfig =
+                RequestConfig.custom()
+                        .setCookieSpec(CookieSpecs.DEFAULT)
+                        .setExpectContinueEnabled(true)
+                        .setSocketTimeout((int) ofSeconds(30).toMillis())
+                        .setConnectTimeout((int) ofSeconds(30).toMillis())
+                        .build();
+        resetCredentials();
+        client = builder().build();
+    }
+
+    private RequestConfig connectionConfig(URL url) {
+        RequestConfig reqConf = this.connectionConfig;
+        Optional<HttpHost> proxy = proxy(url);
+        if (proxy.isPresent()) {
+            HttpHost proxyHost = proxy.get();
+            reqConf = RequestConfig.copy(reqConf).setProxy(proxyHost).build();
+        }
+        return reqConf;
+    }
+
+    private Optional<HttpHost> proxy(URL url) {
+        final ProxyConfig config = this.proxyConfig;
+        final String host = url.getHost();
+        return config.ofProtocol(url.getProtocol()).forHost(host).map(this::toHttpHost);
+    }
+
+    private HttpHost toHttpHost(ProxyHostConfig conf) {
+        String host = conf.getHost();
+        int port = conf.port();
+        return new HttpHost(host, port);
+    }
+
+    private void resetCredentials() {
+        // overrides defaulting to SystemDefaultCredentialsProvider
+        BasicCredentialsProvider provider = new BasicCredentialsProvider();
+        if (user != null && password != null) {
+            setTargetCredentials(provider, user, password);
+        }
+        setProxyCredentials(provider, this.proxyConfig.getHttp());
+        setProxyCredentials(provider, this.proxyConfig.getHttps());
+        this.credsProvider = provider;
+        client = builder().build();
+    }
+
+    private void setProxyCredentials(BasicCredentialsProvider provider, ProxyHostConfig proxy) {
+        if (proxy.isSecured()) {
+            AuthScope scope = new AuthScope(toHttpHost(proxy));
+            String proxyUser = proxy.getUser();
+            String proxyPassword = proxy.getPassword();
+            Credentials credentials = new UsernamePasswordCredentials(proxyUser, proxyPassword);
+            provider.setCredentials(scope, credentials);
+        }
+    }
+
+    private void setTargetCredentials(
+            BasicCredentialsProvider provider, String user2, String password2) {
+        AuthScope authscope = AuthScope.ANY;
+        Credentials credentials = new UsernamePasswordCredentials(user, password);
+        // TODO - check if this works for all types of auth or do we need to look it up?
+        provider.setCredentials(authscope, credentials);
+    }
+
+    private HttpClientBuilder builder() {
+        HttpClientBuilder builder =
+                HttpClientBuilder.create()
+                        .setUserAgent(
+                                String.format(
+                                        "GeoTools/%s (%s)",
+                                        GeoTools.getVersion(), this.getClass().getSimpleName()))
+                        .useSystemProperties()
+                        .setConnectionManager(connectionManager);
+        if (credsProvider != null) {
+            builder.setDefaultCredentialsProvider(credsProvider);
+        }
+        return builder;
+    }
+
+    public @Override HttpMethodResponse post(
+            final URL url, final InputStream postContent, final String postContentType)
+            throws IOException {
+
+        HttpPost postMethod = new HttpPost(url.toExternalForm());
+        postMethod.setConfig(connectionConfig(url));
+        HttpEntity requestEntity;
+        if (credsProvider != null) {
+            // we can't read the input stream twice as would be needed if the server asks us to
+            // authenticate
+            String input =
+                    new BufferedReader(new InputStreamReader(postContent, StandardCharsets.UTF_8))
+                            .lines()
+                            .collect(Collectors.joining("\n"));
+            requestEntity = new StringEntity(input);
+        } else {
+            requestEntity = new InputStreamEntity(postContent);
+        }
+        if (tryGzip) {
+            postMethod.setHeader("Accept-Encoding", "gzip");
+        }
+        if (postContentType != null) {
+            postMethod.setHeader("Content-type", postContentType);
+        }
+
+        postMethod.setEntity(requestEntity);
+
+        HttpMethodResponse response = null;
+        try {
+            response = executeMethod(postMethod);
+        } catch (HttpException e) {
+            throw new IOException(e);
+        }
+        if (200 != response.getStatusCode()) {
+            postMethod.releaseConnection();
+            throw new IOException(
+                    "Server returned HTTP error code "
+                            + response.getStatusCode()
+                            + " for URL "
+                            + url.toExternalForm());
+        }
+
+        return response;
+    }
+
+    /** @return the http status code of the execution */
+    private HttpMethodResponse executeMethod(HttpRequestBase method)
+            throws IOException, HttpException {
+
+        HttpClientContext localContext = HttpClientContext.create();
+        HttpResponse resp;
+        if (credsProvider != null) {
+            localContext.setCredentialsProvider(credsProvider);
+            resp = client.execute(method, localContext);
+        } else {
+            resp = client.execute(method);
+        }
+
+        HttpMethodResponse response = new HttpMethodResponse(resp);
+
+        return response;
+    }
+
+    public @Override HTTPResponse get(final URL url) throws IOException {
+        return this.get(url, null);
+    }
+
+    public @Override HTTPResponse get(URL url, Map<String, String> headers) throws IOException {
+        HttpGet getMethod = new HttpGet(url.toExternalForm());
+        getMethod.setConfig(connectionConfig(url));
+
+        if (tryGzip) {
+            getMethod.setHeader("Accept-Encoding", "gzip");
+        }
+
+        if (headers != null) {
+            for (Map.Entry<String, String> headerNameValue : headers.entrySet()) {
+                getMethod.setHeader(headerNameValue.getKey(), headerNameValue.getValue());
+            }
+        }
+
+        HttpMethodResponse response = null;
+        try {
+            response = executeMethod(getMethod);
+        } catch (HttpException e) {
+            throw new IOException(e);
+        }
+
+        if (200 != response.getStatusCode()) {
+            getMethod.releaseConnection();
+            throw new IOException(
+                    "Server returned HTTP error code "
+                            + response.getStatusCode()
+                            + " for URL "
+                            + url.toExternalForm());
+        }
+        return response;
+    }
+
+    public @Override String getUser() {
+        return user;
+    }
+
+    public @Override void setUser(String user) {
+        this.user = user;
+        resetCredentials();
+    }
+
+    public @Override String getPassword() {
+        return password;
+    }
+
+    public @Override void setPassword(String password) {
+        this.password = password;
+        resetCredentials();
+    }
+
+    public @Override int getConnectTimeout() {
+        return (int) ofMillis(connectionConfig.getConnectionRequestTimeout()).toSeconds();
+    }
+
+    public @Override void setConnectTimeout(int connectTimeout) {
+        connectionConfig =
+                RequestConfig.copy(connectionConfig)
+                        .setConnectionRequestTimeout((int) ofSeconds(connectTimeout).toMillis())
+                        .build();
+    }
+
+    public @Override int getReadTimeout() {
+        return (int) ofMillis(connectionConfig.getSocketTimeout()).toSeconds();
+    }
+
+    public @Override void setReadTimeout(int readTimeout) {
+        connectionConfig =
+                RequestConfig.copy(connectionConfig)
+                        .setSocketTimeout((int) ofSeconds(readTimeout).toMillis())
+                        .build();
+    }
+
+    public @Override int getMaxConnections() {
+        return connectionManager.getDefaultMaxPerRoute();
+    }
+
+    public @Override void setMaxConnections(final int maxConnections) {
+        connectionManager.setDefaultMaxPerRoute(maxConnections);
+        connectionManager.setMaxTotal(maxConnections);
+    }
+
+    static class HttpMethodResponse implements HTTPResponse {
+
+        private org.apache.http.HttpResponse methodResponse;
+
+        private InputStream responseBodyAsStream;
+
+        public HttpMethodResponse(final org.apache.http.HttpResponse methodResponse) {
+            this.methodResponse = methodResponse;
+        }
+
+        public int getStatusCode() {
+            if (methodResponse != null) {
+                StatusLine statusLine = methodResponse.getStatusLine();
+                return statusLine.getStatusCode();
+            } else {
+                return -1;
+            }
+        }
+
+        public @Override void dispose() {
+            if (responseBodyAsStream != null) {
+                try {
+                    responseBodyAsStream.close();
+                } catch (IOException e) {
+                    // ignore
+                }
+            }
+
+            if (methodResponse != null) {
+                methodResponse = null;
+            }
+        }
+
+        public @Override String getContentType() {
+            return getResponseHeader("Content-Type");
+        }
+
+        public @Override String getResponseHeader(final String headerName) {
+            Header responseHeader = methodResponse.getFirstHeader(headerName);
+            return responseHeader == null ? null : responseHeader.getValue();
+        }
+
+        public @Override InputStream getResponseStream() throws IOException {
+            if (responseBodyAsStream == null) {
+                responseBodyAsStream = methodResponse.getEntity().getContent();
+                // commons httpclient does not handle gzip encoding automatically, we have to check
+                // ourselves: https://issues.apache.org/jira/browse/HTTPCLIENT-816
+                Header header = methodResponse.getFirstHeader("Content-Encoding");
+                if (header != null && "gzip".equals(header.getValue())) {
+                    responseBodyAsStream = new GZIPInputStream(responseBodyAsStream);
+                }
+            }
+            return responseBodyAsStream;
+        }
+
+        public @Override String getResponseCharset() {
+            final Header encoding = methodResponse.getEntity().getContentEncoding();
+            return encoding == null ? null : encoding.getValue();
+        }
+    }
+
+    public @Override void setTryGzip(boolean tryGZIP) {
+        this.tryGzip = tryGZIP;
+    }
+
+    public @Override boolean isTryGzip() {
+        return tryGzip;
+    }
+
+    public @Override void close() {
+        this.connectionManager.shutdown();
+    }
+}

--- a/starters/catalog-backend-starter/src/main/java/org/geotools/autoconfigure/httpclient/SpringEnvironmentAwareGeoToolsHttpClientFactory.java
+++ b/starters/catalog-backend-starter/src/main/java/org/geotools/autoconfigure/httpclient/SpringEnvironmentAwareGeoToolsHttpClientFactory.java
@@ -1,0 +1,57 @@
+/*
+ * (c) 2021 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geotools.autoconfigure.httpclient;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Setter;
+import org.geotools.http.AbstractHTTPClientFactory;
+import org.geotools.http.HTTPBehavior;
+import org.geotools.http.HTTPClient;
+import org.geotools.http.HTTPConnectionPooling;
+import org.geotools.http.LoggingHTTPClient;
+
+/** */
+public class SpringEnvironmentAwareGeoToolsHttpClientFactory extends AbstractHTTPClientFactory {
+
+    private static @Setter(value = AccessLevel.PACKAGE) ProxyConfig proxyConfig = new ProxyConfig();
+
+    public @Override List<Class<?>> clientClasses() {
+        return List.of(SpringEnvironmentAwareGeoToolsHttpClient.class);
+    }
+
+    public @Override final HTTPClient createClient(List<Class<? extends HTTPBehavior>> behaviors) {
+        return new SpringEnvironmentAwareGeoToolsHttpClient(proxyConfig);
+    }
+
+    protected @Override HTTPClient createLogging(HTTPClient client) {
+        return new LoggingConnectionPoolingHTTPClient(client);
+    }
+
+    static class LoggingConnectionPoolingHTTPClient extends LoggingHTTPClient
+            implements HTTPConnectionPooling {
+
+        public LoggingConnectionPoolingHTTPClient(HTTPClient delegate) {
+            super(delegate);
+        }
+
+        public LoggingConnectionPoolingHTTPClient(HTTPClient delegate, String charset) {
+            super(delegate, charset);
+        }
+
+        @Override
+        public int getMaxConnections() {
+            return ((HTTPConnectionPooling) delegate).getMaxConnections();
+        }
+
+        @Override
+        public void setMaxConnections(int maxConnections) {
+            ((HTTPConnectionPooling) delegate).setMaxConnections(maxConnections);
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/starters/catalog-backend-starter/src/main/resources/META-INF/services/org.geotools.http.HTTPClientFactory
+++ b/starters/catalog-backend-starter/src/main/resources/META-INF/services/org.geotools.http.HTTPClientFactory
@@ -1,0 +1,1 @@
+org.geotools.autoconfigure.httpclient.SpringEnvironmentAwareGeoToolsHttpClientFactory

--- a/starters/catalog-backend-starter/src/main/resources/META-INF/spring.factories
+++ b/starters/catalog-backend-starter/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,4 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.geotools.autoconfigure.httpclient.GeoToolsHttpClientAutoConfiguration,\
 org.geoserver.cloud.autoconfigure.catalog.GeoServerBackendAutoConfiguration,\
 org.geoserver.cloud.autoconfigure.security.GeoServerSecurityAutoConfiguration


### PR DESCRIPTION
AutoConfiguration for HTTP proxy-aware GeoTools HTTPClientFactory
    
Auto configuration for a GeoTools HTTPClientFactory that can be configured
through spring-boot externalized properties and only affects GeoTools http
clients instead of the whole JVM.
    
The usual way to set an http proxy is through the http.proxyHost, http.proxyPort,
http.proxyUser, http.proxyPassword Java System Properties.
    
In the context of Cloud Native GeoServer containerized applications,
this has a number of drawbacks:
* Standard java proxy parameters only work with System properties, not env variables (at
    least with the apache http client), and setting system properties is more cumbersome
    than env variables (you have to modify the container run command)
* http.proxyUser/Password are not standard properties, though commonly used, it's kind of
    JDK implementation dependent.
* Setting -Dhtt.proxy* System properties affects all HTTP clients in the container, meaning
    requests to the config-service, discovery-service, etc., will also try to go through the proxy,
    or you need to go through the extra burden of figuring out how to ignore them.
* If the proxy is secured, and since the http client used may not respect the
    http.proxyUser/Password parameters, the apps won't start since they'll get
    HTTP 407 "Proxy Authentication Required".
    
The following externalized configuration properties apply:

```yaml
# Common configuration for all services. Override or add service specific config
# properties on each <service-name>-service.yml file

# GeoTools HTTP Client proxy configuration, allows configuring cascaded WMS/WMTS/WFS stores
# that need to go through an HTTP proxy without affecting all the http clients at the JVM level
# These are default settings. The enabled property can be set to false to disable the custom
# HTTPClientFactory altogether.
# The following OS environment variables can be set for easier configuration:
# HTTP(S)_PROXYHOST, HTTP(S)_PROXYPORT, HTTP(S)_PROXYUSER, HTTP(S)_PROXYPASSWORD, HTTP(S)_NONPROXYHOSTS
geotools:
  httpclient:
    proxy:
      enabled: true
      http:
        host: ${http.proxyHost:}
        port: ${http.proxyPort:}
        user: ${http.proxyUser:}
        password: ${http.proxyPassword:}
        nonProxyHosts: ${http.nonProxyHosts:localhost.*}
        # comma separated list of Java regular expressions, e.g.: nonProxyHosts: localhost, example.*
      https:
        host: ${https.proxyHost:${geotools.httpclient.proxy.http.host}}
        port: ${https.proxyPort:${geotools.httpclient.proxy.http.port}}
        user: ${https.proxyUser:${geotools.httpclient.proxy.http.user}}
        password: ${https.proxyPassword:${geotools.httpclient.proxy.http.password}}
        nonProxyHosts: ${https.nonProxyHosts:${geotools.httpclient.proxy.http.nonProxyHosts}}
```