### PR TITLE
Switch to Java17 with default docker images supporting cgroups v2

### DIFF
--- a/.env
+++ b/.env
@@ -8,27 +8,25 @@ JDBCCONFIG_URL=jdbc:postgresql://database:5432/${JDBCCONFIG_DBNAME}
 JDBCCONFIG_USERNAME=geoserver
 JDBCCONFIG_PASSWORD=geo5erver
 
-# Force the max RAM (-XX:MaxRAM) seen by the JVM in case --compatibility 
-# wasn't used to launch the composition. Make sure the value is consistent
-# with each service's deploy.resources.limits.memory in docker-comopose.yml
+# Remember to use docker-compose --compatibility 
 
-DISCOVERY_JAVA_OPTS=-XX:MaxRAMPercentage=80 -XX:MaxRAM=512M
+DISCOVERY_JAVA_OPTS=-XX:MaxRAMPercentage=80 -XshowSettings:system
 
-CONFIG_JAVA_OPTS=-XX:MaxRAMPercentage=80 -XX:MaxRAM=512M
+CONFIG_JAVA_OPTS=-XX:MaxRAMPercentage=80 -XshowSettings:system
 
-GATEWAY_JAVA_OPTS=-XX:MaxRAMPercentage=80 -XX:MaxRAM=1G
+GATEWAY_JAVA_OPTS=-XX:MaxRAMPercentage=80 -XshowSettings:system
 
-CATALOG_JAVA_OPTS=-XX:MaxRAMPercentage=80 -XX:MaxRAM=1G
+CATALOG_JAVA_OPTS=-XX:MaxRAMPercentage=80 -XshowSettings:system
 
-WFS_JAVA_OPTS=-XX:MaxRAMPercentage=80 -XX:MaxRAM=1G
+WFS_JAVA_OPTS=-XX:MaxRAMPercentage=80 -XshowSettings:system
 
-WMS_JAVA_OPTS=-XX:MaxRAMPercentage=80 -XX:MaxRAM=1G
+WMS_JAVA_OPTS=-XX:MaxRAMPercentage=80 -XshowSettings:system
 
-WCS_JAVA_OPTS=-XX:MaxRAMPercentage=80 -XX:MaxRAM=1G
+WCS_JAVA_OPTS=-XX:MaxRAMPercentage=80 -XshowSettings:system
 
-WPS_JAVA_OPTS=-XX:MaxRAMPercentage=80 -XX:MaxRAM=1G
+WPS_JAVA_OPTS=-XX:MaxRAMPercentage=80 -XshowSettings:system
 
-REST_JAVA_OPTS=-XX:MaxRAMPercentage=80 -XX:MaxRAM=1G
+REST_JAVA_OPTS=-XX:MaxRAMPercentage=80 -XshowSettings:system
 
-WEBUI_JAVA_OPTS=-XX:MaxRAMPercentage=80 -XX:MaxRAM=1G
+WEBUI_JAVA_OPTS=-XX:MaxRAMPercentage=80 -XshowSettings:system
 

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '17'
         cache: 'maven'
 
     - name: Validate source code formatting
@@ -44,8 +44,10 @@ jobs:
 #    - name: Update maven dependencies
 #      run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -Dgs.version=2.21-CLOUD -Dgs.community.version=2.21-CLOUD -P-docker -ntp -Dfmt.skip
 
-    - name: Build and push docker images
-      run: ./mvnw install -Dgs.version=2.21-CLOUD -Dgs.community.version=2.21-CLOUD -Ddockerfile.push.skip=false -ntp -Dfmt.skip -T1 -DskipTests
+    - name: Build and push Hotspot and OpenJ9 docker images
+      run: ./mvnw -Pdocker,docker-openj9 install \
+           -Dgs.version=2.21-CLOUD -Dgs.community.version=2.21-CLOUD \
+           -Ddockerfile.push.skip=false -ntp -Dfmt.skip -T1 -DskipTests
 
     - name: Remove project jars from cached repository
       run: |

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -38,16 +38,11 @@ jobs:
     - name: Build GeoServer 2.21-CLOUD
       run: |
         git clone --depth 1 --branch geoserver-cloud_integration https://github.com/groldan/geoserver.git
-        find . -name pom.xml|xargs sed -i 's/2.21-SNAPSHOT/2.21-CLOUD/g' 
         ./mvnw -f ./geoserver/src/ install -PallExtensions,communityRelease --no-transfer-progress -DskipTests -Dfmt.skip -T1C 
 
-#    - name: Update maven dependencies
-#      run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -Dgs.version=2.21-CLOUD -Dgs.community.version=2.21-CLOUD -P-docker -ntp -Dfmt.skip
-
     - name: Build and push Hotspot and OpenJ9 docker images
-      run: ./mvnw -Pdocker,docker-openj9 install \
-           -Dgs.version=2.21-CLOUD -Dgs.community.version=2.21-CLOUD \
-           -Ddockerfile.push.skip=false -ntp -Dfmt.skip -T1 -DskipTests
+      run: ./mvnw -Ddockerfile.push.skip=false  install \
+           -ntp -Dfmt.skip -T1 -DskipTests
 
     - name: Remove project jars from cached repository
       run: |

--- a/.github/workflows/config-service-native-image.yaml
+++ b/.github/workflows/config-service-native-image.yaml
@@ -39,7 +39,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '17'
         cache: 'maven'
 
     - name: Resolve image name

--- a/.github/workflows/config-service-native-image.yaml
+++ b/.github/workflows/config-service-native-image.yaml
@@ -50,7 +50,7 @@ jobs:
 
     - name: Build config-service native image
       run: |
-        ./mvnw clean install -pl :gs-cloud-config-service -am -Dfmt.action=check -ntp -P-docker
+        ./mvnw clean install -pl :gs-cloud-config-service -am -Dfmt.action=check -ntp -P-docker,-docker-openj9
         ./mvnw -f support-services/config/ spring-boot:build-image -Pnative -ntp -DskipTests
 
     - name: Push image to docker.io

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -28,17 +28,13 @@ jobs:
     - name: Build GeoServer 2.21-CLOUD
       run: |
         git clone --depth 1 --branch geoserver-cloud_integration https://github.com/groldan/geoserver.git
-        find . -name pom.xml|xargs sed -i 's/2.21-SNAPSHOT/2.21-CLOUD/g' 
         ./mvnw -f ./geoserver/src/ install -PallExtensions,communityRelease --no-transfer-progress -DskipTests -Dfmt.skip -T1C 
 
-#    - name: Update maven dependencies
-#      run: ./mvnw -Dgs.version=2.21-CLOUD -Dgs.community.version=2.21-CLOUD -P\!docker de.qaware.maven:go-offline-maven-plugin:resolve-dependencies --no-transfer-progress
-
     - name: Build without tests
-      run: ./mvnw -Dgs.version=2.21-CLOUD -Dgs.community.version=2.21-CLOUD -P\!docker -ntp -Dfmt.skip install -T1C -DskipTests
+      run: ./mvnw -P-docker,-docker-openj9 -ntp -Dfmt.skip install -T1C -DskipTests
 
     - name: Test
-      run: ./mvnw -Dgs.version=2.21-CLOUD -Dgs.community.version=2.21-CLOUD -P\!docker -ntp verify -T1C -fae
+      run: ./mvnw -P-docker,-docker-openj9 -ntp verify -T1C -fae
 
     - name: Remove project jars from cached repository
       run: |

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '17'
         cache: 'maven'
 
     - name: Validate source code formatting

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Only a curated list of the [vast amount](http://geoserver.org/release/stable/) o
 
 Requirements:
 
- * Java >= 11 JDK
+ * Java >= 17 JDK
  * [Maven](https://maven.apache.org/) >= `3.6.3`
  * [Docker](https://docs.docker.com/engine/install/) version >= `19.03.3`
  * [docker-compose](https://docs.docker.com/compose/) version >= `1.26.2`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
     depends_on:
       - discovery
     environment:
-      #JAVA_OPTS: "${CONFIG_JAVA_OPTS}"
+      JAVA_OPTS: "${CONFIG_JAVA_OPTS}"
       # Either 'git' or 'native'. Use the default sample git repository to download the services configuration from
       # If 'git', BEWARE config server will look for a branch called "master", and github changed the default branch name to "main"
       # For more information, see https://cloud.spring.io/spring-cloud-config/multi/multi__spring_cloud_config_server.html#_git_backend

--- a/pom.xml
+++ b/pom.xml
@@ -845,7 +845,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <id>enforce-maven-and-java</id>
@@ -855,7 +855,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[11,)</version>
+                  <version>[17,)</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
                   <version>[3.6.3,)</version>

--- a/services/catalog/Dockerfile
+++ b/services/catalog/Dockerfile
@@ -25,6 +25,15 @@ RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
 VOLUME /opt/app/data_directory
 
 WORKDIR /opt/app/bin
+ENV JAVA_TOOL_OPTS=\
+--add-exports=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.util=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.text=ALL-UNNAMED \
+--add-opens=java.desktop/java.awt.font=ALL-UNNAMED \
+--add-opens=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
 ENV JAVA_OPTS=
 EXPOSE 8080
 EXPOSE 8081
@@ -41,4 +50,4 @@ HEALTHCHECK \
 --retries=5 \
 CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
-CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS $JAVA_TOOL_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/catalog/Dockerfile
+++ b/services/catalog/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:11-jre-openj9 as builder
+FROM eclipse-temurin:17-jre as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 RUN apt update && \ 
@@ -14,7 +14,7 @@ COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM adoptopenjdk:11-jre-openj9
+FROM eclipse-temurin:17-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 

--- a/services/catalog/Dockerfile.openj9
+++ b/services/catalog/Dockerfile.openj9
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre as builder
+FROM ibm-semeru-runtimes:open-17-jre as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 RUN apt update && \ 
@@ -14,20 +14,15 @@ COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM eclipse-temurin:17-jre
+FROM ibm-semeru-runtimes:open-17-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
 COPY --from=builder /usr/share/fonts/truetype/* /usr/share/fonts/truetype/
 
-# REVISIT: ideally webui shouldn't even have access to the geowebcache
-# directory, but since it needs to run a lot of gwc and gwc-gs integration
-# services, it might still need it.
-RUN mkdir -p /opt/app/bin /opt/app/data_directory /data/geowebcache
-RUN chmod 0777 /opt/app/data_directory /data/geowebcache
-
+RUN mkdir -p /opt/app/bin
+RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
 VOLUME /opt/app/data_directory
-VOLUME /data/geowebcache
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=

--- a/services/catalog/Dockerfile.openj9
+++ b/services/catalog/Dockerfile.openj9
@@ -25,7 +25,18 @@ RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
 VOLUME /opt/app/data_directory
 
 WORKDIR /opt/app/bin
+ENV JAVA_TOOL_OPTS=\
+--add-exports=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.util=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.text=ALL-UNNAMED \
+--add-opens=java.desktop/java.awt.font=ALL-UNNAMED \
+--add-opens=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
 ENV JAVA_OPTS=
+
+
 EXPOSE 8080
 EXPOSE 8081
 
@@ -41,4 +52,4 @@ HEALTHCHECK \
 --retries=5 \
 CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
-CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS $JAVA_TOOL_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/catalog/pom.xml
+++ b/services/catalog/pom.xml
@@ -59,5 +59,43 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>docker-openj9</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-openj9-image</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+                <configuration>
+                  <dockerfile>Dockerfile.openj9</dockerfile>
+                  <tag>${project.version}-openj9</tag>
+                  <buildArgs>
+                    <TAG>${project.version}-openj9</TAG>
+                    <JAR_FILE>target/${project.build.finalName}-bin.jar</JAR_FILE>
+                  </buildArgs>
+                </configuration>
+              </execution>
+              <execution>
+                <id>push-openj9-image</id>
+                <phase>install</phase>
+                <goals>
+                  <goal>push</goal>
+                </goals>
+                <configuration>
+                  <skip>${dockerfile.push.skip}</skip>
+                  <tag>${project.version}-openj9</tag>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/services/catalog/pom.xml
+++ b/services/catalog/pom.xml
@@ -61,6 +61,9 @@
     </profile>
     <profile>
       <id>docker-openj9</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/services/gwc/Dockerfile
+++ b/services/gwc/Dockerfile
@@ -17,6 +17,15 @@ VOLUME /opt/app/data_directory
 VOLUME /data/geowebcache
 
 WORKDIR /opt/app/bin
+ENV JAVA_TOOL_OPTS=\
+--add-exports=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.util=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.text=ALL-UNNAMED \
+--add-opens=java.desktop/java.awt.font=ALL-UNNAMED \
+--add-opens=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
 ENV JAVA_OPTS=
 
 EXPOSE 8080
@@ -33,4 +42,4 @@ HEALTHCHECK \
 --retries=5 \
 CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
-CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS $JAVA_TOOL_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/gwc/Dockerfile
+++ b/services/gwc/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:11-jre-openj9 as builder
+FROM eclipse-temurin:17-jre as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 COPY ${JAR_FILE} application.jar
@@ -6,7 +6,7 @@ COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM adoptopenjdk:11-jre-openj9
+FROM eclipse-temurin:17-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 

--- a/services/gwc/Dockerfile.openj9
+++ b/services/gwc/Dockerfile.openj9
@@ -17,7 +17,18 @@ VOLUME /opt/app/data_directory
 VOLUME /data/geowebcache
 
 WORKDIR /opt/app/bin
+ENV JAVA_TOOL_OPTS=\
+--add-exports=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.util=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.text=ALL-UNNAMED \
+--add-opens=java.desktop/java.awt.font=ALL-UNNAMED \
+--add-opens=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
 ENV JAVA_OPTS=
+
+
 
 EXPOSE 8080
 
@@ -33,4 +44,4 @@ HEALTHCHECK \
 --retries=5 \
 CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
-CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS $JAVA_TOOL_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/gwc/Dockerfile.openj9
+++ b/services/gwc/Dockerfile.openj9
@@ -1,28 +1,15 @@
-FROM eclipse-temurin:17-jre as builder
+FROM ibm-semeru-runtimes:open-17-jre as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
-
-RUN apt update && \ 
-apt install -y fonts-deva \
-fonts-font-awesome \
-fonts-freefont-ttf \
-fonts-material-design-icons-iconfont \
-fonts-materialdesignicons-webfont \
-fonts-roboto
 
 COPY ${JAR_FILE} application.jar
 
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM eclipse-temurin:17-jre
+FROM ibm-semeru-runtimes:open-17-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
-COPY --from=builder /usr/share/fonts/truetype/* /usr/share/fonts/truetype/
-
-# REVISIT: ideally webui shouldn't even have access to the geowebcache
-# directory, but since it needs to run a lot of gwc and gwc-gs integration
-# services, it might still need it.
 RUN mkdir -p /opt/app/bin /opt/app/data_directory /data/geowebcache
 RUN chmod 0777 /opt/app/data_directory /data/geowebcache
 
@@ -31,8 +18,8 @@ VOLUME /data/geowebcache
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
+
 EXPOSE 8080
-EXPOSE 8081
 
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./

--- a/services/gwc/pom.xml
+++ b/services/gwc/pom.xml
@@ -104,6 +104,9 @@
     </profile>
     <profile>
       <id>docker-openj9</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/services/gwc/pom.xml
+++ b/services/gwc/pom.xml
@@ -103,6 +103,44 @@
       </build>
     </profile>
     <profile>
+      <id>docker-openj9</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-openj9-image</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+                <configuration>
+                  <dockerfile>Dockerfile.openj9</dockerfile>
+                  <tag>${project.version}-openj9</tag>
+                  <buildArgs>
+                    <TAG>${project.version}-openj9</TAG>
+                    <JAR_FILE>target/${project.build.finalName}-bin.jar</JAR_FILE>
+                  </buildArgs>
+                </configuration>
+              </execution>
+              <execution>
+                <id>push-openj9-image</id>
+                <phase>install</phase>
+                <goals>
+                  <goal>push</goal>
+                </goals>
+                <configuration>
+                  <skip>${dockerfile.push.skip}</skip>
+                  <tag>${project.version}-openj9</tag>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <!-- measure to include dependencies not really needed for this service but whose absence make the catalog fail with 
         exceptions like "com.thoughtworks.xstream.mapper.CannotResolveClassException: org.geoserver.gwc.wmts.WMTSInfoImpl". Nonetheless, 
         the spring configuration for these extra dependencies won't be loaded at all -->

--- a/services/restconfig/Dockerfile
+++ b/services/restconfig/Dockerfile
@@ -25,6 +25,15 @@ RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
 VOLUME /opt/app/data_directory
 
 WORKDIR /opt/app/bin
+ENV JAVA_TOOL_OPTS=\
+--add-exports=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.util=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.text=ALL-UNNAMED \
+--add-opens=java.desktop/java.awt.font=ALL-UNNAMED \
+--add-opens=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
 ENV JAVA_OPTS=
 EXPOSE 8080
 EXPOSE 8081
@@ -41,4 +50,4 @@ HEALTHCHECK \
 --retries=5 \
 CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
-CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS $JAVA_TOOL_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/restconfig/Dockerfile
+++ b/services/restconfig/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:11-jre-openj9 as builder
+FROM eclipse-temurin:17-jre as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 RUN apt update && \ 
@@ -14,7 +14,7 @@ COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM adoptopenjdk:11-jre-openj9
+FROM eclipse-temurin:17-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 

--- a/services/restconfig/Dockerfile.openj9
+++ b/services/restconfig/Dockerfile.openj9
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre as builder
+FROM ibm-semeru-runtimes:open-17-jre as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 RUN apt update && \ 
@@ -14,20 +14,15 @@ COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM eclipse-temurin:17-jre
+FROM ibm-semeru-runtimes:open-17-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
 COPY --from=builder /usr/share/fonts/truetype/* /usr/share/fonts/truetype/
 
-# REVISIT: ideally webui shouldn't even have access to the geowebcache
-# directory, but since it needs to run a lot of gwc and gwc-gs integration
-# services, it might still need it.
-RUN mkdir -p /opt/app/bin /opt/app/data_directory /data/geowebcache
-RUN chmod 0777 /opt/app/data_directory /data/geowebcache
-
+RUN mkdir -p /opt/app/bin
+RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
 VOLUME /opt/app/data_directory
-VOLUME /data/geowebcache
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=

--- a/services/restconfig/Dockerfile.openj9
+++ b/services/restconfig/Dockerfile.openj9
@@ -25,7 +25,18 @@ RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
 VOLUME /opt/app/data_directory
 
 WORKDIR /opt/app/bin
+ENV JAVA_TOOL_OPTS=\
+--add-exports=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.util=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.text=ALL-UNNAMED \
+--add-opens=java.desktop/java.awt.font=ALL-UNNAMED \
+--add-opens=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
 ENV JAVA_OPTS=
+
+
 EXPOSE 8080
 EXPOSE 8081
 
@@ -41,4 +52,4 @@ HEALTHCHECK \
 --retries=5 \
 CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
-CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS $JAVA_TOOL_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/restconfig/pom.xml
+++ b/services/restconfig/pom.xml
@@ -66,6 +66,9 @@
     </profile>
     <profile>
       <id>docker-openj9</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/services/restconfig/pom.xml
+++ b/services/restconfig/pom.xml
@@ -65,6 +65,44 @@
       </build>
     </profile>
     <profile>
+      <id>docker-openj9</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-openj9-image</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+                <configuration>
+                  <dockerfile>Dockerfile.openj9</dockerfile>
+                  <tag>${project.version}-openj9</tag>
+                  <buildArgs>
+                    <TAG>${project.version}-openj9</TAG>
+                    <JAR_FILE>target/${project.build.finalName}-bin.jar</JAR_FILE>
+                  </buildArgs>
+                </configuration>
+              </execution>
+              <execution>
+                <id>push-openj9-image</id>
+                <phase>install</phase>
+                <goals>
+                  <goal>push</goal>
+                </goals>
+                <configuration>
+                  <skip>${dockerfile.push.skip}</skip>
+                  <tag>${project.version}-openj9</tag>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <!-- measure to include dependencies not really needed for this service but whose absence make the catalog fail with 
         exceptions like "com.thoughtworks.xstream.mapper.CannotResolveClassException: org.geoserver.gwc.wmts.WMTSInfoImpl". Nonetheless, 
         the spring configuration for these extra dependencies won't be loaded at all -->

--- a/services/wcs/Dockerfile
+++ b/services/wcs/Dockerfile
@@ -15,6 +15,15 @@ RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
 VOLUME /opt/app/data_directory
 
 WORKDIR /opt/app/bin
+ENV JAVA_TOOL_OPTS=\
+--add-exports=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.util=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.text=ALL-UNNAMED \
+--add-opens=java.desktop/java.awt.font=ALL-UNNAMED \
+--add-opens=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
 ENV JAVA_OPTS=
 EXPOSE 8080
 EXPOSE 8081
@@ -31,4 +40,4 @@ HEALTHCHECK \
 --retries=5 \
 CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
-CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS $JAVA_TOOL_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/wcs/Dockerfile.openj9
+++ b/services/wcs/Dockerfile.openj9
@@ -15,7 +15,18 @@ RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
 VOLUME /opt/app/data_directory
 
 WORKDIR /opt/app/bin
+ENV JAVA_TOOL_OPTS=\
+--add-exports=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.util=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.text=ALL-UNNAMED \
+--add-opens=java.desktop/java.awt.font=ALL-UNNAMED \
+--add-opens=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
 ENV JAVA_OPTS=
+
+
 EXPOSE 8080
 EXPOSE 8081
 
@@ -31,4 +42,4 @@ HEALTHCHECK \
 --retries=5 \
 CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
-CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS $JAVA_TOOL_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/wcs/Dockerfile.openj9
+++ b/services/wcs/Dockerfile.openj9
@@ -1,33 +1,18 @@
-FROM eclipse-temurin:17-jre as builder
+FROM ibm-semeru-runtimes:open-17-jre as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
-
-RUN apt update && \ 
-apt install -y fonts-deva \
-fonts-font-awesome \
-fonts-freefont-ttf \
-fonts-material-design-icons-iconfont \
-fonts-materialdesignicons-webfont \
-fonts-roboto
 
 COPY ${JAR_FILE} application.jar
 
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM eclipse-temurin:17-jre
+FROM ibm-semeru-runtimes:open-17-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
-COPY --from=builder /usr/share/fonts/truetype/* /usr/share/fonts/truetype/
-
-# REVISIT: ideally webui shouldn't even have access to the geowebcache
-# directory, but since it needs to run a lot of gwc and gwc-gs integration
-# services, it might still need it.
-RUN mkdir -p /opt/app/bin /opt/app/data_directory /data/geowebcache
-RUN chmod 0777 /opt/app/data_directory /data/geowebcache
-
+RUN mkdir -p /opt/app/bin
+RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
 VOLUME /opt/app/data_directory
-VOLUME /data/geowebcache
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=

--- a/services/wcs/pom.xml
+++ b/services/wcs/pom.xml
@@ -61,6 +61,9 @@
     </profile>
     <profile>
       <id>docker-openj9</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/services/wcs/pom.xml
+++ b/services/wcs/pom.xml
@@ -60,6 +60,44 @@
       </build>
     </profile>
     <profile>
+      <id>docker-openj9</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-openj9-image</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+                <configuration>
+                  <dockerfile>Dockerfile.openj9</dockerfile>
+                  <tag>${project.version}-openj9</tag>
+                  <buildArgs>
+                    <TAG>${project.version}-openj9</TAG>
+                    <JAR_FILE>target/${project.build.finalName}-bin.jar</JAR_FILE>
+                  </buildArgs>
+                </configuration>
+              </execution>
+              <execution>
+                <id>push-openj9-image</id>
+                <phase>install</phase>
+                <goals>
+                  <goal>push</goal>
+                </goals>
+                <configuration>
+                  <skip>${dockerfile.push.skip}</skip>
+                  <tag>${project.version}-openj9</tag>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <!-- measure to include dependencies not really needed for this service but whose absence make the catalog fail with 
         exceptions like "com.thoughtworks.xstream.mapper.CannotResolveClassException: org.geoserver.gwc.wmts.WMTSInfoImpl". Nonetheless, 
         the spring configuration for these extra dependencies won't be loaded at all -->

--- a/services/web-ui/Dockerfile
+++ b/services/web-ui/Dockerfile
@@ -30,6 +30,15 @@ VOLUME /opt/app/data_directory
 VOLUME /data/geowebcache
 
 WORKDIR /opt/app/bin
+ENV JAVA_TOOL_OPTS=\
+--add-exports=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.util=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.text=ALL-UNNAMED \
+--add-opens=java.desktop/java.awt.font=ALL-UNNAMED \
+--add-opens=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
 ENV JAVA_OPTS=
 EXPOSE 8080
 EXPOSE 8081
@@ -46,4 +55,4 @@ HEALTHCHECK \
 --retries=5 \
 CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
-CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS $JAVA_TOOL_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/web-ui/Dockerfile.openj9
+++ b/services/web-ui/Dockerfile.openj9
@@ -30,7 +30,18 @@ VOLUME /opt/app/data_directory
 VOLUME /data/geowebcache
 
 WORKDIR /opt/app/bin
+ENV JAVA_TOOL_OPTS=\
+--add-exports=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.util=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.text=ALL-UNNAMED \
+--add-opens=java.desktop/java.awt.font=ALL-UNNAMED \
+--add-opens=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
 ENV JAVA_OPTS=
+
+
 EXPOSE 8080
 EXPOSE 8081
 
@@ -46,4 +57,4 @@ HEALTHCHECK \
 --retries=5 \
 CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
-CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS $JAVA_TOOL_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/web-ui/Dockerfile.openj9
+++ b/services/web-ui/Dockerfile.openj9
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre as builder
+FROM ibm-semeru-runtimes:open-17-jre as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 RUN apt update && \ 
@@ -14,7 +14,7 @@ COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM eclipse-temurin:17-jre
+FROM ibm-semeru-runtimes:open-17-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 

--- a/services/web-ui/pom.xml
+++ b/services/web-ui/pom.xml
@@ -108,6 +108,44 @@
       </build>
     </profile>
     <profile>
+      <id>docker-openj9</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-openj9-image</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+                <configuration>
+                  <dockerfile>Dockerfile.openj9</dockerfile>
+                  <tag>${project.version}-openj9</tag>
+                  <buildArgs>
+                    <TAG>${project.version}-openj9</TAG>
+                    <JAR_FILE>target/${project.build.finalName}-bin.jar</JAR_FILE>
+                  </buildArgs>
+                </configuration>
+              </execution>
+              <execution>
+                <id>push-openj9-image</id>
+                <phase>install</phase>
+                <goals>
+                  <goal>push</goal>
+                </goals>
+                <configuration>
+                  <skip>${dockerfile.push.skip}</skip>
+                  <tag>${project.version}-openj9</tag>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>xstreamPersisterDependencies</id>
       <activation>
         <activeByDefault>true</activeByDefault>

--- a/services/web-ui/pom.xml
+++ b/services/web-ui/pom.xml
@@ -109,6 +109,9 @@
     </profile>
     <profile>
       <id>docker-openj9</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/services/wfs/Dockerfile
+++ b/services/wfs/Dockerfile
@@ -15,6 +15,15 @@ RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
 VOLUME /opt/app/data_directory
 
 WORKDIR /opt/app/bin
+ENV JAVA_TOOL_OPTS=\
+--add-exports=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.util=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.text=ALL-UNNAMED \
+--add-opens=java.desktop/java.awt.font=ALL-UNNAMED \
+--add-opens=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
 ENV JAVA_OPTS=
 
 EXPOSE 8080
@@ -32,4 +41,4 @@ HEALTHCHECK \
 --retries=5 \
 CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
-CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS $JAVA_TOOL_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/wfs/Dockerfile
+++ b/services/wfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:11-jre-openj9 as builder
+FROM eclipse-temurin:17-jre as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 COPY ${JAR_FILE} application.jar
@@ -6,7 +6,7 @@ COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM adoptopenjdk:11-jre-openj9
+FROM eclipse-temurin:17-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 

--- a/services/wfs/Dockerfile.openj9
+++ b/services/wfs/Dockerfile.openj9
@@ -1,36 +1,22 @@
-FROM eclipse-temurin:17-jre as builder
+FROM ibm-semeru-runtimes:open-17-jre as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
-
-RUN apt update && \ 
-apt install -y fonts-deva \
-fonts-font-awesome \
-fonts-freefont-ttf \
-fonts-material-design-icons-iconfont \
-fonts-materialdesignicons-webfont \
-fonts-roboto
 
 COPY ${JAR_FILE} application.jar
 
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM eclipse-temurin:17-jre
+FROM ibm-semeru-runtimes:open-17-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
-COPY --from=builder /usr/share/fonts/truetype/* /usr/share/fonts/truetype/
-
-# REVISIT: ideally webui shouldn't even have access to the geowebcache
-# directory, but since it needs to run a lot of gwc and gwc-gs integration
-# services, it might still need it.
-RUN mkdir -p /opt/app/bin /opt/app/data_directory /data/geowebcache
-RUN chmod 0777 /opt/app/data_directory /data/geowebcache
-
+RUN mkdir -p /opt/app/bin
+RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
 VOLUME /opt/app/data_directory
-VOLUME /data/geowebcache
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
+
 EXPOSE 8080
 EXPOSE 8081
 

--- a/services/wfs/Dockerfile.openj9
+++ b/services/wfs/Dockerfile.openj9
@@ -15,7 +15,18 @@ RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
 VOLUME /opt/app/data_directory
 
 WORKDIR /opt/app/bin
+ENV JAVA_TOOL_OPTS=\
+--add-exports=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.util=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.text=ALL-UNNAMED \
+--add-opens=java.desktop/java.awt.font=ALL-UNNAMED \
+--add-opens=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
 ENV JAVA_OPTS=
+
+
 
 EXPOSE 8080
 EXPOSE 8081
@@ -32,4 +43,4 @@ HEALTHCHECK \
 --retries=5 \
 CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
-CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS $JAVA_TOOL_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/wfs/pom.xml
+++ b/services/wfs/pom.xml
@@ -58,6 +58,9 @@
     </profile>
     <profile>
       <id>docker-openj9</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/services/wfs/pom.xml
+++ b/services/wfs/pom.xml
@@ -57,6 +57,44 @@
       </build>
     </profile>
     <profile>
+      <id>docker-openj9</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-openj9-image</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+                <configuration>
+                  <dockerfile>Dockerfile.openj9</dockerfile>
+                  <tag>${project.version}-openj9</tag>
+                  <buildArgs>
+                    <TAG>${project.version}-openj9</TAG>
+                    <JAR_FILE>target/${project.build.finalName}-bin.jar</JAR_FILE>
+                  </buildArgs>
+                </configuration>
+              </execution>
+              <execution>
+                <id>push-openj9-image</id>
+                <phase>install</phase>
+                <goals>
+                  <goal>push</goal>
+                </goals>
+                <configuration>
+                  <skip>${dockerfile.push.skip}</skip>
+                  <tag>${project.version}-openj9</tag>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <!-- measure to include dependencies not really needed for this service but whose absence make the catalog fail with 
         exceptions like "com.thoughtworks.xstream.mapper.CannotResolveClassException: org.geoserver.gwc.wmts.WMTSInfoImpl". Nonetheless, 
         the spring configuration for these extra dependencies won't be loaded at all -->

--- a/services/wms/Dockerfile
+++ b/services/wms/Dockerfile
@@ -25,6 +25,15 @@ RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
 VOLUME /opt/app/data_directory
 
 WORKDIR /opt/app/bin
+ENV JAVA_TOOL_OPTS=\
+--add-exports=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.util=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.text=ALL-UNNAMED \
+--add-opens=java.desktop/java.awt.font=ALL-UNNAMED \
+--add-opens=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
 ENV JAVA_OPTS=
 EXPOSE 8080
 EXPOSE 8081
@@ -41,5 +50,5 @@ HEALTHCHECK \
 --retries=5 \
 CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
-CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS $JAVA_TOOL_OPTS org.springframework.boot.loader.JarLauncher
 

--- a/services/wms/Dockerfile
+++ b/services/wms/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:11-jre-openj9 as builder
+FROM eclipse-temurin:17-jre as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 RUN apt update && \ 
@@ -14,7 +14,7 @@ COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM adoptopenjdk:11-jre-openj9
+FROM eclipse-temurin:17-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 

--- a/services/wms/Dockerfile.openj9
+++ b/services/wms/Dockerfile.openj9
@@ -25,7 +25,17 @@ RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
 VOLUME /opt/app/data_directory
 
 WORKDIR /opt/app/bin
+ENV JAVA_TOOL_OPTS=\
+--add-exports=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.util=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.text=ALL-UNNAMED \
+--add-opens=java.desktop/java.awt.font=ALL-UNNAMED \
+--add-opens=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
 ENV JAVA_OPTS=
+
 EXPOSE 8080
 EXPOSE 8081
 
@@ -41,5 +51,5 @@ HEALTHCHECK \
 --retries=5 \
 CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
-CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS $JAVA_TOOL_OPTS org.springframework.boot.loader.JarLauncher
 

--- a/services/wms/Dockerfile.openj9
+++ b/services/wms/Dockerfile.openj9
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre as builder
+FROM ibm-semeru-runtimes:open-17-jre as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 RUN apt update && \ 
@@ -14,20 +14,15 @@ COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM eclipse-temurin:17-jre
+FROM ibm-semeru-runtimes:open-17-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
 COPY --from=builder /usr/share/fonts/truetype/* /usr/share/fonts/truetype/
 
-# REVISIT: ideally webui shouldn't even have access to the geowebcache
-# directory, but since it needs to run a lot of gwc and gwc-gs integration
-# services, it might still need it.
-RUN mkdir -p /opt/app/bin /opt/app/data_directory /data/geowebcache
-RUN chmod 0777 /opt/app/data_directory /data/geowebcache
-
+RUN mkdir -p /opt/app/bin
+RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
 VOLUME /opt/app/data_directory
-VOLUME /data/geowebcache
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
@@ -47,3 +42,4 @@ HEALTHCHECK \
 CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
 CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+

--- a/services/wms/pom.xml
+++ b/services/wms/pom.xml
@@ -56,6 +56,44 @@
       </build>
     </profile>
     <profile>
+      <id>docker-openj9</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-openj9-image</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+                <configuration>
+                  <dockerfile>Dockerfile.openj9</dockerfile>
+                  <tag>${project.version}-openj9</tag>
+                  <buildArgs>
+                    <TAG>${project.version}-openj9</TAG>
+                    <JAR_FILE>target/${project.build.finalName}-bin.jar</JAR_FILE>
+                  </buildArgs>
+                </configuration>
+              </execution>
+              <execution>
+                <id>push-openj9-image</id>
+                <phase>install</phase>
+                <goals>
+                  <goal>push</goal>
+                </goals>
+                <configuration>
+                  <skip>${dockerfile.push.skip}</skip>
+                  <tag>${project.version}-openj9</tag>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <!-- measure to include dependencies not really needed for this service but whose absence make the catalog fail with 
         exceptions like "com.thoughtworks.xstream.mapper.CannotResolveClassException: org.geoserver.gwc.wmts.WMTSInfoImpl". Nonetheless, 
         the spring configuration for these extra dependencies won't be loaded at all -->

--- a/services/wms/pom.xml
+++ b/services/wms/pom.xml
@@ -57,6 +57,9 @@
     </profile>
     <profile>
       <id>docker-openj9</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/services/wps/Dockerfile
+++ b/services/wps/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:11-jre-openj9 as builder
+FROM eclipse-temurin:17-jre as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 COPY ${JAR_FILE} application.jar
@@ -6,7 +6,7 @@ COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM adoptopenjdk:11-jre-openj9
+FROM eclipse-temurin:17-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 

--- a/services/wps/Dockerfile
+++ b/services/wps/Dockerfile
@@ -15,6 +15,15 @@ RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
 VOLUME /opt/app/data_directory
 
 WORKDIR /opt/app/bin
+ENV JAVA_TOOL_OPTS=\
+--add-exports=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.util=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.text=ALL-UNNAMED \
+--add-opens=java.desktop/java.awt.font=ALL-UNNAMED \
+--add-opens=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
 ENV JAVA_OPTS=
 EXPOSE 8080
 EXPOSE 8081
@@ -31,4 +40,4 @@ HEALTHCHECK \
 --retries=5 \
 CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
-CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS $JAVA_TOOL_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/wps/Dockerfile.openj9
+++ b/services/wps/Dockerfile.openj9
@@ -15,7 +15,18 @@ RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
 VOLUME /opt/app/data_directory
 
 WORKDIR /opt/app/bin
+ENV JAVA_TOOL_OPTS=\
+--add-exports=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.util=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.text=ALL-UNNAMED \
+--add-opens=java.desktop/java.awt.font=ALL-UNNAMED \
+--add-opens=java.desktop/sun.awt.image=ALL-UNNAMED \
+--add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
 ENV JAVA_OPTS=
+
+
 EXPOSE 8080
 EXPOSE 8081
 
@@ -31,4 +42,4 @@ HEALTHCHECK \
 --retries=5 \
 CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
-CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS $JAVA_TOOL_OPTS org.springframework.boot.loader.JarLauncher

--- a/services/wps/Dockerfile.openj9
+++ b/services/wps/Dockerfile.openj9
@@ -1,33 +1,18 @@
-FROM eclipse-temurin:17-jre as builder
+FROM ibm-semeru-runtimes:open-17-jre as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
-
-RUN apt update && \ 
-apt install -y fonts-deva \
-fonts-font-awesome \
-fonts-freefont-ttf \
-fonts-material-design-icons-iconfont \
-fonts-materialdesignicons-webfont \
-fonts-roboto
 
 COPY ${JAR_FILE} application.jar
 
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM eclipse-temurin:17-jre
+FROM ibm-semeru-runtimes:open-17-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
-COPY --from=builder /usr/share/fonts/truetype/* /usr/share/fonts/truetype/
-
-# REVISIT: ideally webui shouldn't even have access to the geowebcache
-# directory, but since it needs to run a lot of gwc and gwc-gs integration
-# services, it might still need it.
-RUN mkdir -p /opt/app/bin /opt/app/data_directory /data/geowebcache
-RUN chmod 0777 /opt/app/data_directory /data/geowebcache
-
+RUN mkdir -p /opt/app/bin
+RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
 VOLUME /opt/app/data_directory
-VOLUME /data/geowebcache
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=

--- a/services/wps/pom.xml
+++ b/services/wps/pom.xml
@@ -62,6 +62,9 @@
     </profile>
     <profile>
       <id>docker-openj9</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/services/wps/pom.xml
+++ b/services/wps/pom.xml
@@ -61,6 +61,44 @@
       </build>
     </profile>
     <profile>
+      <id>docker-openj9</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-openj9-image</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+                <configuration>
+                  <dockerfile>Dockerfile.openj9</dockerfile>
+                  <tag>${project.version}-openj9</tag>
+                  <buildArgs>
+                    <TAG>${project.version}-openj9</TAG>
+                    <JAR_FILE>target/${project.build.finalName}-bin.jar</JAR_FILE>
+                  </buildArgs>
+                </configuration>
+              </execution>
+              <execution>
+                <id>push-openj9-image</id>
+                <phase>install</phase>
+                <goals>
+                  <goal>push</goal>
+                </goals>
+                <configuration>
+                  <skip>${dockerfile.push.skip}</skip>
+                  <tag>${project.version}-openj9</tag>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <!-- measure to include dependencies not really needed for this service but whose absence make the catalog fail with 
         exceptions like "com.thoughtworks.xstream.mapper.CannotResolveClassException: org.geoserver.gwc.wmts.WMTSInfoImpl". Nonetheless, 
         the spring configuration for these extra dependencies won't be loaded at all -->

--- a/support-services/admin/Dockerfile
+++ b/support-services/admin/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:11-jre-openj9 as builder
+FROM eclipse-temurin:17-jre as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 COPY ${JAR_FILE} application.jar
@@ -6,7 +6,7 @@ COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM adoptopenjdk:11-jre-openj9
+FROM eclipse-temurin:17-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 

--- a/support-services/admin/Dockerfile.openj9
+++ b/support-services/admin/Dockerfile.openj9
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre as builder
+FROM ibm-semeru-runtimes:open-17-jre as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 COPY ${JAR_FILE} application.jar
@@ -6,18 +6,15 @@ COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM eclipse-temurin:17-jre
+FROM ibm-semeru-runtimes:open-17-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
 RUN mkdir -p /opt/app/bin
-RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
-VOLUME /opt/app/data_directory
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
-EXPOSE 8081
 
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./

--- a/support-services/admin/pom.xml
+++ b/support-services/admin/pom.xml
@@ -93,5 +93,43 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>docker-openj9</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-openj9-image</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+                <configuration>
+                  <dockerfile>Dockerfile.openj9</dockerfile>
+                  <tag>${project.version}-openj9</tag>
+                  <buildArgs>
+                    <TAG>${project.version}-openj9</TAG>
+                    <JAR_FILE>target/${project.build.finalName}-bin.jar</JAR_FILE>
+                  </buildArgs>
+                </configuration>
+              </execution>
+              <execution>
+                <id>push-openj9-image</id>
+                <phase>install</phase>
+                <goals>
+                  <goal>push</goal>
+                </goals>
+                <configuration>
+                  <skip>${dockerfile.push.skip}</skip>
+                  <tag>${project.version}-openj9</tag>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/support-services/admin/pom.xml
+++ b/support-services/admin/pom.xml
@@ -95,6 +95,9 @@
     </profile>
     <profile>
       <id>docker-openj9</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/support-services/api-gateway/Dockerfile
+++ b/support-services/api-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:11-jre-openj9 as builder
+FROM eclipse-temurin:17-jre as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 COPY ${JAR_FILE} application.jar
@@ -6,7 +6,7 @@ COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM adoptopenjdk:11-jre-openj9
+FROM eclipse-temurin:17-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 

--- a/support-services/api-gateway/Dockerfile.openj9
+++ b/support-services/api-gateway/Dockerfile.openj9
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre as builder
+FROM ibm-semeru-runtimes:open-17-jre as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 COPY ${JAR_FILE} application.jar
@@ -6,18 +6,15 @@ COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM eclipse-temurin:17-jre
+FROM ibm-semeru-runtimes:open-17-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
 RUN mkdir -p /opt/app/bin
-RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
-VOLUME /opt/app/data_directory
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
-EXPOSE 8081
 
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./

--- a/support-services/api-gateway/pom.xml
+++ b/support-services/api-gateway/pom.xml
@@ -91,5 +91,43 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>docker-openj9</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-openj9-image</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+                <configuration>
+                  <dockerfile>Dockerfile.openj9</dockerfile>
+                  <tag>${project.version}-openj9</tag>
+                  <buildArgs>
+                    <TAG>${project.version}-openj9</TAG>
+                    <JAR_FILE>target/${project.build.finalName}-bin.jar</JAR_FILE>
+                  </buildArgs>
+                </configuration>
+              </execution>
+              <execution>
+                <id>push-openj9-image</id>
+                <phase>install</phase>
+                <goals>
+                  <goal>push</goal>
+                </goals>
+                <configuration>
+                  <skip>${dockerfile.push.skip}</skip>
+                  <tag>${project.version}-openj9</tag>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/support-services/api-gateway/pom.xml
+++ b/support-services/api-gateway/pom.xml
@@ -93,6 +93,9 @@
     </profile>
     <profile>
       <id>docker-openj9</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/support-services/config/Dockerfile
+++ b/support-services/config/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:11-jre-openj9 as builder
+FROM eclipse-temurin:17-jre as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 COPY ${JAR_FILE} application.jar
@@ -6,7 +6,7 @@ COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM adoptopenjdk:11-jre-openj9
+FROM eclipse-temurin:17-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 

--- a/support-services/config/Dockerfile.openj9
+++ b/support-services/config/Dockerfile.openj9
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre as builder
+FROM ibm-semeru-runtimes:open-17-jre as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 COPY ${JAR_FILE} application.jar
@@ -6,18 +6,18 @@ COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM eclipse-temurin:17-jre
+FROM ibm-semeru-runtimes:open-17-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
 RUN mkdir -p /opt/app/bin
-RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
-VOLUME /opt/app/data_directory
+
+# Where jgit will try to create a .config directory
+ENV XDG_CONFIG_HOME=/tmp
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
 EXPOSE 8080
-EXPOSE 8081
 
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./

--- a/support-services/config/pom.xml
+++ b/support-services/config/pom.xml
@@ -85,7 +85,7 @@
               <pullPolicy>IF_NOT_PRESENT</pullPolicy>
               <env>
                 <!-- Builder config options -->
-                <BP_JVM_VERSION>11</BP_JVM_VERSION>
+                <BP_JVM_VERSION>17</BP_JVM_VERSION>
                 <BP_JVM_TYPE>JRE</BP_JVM_TYPE>
                 <BPL_JVM_THREAD_COUNT>8</BPL_JVM_THREAD_COUNT>
                 <!-- Runtime config options -->
@@ -140,6 +140,59 @@
           <plugin>
             <groupId>com.spotify</groupId>
             <artifactId>dockerfile-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>docker-openj9</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>repackage</id>
+                <goals>
+                  <goal>repackage</goal>
+                </goals>
+                <configuration>
+                  <classifier>bin</classifier>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-openj9-image</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+                <configuration>
+                  <dockerfile>Dockerfile.openj9</dockerfile>
+                  <tag>${project.version}-openj9</tag>
+                  <buildArgs>
+                    <TAG>${project.version}-openj9</TAG>
+                    <JAR_FILE>target/${project.build.finalName}-bin.jar</JAR_FILE>
+                  </buildArgs>
+                </configuration>
+              </execution>
+              <execution>
+                <id>push-openj9-image</id>
+                <phase>install</phase>
+                <goals>
+                  <goal>push</goal>
+                </goals>
+                <configuration>
+                  <skip>${dockerfile.push.skip}</skip>
+                  <tag>${project.version}-openj9</tag>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/support-services/config/pom.xml
+++ b/support-services/config/pom.xml
@@ -146,6 +146,9 @@
     </profile>
     <profile>
       <id>docker-openj9</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/support-services/discovery/Dockerfile
+++ b/support-services/discovery/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:11-jre-openj9 as builder
+FROM eclipse-temurin:17-jre as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 COPY ${JAR_FILE} application.jar
@@ -6,7 +6,7 @@ COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM adoptopenjdk:11-jre-openj9
+FROM eclipse-temurin:17-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 

--- a/support-services/discovery/Dockerfile.openj9
+++ b/support-services/discovery/Dockerfile.openj9
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre as builder
+FROM ibm-semeru-runtimes:open-17-jre as builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
 COPY ${JAR_FILE} application.jar
@@ -6,18 +6,15 @@ COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
 ##########
-FROM eclipse-temurin:17-jre
+FROM ibm-semeru-runtimes:open-17-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
 RUN mkdir -p /opt/app/bin
-RUN mkdir -p /opt/app/data_directory && chmod 0777 /opt/app/data_directory
-VOLUME /opt/app/data_directory
 
 WORKDIR /opt/app/bin
 ENV JAVA_OPTS=
-EXPOSE 8080
-EXPOSE 8081
+EXPOSE 8761
 
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./

--- a/support-services/discovery/pom.xml
+++ b/support-services/discovery/pom.xml
@@ -73,5 +73,43 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>docker-openj9</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-openj9-image</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+                <configuration>
+                  <dockerfile>Dockerfile.openj9</dockerfile>
+                  <tag>${project.version}-openj9</tag>
+                  <buildArgs>
+                    <TAG>${project.version}-openj9</TAG>
+                    <JAR_FILE>target/${project.build.finalName}-bin.jar</JAR_FILE>
+                  </buildArgs>
+                </configuration>
+              </execution>
+              <execution>
+                <id>push-openj9-image</id>
+                <phase>install</phase>
+                <goals>
+                  <goal>push</goal>
+                </goals>
+                <configuration>
+                  <skip>${dockerfile.push.skip}</skip>
+                  <tag>${project.version}-openj9</tag>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/support-services/discovery/pom.xml
+++ b/support-services/discovery/pom.xml
@@ -75,6 +75,9 @@
     </profile>
     <profile>
       <id>docker-openj9</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
- Switch to Java 17
- Change default docker base image to `eclipse-temurin:17-jre`
- Create OpenJ9 images based on `ibm-semeru-runtimes:open-17-jre`

Note:
The default `eclipse-temurin:17-jre` based images properly support
cgroups v2 to limit cpu and memory resources.

`1.0-SNAPSHOT-openj9` tagged images based on
`ibm-semeru-runtimes:open-17-jre` don't yet, as
of  https://github.com/eclipse-openj9/openj9/issues/14190

Fixes #192
