### PR TITLE
Use different session cookie names in web-ui and gwc-service

### DIFF
--- a/services/gwc/src/main/resources/bootstrap.yml
+++ b/services/gwc/src/main/resources/bootstrap.yml
@@ -26,7 +26,13 @@ server:
   port: 8080
   # Let spring-boot's ForwardedHeaderFilter take care of reflecting the client-originated protocol and address in the HttpServletRequest  
   forward-headers-strategy: framework
-  servlet.context-path: /
+  servlet:
+    context-path: /
+    session:
+      tracking-modes: COOKIE
+      cookie:
+        name: JSESSIONID_${spring.application.name}
+        http-only: true
 management.server.port: 8081
 spring:
   config:

--- a/services/web-ui/src/main/resources/bootstrap.yml
+++ b/services/web-ui/src/main/resources/bootstrap.yml
@@ -7,7 +7,12 @@ server:
   forward-headers-strategy: framework
   servlet:
     context-path: /
-    session.tracking-modes: COOKIE
+    session:
+      tracking-modes: COOKIE
+      cookie:
+        name: JSESSIONID_${spring.application.name}
+        http-only: true
+        
 management.server.port: 8081
 spring:
   config:


### PR DESCRIPTION
Both web-ui and gwc-service use sessions. Configure different
cookie names so going back and forth between the two doesn't
lose the authentication. Otherwise the effect is to be logged
out when moving from one to the other.

E.g.:

![image](https://user-images.githubusercontent.com/207423/154826644-8cc7fabf-a65d-48a3-ac8c-4ee0ccf69ac0.png)
