### PR TITLE
Fetch eureka service registry only on services that use it

### DIFF
--- a/services/catalog/src/main/resources/bootstrap.yml
+++ b/services/catalog/src/main/resources/bootstrap.yml
@@ -58,6 +58,9 @@ spring:
       - org.springframework.boot.autoconfigure.security.reactive.ReactiveUserDetailsServiceAutoConfiguration
       - org.springframework.boot.actuate.autoconfigure.security.reactive.ReactiveManagementWebSecurityAutoConfiguration
 
+# override default of true, this service does not use the registry (when eureka client is enabled)
+eureka.client.fetch-registry: false
+
 logging:
   level:
     org.springframework.retry: debug

--- a/services/gwc/src/main/resources/bootstrap.yml
+++ b/services/gwc/src/main/resources/bootstrap.yml
@@ -55,6 +55,9 @@ spring:
       - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
       - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
 
+# override default of true, this service does not use the registry (when eureka client is enabled)
+eureka.client.fetch-registry: false
+
 logging.level:
     '[org.springframework.retry]': debug
 

--- a/services/restconfig/src/main/resources/bootstrap.yml
+++ b/services/restconfig/src/main/resources/bootstrap.yml
@@ -34,6 +34,9 @@ spring:
       - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
       - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
 
+# override default of true, this service does not use the registry (when eureka client is enabled)
+eureka.client.fetch-registry: false
+
 logging.level:
     '[org.springframework.retry]': debug
 

--- a/services/wcs/src/main/resources/bootstrap.yml
+++ b/services/wcs/src/main/resources/bootstrap.yml
@@ -34,6 +34,9 @@ spring:
       - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
       - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
 
+# override default of true, this service does not use the registry (when eureka client is enabled)
+eureka.client.fetch-registry: false
+
 logging.level:
     '[org.springframework.retry]': debug
 

--- a/services/web-ui/src/main/resources/bootstrap.yml
+++ b/services/web-ui/src/main/resources/bootstrap.yml
@@ -46,6 +46,11 @@ spring:
       - org.geoserver.cloud.autoconfigure.gwc.service.RESTConfigAutoConfiguration
       - org.geoserver.cloud.autoconfigure.web.gwc.GeoWebCacheUIAutoConfiguration
 
+# same as default of true, this service does use the registry (when eureka client is enabled)
+eureka.client:
+  fetch-registry: true
+  registry-fetch-interval-seconds: 10
+
 geoserver:
   styling:
     css.enabled: true

--- a/services/wfs/src/main/resources/bootstrap.yml
+++ b/services/wfs/src/main/resources/bootstrap.yml
@@ -36,6 +36,9 @@ spring:
       - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
       - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
 
+# override default of true, this service does not use the registry (when eureka client is enabled)
+eureka.client.fetch-registry: false
+
 logging.level:
     '[org.springframework.retry]': debug
 

--- a/services/wms/src/main/resources/bootstrap.yml
+++ b/services/wms/src/main/resources/bootstrap.yml
@@ -34,6 +34,9 @@ spring:
       - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
       - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
 
+# override default of true, this service does not use the registry (when eureka client is enabled)
+eureka.client.fetch-registry: false
+
 logging.level:
     '[org.springframework.retry]': debug
 ---

--- a/services/wps/src/main/resources/bootstrap.yml
+++ b/services/wps/src/main/resources/bootstrap.yml
@@ -34,6 +34,9 @@ spring:
       - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
       - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
 
+# override default of true, this service does not use the registry (when eureka client is enabled)
+eureka.client.fetch-registry: false
+
 logging.level:
     '[org.springframework.retry]': debug
 ---

--- a/starters/starter-spring-boot/src/main/resources/gs_cloud_bootstrap_profiles.yml
+++ b/starters/starter-spring-boot/src/main/resources/gs_cloud_bootstrap_profiles.yml
@@ -45,8 +45,7 @@ eureka:
   client:
     enabled: true
     registerWithEureka: true
-    fetchRegistry: true
-    registry-fetch-interval-seconds: 30
+    #registry-fetch-interval-seconds: 10
     serviceUrl:
       defaultZone: ${eureka.server.url}
     healthcheck:
@@ -103,8 +102,7 @@ eureka:
   client:
     enabled: true
     registerWithEureka: true
-    fetchRegistry: true
-    registry-fetch-interval-seconds: 30
+    registry-fetch-interval-seconds: 10
     serviceUrl:
       defaultZone: ${eureka.server.url}
     healthcheck:

--- a/support-services/admin/src/main/resources/bootstrap.yml
+++ b/support-services/admin/src/main/resources/bootstrap.yml
@@ -31,6 +31,9 @@ spring:
         enabled: false
         service-id: config-service
 
+# override default of false, this service uses the registry (when eureka client is enabled)
+eureka.client.fetch-registry: true
+
 logging.level:
     '[org.springframework.retry]': debug
 

--- a/support-services/api-gateway/src/main/resources/bootstrap.yml
+++ b/support-services/api-gateway/src/main/resources/bootstrap.yml
@@ -25,6 +25,11 @@ spring:
 logging.level:
     '[org.springframework.retry]': debug
 
+# this service uses the registry (when eureka client is enabled)
+eureka.client:
+  fetch-registry: true
+  registry-fetch-interval-seconds: 5
+
 ---
 # local profile, used for development only. Other settings like config and eureka urls in gs_cloud_bootstrap_profiles.yml
 spring.config.activate.on-profile: local

--- a/support-services/config/src/main/resources/application.yml
+++ b/support-services/config/src/main/resources/application.yml
@@ -47,6 +47,9 @@ spring:
           search-locations:
           - ${config.native.path:file:./config}
 
+# override default of true, this service does not use the registry (when eureka client is enabled)
+eureka.client.fetch-registry: false
+
 management:
   endpoints:
     enabled-by-default: true


### PR DESCRIPTION
Set `eureka.client.fetch-registry: false` by default,
enable it only on services that make actual use of it:
- admin-service
- gateway-service
- web-ui

For gateway, set `eureka.registry-fetch-interval-seconds: 5`
to fetch the registry every 5 seconds, speeding up the inital
awarness of services.

Fixes #10