### PR TITLE
Use a lazy gwc xml configuration provider

### DIFF
--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalogclient/CatalogClientBackendConfigurer.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalogclient/CatalogClientBackendConfigurer.java
@@ -50,7 +50,8 @@ public class CatalogClientBackendConfigurer implements GeoServerBackendConfigure
         return configClientFacade;
     }
 
-    public @Override @Bean CatalogClientResourceStore resourceStoreImpl() {
+    @Bean(name = {"resourceStoreImpl"})
+    public @Override CatalogClientResourceStore resourceStoreImpl() {
         CatalogClientResourceStore store = catalogServiceResourceStore;
         File cacheDirectory = configProps.getCatalogService().getCacheDirectory();
         if (null != cacheDirectory) {

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/datadirectory/DataDirectoryBackendConfigurer.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/datadirectory/DataDirectoryBackendConfigurer.java
@@ -77,7 +77,8 @@ public class DataDirectoryBackendConfigurer implements GeoServerBackendConfigure
         return resourceLoader;
     }
 
-    public @Override @Bean ResourceStore resourceStoreImpl() {
+    @Bean(name = {"resourceStoreImpl"})
+    public @Override ResourceStore resourceStoreImpl() {
         final @NonNull File dataDirectory = dataDirectoryFile().toFile();
         NoServletContextDataDirectoryResourceStore store =
                 new NoServletContextDataDirectoryResourceStore(dataDirectory);

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/jdbcconfig/JDBCConfigBackendConfigurer.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/jdbcconfig/JDBCConfigBackendConfigurer.java
@@ -153,7 +153,8 @@ public class JDBCConfigBackendConfigurer implements GeoServerBackendConfigurer {
     }
 
     @DependsOn({"extensions", "JDBCConfigDB", "jdbcConfigDataSourceStartupValidator"})
-    public @Override @Bean @NonNull ResourceStore resourceStoreImpl() {
+    @Bean(name = {"resourceStoreImpl"})
+    public @Override @NonNull ResourceStore resourceStoreImpl() {
         final JDBCConfigProperties jdbcConfigProperties = jdbcConfigProperties();
         final CloudJdbcStoreProperties jdbcStoreProperties = jdbcStoreProperties();
         final ConfigDatabase jdbcConfigDB = jdbcConfigDB();

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/SeedingWMSAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/SeedingWMSAutoConfiguration.java
@@ -42,10 +42,10 @@ import org.springframework.context.annotation.ImportResource;
     locations = { //
         "jar:gs-wms-.*!/applicationContext.xml#name=^(?!getMapKvpReader).*$", //
         "jar:gs-wfs-.*!/applicationContext.xml#name="
-                + SedingWMSAutoConfiguration.WFS_BEANS_REGEX //
+                + SeedingWMSAutoConfiguration.WFS_BEANS_REGEX //
     }
 )
-public class SedingWMSAutoConfiguration {
+public class SeedingWMSAutoConfiguration {
 
     static final String WFS_BEANS_REGEX =
             "^(gml.*OutputFormat|bboxKvpParser|xmlConfiguration.*|gml[1-9]*SchemaBuilder|wfsXsd.*|wfsSqlViewKvpParser).*$";

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/CloudCatalogConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/CloudCatalogConfiguration.java
@@ -16,7 +16,7 @@ import org.geowebcache.grid.GridSetBroker;
 import org.springframework.context.event.EventListener;
 
 /** @since 1.0 */
-@Slf4j
+@Slf4j(topic = "org.geoserver.cloud.gwc.repository")
 public class CloudCatalogConfiguration extends CatalogConfiguration {
 
     private LoadingCache<String, GeoServerTileLayer> spyedLayerCache;

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/CloudGwcXmlConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/CloudGwcXmlConfiguration.java
@@ -42,7 +42,7 @@ import org.springframework.context.event.EventListener;
  *     and {@link BlobStoreEvent} appropriately.
  * @since 1.0
  */
-@Slf4j
+@Slf4j(topic = "org.geoserver.cloud.gwc.repository")
 public class CloudGwcXmlConfiguration extends XMLConfiguration {
 
     private final @NonNull Consumer<GeoWebCacheEvent> publisher;

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/CloudXMLResourceProvider.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/CloudXMLResourceProvider.java
@@ -1,0 +1,158 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.gwc.repository;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.ResourceStore;
+import org.geoserver.platform.resource.Resources;
+import org.geoserver.util.IOUtils;
+import org.geowebcache.config.ConfigurationException;
+import org.geowebcache.config.ConfigurationResourceProvider;
+
+/** @since 1.0 */
+@Slf4j(topic = "org.geoserver.cloud.gwc.repository")
+public class CloudXMLResourceProvider implements ConfigurationResourceProvider {
+
+    private String templateLocation = "/geowebcache_empty.xml";
+
+    private Supplier<Resource> configDirectory;
+    private @NonNull String configFileName = "geowebcache.xml";
+
+    /**
+     * @param resourceStore where to {@link ResourceStore#get(String) get} the config directory from
+     * @param configFileName name of the core gwc config file (e.g. {@literal geowebcache.xml})
+     * @throws ConfigurationException
+     */
+    public CloudXMLResourceProvider(@NonNull Supplier<Resource> configDirectory) {
+        this.configDirectory = configDirectory;
+    }
+
+    @Override
+    public InputStream in() throws IOException {
+        return findOrCreateConfFile().in();
+    }
+
+    @Override
+    public OutputStream out() throws IOException {
+        return findOrCreateConfFile().out();
+    }
+
+    @Override
+    public void backup() throws IOException {
+        backUpConfig(findOrCreateConfFile());
+    }
+
+    @Override
+    public String getId() {
+        return getConfigDirectory().path();
+    }
+
+    @Override
+    public void setTemplate(final String templateLocation) {
+        this.templateLocation = templateLocation;
+    }
+
+    private Resource findConfigFile() throws IOException {
+        Resource dir = getConfigDirectory();
+        return dir.get(configFileName);
+    }
+
+    public Resource getConfigDirectory() {
+        Resource dir = configDirectory.get();
+        Objects.requireNonNull(dir);
+        return dir;
+    }
+
+    public String getConfigFileName() {
+        return configFileName;
+    }
+
+    @Override
+    public String getLocation() throws IOException {
+        return findConfigFile().path();
+    }
+
+    private Resource findOrCreateConfFile() throws IOException {
+        Resource xmlFile = findConfigFile();
+
+        if (!Resources.exists(xmlFile)) {
+            log.warn(
+                    "Found no configuration file in config directory, will create one at '{}' from template {}",
+                    xmlFile.path(),
+                    getClass().getResource(templateLocation).toExternalForm());
+            // grab template from classpath
+            try {
+                IOUtils.copy(getClass().getResourceAsStream(templateLocation), xmlFile.out());
+            } catch (IOException e) {
+                throw new IOException("Error copying template config to " + xmlFile.path(), e);
+            }
+        }
+
+        return xmlFile;
+    }
+
+    private void backUpConfig(final Resource xmlFile) throws IOException {
+        String timeStamp = new SimpleDateFormat("yyyy-MM-dd'T'HHmmss").format(new Date());
+        String backUpFileName = "geowebcache_" + timeStamp + ".bak";
+        Resource parentFile = xmlFile.parent();
+
+        log.debug("Backing up config file {} to {}", xmlFile.name(), backUpFileName);
+
+        List<Resource> previousBackUps =
+                Resources.list(
+                        parentFile,
+                        res -> {
+                            if (configFileName.equals(res.name())) {
+                                return false;
+                            }
+                            if (res.name().startsWith(configFileName)
+                                    && res.name().endsWith(".bak")) {
+                                return true;
+                            }
+                            return false;
+                        });
+
+        final int maxBackups = 10;
+        if (previousBackUps.size() > maxBackups) {
+            Collections.sort(
+                    previousBackUps, (o1, o2) -> (int) (o1.lastmodified() - o2.lastmodified()));
+            Resource oldest = previousBackUps.get(0);
+            log.debug(
+                    "Deleting oldest config backup {} to keep a maximum of {} backups.",
+                    oldest,
+                    maxBackups);
+            oldest.delete();
+        }
+
+        Resource backUpFile = parentFile.get(backUpFileName);
+        IOUtils.copy(xmlFile.in(), backUpFile.out());
+        log.debug("Config backup done");
+    }
+
+    @Override
+    public boolean hasInput() {
+        try {
+            return Resources.exists(findOrCreateConfFile());
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean hasOutput() {
+        return true;
+    }
+}

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/ResourceStoreTileLayerCatalog.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/ResourceStoreTileLayerCatalog.java
@@ -52,7 +52,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.context.WebApplicationContext;
 
 /** @since 1.0 */
-@Slf4j
+@Slf4j(topic = "org.geoserver.cloud.gwc.repository")
 @RequiredArgsConstructor
 public class ResourceStoreTileLayerCatalog implements TileLayerCatalog {
 

--- a/starters/starter-gwc/src/main/resources/META-INF/spring.factories
+++ b/starters/starter-gwc/src/main/resources/META-INF/spring.factories
@@ -3,6 +3,6 @@ org.geoserver.cloud.autoconfigure.gwc.core.GwcCoreAutoConfiguration,\
 org.geoserver.cloud.autoconfigure.gwc.integration.GeoServerIntegrationAutoConfiguration,\
 org.geoserver.cloud.autoconfigure.gwc.integration.LocalEventsAutoConfiguration,\
 org.geoserver.cloud.autoconfigure.gwc.integration.RemoteEventsAutoConfiguration,\
-org.geoserver.cloud.autoconfigure.gwc.integration.SedingWMSAutoConfiguration,\
+org.geoserver.cloud.autoconfigure.gwc.integration.SeedingWMSAutoConfiguration,\
 org.geoserver.cloud.autoconfigure.gwc.integration.WMTSIntegrationAutoConfiguration,\
 org.geoserver.cloud.autoconfigure.web.gwc.WebUIAutoConfiguration

--- a/starters/starter-webmvc/src/main/java/org/geoserver/cloud/config/main/GeoServerMainModuleConfiguration.java
+++ b/starters/starter-webmvc/src/main/java/org/geoserver/cloud/config/main/GeoServerMainModuleConfiguration.java
@@ -64,11 +64,31 @@ import org.springframework.context.annotation.ImportResource;
 public class GeoServerMainModuleConfiguration {
 
     private static final String UNUSED_BEAN_NAMES =
-            "proxyfierHeaderCollector|proxyfierHeaderTransfer|proxyfier" //
-                    + "|fileLockProvider|memoryLockProvider|nullLockProvider|lockProviderInitializer";
+            "proxyfierHeaderCollector"
+                    + "|proxyfierHeaderTransfer"
+                    + "|proxyfier"
+                    + "|fileLockProvider"
+                    + "|memoryLockProvider"
+                    + "|nullLockProvider"
+                    + "|lockProviderInitializer";
 
     private static final String OVERRIDDEN_BEAN_NAMES =
-            "rawCatalog|secureCatalog|localWorkspaceCatalog|catalog|advertisedCatalog|accessRulesDao|catalogFacade|dataDirectory|extensions|geoServer|geoserverFacade|geoServerLoader|geoServerSecurityManager|resourceLoader|resourceStoreImpl|secureCatalog|xstreamPersisterFactory";
+            "rawCatalog"
+                    + "|secureCatalog"
+                    + "|localWorkspaceCatalog"
+                    + "|catalog"
+                    + "|advertisedCatalog"
+                    + "|accessRulesDao"
+                    + "|catalogFacade"
+                    + "|dataDirectory"
+                    + "|extensions"
+                    + "|geoServer"
+                    + "|geoserverFacade"
+                    + "|geoServerLoader"
+                    + "|geoServerSecurityManager"
+                    + "|resourceLoader"
+                    + "|resourceStoreImpl"
+                    + "|xstreamPersisterFactory";
 
     static final String EXCLUDE_BEANS_REGEX =
             "^(?!" + OVERRIDDEN_BEAN_NAMES + "|" + UNUSED_BEAN_NAMES + ").*$";


### PR DESCRIPTION
GeoserverXMLResourceProvider eagerly resolves the
geoserver.xml resource and its parent at its
constructor, which is not good practice as
it may end calling an unitialized GeoServerExtensions
bean.

Resolve the location at the @Configuration and use
a resource provider that only cares about its
Supplier<Resource> instead.