### PR TITLE
gs-jackson-bindings: add new property AttributeType.source:String

### DIFF
--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/AttributeType.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/AttributeType.java
@@ -17,4 +17,12 @@ public class AttributeType {
     private Map<String, Serializable> metadata;
     private String binding;
     private Integer length;
+
+    /**
+     * Source expression (a valid CQL expression). If not set, it will default to the attribute name
+     * (in AttributeTypeInfoImpl, not here, here it can be {@code null}).
+     *
+     * @since GeoServer 2.21
+     */
+    private String source;
 }


### PR DESCRIPTION
`AttributeTypeInfo` for a new property `source` at
https://github.com/geoserver/geoserver/commit/01bd2f2deb6fee761ca96b7035f6178996c6a16e.

Add it to geoserver's jackson module's `AttributeType`.