### PR TITLE
Add vector tiles output format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,11 @@
       </dependency>
       <dependency>
         <groupId>org.geoserver.cloud</groupId>
+        <artifactId>gs-cloud-starter-wms-extensions</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.cloud</groupId>
         <artifactId>gs-cloud-pluggable-catalog-support</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -489,9 +494,19 @@
         <version>${gs.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.geoserver.extension</groupId>
+        <artifactId>gs-ysld</artifactId>
+        <version>${gs.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.geoserver.community</groupId>
         <artifactId>gs-geostyler</artifactId>
         <version>${gs.community.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.extension</groupId>
+        <artifactId>gs-vectortiles</artifactId>
+        <version>${gs.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geotools</groupId>

--- a/services/web-ui/pom.xml
+++ b/services/web-ui/pom.xml
@@ -22,6 +22,10 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-starter-wms-extensions</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-cloud-starter-vector-formats</artifactId>
     </dependency>
     <dependency>
@@ -239,18 +243,6 @@
         <dependency>
           <groupId>org.geoserver.importer</groupId>
           <artifactId>gs-importer-web</artifactId>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>css</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>org.geoserver.extension</groupId>
-          <artifactId>gs-css</artifactId>
         </dependency>
       </dependencies>
     </profile>

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebCoreConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebCoreConfiguration.java
@@ -18,8 +18,7 @@ import org.springframework.context.annotation.ImportResource;
 @ImportResource( //
     reader = FilteringXmlBeanDefinitionReader.class, //
     locations = { //
-        "jar:gs-web-core-.*!/applicationContext.xml", //
-        "jar:gs-css-.*!/applicationContext.xml" //
+        "jar:gs-web-core-.*!/applicationContext.xml" //
     }
 )
 public class WebCoreConfiguration {

--- a/services/web-ui/src/main/resources/bootstrap.yml
+++ b/services/web-ui/src/main/resources/bootstrap.yml
@@ -57,6 +57,14 @@ eureka:
       enabled: false # must only be set to true in application.yml, not bootstrap
 
 geoserver:
+  styling:
+    css.enabled: true
+  wms:
+    output-formats:
+      vector-tiles:
+        mapbox.enabled: true
+        geojson.enabled: false
+        topojson.enabled: false
   web-ui:
     file-browser.hide-file-system: true
     # These are all default values, here just for reference. You can omit them and add only the ones to disable or further configure

--- a/services/wms/pom.xml
+++ b/services/wms/pom.xml
@@ -21,6 +21,10 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-starter-wms-extensions</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-cloud-starter-vector-formats</artifactId>
     </dependency>
     <dependency>
@@ -115,24 +119,6 @@
         <dependency>
           <groupId>org.geotools</groupId>
           <artifactId>gt-process-feature</artifactId>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>css</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>org.geoserver.extension</groupId>
-          <artifactId>gs-css</artifactId>
-          <exclusions>
-            <exclusion>
-              <artifactId>wicket-extensions</artifactId>
-              <groupId>org.apache.wicket</groupId>
-            </exclusion>
-          </exclusions>
         </dependency>
       </dependencies>
     </profile>

--- a/services/wms/src/main/java/org/geoserver/cloud/wms/WmsApplicationConfiguration.java
+++ b/services/wms/src/main/java/org/geoserver/cloud/wms/WmsApplicationConfiguration.java
@@ -19,8 +19,7 @@ import org.springframework.context.annotation.ImportResource;
     locations = { //
         "jar:gs-wms-.*!/applicationContext.xml", //
         "jar:gs-wfs-.*!/applicationContext.xml#name="
-                + WmsApplicationConfiguration.WFS_BEANS_REGEX, //
-        "jar:gs-css-.*!/applicationContext.xml" //
+                + WmsApplicationConfiguration.WFS_BEANS_REGEX //
     }
 )
 public class WmsApplicationConfiguration {

--- a/starters/pom.xml
+++ b/starters/pom.xml
@@ -17,6 +17,7 @@
     <module>starter-raster-formats</module>
     <module>starter-webmvc</module>
     <module>starter-reactive</module>
+    <module>starter-wms-extensions</module>
   </modules>
   <dependencies>
     <dependency>

--- a/starters/starter-wms-extensions/pom.xml
+++ b/starters/starter-wms-extensions/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.geoserver.cloud</groupId>
+    <artifactId>gs-cloud-starters</artifactId>
+    <version>${revision}</version>
+  </parent>
+  <artifactId>gs-cloud-starter-wms-extensions</artifactId>
+  <packaging>jar</packaging>
+  <description>Curated list of supported WMS extensions with auto configuration</description>
+  <dependencies>
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-css</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>wicket-extensions</artifactId>
+          <groupId>org.apache.wicket</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-vectortiles</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+</project>

--- a/starters/starter-wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/CssStylingConfiguration.java
+++ b/starters/starter-wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/CssStylingConfiguration.java
@@ -1,0 +1,70 @@
+/*
+ * (c) 2021 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.wms;
+
+import org.apache.batik.svggen.StyleHandler;
+import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.community.css.web.CssHandler;
+import org.geoserver.platform.ModuleStatus;
+import org.geoserver.platform.ModuleStatusImpl;
+import org.geotools.styling.css.CssParser;
+import org.geotools.util.Version;
+import org.geotools.util.factory.GeoTools;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.ImportResource;
+
+/** @since 1.0 */
+@Configuration
+@Import(value = {CssStylingConfiguration.Enabled.class, CssStylingConfiguration.Disabled.class})
+class CssStylingConfiguration {
+
+    @ConditionalOnBean(name = "sldHandler")
+    @ConditionalOnProperty(
+        name = "geoserver.styling.css.enabled",
+        havingValue = "true",
+        matchIfMissing = true
+    )
+    @ConditionalOnClass(CssHandler.class)
+    @ImportResource( //
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = {"jar:gs-css-.*!/applicationContext.xml"}
+    )
+    static class Enabled {}
+
+    /**
+     * {@link CssHandler} is both a {@link StyleHandler} and a {@link ModuleStatus}. This config
+     * engages when css is disabled and provides a {@link ModuleStatus} with {@link
+     * ModuleStatus#isEnabled() == false}
+     *
+     * @since 1.0
+     */
+    @ConditionalOnBean(name = "sldHandler")
+    @ConditionalOnProperty(
+        name = "geoserver.styling.css.enabled",
+        havingValue = "false",
+        matchIfMissing = false
+    )
+    static class Disabled {
+
+        public @Bean ModuleStatus cssDisabledModuleStatus() {
+            ModuleStatusImpl mod = new ModuleStatusImpl();
+            mod.setAvailable(false);
+            mod.setEnabled(false);
+            mod.setMessage(
+                    "CSS module disabled through config property geoserver.styling.css.enabled=false");
+            mod.setComponent("GeoServer CSS Styling");
+            mod.setModule("gs-css");
+            mod.setName("CSS");
+            Version v = GeoTools.getVersion(CssParser.class);
+            mod.setVersion(v == null ? null : v.toString());
+            return mod;
+        }
+    }
+}

--- a/starters/starter-wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/VectorTilesConfiguration.java
+++ b/starters/starter-wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/VectorTilesConfiguration.java
@@ -1,0 +1,81 @@
+/*
+ * (c) 2021 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.wms;
+
+import javax.annotation.PostConstruct;
+import org.geoserver.cloud.autoconfigure.wms.WmsExtensionsConfigProperties.Wms.WmsOutputFormatsConfigProperties.VectorTilesConfigProperties;
+import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.wms.vector.VectorTileMapOutputFormat;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportResource;
+
+/** @since 1.0 */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(VectorTileMapOutputFormat.class)
+@EnableConfigurationProperties(WmsExtensionsConfigProperties.class)
+@ImportResource( //
+    reader = FilteringXmlBeanDefinitionReader.class, //
+    locations = {"jar:gs-vectortiles-.*!/applicationContext.xml#name=(VectorTilesExtension)"}
+)
+class VectorTilesConfiguration {
+
+    static final String PREFIX = "geoserver.wms.output-formats.vector-tiles";
+
+    private @Autowired @Qualifier("VectorTilesExtension") org.geoserver.platform.ModuleStatusImpl
+            extensionInfo;
+    private @Autowired WmsExtensionsConfigProperties config;
+
+    public @PostConstruct void init() {
+        VectorTilesConfigProperties vt = config.getWms().getOutputFormats().getVectorTiles();
+        extensionInfo.setEnabled(vt.anyEnabled());
+    }
+
+    @ConditionalOnProperty(
+        prefix = PREFIX + ".mapbox",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true
+    )
+    @ImportResource( //
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = {
+            "jar:gs-vectortiles-.*!/applicationContext.xml#name=(wmsMapBoxBuilderFactory|wmsMapBoxMapOutputFormat)"
+        }
+    )
+    static @Configuration class MapBox {}
+
+    @ConditionalOnProperty(
+        prefix = PREFIX + ".geojson",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true
+    )
+    @ImportResource( //
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = {
+            "jar:gs-vectortiles-.*!/applicationContext.xml#name=(wmsGeoJsonBuilderFactory|wmsGeoJsonMapOutputFormat)"
+        }
+    )
+    static @Configuration class GeoJson {}
+
+    @ConditionalOnProperty(
+        prefix = PREFIX + ".topojson",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true
+    )
+    @ImportResource( //
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = {
+            "jar:gs-vectortiles-.*!/applicationContext.xml#name=(wmsTopoJSONBuilderFactory|wmsTopoJSONMapOutputFormat)"
+        }
+    )
+    static @Configuration class TopoJson {}
+}

--- a/starters/starter-wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/WmsExtensionsAutoConfiguration.java
+++ b/starters/starter-wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/WmsExtensionsAutoConfiguration.java
@@ -1,0 +1,15 @@
+/*
+ * (c) 2021 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.wms;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/** @since 1.0 */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(WmsExtensionsConfigProperties.class)
+@Import(value = {CssStylingConfiguration.class, VectorTilesConfiguration.class})
+public class WmsExtensionsAutoConfiguration {}

--- a/starters/starter-wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/WmsExtensionsConfigProperties.java
+++ b/starters/starter-wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/WmsExtensionsConfigProperties.java
@@ -1,0 +1,70 @@
+/*
+ * (c) 2021 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.wms;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for Web Map Service extensions.
+ *
+ * <p>Available properties:
+ *
+ * <pre>{@code
+ * geoserver:
+ *   styling:
+ *     css.enabled: true
+ *   wms:
+ *     outputFormats:
+ *       vectorTiles:
+ *         mapbox.enabled: true
+ *         geojson.enabled: true
+ *         topojson.enabled: true
+ * }</pre>
+ *
+ * @since 1.0
+ */
+@ConfigurationProperties(prefix = "geoserver")
+public @Data class WmsExtensionsConfigProperties {
+
+    private Styling styling = new Styling();
+    private Wms wms = new Wms();
+
+    public static @Data @NoArgsConstructor @AllArgsConstructor class EnabledProperty {
+        private boolean enabled;
+    }
+
+    public static @Data class Styling {
+        private EnabledProperty css = new EnabledProperty();
+    }
+
+    public static @Data class Wms {
+        private WmsOutputFormatsConfigProperties outputFormats =
+                new WmsOutputFormatsConfigProperties();
+
+        public static @Data class WmsOutputFormatsConfigProperties {
+            private VectorTilesConfigProperties vectorTiles = new VectorTilesConfigProperties();
+
+            public static @Data class VectorTilesConfigProperties {
+                /** Enable or disable MapBox VectorTiles output format */
+                private EnabledProperty mapbox = new EnabledProperty(true);
+                /** Enable or disable GeoJSON VectorTiles output format */
+                private EnabledProperty geojson = new EnabledProperty(true);
+                /** Enable or disable TopoJSON VectorTiles output format */
+                private EnabledProperty topojson = new EnabledProperty(true);
+
+                public boolean anyEnabled() {
+                    return isEnabled(mapbox) || isEnabled(geojson) || isEnabled(topojson);
+                }
+
+                private boolean isEnabled(EnabledProperty p) {
+                    return p != null && p.isEnabled();
+                }
+            }
+        }
+    }
+}

--- a/starters/starter-wms-extensions/src/main/resources/META-INF/spring.factories
+++ b/starters/starter-wms-extensions/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.geoserver.cloud.autoconfigure.wms.WmsExtensionsAutoConfiguration

--- a/starters/starter-wms-extensions/src/test/java/org/geoserver/cloud/autoconfigure/wms/CssStylingConfigurationTest.java
+++ b/starters/starter-wms-extensions/src/test/java/org/geoserver/cloud/autoconfigure/wms/CssStylingConfigurationTest.java
@@ -1,0 +1,68 @@
+/*
+ * (c) 2021 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.wms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.geoserver.catalog.SLDHandler;
+import org.geoserver.community.css.web.CssHandler;
+import org.geoserver.platform.ModuleStatusImpl;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * Test suite for {@link CssStylingConfiguration}
+ *
+ * @since 1.0
+ */
+public class CssStylingConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner()
+                    .withConfiguration(AutoConfigurations.of(CssStylingConfiguration.class));
+
+    @Test
+    void cssHandler_no_config() {
+        contextRunner
+                .withBean("sldHandler", SLDHandler.class)
+                .run(context -> assertThat(context).hasSingleBean(CssHandler.class));
+    }
+
+    @Test
+    void cssHandler_enabled() {
+        contextRunner
+                .withBean("sldHandler", SLDHandler.class)
+                .withPropertyValues("geoserver.styling.css.enabled=true")
+                .run(context -> assertThat(context).hasSingleBean(CssHandler.class));
+    }
+
+    @Test
+    void cssHandler_disabled_registers_module_status() {
+        contextRunner
+                .withBean("sldHandler", SLDHandler.class)
+                .withPropertyValues("geoserver.styling.css.enabled=false")
+                .run(
+                        (context) -> {
+                            assertThat(context).doesNotHaveBean(CssHandler.class);
+                            assertThat(context).hasBean("cssDisabledModuleStatus");
+                            assertThat(context)
+                                    .getBean("cssDisabledModuleStatus")
+                                    .isInstanceOf(ModuleStatusImpl.class);
+                        });
+    }
+
+    @Test
+    void cssHandler_conditional_on_sldHandler() {
+        contextRunner
+                .withPropertyValues("geoserver.styling.css.enabled=true")
+                .run(
+                        (context) -> {
+                            assertThat(context).doesNotHaveBean(SLDHandler.class);
+                            assertThat(context).doesNotHaveBean(CssHandler.class);
+                            assertThat(context).doesNotHaveBean("cssDisabledModuleStatus");
+                        });
+    }
+}

--- a/starters/starter-wms-extensions/src/test/java/org/geoserver/cloud/autoconfigure/wms/VectorTilesConfigurationTest.java
+++ b/starters/starter-wms-extensions/src/test/java/org/geoserver/cloud/autoconfigure/wms/VectorTilesConfigurationTest.java
@@ -1,0 +1,109 @@
+/*
+ * (c) 2021 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.wms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.geoserver.platform.ModuleStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * Test suite for {@link VectorTilesConfiguration}
+ *
+ * @since 1.0
+ */
+public class VectorTilesConfigurationTest {
+
+    private ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner()
+                    // .withBean(WmsExtensionsConfigProperties.class)
+                    .withConfiguration(AutoConfigurations.of(VectorTilesConfiguration.class));
+
+    @Test
+    void allEnabledByDefault() {
+        testAllEnabled();
+    }
+
+    @Test
+    void allEnabledExplicitly() {
+        contextRunner =
+                contextRunner.withPropertyValues(
+                        "geoserver.wms.output-formats.vector-tiles.mapbox.enabled=true",
+                        "geoserver.wms.output-formats.vector-tiles.geojson.enabled=true",
+                        "geoserver.wms.output-formats.vector-tiles.topojson.enabled=true");
+        testAllEnabled();
+    }
+
+    private void testAllEnabled() {
+        hasBeans(
+                "VectorTilesExtension",
+                "wmsMapBoxBuilderFactory",
+                "wmsMapBoxMapOutputFormat",
+                "wmsGeoJsonBuilderFactory",
+                "wmsGeoJsonMapOutputFormat",
+                "wmsGeoJsonBuilderFactory",
+                "wmsGeoJsonMapOutputFormat");
+    }
+
+    @Test
+    void enableOne() {
+        contextRunner =
+                contextRunner.withPropertyValues(
+                        "geoserver.wms.output-formats.vector-tiles.mapbox.enabled=true",
+                        "geoserver.wms.output-formats.vector-tiles.geojson.enabled=false",
+                        "geoserver.wms.output-formats.vector-tiles.topojson.enabled=false");
+
+        hasBeans("VectorTilesExtension", "wmsMapBoxBuilderFactory", "wmsMapBoxMapOutputFormat");
+        doesNotHaveBeans(
+                "wmsGeoJsonBuilderFactory",
+                "wmsGeoJsonMapOutputFormat",
+                "wmsGeoJsonBuilderFactory",
+                "wmsGeoJsonMapOutputFormat");
+    }
+
+    @Test
+    void allDisabled() {
+        contextRunner =
+                contextRunner.withPropertyValues(
+                        "geoserver.wms.output-formats.vector-tiles.mapbox.enabled=false",
+                        "geoserver.wms.output-formats.vector-tiles.geojson.enabled=false",
+                        "geoserver.wms.output-formats.vector-tiles.topojson.enabled=false");
+
+        hasBeans("VectorTilesExtension");
+        doesNotHaveBeans(
+                "wmsMapBoxBuilderFactory",
+                "wmsMapBoxMapOutputFormat",
+                "wmsGeoJsonBuilderFactory",
+                "wmsGeoJsonMapOutputFormat",
+                "wmsGeoJsonBuilderFactory",
+                "wmsGeoJsonMapOutputFormat");
+
+        contextRunner.run(
+                context ->
+                        assertThat(context)
+                                .getBean("VectorTilesExtension", ModuleStatus.class)
+                                .hasFieldOrPropertyWithValue("enabled", false));
+    }
+
+    private void hasBeans(String... beans) {
+        contextRunner.run(
+                context -> {
+                    for (String bean : beans) {
+                        assertThat(context).hasBean(bean);
+                    }
+                });
+    }
+
+    private void doesNotHaveBeans(String... beans) {
+        contextRunner.run(
+                context -> {
+                    for (String bean : beans) {
+                        assertThat(context).doesNotHaveBean(bean);
+                    }
+                });
+    }
+}


### PR DESCRIPTION
Fixes #135

Create gs-cloud-starter-wms-extensions module, and
externalize CSS styling and VT configuration
as autoconfiguration.

Added config properties:

```
geoserver:
  styling:
    css.enabled: true
  wms:
    output-formats:
      vector-tiles:
        mapbox.enabled: true
        geojson.enabled: true
        topojson.enabled: true
```