### PR TITLE
RemoteApplicationEvent event serialization fails on remote style infos

### DIFF
--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/autoconfigure/bus/RemoteInfoEventInboundResolver.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/autoconfigure/bus/RemoteInfoEventInboundResolver.java
@@ -39,15 +39,15 @@ public class RemoteInfoEventInboundResolver {
     private Function<Info, Info> configInfoResolver;
     private Function<CatalogInfo, CatalogInfo> catalogInfoResolver;
 
-    public @Autowired void setCatalog(@Qualifier("catalog") Catalog catalog) {
+    public @Autowired void setCatalog(@Qualifier("rawCatalog") Catalog rawCatalog) {
         configInfoResolver =
                 CollectionPropertiesInitializer.<Info>instance()
-                        .andThen(ResolvingProxyResolver.<Info>of(catalog));
+                        .andThen(ResolvingProxyResolver.<Info>of(rawCatalog));
 
         catalogInfoResolver =
                 CollectionPropertiesInitializer.<CatalogInfo>instance()
-                        .andThen(CatalogPropertyResolver.of(catalog))
-                        .andThen(ResolvingProxyResolver.of(catalog));
+                        .andThen(CatalogPropertyResolver.of(rawCatalog))
+                        .andThen(ResolvingProxyResolver.of(rawCatalog));
     }
 
     @Order(HIGHEST_PRECEDENCE)

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/LocalApplicationEventPublisher.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/LocalApplicationEventPublisher.java
@@ -91,6 +91,10 @@ public class LocalApplicationEventPublisher {
         private final LocalApplicationEventPublisher publisher;
         private final Catalog catalog;
 
+        /**
+         * @throws CatalogException meaning the operation that generated the event should be
+         *     reverted (as handled by Catalog.event())
+         */
         private void publish(LocalInfoEvent<?, ?> event) throws CatalogException {
             try {
                 publisher.publish(event);


### PR DESCRIPTION
Cascaded WMS stores configure layers with a default style that has no id, and produces a serialization error for the distributed event that's to be sent over the bus.

This fixes by using the "raw catalog" to process incoming events, and hence avoid potential issues with Catalog decorators (e.g. `SecuredCatalogImpl`), and ignoring the serialization of event payload for id-less styles with `isRemote=true` metadata in `LayerInfo's`.