### PR TITLE
Make sure all known XStreamServiceLoaders are provided to GeoServerLoader

### DIFF
--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/catalog/GeoServerBackendAutoConfiguration.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/catalog/GeoServerBackendAutoConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.autoconfigure.catalog;
 
 import org.geoserver.cloud.config.catalog.CoreBackendConfiguration;
+import org.geoserver.cloud.config.catalog.XstreamServiceLoadersConfiguration;
 import org.geotools.autoconfigure.httpclient.GeoToolsHttpClientAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.context.annotation.Configuration;
@@ -23,39 +24,11 @@ import org.springframework.context.annotation.Import;
 @AutoConfigureAfter(GeoToolsHttpClientAutoConfiguration.class)
 @Import({ //
     CoreBackendConfiguration.class, //
+    XstreamServiceLoadersConfiguration.class, //
     DataDirectoryAutoConfiguration.class, //
     JDBCConfigAutoConfiguration.class, //
     JDBCConfigWebAutoConfiguration.class, //
     CatalogClientBackendAutoConfiguration.class, //
     BackendCacheAutoConfiguration.class //
 })
-public class GeoServerBackendAutoConfiguration {
-
-    // // REVISIT: @ConfigurationProperties is not working
-    // // @ConfigurationProperties(prefix = "geoserver.backend")
-    // public @Bean GeoServerBackendProperties geoServerBackendProperties() {
-    // GeoServerBackendProperties props = new GeoServerBackendProperties();
-    // props.setCatalogService(catalogServiceClientProperties());
-    // props.setDataDirectory(dataDirectoryProperties());
-    // props.setJdbcconfig(jdbcconfigProperties());
-    // return props;
-    // }
-    //
-    // // REVISIT: @ConfigurationProperties is not working
-    // // @ConfigurationProperties(prefix = "geoserver.backend.data-directory")
-    // public @Bean DataDirectoryProperties dataDirectoryProperties() {
-    // return new DataDirectoryProperties();
-    // }
-    //
-    // // REVISIT: @ConfigurationProperties is not working
-    // // @ConfigurationProperties(prefix = "geoserver.backend.jdbcconfig")
-    // public @Bean JdbcconfigProperties jdbcconfigProperties() {
-    // return new JdbcconfigProperties();
-    // }
-    //
-    // // REVISIT: @ConfigurationProperties is not working
-    // // @ConfigurationProperties(prefix = "geoserver.backend.catalog-service")
-    // public @Bean CatalogClientProperties catalogServiceClientProperties() {
-    // return new CatalogClientProperties();
-    // }
-}
+public class GeoServerBackendAutoConfiguration {}

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalog/CoreBackendConfiguration.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalog/CoreBackendConfiguration.java
@@ -27,6 +27,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 
+// proxyBeanMethods = true required to avoid circular reference exceptions, especially related to
+// GeoServerExtensions still being created
 @Configuration(proxyBeanMethods = true)
 @EnableConfigurationProperties({GeoServerBackendProperties.class, CatalogProperties.class})
 public class CoreBackendConfiguration {

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalog/XstreamServiceLoadersConfiguration.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalog/XstreamServiceLoadersConfiguration.java
@@ -1,0 +1,62 @@
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.config.catalog;
+
+import lombok.extern.slf4j.Slf4j;
+import org.geoserver.config.util.XStreamServiceLoader;
+import org.geoserver.gwc.wmts.WMTSXStreamLoader;
+import org.geoserver.platform.GeoServerResourceLoader;
+import org.geoserver.wcs.WCSXStreamLoader;
+import org.geoserver.wfs.WFSXStreamLoader;
+import org.geoserver.wms.WMSXStreamLoader;
+import org.geoserver.wps.WPSXStreamLoader;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration to make sure all {@link XStreamServiceLoader} extensions are loaded regardless of
+ * the microservice this starter is used from.
+ *
+ * @since 1.0
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties({GeoServerBackendProperties.class, CatalogProperties.class})
+@Slf4j(topic = "org.geoserver.cloud.config.catalog")
+public class XstreamServiceLoadersConfiguration {
+
+    @ConditionalOnMissingBean(WFSXStreamLoader.class)
+    public @Bean WFSXStreamLoader wfsLoader(GeoServerResourceLoader resourceLoader) {
+        return log(new WFSXStreamLoader(resourceLoader));
+    }
+
+    @ConditionalOnMissingBean(WMSXStreamLoader.class)
+    public @Bean WMSXStreamLoader wmsLoader(GeoServerResourceLoader resourceLoader) {
+        return log(new WMSXStreamLoader(resourceLoader));
+    }
+
+    @ConditionalOnMissingBean(WCSXStreamLoader.class)
+    public @Bean WCSXStreamLoader wcsLoader(GeoServerResourceLoader resourceLoader) {
+        return log(new WCSXStreamLoader(resourceLoader));
+    }
+
+    @ConditionalOnMissingBean(WMTSXStreamLoader.class)
+    public @Bean WMTSXStreamLoader wmtsLoader(GeoServerResourceLoader resourceLoader) {
+        return log(new WMTSXStreamLoader(resourceLoader));
+    }
+
+    @ConditionalOnMissingBean(WPSXStreamLoader.class)
+    public @Bean WPSXStreamLoader wpsServiceLoader(GeoServerResourceLoader resourceLoader) {
+        return log(new WPSXStreamLoader(resourceLoader));
+    }
+
+    private <T extends XStreamServiceLoader<?>> T log(T loader) {
+        log.info(
+                "Automatically contributing {} service xstream loader",
+                loader.getClass().getSimpleName());
+        return loader;
+    }
+}

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalogclient/CatalogClientBackendConfigurer.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalogclient/CatalogClientBackendConfigurer.java
@@ -21,6 +21,7 @@ import org.geoserver.platform.resource.ResourceStore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
 
@@ -58,6 +59,14 @@ public class CatalogClientBackendConfigurer implements GeoServerBackendConfigure
         return store;
     }
 
+    @DependsOn({
+        "extensions",
+        "wmsLoader",
+        "wfsLoader",
+        "wcsLoader",
+        "wpsServiceLoader",
+        "wmtsLoader"
+    })
     public @Override @Bean GeoServerLoader geoServerLoaderImpl() {
         return new CatalogClientGeoServerLoader(resourceLoader());
     }

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/datadirectory/DataDirectoryBackendConfigurer.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/datadirectory/DataDirectoryBackendConfigurer.java
@@ -19,10 +19,6 @@ import org.geoserver.config.GeoServerLoader;
 import org.geoserver.config.plugin.RepositoryGeoServerFacade;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.platform.resource.ResourceStore;
-import org.geoserver.wcs.WCSXStreamLoader;
-import org.geoserver.wfs.WFSXStreamLoader;
-import org.geoserver.wms.WMSXStreamLoader;
-import org.geoserver.wps.WPSXStreamLoader;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -60,7 +56,14 @@ public class DataDirectoryBackendConfigurer implements GeoServerBackendConfigure
         return new org.geoserver.config.plugin.RepositoryGeoServerFacadeImpl();
     }
 
-    @DependsOn({"extensions", "wmsLoader", "wfsLoader", "wcsLoader", "wpsServiceLoader"})
+    @DependsOn({
+        "extensions",
+        "wmsLoader",
+        "wfsLoader",
+        "wcsLoader",
+        "wpsServiceLoader",
+        "wmtsLoader"
+    })
     public @Override @Bean GeoServerLoader geoServerLoaderImpl() {
         return new DataDirectoryGeoServerLoader(resourceLoader());
     }
@@ -88,37 +91,5 @@ public class DataDirectoryBackendConfigurer implements GeoServerBackendConfigure
         Objects.requireNonNull(
                 path, "geoserver.backend.data-directory.location config property resolves to null");
         return path;
-    }
-
-    /**
-     * Provide {@code wmsLoader} if not loaded from {@code
-     * gs-wms-<version>.jar!/applicationContext.xml#wmsLoader}
-     */
-    public @Bean WMSXStreamLoader wmsLoader(GeoServerResourceLoader resourceLoader) {
-        return new WMSXStreamLoader(resourceLoader);
-    }
-
-    /**
-     * Provide {@code wfsLoader} if not loaded from {@code
-     * gs-wfs-<version>.jar!/applicationContext.xml#wfsLoader}
-     */
-    public @Bean WFSXStreamLoader wfsLoader(GeoServerResourceLoader resourceLoader) {
-        return new WFSXStreamLoader(resourceLoader);
-    }
-
-    /**
-     * Provide {@code wcsLoader} if not loaded from {@code
-     * gs-wcs-<version>.jar!/applicationContext.xml#wcsLoader}
-     */
-    public @Bean WCSXStreamLoader wcsLoader(GeoServerResourceLoader resourceLoader) {
-        return new WCSXStreamLoader(resourceLoader);
-    }
-
-    /**
-     * Provide {@code wcsLoader} if not loaded from {@code
-     * gs-wps-<version>.jar!/applicationContext.xml#wpsServiceLoader}
-     */
-    public @Bean WPSXStreamLoader wpsServiceLoader(GeoServerResourceLoader resourceLoader) {
-        return new WPSXStreamLoader(resourceLoader);
     }
 }

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/jdbcconfig/JDBCConfigBackendConfigurer.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/jdbcconfig/JDBCConfigBackendConfigurer.java
@@ -229,7 +229,16 @@ public class JDBCConfigBackendConfigurer implements GeoServerBackendConfigurer {
     }
 
     @Bean(name = {"geoServerLoaderImpl", "JDBCGeoServerLoader"})
-    @DependsOn({"catalogFacade", "geoserverFacade"})
+    @DependsOn({
+        "catalogFacade",
+        "geoserverFacade",
+        "extensions",
+        "wmsLoader",
+        "wfsLoader",
+        "wcsLoader",
+        "wpsServiceLoader",
+        "wmtsLoader"
+    })
     public @Override CloudJdbcGeoServerLoader geoServerLoaderImpl() {
         JDBCConfigProperties config = jdbcConfigProperties();
         ConfigDatabase configdb = jdbcConfigDB();


### PR DESCRIPTION
Add a configuration that contributes any missing XStreamServiceLoader
to the application context, regardless of which microservice is
being ran or whether it's missing to load them from geoserver's
applicationContext.xml files located in different jars.

This makes sure all services catalog/config backends will be able
to load the configuration, despite not having anything else to
do with a given service type (e.g., wfs-service may not load any
wms bean, but its config backend still needs to be able to load
the geoserver configuration for WMSInfo).