### PR TITLE
gs-jackson-bindings: workaround erroneous Locale serialization, model i18n strings as Map<String, String>

### DIFF
--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModule.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModule.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;
@@ -202,6 +203,12 @@ public class GeoServerCatalogModule extends SimpleModule {
 
         addMapperSerializer(
                 Query.class, VALUE_MAPPER::queryToDto, QueryDto.class, VALUE_MAPPER::dtoToQuery);
+
+        addMapperSerializer(
+                Locale.class,
+                VALUE_MAPPER::localeToString,
+                String.class,
+                VALUE_MAPPER::stringToLocale);
 
         addMapperSerializer(
                 InternationalString.class,

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/LayerGroup.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/LayerGroup.java
@@ -5,7 +5,6 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -33,9 +32,9 @@ public class LayerGroup extends Published {
     protected Envelope bounds;
     private List<Keyword> keywords;
     /** @since geoserver 2.20.0 */
-    private Map<Locale, String> internationalTitle;
+    private Map<String, String> internationalTitle;
     /** @since geoserver 2.20.0 */
-    private Map<Locale, String> internationalAbstract;
+    private Map<String, String> internationalAbstract;
     /** @since geoserver 2.21.0 */
     private List<LayerGroupStyle> layerGroupStyles;
 }

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/LayerGroupStyle.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/LayerGroupStyle.java
@@ -5,7 +5,6 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import lombok.Data;
 
@@ -30,8 +29,8 @@ public class LayerGroupStyle {
     private List<InfoReference> styles;
 
     private String title;
-    private Map<Locale, String> internationalTitle;
+    private Map<String, String> internationalTitle;
 
     private String Abstract;
-    private Map<Locale, String> internationalAbstract;
+    private Map<String, String> internationalAbstract;
 }

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Resource.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Resource.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.io.Serializable;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -53,7 +52,7 @@ public abstract class Resource extends CatalogInfoDto {
     private Boolean simpleConversionEnabled;
 
     /** @since geoserver 2.20.0 */
-    private Map<Locale, String> internationalTitle;
+    private Map<String, String> internationalTitle;
     /** @since geoserver 2.20.0 */
-    private Map<Locale, String> internationalAbstract;
+    private Map<String, String> internationalAbstract;
 }

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/mapper/ValueMappers.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/mapper/ValueMappers.java
@@ -245,19 +245,24 @@ public interface ValueMappers {
     // there's no implementation for ImagingInfo and ImageFormatInfo, looks like dead code
     // ImageFormatInfo infoToDto();
 
-    Locale UNDEF_LOCALE = new Locale("");
+    default String localeToString(Locale locale) {
+        return locale == null ? "" : locale.toLanguageTag();
+    }
 
-    default Map<Locale, String> internationalStringToDto(InternationalString s) {
+    default Locale stringToLocale(String s) {
+        return s == null || s.isBlank() ? null : Locale.forLanguageTag(s);
+    }
+
+    default Map<String, String> internationalStringToDto(InternationalString s) {
         if (s instanceof GrowableInternationalString) {
             GrowableInternationalString gs = (GrowableInternationalString) s;
             Set<Locale> locales = gs.getLocales();
-            Map<Locale, String> dto = new HashMap<>(locales.size());
-            locales.forEach(
-                    locale -> dto.put(locale == null ? UNDEF_LOCALE : locale, gs.toString(locale)));
+            Map<String, String> dto = new HashMap<>(locales.size());
+            locales.forEach(locale -> dto.put(localeToString(locale), gs.toString(locale)));
             return dto;
         }
         if (s instanceof SimpleInternationalString) {
-            return Collections.singletonMap(null, s.toString());
+            return Collections.singletonMap("", s.toString());
         }
         if (s == null) return null;
 
@@ -269,16 +274,10 @@ public interface ValueMappers {
         return null;
     }
 
-    default GrowableInternationalString dtoToInternationalString(Map<Locale, String> s) {
+    default GrowableInternationalString dtoToInternationalString(Map<String, String> s) {
         if (s == null) return null;
         GrowableInternationalString gs = new GrowableInternationalString();
-        s.forEach(
-                (locale, value) -> {
-                    if (UNDEF_LOCALE.equals(locale)) {
-                        locale = null;
-                    }
-                    gs.add(locale, value);
-                });
+        s.forEach((locale, value) -> gs.add(stringToLocale(locale), value));
         return gs;
     }
 }

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/Contact.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/Contact.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.jackson.databind.config.dto;
 
-import java.util.Locale;
 import java.util.Map;
 import lombok.Data;
 import org.geoserver.config.ContactInfo;
@@ -28,31 +27,31 @@ public @Data class Contact {
     private String onlineResource;
 
     /** @since geoserver 2.20.0 */
-    private Map<Locale, String> internationalAddress;
+    private Map<String, String> internationalAddress;
     /** @since geoserver 2.20.0 */
-    private Map<Locale, String> internationalContactFacsimile;
+    private Map<String, String> internationalContactFacsimile;
     /** @since geoserver 2.20.0 */
-    private Map<Locale, String> internationalContactOrganization;
+    private Map<String, String> internationalContactOrganization;
     /** @since geoserver 2.20.0 */
-    private Map<Locale, String> internationalContactPerson;
+    private Map<String, String> internationalContactPerson;
     /** @since geoserver 2.20.0 */
-    private Map<Locale, String> internationalContactPosition;
+    private Map<String, String> internationalContactPosition;
     /** @since geoserver 2.20.0 */
-    private Map<Locale, String> internationalContactVoice;
+    private Map<String, String> internationalContactVoice;
     /** @since geoserver 2.20.0 */
-    private Map<Locale, String> internationalOnlineResource;
+    private Map<String, String> internationalOnlineResource;
     /** @since geoserver 2.20.0 */
-    private Map<Locale, String> internationalAddressCity;
+    private Map<String, String> internationalAddressCity;
     /** @since geoserver 2.20.0 */
-    private Map<Locale, String> internationalAddressCountry;
+    private Map<String, String> internationalAddressCountry;
     /** @since geoserver 2.20.0 */
-    private Map<Locale, String> internationalAddressDeliveryPoint;
+    private Map<String, String> internationalAddressDeliveryPoint;
     /** @since geoserver 2.20.0 */
-    private Map<Locale, String> internationalAddressPostalCode;
+    private Map<String, String> internationalAddressPostalCode;
     /** @since geoserver 2.20.0 */
-    private Map<Locale, String> internationalAddressState;
+    private Map<String, String> internationalAddressState;
     /** @since geoserver 2.20.0 */
-    private Map<Locale, String> internationalAddressType;
+    private Map<String, String> internationalAddressType;
     /** @since geoserver 2.20.0 */
-    private Map<Locale, String> internationalContactEmail;
+    private Map<String, String> internationalContactEmail;
 }

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/Service.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/Service.java
@@ -66,9 +66,9 @@ public abstract @Data class Service extends ConfigInfoDto {
     /** @since geoserver 2.20.0 */
     private Locale defaultLocale;
     /** @since geoserver 2.20.0 */
-    private Map<Locale, String> internationalTitle;
+    private Map<String, String> internationalTitle;
     /** @since geoserver 2.20.0 */
-    private Map<Locale, String> internationalAbstract;
+    private Map<String, String> internationalAbstract;
 
     @EqualsAndHashCode(callSuper = true)
     public static @Data class WmsService extends Service {
@@ -102,9 +102,9 @@ public abstract @Data class Service extends ConfigInfoDto {
         private boolean defaultGroupStyleEnabled;
 
         /** @since geoserver 2.20.0 */
-        private Map<Locale, String> internationalRootLayerTitle;
+        private Map<String, String> internationalRootLayerTitle;
         /** @since geoserver 2.20.0 */
-        private Map<Locale, String> internationalRootLayerAbstract;
+        private Map<String, String> internationalRootLayerAbstract;
     }
 
     @EqualsAndHashCode(callSuper = true)

--- a/catalog-support/geoserver-jackson-bindings/src/test/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModuleTest.java
+++ b/catalog-support/geoserver-jackson-bindings/src/test/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModuleTest.java
@@ -91,7 +91,9 @@ import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.jdbc.VirtualTable;
 import org.geotools.measure.Measure;
 import org.geotools.referencing.CRS;
+import org.geotools.util.GrowableInternationalString;
 import org.geotools.util.NumberRange;
+import org.geotools.util.SimpleInternationalString;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -106,6 +108,7 @@ import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.Literal;
 import org.opengis.filter.sort.SortOrder;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.util.InternationalString;
 import si.uom.SI;
 
 /**
@@ -415,6 +418,28 @@ public class GeoServerCatalogModuleTest {
         testPatch("serviceInfos", services);
         testPatch("attribution", attributionInfos);
         testPatch("contact", contactInfos);
+    }
+
+    public @Test void testPatchWithSimpleInternationalStringProperty() throws Exception {
+        InternationalString simpleI18n = new SimpleInternationalString("simpleI18n");
+        Patch patch = new Patch();
+        patch.add("simpleI18n", simpleI18n);
+
+        ObjectWriter writer = objectMapper.writer();
+        writer = writer.withDefaultPrettyPrinter();
+        String encoded = writer.writeValueAsString(patch);
+        log.info(encoded);
+        Patch decoded = objectMapper.readValue(encoded, Patch.class);
+        Patch expected = new Patch();
+        expected.add("simpleI18n", new GrowableInternationalString(simpleI18n.toString()));
+        assertEquals(expected, decoded);
+    }
+
+    public @Test void testPatchWithGrowableInternationalStringProperty() throws Exception {
+        GrowableInternationalString growableI18n = new GrowableInternationalString("default lang");
+        growableI18n.add(Locale.forLanguageTag("es-AR"), "en argentino");
+        growableI18n.add(Locale.forLanguageTag("es"), "en español");
+        testPatch("growableI18n", growableI18n);
     }
 
     private void testPatch(String name, Object value) throws Exception {


### PR DESCRIPTION
gs-jackson-bindings: model i18n strings as Map<String, String>

jackson-databind's default map key serializer is TostringSerialier. 

Model i18n strings as `Map<String, String>` instead of
`Map<Locale, String>`. Jackson's key serializer uses
`toString()` which is not good rountrip candidate
for `Locale`.