### PR TITLE
Web UI: hide unused global configuration UI controls

### DIFF
--- a/services/web-ui/README.md
+++ b/services/web-ui/README.md
@@ -109,3 +109,7 @@ The nested properties obey their parent's `enabled` settings, so for example, if
 ## Differences with monolith GeoServer application's Web UI
 
 - The `LogPage` (`/web/wicket/bookmarkable/org.geoserver.web.admin.LogPage`) menu entry is removed.
+- The `GlobalSettingsPage`'s `logging settings` field set is hidden. A copy of `GlobalSettingsPage.html`
+is provided, adding an `id` attribute to the `fieldset` that groups the logging configuration form elements
+(`<fieldset id="loggingSettingsFieldset">`), which is in turn hidden using CSS in the contributed `geoserver-cloud.css` stylesheet.
+

--- a/services/web-ui/README.md
+++ b/services/web-ui/README.md
@@ -112,8 +112,10 @@ The nested properties obey their parent's `enabled` settings, so for example, if
 
 ### Changes to GlobalSettings page:
 
-A copy of `GlobalSettingsPage.html` is provided, adding HTML `id` attributes some elements
-so they can be hidden using an id CSS selector in the contributed `geoserver-cloud.css` stylesheet.
+A copy of `GlobalSettingsPage.html` is provided, setting `class="unused"` to HTML elements
+that shall be hidden.
+
+The contributed `geoserver-cloud.css` stylesheet defines `.unused{display: none;}`.
 
 - The "**Logging settings**" section set is hidden.
 - The "**Lock Provider**" selection is hidden, each Configuration and Catalog backend implementation is in charge of
@@ -121,3 +123,7 @@ setting up a lock provider appropriate to the backend that works effectively on 
 - The "**Web UI Mode**" selection is hidden. `WebUIApplicationAutoConfiguration` forces it to be
 `WebUIMode.DO_NOT_REDIRECT` "Never redirect to persist page state (supports clustering but doesn't
 prevent double submit problem)."
+- The "**Proxy Base URL**" field is hidden. The gateway app is in charge of providing the appropriate
+`X-Forward` headers. The spring-boot applications must set the `server.forward-headers-strategy=framework`
+config property to let spring-boot's `ForwardedHeaderFilter` take care of reflecting the client-originated
+protocol and address in the `HttpServletRequest`.

--- a/services/web-ui/README.md
+++ b/services/web-ui/README.md
@@ -109,7 +109,13 @@ The nested properties obey their parent's `enabled` settings, so for example, if
 ## Differences with monolith GeoServer application's Web UI
 
 - The `LogPage` (`/web/wicket/bookmarkable/org.geoserver.web.admin.LogPage`) menu entry is removed.
-- The `GlobalSettingsPage`'s `logging settings` field set is hidden. A copy of `GlobalSettingsPage.html`
-is provided, adding an `id` attribute to the `fieldset` that groups the logging configuration form elements
-(`<fieldset id="loggingSettingsFieldset">`), which is in turn hidden using CSS in the contributed `geoserver-cloud.css` stylesheet.
+
+### Changes to GlobalSettings page:
+
+A copy of `GlobalSettingsPage.html` is provided, adding HTML `id` attributes some elements
+so they can be hidden using an id CSS selector in the contributed `geoserver-cloud.css` stylesheet.
+
+- The "Logging settings" section set is hidden.
+- The "Lock Provider" selection is hidden, each Configuration and Catalog backend implementation is in charge of
+setting up a lock provider appropriate to the backend that works effectively on a distributed system.
 

--- a/services/web-ui/README.md
+++ b/services/web-ui/README.md
@@ -1,14 +1,20 @@
 # Web UI Microservice
 
-The traditional GeoServer wicket based configuration user interface built as a microservice. Just the UI, no REST api, or OWS services.
+The traditional GeoServer's [Wicket](https://wicket.apache.org/) based configuration user interface built as a microservice.
 
-For the time being, this microservice is not ready to scale out, so keep it at one instance. More over, it may make sense to just wake it up when you need to use it, and then shut it down.
+Just the UI, no REST api, or OWS services.
 
-When it's up, it'll be available at the `/web` gateway service entry point, `http://localhost:9090/web` if you're running the default docker composition provided at the root project directory.
+For the time being, this microservice is not ready to scale out, so keep it at one instance. More over, it may make sense to
+just wake it up when you need to use it, and then shut it down.
+
+When it's up, it'll be available at the `/web` gateway service entry point, `http://localhost:9090/web`
+if you're running the default docker composition provided at the root project directory.
 
 ## Build
 
-Follow the regular maven build as explained in the project's root `README.md`. Optionally include or exclude components by enabling or disabling the following maven profiles.
+Follow the regular maven build as explained in the project's root `README.md`.
+
+Optionally include or exclude components by enabling or disabling the following maven profiles.
 
 ### Maven Profiles
 
@@ -20,6 +26,8 @@ The following profiles are enabled by default:
 * `wps`
 * `gwc` (not yet functional)
 * `web-resource`
+* `geostyler`
+* `importer`
 
 And the following profiles can be enabled explicitly at build time:
 
@@ -27,7 +35,13 @@ And the following profiles can be enabled explicitly at build time:
 
 Additional profiles may be added as new components are included in the build.
 
-Disabling or enabling a profile is a build-time step, resulting in the profile's module dependencies being or not included in the final application binary.
+Disabling or enabling a profile is a build-time step, resulting in the profile's
+module dependencies being or not included in the final application binary.
+
+Nonetheless, Cloud Native Geoserver's approach to plugin inclusion and enablement
+is to incorporate the full curated list of plugins and extensions at build time,
+and being able to enable or disable them through configuration properties. See the
+"Configuration" section bellow for more detail.
 
 To enable a specific profile, run 
 
@@ -40,11 +54,20 @@ to disable a profile, it has to be negated with the exclamation mark (and excape
 
 ## Configuration
 
-Each profile comes with a spring-boot auto-configuration, that allows you to disable a component through the `webui-service.yml` config file when using the default externalized configuration (see the `config/webui-service.yml` file at the project's root folder).
+Each profile comes with a spring-boot auto-configuration, that allows you to disable a component
+through the `webui-service.yml` config file when using the default externalized configuration
+(see the `config/webui-service.yml` file at the project's root folder).
 
-Hence, for a certain web-ui module to be enabled and hence accessible through the user interface, its dependencies have to be on the classpath and it has to be enabled through the service configuration properties. The auto-configurations take care of checking both conditions, and they're all enabled by default when the module is included in the application.
+Hence, for a certain web-ui module to be enabled and hence accessible through the user interface,
+its dependencies have to be on the classpath and it has to be enabled through the service configuration
+properties. The auto-configurations take care of checking both conditions, and they're all enabled
+by default when the module is included in the application.
 
-To disable or further configure a certain module, may it expose additional configuration options, just edit the microservice's config file. For example, to disable the `wms` component, edit the following section, set the `geoserver.web-ui.wms=false` property.
+To disable or further configure a certain module, may it expose additional configuration options,
+just edit the microservice's config file. 
+
+For example, to disable the `wms` component, edit the following section,
+set the `geoserver.web-ui.wms=false` property.
 
 Here is the full list of `web-ui` config properties in YAML format:
 
@@ -82,3 +105,7 @@ geoserver:
 All these config options can also be provided at run-time through environment variables or Java System Properties, or overridden by a spring profile configuration file. 
 
 The nested properties obey their parent's `enabled` settings, so for example, if `geoserver.web-ui.demos=false`, all its children are disable disregard their individual value.
+
+## Differences with monolith GeoServer application's Web UI
+
+- The `LogPage` (`/web/wicket/bookmarkable/org.geoserver.web.admin.LogPage`) menu entry is removed.

--- a/services/web-ui/README.md
+++ b/services/web-ui/README.md
@@ -115,7 +115,9 @@ The nested properties obey their parent's `enabled` settings, so for example, if
 A copy of `GlobalSettingsPage.html` is provided, adding HTML `id` attributes some elements
 so they can be hidden using an id CSS selector in the contributed `geoserver-cloud.css` stylesheet.
 
-- The "Logging settings" section set is hidden.
-- The "Lock Provider" selection is hidden, each Configuration and Catalog backend implementation is in charge of
+- The "**Logging settings**" section set is hidden.
+- The "**Lock Provider**" selection is hidden, each Configuration and Catalog backend implementation is in charge of
 setting up a lock provider appropriate to the backend that works effectively on a distributed system.
-
+- The "**Web UI Mode**" selection is hidden. `WebUIApplicationAutoConfiguration` forces it to be
+`WebUIMode.DO_NOT_REDIRECT` "Never redirect to persist page state (supports clustering but doesn't
+prevent double submit problem)."

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebCoreConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebCoreConfiguration.java
@@ -18,10 +18,13 @@ import org.springframework.context.annotation.ImportResource;
 @ImportResource( //
     reader = FilteringXmlBeanDefinitionReader.class, //
     locations = { //
-        "jar:gs-web-core-.*!/applicationContext.xml" //
+        "jar:gs-web-core-.*!/applicationContext.xml#name="
+                + WebCoreConfiguration.EXCLUDED_BEANS_PATTERN //
     }
 )
 public class WebCoreConfiguration {
+
+    static final String EXCLUDED_BEANS_PATTERN = "^(?!logsPage).*$";
 
     public @Bean GeoServerWicketServlet geoServerWicketServlet() {
         return new GeoServerWicketServlet();

--- a/services/web-ui/src/main/resources/org/geoserver/web/admin/GlobalSettingsPage.html
+++ b/services/web-ui/src/main/resources/org/geoserver/web/admin/GlobalSettingsPage.html
@@ -1,0 +1,144 @@
+<html xmlns:wicket="http://wicket.apache.org/">
+<head></head>
+<body>
+<wicket:extend>
+<form wicket:id="form">
+  <h3><span><wicket:message key="ogcServices">OGC Services</wicket:message></span></h3>
+  <fieldset>
+    <legend><span><wicket:message key="serviceSettings">Services Settings</wicket:message></span></legend>
+    <ul>
+      <li>
+        <label for="proxyBaseUrl"><wicket:message key="proxyBaseUrl">Proxy Base URL</wicket:message></label>
+        <input id="proxyBaseUrl" class="field text" type="text" wicket:id="proxyBaseUrl" />
+      </li>
+      <li class="choiceItem">
+        <input id="useHeadersProxyURL" type="checkbox" wicket:id="useHeadersProxyURL" />
+        <label for="useHeadersProxyURL"><wicket:message key="useHeadersProxyURL">Use headers for Proxy URL</wicket:message></label>
+      </li>
+      <li class="choiceItem">
+        <input id="globalServices" type="checkbox" wicket:id="globalServices" />
+        <label for="globalServices"><wicket:message key="globalServices">Enable Global Services</wicket:message></label>
+      </li>
+      <li class="choiceItem">
+        <input type="checkbox" id="allowStoredQueriesPerWorkspace" wicket:id="allowStoredQueriesPerWorkspace"></input>
+        <label><wicket:message key="allowStoredQueriesPerWorkspace">Allow Per-Workspace Stored Queries</wicket:message></label>
+      </li>
+    </ul>
+  </fieldset>
+  <fieldset>
+    <legend><span><wicket:message key="serviceRequestSettings">Service Request Settings</wicket:message></span></legend>
+    <ul>
+      <li class="choiceItem">
+        <input id="xmlExternalEntitiesEnabled" type="checkbox" wicket:id="xmlExternalEntitiesEnabled" />
+        <label for="xmlExternalEntitiesEnabled"><wicket:message key="xmlExternalEntitiesEnabled">Evaluate XML Entities</wicket:message></label>
+      </li>
+    </ul>
+  </fieldset>
+  <fieldset>
+    <legend><span><wicket:message key="serviceResponseSettings">Service Response Settings</wicket:message></span></legend>
+    <ul>
+      <li>
+        <label for="charset"><wicket:message key="charset">Character Set</wicket:message></label>
+        <select id="charset" class="field" wicket:id="charset" />
+      </li>
+      <li>
+        <label for="numDecimals"><wicket:message key="numDecimals">Number of Decimals</wicket:message></label>
+        <input id="numDecimals" class="field text" type="text" wicket:id="numDecimals" />
+      </li>
+      <li class="choiceItem">
+        <input id="verbose" type="checkbox" wicket:id="verbose" />
+        <label for="verbose"><wicket:message key="verboseMessaging">Verbose XML (Pretty Print)</wicket:message></label>
+      </li>
+    </ul>
+  </fieldset>
+  <fieldset>
+    <legend><span><wicket:message key="serviceErrorSettings">Service Error Settings</wicket:message></span></legend>
+    <ul>
+      <li>
+        <label for="charset"><wicket:message key="resourceErrorHandling">Resource Error Handling</wicket:message></label>
+        <select id="charset" class="field" wicket:id="resourceErrorHandling" />
+      </li>
+      <li class="choiceItem">
+        <input id="verboseExceptions" type="checkbox" wicket:id="verboseExceptions" />
+        <label for="verboseExceptions"><wicket:message key="verboseExceptions">Enable Verbose Exceptions</wicket:message></label>
+      </li>
+    </ul>
+  </fieldset>
+  <h3><span><wicket:message key="internalSettings">Internal Settings</wicket:message></span></h3>
+  <fieldset id="loggingSettingsFieldset">
+    <legend><span><wicket:message key="loggingSettings">Logging Settings</wicket:message></span></legend>
+    <ul>
+      <li>
+        <label for="loggingLocation"><wicket:message key="loggingLocation">Logfile</wicket:message></label>
+        <input id="loggingLocation"class="field text" type="text" wicket:id="loggingLocation" />
+      </li>
+      <li>
+        <label for="log4jConfigFile"><wicket:message key="log4jConfigFile">Logging Profile</wicket:message></label>
+        <select id="log4jConfigFile" class="field select" wicket:id="log4jConfigFile" />
+      </li>
+      <li class="choiceItem">
+        <input id="stdOutLogging" type="checkbox" wicket:id="stdOutLogging" />
+        <label for="stdOutLogging"><wicket:message key="stdOutLogging">Enable logging to STDOUT</wicket:message></label>
+      </li>
+      <li>
+        <label for="xmlPostRequestLogBufferSize"><wicket:message key="xmlPostRequestLogBufferSize">Number of characters to log for incoming POST requests</wicket:message></label>
+        <input id="xmlPostRequestLogBufferSize"class="field text" type="text" wicket:id="xmlPostRequestLogBufferSize" />
+      </li>
+    </ul>
+  </fieldset>
+  <fieldset>
+    <legend><span><wicket:message key="catalogSettings">Catalog Settings</wicket:message></span></legend>
+    <ul>
+      <li>
+        <label for="featureTypeCacheSize"><wicket:message key="featureTypeCacheSize">Feature Type Cache Size</wicket:message></label>
+        <input id="featureTypeCacheSize"class="field text" type="text" wicket:id="featureTypeCacheSize" />
+      </li>
+      <li>
+       <label><wicket:message key="lockProvider">lockProvider:</wicket:message></label>
+       <select class="select" id="lockProvider" wicket:id="lockProvider"></select>
+      </li>
+    </ul>
+  </fieldset>
+   <fieldset>
+    <legend><span><wicket:message key="webUISettings">WebUI Settings</wicket:message></span></legend>
+    <ul>
+      <li>
+       <label><wicket:message key="webUIMode">WebUI Mode:</wicket:message></label>
+       <select class="select" id="webUIMode" wicket:id="webUIMode"></select>
+      </li>
+    </ul>
+  </fieldset>
+  <fieldset>
+    <legend><span><wicket:message key="i18nSettings">i18n Settings</wicket:message></span></legend>
+    <ul>
+      <li>
+        <label><wicket:message key="defaultLocale">Default Language</wicket:message></label>
+        <select id="defaultLocale" wicket:id="defaultLocale" />
+      </li>
+    </ul>
+  </fieldset>
+  <h3><span><wicket:message key="otherSettings">Other Settings</wicket:message></span></h3>
+  <ul>
+    <li wicket:id="extensions">
+      <fieldset wicket:id="content"></fieldset>
+    </li>
+  </ul>
+  <ul>
+      <li class="choiceItem">
+        <input id="showCreatedTimeCols" type="checkbox" wicket:id="showCreatedTimeCols" />
+        <label><wicket:message key="timeCreatedColChkBox">Display creation timestamps on administration lists</wicket:message></label>
+      </li>
+      <li class="choiceItem">
+        <input id="showModifiedTimeCols" type="checkbox" wicket:id="showModifiedTimeCols" />
+        <label><wicket:message key="timeModifiedColChkBox">Display modification timestamps on administration lists</wicket:message></label>
+      </li>
+  </ul>
+  <div class="button-group toolbar-sticky selfclear">
+    <button type="submit" class="form-button-save" wicket:id="submit"><wicket:message key="save">save</wicket:message></button>
+    <a href="#a" class="form-button-apply" wicket:id="apply"><wicket:message key="apply">Apply</wicket:message></a>
+    <button type="submit" class="form-button-cancel" wicket:id="cancel"><wicket:message key="cancel">cancel</wicket:message></button>
+  </div>
+</form>
+</wicket:extend>
+</body>
+</html>

--- a/services/web-ui/src/main/resources/org/geoserver/web/admin/GlobalSettingsPage.html
+++ b/services/web-ui/src/main/resources/org/geoserver/web/admin/GlobalSettingsPage.html
@@ -93,7 +93,7 @@
         <label for="featureTypeCacheSize"><wicket:message key="featureTypeCacheSize">Feature Type Cache Size</wicket:message></label>
         <input id="featureTypeCacheSize"class="field text" type="text" wicket:id="featureTypeCacheSize" />
       </li>
-      <li>
+      <li id="lockProviderListItem">
        <label><wicket:message key="lockProvider">lockProvider:</wicket:message></label>
        <select class="select" id="lockProvider" wicket:id="lockProvider"></select>
       </li>

--- a/services/web-ui/src/main/resources/org/geoserver/web/admin/GlobalSettingsPage.html
+++ b/services/web-ui/src/main/resources/org/geoserver/web/admin/GlobalSettingsPage.html
@@ -7,11 +7,11 @@
   <fieldset>
     <legend><span><wicket:message key="serviceSettings">Services Settings</wicket:message></span></legend>
     <ul>
-      <li>
+      <li class="unused">
         <label for="proxyBaseUrl"><wicket:message key="proxyBaseUrl">Proxy Base URL</wicket:message></label>
         <input id="proxyBaseUrl" class="field text" type="text" wicket:id="proxyBaseUrl" />
       </li>
-      <li class="choiceItem">
+      <li class="unused">
         <input id="useHeadersProxyURL" type="checkbox" wicket:id="useHeadersProxyURL" />
         <label for="useHeadersProxyURL"><wicket:message key="useHeadersProxyURL">Use headers for Proxy URL</wicket:message></label>
       </li>
@@ -65,7 +65,7 @@
     </ul>
   </fieldset>
   <h3><span><wicket:message key="internalSettings">Internal Settings</wicket:message></span></h3>
-  <fieldset id="loggingSettingsFieldset">
+  <fieldset class="unused">
     <legend><span><wicket:message key="loggingSettings">Logging Settings</wicket:message></span></legend>
     <ul>
       <li>
@@ -93,13 +93,13 @@
         <label for="featureTypeCacheSize"><wicket:message key="featureTypeCacheSize">Feature Type Cache Size</wicket:message></label>
         <input id="featureTypeCacheSize"class="field text" type="text" wicket:id="featureTypeCacheSize" />
       </li>
-      <li id="lockProviderListItem">
+      <li class="unused">
        <label><wicket:message key="lockProvider">lockProvider:</wicket:message></label>
        <select class="select" id="lockProvider" wicket:id="lockProvider"></select>
       </li>
     </ul>
   </fieldset>
-   <fieldset id="webUIModeSelection">
+   <fieldset class="unused">
     <legend><span><wicket:message key="webUISettings">WebUI Settings</wicket:message></span></legend>
     <ul>
       <li>

--- a/services/web-ui/src/main/resources/org/geoserver/web/admin/GlobalSettingsPage.html
+++ b/services/web-ui/src/main/resources/org/geoserver/web/admin/GlobalSettingsPage.html
@@ -99,7 +99,7 @@
       </li>
     </ul>
   </fieldset>
-   <fieldset>
+   <fieldset id="webUIModeSelection">
     <legend><span><wicket:message key="webUISettings">WebUI Settings</wicket:message></span></legend>
     <ul>
       <li>

--- a/services/web-ui/src/main/resources/org/geoserver/web/geoserver-cloud.css
+++ b/services/web-ui/src/main/resources/org/geoserver/web/geoserver-cloud.css
@@ -1,26 +1,3 @@
-/* hide the proxy base URL form fields*/
-/* input[id="proxyBaseUrl"] { */
-/*   display: none; */
-/* } */
-/* label[for="proxyBaseUrl"] { */
-/*   display: none; */
-/* } */
-/* input[id="useHeadersProxyURL"] { */
-/*   display: none; */
-/* } */
-/* label[for="useHeadersProxyURL"] { */
-/*   display: none; */
-/* } */
-/* li[class="choiceItem"]/label[for="proxyBaseUrl"]{ */
-/*   display: none; */
-/* } */
-
-#loggingSettingsFieldset{
-	display: none;
-}
-#lockProviderListItem{
+.unused{
   display: none;
-}
-#webUIModeSelection{
-	display: none;
 }

--- a/services/web-ui/src/main/resources/org/geoserver/web/geoserver-cloud.css
+++ b/services/web-ui/src/main/resources/org/geoserver/web/geoserver-cloud.css
@@ -18,3 +18,6 @@
 #loggingSettingsFieldset{
 	display: none;
 }
+#lockProviderListItem{
+  display: none;
+}

--- a/services/web-ui/src/main/resources/org/geoserver/web/geoserver-cloud.css
+++ b/services/web-ui/src/main/resources/org/geoserver/web/geoserver-cloud.css
@@ -21,3 +21,6 @@
 #lockProviderListItem{
   display: none;
 }
+#webUIModeSelection{
+	display: none;
+}

--- a/services/web-ui/src/main/resources/org/geoserver/web/geoserver-cloud.css
+++ b/services/web-ui/src/main/resources/org/geoserver/web/geoserver-cloud.css
@@ -14,3 +14,7 @@
 /* li[class="choiceItem"]/label[for="proxyBaseUrl"]{ */
 /*   display: none; */
 /* } */
+
+#loggingSettingsFieldset{
+	display: none;
+}


### PR DESCRIPTION
* hide GlobalSetting's page WebUI mode selection
* hide GlobalSetting's page lock provider selection
* hide the logging settings form items in GlobalSettingsPage
* hide GlobalSetting's page Proxy base URL form entry
* exclude the LogPage menu entry
