### PR TITLE
web-ui calls Catalog.add() with a ModificationProxy, not allowed by CatalogPlugin.

### DIFF
--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/validation/CatalogValidationRules.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/validation/CatalogValidationRules.java
@@ -73,6 +73,9 @@ public class CatalogValidationRules {
     public <T extends CatalogInfo> ValidationResult validate(T object, boolean isNew) {
         CatalogValidatorVisitor visitor = new CatalogValidatorVisitor(defaultValidator, isNew);
         if (isNew) {
+            // REVISIT: of course the webui will call catalog.validate with a mod proxy and
+            // isNew=true... ResourceConfigurationPage.doSaveInternal() for instance
+            object = ModificationProxy.unwrap(object);
             object.accept(visitor);
         } else {
             object =


### PR DESCRIPTION
Hack into CatalogPlugin.validate() to avoid ClassCastException due to web-ui's fault. This is a work around, we can't hack into geoserver wicket's `NewDataPage`.