### PR TITLE
gwc: disable diskquota and force hide it from the web UI.

### DIFF
--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebUIApplicationAutoConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebUIApplicationAutoConfiguration.java
@@ -9,7 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.geoserver.cloud.autoconfigure.core.GeoServerWebMvcMainAutoConfiguration;
 import org.geoserver.cloud.autoconfigure.web.demo.DemosAutoConfiguration;
 import org.geoserver.cloud.autoconfigure.web.extension.ExtensionsAutoConfiguration;
-import org.geoserver.cloud.autoconfigure.web.gwc.GwcWebAutoConfiguration;
 import org.geoserver.cloud.autoconfigure.web.security.SecurityAutoConfiguration;
 import org.geoserver.cloud.autoconfigure.web.tools.ToolsAutoConfiguration;
 import org.geoserver.cloud.autoconfigure.web.wcs.WcsAutoConfiguration;
@@ -36,8 +35,7 @@ import org.springframework.core.env.Environment;
     WpsAutoConfiguration.class,
     ExtensionsAutoConfiguration.class,
     DemosAutoConfiguration.class,
-    ToolsAutoConfiguration.class,
-    GwcWebAutoConfiguration.class
+    ToolsAutoConfiguration.class
 })
 @Slf4j
 public class WebUIApplicationAutoConfiguration {

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/GeoServerIntegrationAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/GeoServerIntegrationAutoConfiguration.java
@@ -2,9 +2,10 @@
  * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
  * GPL 2.0 license, available at the root application directory.
  */
-package org.geoserver.cloud.autoconfigure.gwc;
+package org.geoserver.cloud.autoconfigure.gwc.integration;
 
 import org.geoserver.catalog.Catalog;
+import org.geoserver.cloud.autoconfigure.gwc.core.GwcCoreAutoConfiguration;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.geoserver.cloud.gwc.repository.CachingTileLayerCatalog;
 import org.geoserver.cloud.gwc.repository.CloudCatalogConfiguration;
@@ -31,7 +32,7 @@ import org.springframework.context.annotation.Primary;
         "jar:gs-gwc-.*!/geowebcache-geoserver-context.xml#name=^(?!GeoSeverTileLayerCatalog|gwcCatalogConfiguration).*$"
     }
 )
-public class GwcGeoServerAutoConfiguration {
+public class GeoServerIntegrationAutoConfiguration {
 
     @Bean(name = "gwcCatalogConfiguration")
     CatalogConfiguration gwcCatalogConfiguration( //

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/LocalEventsAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/LocalEventsAutoConfiguration.java
@@ -2,7 +2,7 @@
  * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
  * GPL 2.0 license, available at the root application directory.
  */
-package org.geoserver.cloud.autoconfigure.gwc;
+package org.geoserver.cloud.autoconfigure.gwc.integration;
 
 import org.geoserver.cloud.gwc.event.TileLayerEventPublisher;
 import org.springframework.context.annotation.Bean;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 
 /** @since 1.0 */
 @Configuration(proxyBeanMethods = false)
-public class GwcLocalEventsAutoConfiguration {
+public class LocalEventsAutoConfiguration {
 
     public @Bean TileLayerEventPublisher tileLayerEventPublisher() {
         return new TileLayerEventPublisher();

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/RemoteEventsAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/RemoteEventsAutoConfiguration.java
@@ -2,7 +2,7 @@
  * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
  * GPL 2.0 license, available at the root application directory.
  */
-package org.geoserver.cloud.autoconfigure.gwc;
+package org.geoserver.cloud.autoconfigure.gwc.integration;
 
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -24,7 +24,7 @@ import org.springframework.context.annotation.Configuration;
 @AutoConfigureAfter(BusAutoConfiguration.class)
 @ConditionalOnGeoServerRemoteEventsEnabled
 @RemoteApplicationEventScan(basePackageClasses = {RemoteGeoWebCacheEvent.class})
-public class GwcEventBusAutoConfiguration {
+public class RemoteEventsAutoConfiguration {
 
     public @Bean GeoWebCacheRemoteEventsBroker tileLayerRemoteEventBroadcaster( //
             ApplicationEventPublisher eventPublisher, ServiceMatcher busServiceMatcher) {

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/SedingWMSAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/SedingWMSAutoConfiguration.java
@@ -2,7 +2,7 @@
  * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
  * GPL 2.0 license, available at the root application directory.
  */
-package org.geoserver.cloud.autoconfigure.gwc;
+package org.geoserver.cloud.autoconfigure.gwc.integration;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -42,10 +42,10 @@ import org.springframework.context.annotation.ImportResource;
     locations = { //
         "jar:gs-wms-.*!/applicationContext.xml#name=^(?!getMapKvpReader).*$", //
         "jar:gs-wfs-.*!/applicationContext.xml#name="
-                + GwcSedingWmsAutoConfiguration.WFS_BEANS_REGEX //
+                + SedingWMSAutoConfiguration.WFS_BEANS_REGEX //
     }
 )
-public class GwcSedingWmsAutoConfiguration {
+public class SedingWMSAutoConfiguration {
 
     static final String WFS_BEANS_REGEX =
             "^(gml.*OutputFormat|bboxKvpParser|xmlConfiguration.*|gml[1-9]*SchemaBuilder|wfsXsd.*|wfsSqlViewKvpParser).*$";

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/WMTSIntegrationAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/WMTSIntegrationAutoConfiguration.java
@@ -2,7 +2,7 @@
  * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
  * GPL 2.0 license, available at the root application directory.
  */
-package org.geoserver.cloud.autoconfigure.gwc;
+package org.geoserver.cloud.autoconfigure.gwc.integration;
 
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.springframework.context.annotation.Configuration;
@@ -14,4 +14,4 @@ import org.springframework.context.annotation.ImportResource;
     reader = FilteringXmlBeanDefinitionReader.class, //
     locations = {"jar:gs-gwc-.*!/geowebcache-geoserver-wmts-integration.xml"}
 )
-public class GwcWMTSAutoConfiguration {}
+public class WMTSIntegrationAutoConfiguration {}

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/package-info.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/package-info.java
@@ -1,0 +1,41 @@
+/**
+ * Upstream's {@literal applicatonContext.xml} is the following aggregate:
+ *
+ * <pre>
+ * {@code
+ * <beans>
+ *   <import resource="geowebcache-servlet.xml" />
+ *   <import resource="geowebcache-geoserver-context.xml" />
+ *   <import resource="geowebcache-geoserver-wms-integration.xml" />
+ *   <import resource="geowebcache-geoserver-wmts-integration.xml" />
+ * </beans>
+ * }
+ * </pre>
+ * <p>
+ * In turn, {@literal geowebcache-servlet.xml} aggregates the following xml files:
+ * <pre>
+ * {@code
+ *   <import resource="geowebcache-core-context.xml"/>
+ *   <import resource="geowebcache-georss-context.xml"/>
+ *   <import resource="geowebcache-gmaps-context.xml"/>
+ *   <import resource="geowebcache-kmlservice-context.xml"/>
+ *   <import resource="geowebcache-rest-context.xml"/>
+ *   <import resource="geowebcache-tmsservice-context.xml"/>
+ *   <import resource="geowebcache-virtualearth-context.xml"/>
+ *   <import resource="geowebcache-wmsservice-context.xml"/>
+ *   <import resource="geowebcache-wmtsservice-context.xml"/>
+ *   <import resource="geowebcache-diskquota-context.xml"/>
+ *   <!--
+ *     This mappings are different from the standalone gwc ones in that they prepend the /gwc prefix to the context so it
+ *     ends up being, for example, /geoserver/gwc/*
+ *   -->
+ *   <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+ *     <property name="ignoreUnresolvablePlaceholders" value="true" />
+ *     <property name="location">
+ *       <value>classpath:application.properties</value>
+ *     </property>
+ *   </bean>
+ *   <context:component-scan base-package="org.geoserver.gwc.dispatch"/>
+ * }
+ */
+package org.geoserver.cloud.autoconfigure.gwc;

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/web/gwc/WebUIAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/web/gwc/WebUIAutoConfiguration.java
@@ -4,8 +4,9 @@
  */
 package org.geoserver.cloud.autoconfigure.web.gwc;
 
+import javax.annotation.PostConstruct;
 import lombok.Getter;
-import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
+import lombok.extern.slf4j.Slf4j;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.geoserver.gwc.web.GWCSettingsPage;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -16,18 +17,33 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration
 @ConditionalOnClass(GWCSettingsPage.class)
 @ConditionalOnProperty( // enabled by default
-    prefix = GwcWebAutoConfiguration.CONFIG_PREFIX,
+    prefix = WebUIAutoConfiguration.CONFIG_PREFIX,
     name = "enabled",
     havingValue = "true",
     matchIfMissing = true
 )
 @ImportResource( //
     reader = FilteringXmlBeanDefinitionReader.class,
-    locations = {"jar:gs-web-gwc-.*!/applicationContext.xml"}
+    locations = {
+        "jar:gs-web-gwc-.*!/applicationContext.xml#name=^(?!"
+                + WebUIAutoConfiguration.EXCLUDED_BEANS
+                + ").*$"
+    }
 )
-public class GwcWebAutoConfiguration extends AbstractWebUIAutoConfiguration {
+@Slf4j(topic = "org.geoserver.cloud.autoconfigure.web.gwc")
+public class WebUIAutoConfiguration {
 
     static final String CONFIG_PREFIX = "geoserver.web-ui.gwc";
 
+    /*
+     * Disable disk-quota by brute force for now. We need to resolve how and where to store the
+     * configuration and database.
+     */
+    static final String EXCLUDED_BEANS = "diskQuotaMenuPage";
+
     private final @Getter String configPrefix = CONFIG_PREFIX;
+
+    public @PostConstruct void log() {
+        log.info(getConfigPrefix() + " enabled");
+    }
 }

--- a/starters/starter-gwc/src/main/resources/META-INF/spring.factories
+++ b/starters/starter-gwc/src/main/resources/META-INF/spring.factories
@@ -1,7 +1,8 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.geoserver.cloud.autoconfigure.gwc.GwcCoreAutoConfiguration,\
-org.geoserver.cloud.autoconfigure.gwc.GwcGeoServerAutoConfiguration,\
-org.geoserver.cloud.autoconfigure.gwc.GwcWMTSAutoConfiguration,\
-org.geoserver.cloud.autoconfigure.gwc.GwcSedingWmsAutoConfiguration,\
-org.geoserver.cloud.autoconfigure.gwc.GwcLocalEventsAutoConfiguration,\
-org.geoserver.cloud.autoconfigure.gwc.GwcEventBusAutoConfiguration
+org.geoserver.cloud.autoconfigure.gwc.core.GwcCoreAutoConfiguration,\
+org.geoserver.cloud.autoconfigure.gwc.integration.GeoServerIntegrationAutoConfiguration,\
+org.geoserver.cloud.autoconfigure.gwc.integration.LocalEventsAutoConfiguration,\
+org.geoserver.cloud.autoconfigure.gwc.integration.RemoteEventsAutoConfiguration,\
+org.geoserver.cloud.autoconfigure.gwc.integration.SedingWMSAutoConfiguration,\
+org.geoserver.cloud.autoconfigure.gwc.integration.WMTSIntegrationAutoConfiguration,\
+org.geoserver.cloud.autoconfigure.web.gwc.WebUIAutoConfiguration


### PR DESCRIPTION
Initial gwc autoconfiguration refactoring into finer grained
configuration classes.

Disable disk-quota by brute force for now, or there'll be a race condition
to connect to the default H2 database in the data directory, or the temporary
datadir if using jdbcconfig.

We need to resolve how and where to store the configuration and database.

* Force disabling with `System.setProperty(DiskQuotaMonitor.GWC_DISKQUOTA_DISABLED, "true");`
* Hide it from web-ui by excluding the `diskQuotaMenuPage` in
  `org.geoserver.cloud.autoconfigure.web.gwc.WebUIAutoConfiguration`.