### PR TITLE
gwc: fix blobstore remote event handling, CompositeBlobStore didn't notice

### DIFF
--- a/starters/starter-gwc/README.md
+++ b/starters/starter-gwc/README.md
@@ -2,3 +2,36 @@
 
 A set of spring-boot auto configurations to integrate different
 GeoWebcache functionalities into other microservices.
+
+## Cloud Native GeoServer specific extensions
+
+```mermaid
+classDiagram
+    direction TB
+    TileLayerCatalog <|-- ResourceStoreTileLayerCatalog
+    TileLayerCatalog <|-- CachingTileLayerCatalog
+    CatalogConfiguration <|-- CloudCatalogConfiguration
+    CatalogConfiguration --> TileLayerCatalog
+    XmlConfiguration <|-- CloudGwcXmlConfiguration
+    ConfigurationResourceProvider <|-- CloudXMLResourceProvider
+    XmlConfiguration --> ConfigurationResourceProvider
+    <<Interface>> TileLayerCatalog
+    <<Interface>> ConfigurationResourceProvider
+    class CloudCatalogConfiguration{
+        <<EventListener>>
+        onTileLayerEvent(TileLayerEvent event)
+    }
+    class ResourceStoreTileLayerCatalog{
+        - ResourceStore resourceStore
+        findAll() Stream~GeoServerTileLayerInfo~
+    }
+    class CachingTileLayerCatalog{
+        - CacheManager cacheManager
+        - TileLayerCatalog delegate
+    }
+    class CloudGwcXmlConfiguration{
+        <<EventListener>>
+        onGridsetEvent(GridsetEvent event)
+        onBlobStoreEvent(BlobStoreEvent event)
+    }
+```

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/bus/RemoteBlobStoreEvent.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/bus/RemoteBlobStoreEvent.java
@@ -16,6 +16,7 @@ public class RemoteBlobStoreEvent extends RemoteGeoWebCacheEvent {
     private static final long serialVersionUID = 1L;
 
     private @Getter @Setter String blobStoreId;
+    private @Getter @Setter String oldName;
 
     public RemoteBlobStoreEvent(Object source, @NonNull String originService) {
         super(source, originService);

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/event/BlobStoreEvent.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/event/BlobStoreEvent.java
@@ -14,13 +14,22 @@ public class BlobStoreEvent extends GeoWebCacheEvent {
 
     private @Getter @Setter String blobStoreId;
 
+    private @Getter @Setter String oldName;
+
     public BlobStoreEvent(Object source) {
         super(source);
     }
 
-    public BlobStoreEvent(Object source, @NonNull Type eventType, @NonNull String blobStoreId) {
+    public BlobStoreEvent(Object source, @NonNull Type eventType, @NonNull String blobStoreName) {
         super(source, eventType);
-        this.blobStoreId = blobStoreId;
+        this.blobStoreId = blobStoreName;
+    }
+
+    public BlobStoreEvent(
+            Object source, @NonNull Type eventType, String oldName, @NonNull String blobStoreName) {
+        super(source, eventType);
+        this.oldName = oldName;
+        this.blobStoreId = blobStoreName;
     }
 
     protected @Override String getObjectId() {

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/CloudCatalogConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/CloudCatalogConfiguration.java
@@ -19,7 +19,7 @@ import org.springframework.context.event.EventListener;
 @Slf4j(topic = "org.geoserver.cloud.gwc.repository")
 public class CloudCatalogConfiguration extends CatalogConfiguration {
 
-    private LoadingCache<String, GeoServerTileLayer> spyedLayerCache;
+    private LoadingCache<String, GeoServerTileLayer> spiedLayerCache;
 
     @SuppressWarnings("unchecked")
     public CloudCatalogConfiguration(
@@ -28,7 +28,7 @@ public class CloudCatalogConfiguration extends CatalogConfiguration {
         super(catalog, tileLayerCatalog, gridSetBroker);
 
         try {
-            spyedLayerCache =
+            spiedLayerCache =
                     (LoadingCache<String, GeoServerTileLayer>)
                             FieldUtils.readField(this, "layerCache", true);
         } catch (IllegalAccessException e) {
@@ -39,6 +39,6 @@ public class CloudCatalogConfiguration extends CatalogConfiguration {
     @EventListener(TileLayerEvent.class)
     public void onTileLayerEvent(TileLayerEvent event) {
         log.debug("evicting GeoServerTileLayer cache entry upon {}", event);
-        spyedLayerCache.invalidate(event.getLayerId());
+        spiedLayerCache.invalidate(event.getLayerId());
     }
 }


### PR DESCRIPTION
Upstream's `CompositeBlobStore` registers itself as a
`BlobStoreConfigurationListener`.

When the `RemoteBlobstoreEvent`s came in through the event
bus, the xml configuration was correctly reloaded, but
`CompositeBlobStore`, which holds the `BlobStoreInfo`s
as internal state, didn't notice.

Now `CloudGwcXmlConfiguration` will notify its (legacy style)
listeners when `BlobStoreEvent` is being handled, as a
result of `GeoWebCacheRemoteEventsBroker` publishing
a conveying a remote event as a local event.