### PR TITLE
Add MBStyle extension (wms, gwc, and webui services)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -502,6 +502,11 @@
       </dependency>
       <dependency>
         <groupId>org.geoserver.extension</groupId>
+        <artifactId>gs-mbstyle</artifactId>
+        <version>${gs.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.extension</groupId>
         <artifactId>gs-ysld</artifactId>
         <version>${gs.version}</version>
       </dependency>

--- a/starters/starter-wms-extensions/pom.xml
+++ b/starters/starter-wms-extensions/pom.xml
@@ -16,6 +16,10 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-mbstyle</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-css</artifactId>
       <exclusions>
         <exclusion>

--- a/starters/starter-wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/WmsExtensionsAutoConfiguration.java
+++ b/starters/starter-wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/WmsExtensionsAutoConfiguration.java
@@ -11,5 +11,11 @@ import org.springframework.context.annotation.Import;
 /** @since 1.0 */
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(WmsExtensionsConfigProperties.class)
-@Import(value = {CssStylingConfiguration.class, VectorTilesConfiguration.class})
+@Import(
+    value = {
+        CssStylingConfiguration.class,
+        MapBoxStylingConfiguration.class,
+        VectorTilesConfiguration.class
+    }
+)
 public class WmsExtensionsAutoConfiguration {}

--- a/starters/starter-wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/WmsExtensionsConfigProperties.java
+++ b/starters/starter-wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/WmsExtensionsConfigProperties.java
@@ -18,6 +18,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * geoserver:
  *   styling:
  *     css.enabled: true
+ *     mapbox.enabled: true
  *   wms:
  *     outputFormats:
  *       vectorTiles:
@@ -40,6 +41,7 @@ public @Data class WmsExtensionsConfigProperties {
 
     public static @Data class Styling {
         private EnabledProperty css = new EnabledProperty();
+        private EnabledProperty mapbox = new EnabledProperty();
     }
 
     public static @Data class Wms {

--- a/starters/starter-wms-extensions/src/test/java/org/geoserver/cloud/autoconfigure/wms/MapBoxStylingConfigurationTest.java
+++ b/starters/starter-wms-extensions/src/test/java/org/geoserver/cloud/autoconfigure/wms/MapBoxStylingConfigurationTest.java
@@ -1,0 +1,62 @@
+/*
+ * (c) 2021 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.wms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.geoserver.catalog.SLDHandler;
+import org.geoserver.community.mbstyle.MBStyleHandler;
+import org.geoserver.platform.ModuleStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * Test suite for {@link CssStylingConfiguration}
+ *
+ * @since 1.0
+ */
+public class MapBoxStylingConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner()
+                    .withBean("sldHandler", SLDHandler.class)
+                    .withConfiguration(AutoConfigurations.of(MapBoxStylingConfiguration.class));
+
+    @Test
+    void MBStyleHandler_no_config() {
+        contextRunner
+                .run(context -> assertThat(context).hasSingleBean(MBStyleHandler.class))
+                .run(context -> assertThat(context).hasBean("MBStyleExtension"))
+                .run(
+                        context ->
+                                assertThat(context.getBean("MBStyleExtension", ModuleStatus.class))
+                                        .hasFieldOrPropertyWithValue("enabled", true));
+    }
+
+    @Test
+    void MBStyleHandler_enabled() {
+        contextRunner
+                .withPropertyValues("geoserver.styling.mapbox.enabled=true")
+                .run(context -> assertThat(context).hasSingleBean(MBStyleHandler.class))
+                .run(context -> assertThat(context).hasBean("MBStyleExtension"))
+                .run(
+                        context ->
+                                assertThat(context.getBean("MBStyleExtension", ModuleStatus.class))
+                                        .hasFieldOrPropertyWithValue("enabled", true));
+    }
+
+    @Test
+    void MBStyleHandler_disabled_registers_module_status() {
+        contextRunner
+                .withPropertyValues("geoserver.styling.mapbox.enabled=false")
+                .run(context -> assertThat(context).doesNotHaveBean(MBStyleHandler.class))
+                .run(context -> assertThat(context).hasBean("MBStyleExtension"))
+                .run(
+                        context ->
+                                assertThat(context.getBean("MBStyleExtension", ModuleStatus.class))
+                                        .hasFieldOrPropertyWithValue("enabled", false));
+    }
+}


### PR DESCRIPTION
Fixes #156

Enabled by default, can be disabled with the following
configuration property:

```
geoserver.styling.mapbox.enabled=false
```

Applies to `wms-service`, `gwc-service`, and `webui-service`, as per the `gs-cloud-starter-wms-extensions` dependency.
