### PR TITLE
Integrate AuthKey security extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,11 @@
       </dependency>
       <dependency>
         <groupId>org.geoserver.cloud</groupId>
+        <artifactId>gs-cloud-starter-security</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.cloud</groupId>
         <artifactId>gs-cloud-starter-jackson</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -358,6 +363,16 @@
         <version>${gs.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.geoserver.web</groupId>
+        <artifactId>gs-web-sec-core</artifactId>
+        <version>${gs.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver</groupId>
+        <artifactId>gs-rest</artifactId>
+        <version>${gs.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-restconfig</artifactId>
         <version>${gs.version}</version>
@@ -518,6 +533,11 @@
       <dependency>
         <groupId>org.geoserver.extension</groupId>
         <artifactId>gs-vectortiles</artifactId>
+        <version>${gs.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.extension</groupId>
+        <artifactId>gs-authkey</artifactId>
         <version>${gs.version}</version>
       </dependency>
       <dependency>

--- a/services/gwc/pom.xml
+++ b/services/gwc/pom.xml
@@ -21,11 +21,15 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
-      <artifactId>gs-cloud-starter-gwc</artifactId>
+      <artifactId>gs-cloud-starter-webmvc</artifactId>
     </dependency>
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
-      <artifactId>gs-cloud-starter-webmvc</artifactId>
+      <artifactId>gs-cloud-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-starter-gwc</artifactId>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>

--- a/services/restconfig/pom.xml
+++ b/services/restconfig/pom.xml
@@ -21,6 +21,10 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-cloud-starter-vector-formats</artifactId>
     </dependency>
     <dependency>

--- a/services/wcs/pom.xml
+++ b/services/wcs/pom.xml
@@ -21,6 +21,10 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-cloud-starter-raster-formats</artifactId>
     </dependency>
     <dependency>

--- a/services/web-ui/pom.xml
+++ b/services/web-ui/pom.xml
@@ -22,6 +22,10 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-cloud-starter-wms-extensions</artifactId>
     </dependency>
     <dependency>

--- a/services/wfs/pom.xml
+++ b/services/wfs/pom.xml
@@ -21,6 +21,10 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-cloud-starter-vector-formats</artifactId>
     </dependency>
     <dependency>

--- a/services/wms/pom.xml
+++ b/services/wms/pom.xml
@@ -21,6 +21,10 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-cloud-starter-wms-extensions</artifactId>
     </dependency>
     <dependency>

--- a/services/wps/pom.xml
+++ b/services/wps/pom.xml
@@ -21,6 +21,10 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-cloud-starter-vector-formats</artifactId>
     </dependency>
     <dependency>

--- a/starters/pom.xml
+++ b/starters/pom.xml
@@ -19,6 +19,7 @@
     <module>starter-reactive</module>
     <module>starter-wms-extensions</module>
     <module>starter-gwc</module>
+    <module>starter-security</module>
   </modules>
   <dependencies>
     <dependency>

--- a/starters/starter-security/pom.xml
+++ b/starters/starter-security/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.geoserver.cloud</groupId>
+    <artifactId>gs-cloud-starters</artifactId>
+    <version>${revision}</version>
+  </parent>
+  <artifactId>gs-cloud-starter-security</artifactId>
+  <packaging>jar</packaging>
+  <description>Curated Autoconfigurations of supported AuthZN extensions</description>
+  <dependencies>
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-authkey</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>gs-rest</artifactId>
+          <groupId>org.geoserver</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>gs-web-sec-core</artifactId>
+          <groupId>org.geoserver.web</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-rest</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.web</groupId>
+      <artifactId>gs-web-sec-core</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <!-- need it on the classpath just to avoid ClassNotFoundExceptions when loading some GeoServer bean definitions -->
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+</project>

--- a/starters/starter-security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/AuthKeyAutoConfiguration.java
+++ b/starters/starter-security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/AuthKeyAutoConfiguration.java
@@ -1,0 +1,79 @@
+/*
+ * (c) 2021 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.authzn;
+
+import javax.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.platform.ModuleStatus;
+import org.geoserver.platform.ModuleStatusImpl;
+import org.geoserver.security.web.auth.AuthenticationFilterPanel;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.ImportResource;
+
+/** @since 1.0 */
+@Configuration(proxyBeanMethods = false)
+@Import({AuthKeyAutoConfiguration.Enabled.class, AuthKeyAutoConfiguration.WebUI.class})
+@Slf4j(topic = "org.geoserver.cloud.autoconfigure.authzn")
+public class AuthKeyAutoConfiguration {
+
+    static final String GEOSERVER_SECURITY_AUTHKEY = "geoserver.security.authkey";
+
+    private static final String WEB_UI_BEANS =
+            "authKeyPanelInfo|authKeyRESTRoleServicePanelInfo|authKeyWebServiceBodyResponseUserGroupServicePanelInfo";
+
+    @Bean(name = "authKeyExtension")
+    ModuleStatus authKeyExtension(
+            @Value(
+                            "${"
+                                    + GEOSERVER_SECURITY_AUTHKEY
+                                    + ":"
+                                    + ConditionalOnAuthKeyEnabled.enabledByDefault
+                                    + "}")
+                    boolean enabled) {
+
+        ModuleStatusImpl module = new ModuleStatusImpl();
+        module.setName("Authkey Extension");
+        module.setModule("gs-authkey");
+        module.setComponent("Authkey extension");
+        module.setAvailable(true);
+        module.setEnabled(enabled);
+        if (!enabled) {
+            module.setMessage(
+                    "Authkey Extension disabled. " + GEOSERVER_SECURITY_AUTHKEY + "=false");
+        }
+        return module;
+    }
+
+    @ConditionalOnAuthKeyEnabled
+    @ImportResource(
+        reader = FilteringXmlBeanDefinitionReader.class,
+        locations = {Enabled.INCLUDE}
+    )
+    static @Configuration class Enabled {
+        static final String EXCLUDE = "authKeyExtension|" + WEB_UI_BEANS;
+        static final String INCLUDE =
+                "jar:gs-authkey-.*!/applicationContext.xml#name=^(?!" + EXCLUDE + ").*$";
+
+        public @PostConstruct void log() {
+            log.info("{} enabled", GEOSERVER_SECURITY_AUTHKEY);
+        }
+    }
+
+    @ConditionalOnAuthKeyEnabled
+    @ConditionalOnClass(AuthenticationFilterPanel.class)
+    @ImportResource(
+        reader = FilteringXmlBeanDefinitionReader.class,
+        locations = {WebUI.INCLUDE}
+    )
+    static @Configuration class WebUI {
+        static final String INCLUDE =
+                "jar:gs-authkey-.*!/applicationContext.xml#name=^(" + WEB_UI_BEANS + ").*$";
+    }
+}

--- a/starters/starter-security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/ConditionalOnAuthKeyEnabled.java
+++ b/starters/starter-security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/ConditionalOnAuthKeyEnabled.java
@@ -1,0 +1,41 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.authzn;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.geoserver.security.GeoServerAuthenticationKeyProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+
+/**
+ * Conditionals:
+ *
+ * <ul>
+ *   <li>Authkey extension is in the classpath
+ *   <li>{@literal geoserver.security.authkey=true}: Authkey module enabled. Defaults to {@code
+ *       false}
+ * </ul>
+ *
+ * @since 1.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Documented
+@ConditionalOnWebApplication(type = Type.SERVLET)
+@ConditionalOnClass(GeoServerAuthenticationKeyProvider.class)
+@ConditionalOnProperty(
+    name = AuthKeyAutoConfiguration.GEOSERVER_SECURITY_AUTHKEY,
+    havingValue = "true",
+    matchIfMissing = ConditionalOnAuthKeyEnabled.enabledByDefault
+)
+public @interface ConditionalOnAuthKeyEnabled {
+    boolean enabledByDefault = false;
+}

--- a/starters/starter-security/src/main/resources/META-INF/spring.factories
+++ b/starters/starter-security/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.geoserver.cloud.autoconfigure.authzn.AuthKeyAutoConfiguration

--- a/starters/starter-security/src/test/java/org/geoserver/cloud/autoconfigure/authzn/AuthKeyAutoConfigurationTest.java
+++ b/starters/starter-security/src/test/java/org/geoserver/cloud/autoconfigure/authzn/AuthKeyAutoConfigurationTest.java
@@ -1,0 +1,116 @@
+/*
+ * (c) 2021 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.authzn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.geoserver.platform.ModuleStatus;
+import org.geoserver.security.AuthenticationKeyMangler;
+import org.geoserver.security.GeoServerAuthenticationKeyProvider;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.PropertyAuthenticationKeyMapper;
+import org.geoserver.security.UserPropertyAuthenticationKeyMapper;
+import org.geoserver.security.WebServiceAuthenticationKeyMapper;
+import org.geoserver.security.WebServiceBodyResponseSecurityProvider;
+import org.geoserver.security.web.AuthenticationKeyFilterPanelInfo;
+import org.geoserver.security.web.GeoServerRestRoleServicePanelInfo;
+import org.geoserver.security.web.WebServiceBodyResponseUserGroupServicePanelInfo;
+import org.geoserver.security.web.auth.AuthenticationFilterPanel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+
+/**
+ * Test suite for {@link AuthKeyAutoConfiguration}
+ *
+ * @since 1.0
+ */
+public class AuthKeyAutoConfigurationTest {
+
+    private WebApplicationContextRunner contextRunner =
+            new WebApplicationContextRunner()
+                    .withConfiguration(AutoConfigurations.of(AuthKeyAutoConfiguration.class));
+
+    @BeforeEach
+    void mockBeanDependencies() {
+        GeoServerSecurityManager mockSM = mock(GeoServerSecurityManager.class);
+        contextRunner = contextRunner.withBean(GeoServerSecurityManager.class, () -> mockSM);
+    }
+
+    public @Test void testModuleStatus_disabled_by_default() {
+        contextRunner
+                .run(context -> assertThat(context).hasBean("authKeyExtension"))
+                .run(
+                        context ->
+                                assertThat(context)
+                                        .getBean("authKeyExtension", ModuleStatus.class)
+                                        .hasFieldOrPropertyWithValue("enabled", false));
+    }
+
+    public @Test void testModuleStatus_enabled() {
+        contextRunner
+                .withPropertyValues("geoserver.security.authkey=true")
+                .run(context -> assertThat(context).hasBean("authKeyExtension"))
+                .run(
+                        context ->
+                                assertThat(context)
+                                        .getBean("authKeyExtension", ModuleStatus.class)
+                                        .hasFieldOrPropertyWithValue("enabled", true));
+    }
+
+    public @Test void testModuleStatus_disabled() {
+        contextRunner
+                .withPropertyValues("geoserver.security.authkey=false")
+                .run(context -> assertThat(context).hasBean("authKeyExtension"))
+                .run(
+                        context ->
+                                assertThat(context)
+                                        .getBean("authKeyExtension", ModuleStatus.class)
+                                        .hasFieldOrPropertyWithValue("enabled", false));
+    }
+
+    public @Test void testGeoServerAuthenticationKeyProvider_enabled_no_GsWebSecCore_InClasspath() {
+        contextRunner
+                .withPropertyValues("geoserver.security.authkey=true")
+                // AuthenticationFilterPanel is from gs-web-sec-core, used as @ConditionalOnClass to
+                // enabled the web-ui components
+                .withClassLoader(new FilteredClassLoader(AuthenticationFilterPanel.class))
+                .run(
+                        ctx -> {
+                            assertThat(ctx).doesNotHaveBean(AuthenticationKeyFilterPanelInfo.class);
+                            assertThat(ctx)
+                                    .doesNotHaveBean(GeoServerRestRoleServicePanelInfo.class);
+                            assertThat(ctx)
+                                    .doesNotHaveBean(
+                                            WebServiceBodyResponseUserGroupServicePanelInfo.class);
+                        });
+    }
+
+    public @Test void testGeoServerAuthenticationKeyProvider_enabled() {
+        contextRunner
+                .withPropertyValues("geoserver.security.authkey=true")
+                .run(
+                        ctx -> {
+                            assertThat(ctx).hasSingleBean(GeoServerAuthenticationKeyProvider.class);
+                            assertThat(ctx).hasSingleBean(AuthenticationKeyMangler.class);
+                            assertThat(ctx).hasSingleBean(PropertyAuthenticationKeyMapper.class);
+                            assertThat(ctx)
+                                    .hasSingleBean(UserPropertyAuthenticationKeyMapper.class);
+                            assertThat(ctx).hasSingleBean(WebServiceAuthenticationKeyMapper.class);
+                            assertThat(ctx).hasSingleBean(GeoServerAuthenticationKeyProvider.class);
+                            assertThat(ctx)
+                                    .hasSingleBean(WebServiceBodyResponseSecurityProvider.class);
+
+                            assertThat(ctx).hasSingleBean(AuthenticationKeyFilterPanelInfo.class);
+                            assertThat(ctx)
+                                    .hasSingleBean(
+                                            WebServiceBodyResponseUserGroupServicePanelInfo.class);
+                            assertThat(ctx).hasSingleBean(GeoServerRestRoleServicePanelInfo.class);
+                        });
+    }
+}


### PR DESCRIPTION
AuthKey extension spring-boot autoconfiguration.

It is disabled by default. Enable in `application.yml`
as follows:

```
 geoserver:
  security:
    enabled: true
    authkey: true
```

The auto-configuration integrates the core security beans, and the
WebUI components only if the running application context contains
the `gs-sec-core` compoenents.