### PR TITLE
Build/fmt maven plugin coordinates changed

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,5 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/catalog-support/catalog-cache/src/main/java/org/geoserver/cloud/catalog/caching/CachingCatalogFacade.java
+++ b/catalog-support/catalog-cache/src/main/java/org/geoserver/cloud/catalog/caching/CachingCatalogFacade.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.catalog.caching;
 
 import lombok.NonNull;
+
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.Info;

--- a/catalog-support/catalog-cache/src/main/java/org/geoserver/cloud/catalog/caching/CachingCatalogFacadeImpl.java
+++ b/catalog-support/catalog-cache/src/main/java/org/geoserver/cloud/catalog/caching/CachingCatalogFacadeImpl.java
@@ -6,9 +6,8 @@ package org.geoserver.cloud.catalog.caching;
 
 import static org.geoserver.cloud.catalog.caching.CachingCatalogFacade.generateLayersByResourceKey;
 
-import java.util.List;
-import java.util.function.BiFunction;
 import lombok.NonNull;
+
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.LayerGroupInfo;
@@ -30,6 +29,9 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.Caching;
+
+import java.util.List;
+import java.util.function.BiFunction;
 
 /** */
 @CacheConfig(cacheNames = {CachingCatalogFacade.CACHE_NAME})
@@ -114,16 +116,14 @@ public class CachingCatalogFacadeImpl extends ForwardingExtendedCatalogFacade
     }
 
     @Caching(
-        evict = {
-            // cached layers
-            @CacheEvict(key = "new org.geoserver.cloud.catalog.caching.CatalogInfoKey(#p0)"),
-            // layers by resource (see getLayers(ResourceInfo)
-            @CacheEvict(
-                key =
-                        "new org.geoserver.cloud.catalog.caching.CatalogInfoKey('layers@' + #layer.resource.id, 'LAYER')"
-            )
-        }
-    )
+            evict = {
+                // cached layers
+                @CacheEvict(key = "new org.geoserver.cloud.catalog.caching.CatalogInfoKey(#p0)"),
+                // layers by resource (see getLayers(ResourceInfo)
+                @CacheEvict(
+                        key =
+                                "new org.geoserver.cloud.catalog.caching.CatalogInfoKey('layers@' + #layer.resource.id, 'LAYER')")
+            })
     public @Override void remove(LayerInfo layer) {
         super.remove(layer);
     }
@@ -184,25 +184,22 @@ public class CachingCatalogFacadeImpl extends ForwardingExtendedCatalogFacade
     }
 
     @CachePut(
-        key = "new org.geoserver.cloud.catalog.caching.CatalogInfoKey(#info)",
-        unless = "#result == null"
-    )
+            key = "new org.geoserver.cloud.catalog.caching.CatalogInfoKey(#info)",
+            unless = "#result == null")
     public @Override <I extends CatalogInfo> I update(final I info, final Patch patch) {
         return super.update(info, patch);
     }
 
     @Cacheable(
-        key = "new org.geoserver.cloud.catalog.caching.CatalogInfoKey(#id, 'WORKSPACE')",
-        unless = "#result == null"
-    )
+            key = "new org.geoserver.cloud.catalog.caching.CatalogInfoKey(#id, 'WORKSPACE')",
+            unless = "#result == null")
     public @Override WorkspaceInfo getWorkspace(String id) {
         return super.getWorkspace(id);
     }
 
     @Cacheable(
-        key = "new org.geoserver.cloud.catalog.caching.CatalogInfoKey(#id, 'NAMESPACE')",
-        unless = "#result == null"
-    )
+            key = "new org.geoserver.cloud.catalog.caching.CatalogInfoKey(#id, 'NAMESPACE')",
+            unless = "#result == null")
     public @Override NamespaceInfo getNamespace(String id) {
         return super.getNamespace(id);
     }
@@ -247,34 +244,30 @@ public class CachingCatalogFacadeImpl extends ForwardingExtendedCatalogFacade
     }
 
     @Cacheable(
-        key = "new org.geoserver.cloud.catalog.caching.CatalogInfoKey(#id, 'STYLE')",
-        unless = "#result == null"
-    )
+            key = "new org.geoserver.cloud.catalog.caching.CatalogInfoKey(#id, 'STYLE')",
+            unless = "#result == null")
     public @Override StyleInfo getStyle(String id) {
         return super.getStyle(id);
     }
 
     @Cacheable(
-        key = "new org.geoserver.cloud.catalog.caching.CatalogInfoKey(#id, 'LAYER')",
-        unless = "#result == null"
-    )
+            key = "new org.geoserver.cloud.catalog.caching.CatalogInfoKey(#id, 'LAYER')",
+            unless = "#result == null")
     public @Override LayerInfo getLayer(String id) {
         return super.getLayer(id);
     }
 
     @Cacheable(
-        key =
-                "new org.geoserver.cloud.catalog.caching.CatalogInfoKey('layers@' + #resource.id, 'LAYER')",
-        unless = "#result == null"
-    )
+            key =
+                    "new org.geoserver.cloud.catalog.caching.CatalogInfoKey('layers@' + #resource.id, 'LAYER')",
+            unless = "#result == null")
     public @Override List<LayerInfo> getLayers(ResourceInfo resource) {
         return super.getLayers(resource);
     }
 
     @Cacheable(
-        key = "new org.geoserver.cloud.catalog.caching.CatalogInfoKey(#id, 'LAYERGROUP')",
-        unless = "#result == null"
-    )
+            key = "new org.geoserver.cloud.catalog.caching.CatalogInfoKey(#id, 'LAYERGROUP')",
+            unless = "#result == null")
     public @Override LayerGroupInfo getLayerGroup(String id) {
         return super.getLayerGroup(id);
     }
@@ -300,9 +293,8 @@ public class CachingCatalogFacadeImpl extends ForwardingExtendedCatalogFacade
     }
 
     @Cacheable(
-        key = "'" + DEFAULT_DATASTORE_CACHE_KEY_PREFIX + "' + #p0.id",
-        unless = "#result == null"
-    )
+            key = "'" + DEFAULT_DATASTORE_CACHE_KEY_PREFIX + "' + #p0.id",
+            unless = "#result == null")
     public @Override DataStoreInfo getDefaultDataStore(WorkspaceInfo workspace) {
         return super.getDefaultDataStore(workspace);
     }

--- a/catalog-support/catalog-cache/src/main/java/org/geoserver/cloud/catalog/caching/CachingGeoServerFacade.java
+++ b/catalog-support/catalog-cache/src/main/java/org/geoserver/cloud/catalog/caching/CachingGeoServerFacade.java
@@ -4,8 +4,8 @@
  */
 package org.geoserver.cloud.catalog.caching;
 
-import javax.annotation.Nullable;
 import lombok.NonNull;
+
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.WorkspaceInfo;
@@ -15,6 +15,8 @@ import org.geoserver.config.LoggingInfo;
 import org.geoserver.config.ServiceInfo;
 import org.geoserver.config.SettingsInfo;
 import org.springframework.cache.CacheManager;
+
+import javax.annotation.Nullable;
 
 /**
  * Extension of {@link GeoServerFacade} to signify some methods cache or evict {@link Info} objects.

--- a/catalog-support/catalog-cache/src/main/java/org/geoserver/cloud/catalog/caching/CachingGeoServerFacadeImpl.java
+++ b/catalog-support/catalog-cache/src/main/java/org/geoserver/cloud/catalog/caching/CachingGeoServerFacadeImpl.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.catalog.caching;
 
 import lombok.NonNull;
+
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.config.GeoServerFacade;
@@ -133,21 +134,19 @@ public class CachingGeoServerFacadeImpl extends ForwardingGeoServerFacade
     }
 
     @Caching(
-        evict = {
-            @CacheEvict(key = "#settings.id"),
-            @CacheEvict(key = "'settings@' + #settings.workspace.id")
-        }
-    )
+            evict = {
+                @CacheEvict(key = "#settings.id"),
+                @CacheEvict(key = "'settings@' + #settings.workspace.id")
+            })
     public @Override void save(SettingsInfo settings) {
         super.save(settings);
     }
 
     @Caching(
-        evict = {
-            @CacheEvict(key = "#settings.id"),
-            @CacheEvict(key = "'settings@' + #settings.workspace.id")
-        }
-    )
+            evict = {
+                @CacheEvict(key = "#settings.id"),
+                @CacheEvict(key = "'settings@' + #settings.workspace.id")
+            })
     public @Override void remove(SettingsInfo settings) {
         super.remove(settings);
     }

--- a/catalog-support/catalog-cache/src/main/java/org/geoserver/cloud/catalog/caching/CatalogInfoKey.java
+++ b/catalog-support/catalog-cache/src/main/java/org/geoserver/cloud/catalog/caching/CatalogInfoKey.java
@@ -4,14 +4,14 @@
  */
 package org.geoserver.cloud.catalog.caching;
 
-import static java.util.Objects.requireNonNull;
 import static org.geoserver.catalog.impl.ClassMappings.PUBLISHED;
 import static org.geoserver.catalog.impl.ClassMappings.RESOURCE;
 import static org.geoserver.catalog.impl.ClassMappings.STORE;
 
-import java.io.Serializable;
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
+
 import lombok.ToString;
+
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.catalog.ResourceInfo;
@@ -19,6 +19,9 @@ import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.impl.ClassMappings;
 import org.geoserver.catalog.plugin.CatalogInfoTypeRegistry;
 import org.springframework.cache.interceptor.SimpleKey;
+
+import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * A key to for a cached {@link Info}, easier than implementing multiple key generators; it's also a

--- a/catalog-support/catalog-cache/src/main/java/org/geoserver/cloud/catalog/caching/GeoServerBackendCacheConfiguration.java
+++ b/catalog-support/catalog-cache/src/main/java/org/geoserver/cloud/catalog/caching/GeoServerBackendCacheConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.catalog.caching;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.plugin.CatalogFacadeExtensionAdapter;

--- a/catalog-support/catalog-cache/src/main/java/org/geoserver/cloud/catalog/caching/ServiceInfoKey.java
+++ b/catalog-support/catalog-cache/src/main/java/org/geoserver/cloud/catalog/caching/ServiceInfoKey.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.catalog.caching;
 
 import lombok.Value;
+
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.config.ServiceInfo;
 

--- a/catalog-support/catalog-cache/src/test/java/org/geoserver/cloud/catalog/caching/CachingCatalogFacadeTest.java
+++ b/catalog-support/catalog-cache/src/test/java/org/geoserver/cloud/catalog/caching/CachingCatalogFacadeTest.java
@@ -18,10 +18,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.function.Consumer;
-import java.util.function.Function;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.CoverageStoreInfo;
@@ -55,6 +51,11 @@ import org.springframework.cache.Cache;
 import org.springframework.cache.Cache.ValueWrapper;
 import org.springframework.cache.CacheManager;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 @SpringBootTest(classes = GeoServerBackendCacheConfiguration.class)
 @EnableAutoConfiguration

--- a/catalog-support/catalog-cache/src/test/java/org/geoserver/cloud/catalog/caching/CachingGeoServerFacadeTest.java
+++ b/catalog-support/catalog-cache/src/test/java/org/geoserver/cloud/catalog/caching/CachingGeoServerFacadeTest.java
@@ -11,9 +11,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
-import java.util.function.Function;
-import java.util.function.Supplier;
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.ResolvingProxy;
@@ -38,6 +35,10 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Arrays;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 @SpringBootTest(classes = GeoServerBackendCacheConfiguration.class)
 @EnableAutoConfiguration

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/impl/CatalogClientCatalogFacade.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/impl/CatalogClientCatalogFacade.java
@@ -4,10 +4,8 @@
  */
 package org.geoserver.cloud.catalog.client.impl;
 
-import java.lang.reflect.Proxy;
-import java.util.function.Function;
-import java.util.function.Supplier;
 import lombok.NonNull;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.CatalogInfo;
@@ -27,6 +25,10 @@ import org.geoserver.catalog.plugin.resolving.CatalogPropertyResolver;
 import org.geoserver.catalog.plugin.resolving.CollectionPropertiesInitializer;
 import org.geoserver.catalog.plugin.resolving.ResolvingProxyResolver;
 import org.geoserver.cloud.catalog.client.repository.CatalogClientRepository;
+
+import java.lang.reflect.Proxy;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * {@link CatalogFacade} for {@code catalog-service}, being a {@link

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/impl/CatalogClientProperties.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/impl/CatalogClientProperties.java
@@ -4,9 +4,11 @@
  */
 package org.geoserver.cloud.catalog.client.impl;
 
-import java.io.File;
 import lombok.Data;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.io.File;
 
 /**
  * Configuration properties bean to use the {@code catalog-service} micro-service client back-end

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/impl/CatalogClientResource.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/impl/CatalogClientResource.java
@@ -5,6 +5,15 @@
 package org.geoserver.cloud.catalog.client.impl;
 
 import com.google.common.io.ByteStreams;
+
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+
+import org.geoserver.cloud.catalog.client.reactivefeign.ReactiveResourceStoreClient;
+import org.geoserver.cloud.catalog.client.reactivefeign.ReactiveResourceStoreClient.ResourceDescriptor;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.ResourceListener;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -18,12 +27,6 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import lombok.AllArgsConstructor;
-import lombok.NonNull;
-import org.geoserver.cloud.catalog.client.reactivefeign.ReactiveResourceStoreClient;
-import org.geoserver.cloud.catalog.client.reactivefeign.ReactiveResourceStoreClient.ResourceDescriptor;
-import org.geoserver.platform.resource.Resource;
-import org.geoserver.platform.resource.ResourceListener;
 
 /** */
 @AllArgsConstructor

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/impl/CatalogClientResourceStore.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/impl/CatalogClientResourceStore.java
@@ -5,21 +5,12 @@
 package org.geoserver.cloud.catalog.client.impl;
 
 import com.google.common.io.ByteStreams;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.UncheckedIOException;
-import java.nio.ByteBuffer;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Stream;
+
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.catalog.client.reactivefeign.BlockingResourceStoreClient;
 import org.geoserver.cloud.catalog.client.reactivefeign.ReactiveResourceStoreClient.ResourceDescriptor;
 import org.geoserver.platform.resource.FileSystemResourceStore;
@@ -34,6 +25,18 @@ import org.geoserver.platform.resource.ResourceNotification;
 import org.geoserver.platform.resource.ResourceNotificationDispatcher;
 import org.geoserver.platform.resource.ResourceStore;
 import org.springframework.util.Assert;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 
 /** */
 @Slf4j

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/impl/InnerResolvingProxy.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/impl/InnerResolvingProxy.java
@@ -4,15 +4,10 @@
  */
 package org.geoserver.cloud.catalog.client.impl;
 
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Proxy;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.CatalogInfo;
@@ -43,6 +38,13 @@ import org.geoserver.config.LoggingInfo;
 import org.geoserver.config.ServiceInfo;
 import org.geoserver.config.SettingsInfo;
 import org.springframework.lang.Nullable;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Resolves {@link ResolvingProxy} references based only on {@link CatalogInfo#getId() id} using

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/reactivefeign/BlockingResourceStoreClient.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/reactivefeign/BlockingResourceStoreClient.java
@@ -4,17 +4,20 @@
  */
 package org.geoserver.cloud.catalog.client.reactivefeign;
 
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import org.geoserver.cloud.catalog.client.reactivefeign.ReactiveResourceStoreClient.ResourceDescriptor;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import org.geoserver.cloud.catalog.client.reactivefeign.ReactiveResourceStoreClient.ResourceDescriptor;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 @RequiredArgsConstructor
 public class BlockingResourceStoreClient {

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/reactivefeign/ReactiveCatalogApiClientConfiguration.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/reactivefeign/ReactiveCatalogApiClientConfiguration.java
@@ -5,15 +5,15 @@
 package org.geoserver.cloud.catalog.client.reactivefeign;
 
 import org.springframework.context.annotation.Configuration;
+
 import reactivefeign.spring.config.EnableReactiveFeignClients;
 
 @Configuration
 @EnableReactiveFeignClients( //
-    defaultConfiguration = ReactiveFeignConfigurationOverrides.class, //
-    clients = { //
-        ReactiveCatalogClient.class, //
-        ReactiveConfigClient.class, //
-        ReactiveResourceStoreClient.class
-    }
-)
+        defaultConfiguration = ReactiveFeignConfigurationOverrides.class, //
+        clients = { //
+            ReactiveCatalogClient.class, //
+            ReactiveConfigClient.class, //
+            ReactiveResourceStoreClient.class
+        })
 public class ReactiveCatalogApiClientConfiguration {}

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/reactivefeign/ReactiveCatalogClient.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/reactivefeign/ReactiveCatalogClient.java
@@ -25,16 +25,17 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+
 import reactivefeign.spring.config.ReactiveFeignClient;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @ReactiveFeignClient( //
-    name = "catalog-service", //
-    url = "${geoserver.backend.catalog-service.uri:}", //
-    qualifier = "catalog-client", //
-    path = "/api/v1/catalog"
-)
+        name = "catalog-service", //
+        url = "${geoserver.backend.catalog-service.uri:}", //
+        qualifier = "catalog-client", //
+        path = "/api/v1/catalog")
 public interface ReactiveCatalogClient {
 
     @PostMapping(path = "/{endpoint}")

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/reactivefeign/ReactiveConfigClient.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/reactivefeign/ReactiveConfigClient.java
@@ -16,16 +16,17 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+
 import reactivefeign.spring.config.ReactiveFeignClient;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @ReactiveFeignClient( //
-    name = "catalog-service", //
-    url = "${geoserver.backend.catalog-service.uri:}", //
-    qualifier = "config-client", //
-    path = "/api/v1/config"
-)
+        name = "catalog-service", //
+        url = "${geoserver.backend.catalog-service.uri:}", //
+        qualifier = "config-client", //
+        path = "/api/v1/config")
 public interface ReactiveConfigClient {
 
     /** The global geoserver configuration. */

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/reactivefeign/ReactiveFeignConfigurationOverrides.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/reactivefeign/ReactiveFeignConfigurationOverrides.java
@@ -6,12 +6,15 @@ package org.geoserver.cloud.catalog.client.reactivefeign;
 
 import feign.Contract;
 import feign.MethodMetadata;
-import java.util.List;
+
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.cloud.openfeign.support.SpringMvcContract;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 public class ReactiveFeignConfigurationOverrides {

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/reactivefeign/ReactiveResourceStoreClient.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/reactivefeign/ReactiveResourceStoreClient.java
@@ -7,25 +7,30 @@ package org.geoserver.cloud.catalog.client.reactivefeign;
 import feign.Headers;
 import feign.Param;
 import feign.RequestLine;
-import java.nio.ByteBuffer;
+
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
 import org.geoserver.platform.resource.Paths;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.platform.resource.Resource.Type;
 import org.geoserver.platform.resource.ResourceStore;
+
 import reactivefeign.spring.config.ReactiveFeignClient;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.nio.ByteBuffer;
+
 /** Catalog-service client to support {@link ResourceStore} */
 @ReactiveFeignClient( //
-    name = "catalog-service", //
-    url = "${geoserver.backend.catalog-service.uri:}", //
-    qualifier = "resource-store-client", //
-    path = "/api/v1/resources" //
-    // , fallbackFactory = ResourceStoreFallbackFactory.class
-)
+        name = "catalog-service", //
+        url = "${geoserver.backend.catalog-service.uri:}", //
+        qualifier = "resource-store-client", //
+        path = "/api/v1/resources" //
+        // , fallbackFactory = ResourceStoreFallbackFactory.class
+        )
 public interface ReactiveResourceStoreClient {
 
     @Data

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientConfigRepository.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientConfigRepository.java
@@ -4,12 +4,9 @@
  */
 package org.geoserver.cloud.catalog.client.repository;
 
-import java.lang.reflect.Proxy;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.Setter;
+
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.Patch;
@@ -19,8 +16,14 @@ import org.geoserver.config.LoggingInfo;
 import org.geoserver.config.ServiceInfo;
 import org.geoserver.config.SettingsInfo;
 import org.geoserver.config.plugin.ConfigRepository;
+
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
+
+import java.lang.reflect.Proxy;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 
 /** */
 public class CatalogClientConfigRepository implements ConfigRepository {

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientFilterSupport.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientFilterSupport.java
@@ -4,11 +4,11 @@
  */
 package org.geoserver.cloud.catalog.client.repository;
 
-import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import lombok.experimental.Accessors;
+
 import org.geotools.filter.Capabilities;
 import org.geotools.filter.visitor.CapabilitiesFilterSplitter;
 import org.opengis.filter.Filter;
@@ -48,6 +48,8 @@ import org.opengis.filter.temporal.OverlappedBy;
 import org.opengis.filter.temporal.TContains;
 import org.opengis.filter.temporal.TEquals;
 import org.opengis.filter.temporal.TOverlaps;
+
+import java.util.List;
 
 /** */
 @RequiredArgsConstructor

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientLayerGroupRepository.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientLayerGroupRepository.java
@@ -4,14 +4,16 @@
  */
 package org.geoserver.cloud.catalog.client.repository;
 
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.NonNull;
+
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.LayerGroupRepository;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 public class CatalogClientLayerGroupRepository extends CatalogClientRepository<LayerGroupInfo>
         implements LayerGroupRepository {

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientLayerRepository.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientLayerRepository.java
@@ -4,14 +4,16 @@
  */
 package org.geoserver.cloud.catalog.client.repository;
 
-import java.util.Optional;
-import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.NonNull;
+
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.LayerRepository;
+
+import java.util.Optional;
+import java.util.stream.Stream;
 
 public class CatalogClientLayerRepository extends CatalogClientRepository<LayerInfo>
         implements LayerRepository {

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientMapRepository.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientMapRepository.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.catalog.client.repository;
 
 import lombok.Getter;
+
 import org.geoserver.catalog.MapInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.MapRepository;
 

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientNamespaceRepository.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientNamespaceRepository.java
@@ -4,14 +4,16 @@
  */
 package org.geoserver.cloud.catalog.client.repository;
 
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.NonNull;
+
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.NamespaceRepository;
 import org.springframework.lang.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 public class CatalogClientNamespaceRepository extends CatalogClientRepository<NamespaceInfo>
         implements NamespaceRepository {

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientRepository.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientRepository.java
@@ -6,20 +6,10 @@ package org.geoserver.cloud.catalog.client.repository;
 
 import static org.geotools.filter.visitor.SimplifyingFilterVisitor.simplify;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.impl.ClassMappings;
@@ -33,9 +23,22 @@ import org.opengis.filter.Filter;
 import org.opengis.filter.capability.FunctionName;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.Nullable;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Slf4j
 public abstract class CatalogClientRepository<CI extends CatalogInfo>

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientResourceRepository.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientResourceRepository.java
@@ -4,10 +4,9 @@
  */
 package org.geoserver.cloud.catalog.client.repository;
 
-import java.util.Optional;
-import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.NonNull;
+
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StoreInfo;
@@ -18,6 +17,9 @@ import org.geotools.factory.CommonFactoryFinder;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
 import org.springframework.lang.Nullable;
+
+import java.util.Optional;
+import java.util.stream.Stream;
 
 public class CatalogClientResourceRepository extends CatalogClientRepository<ResourceInfo>
         implements ResourceRepository {

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientStoreRepository.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientStoreRepository.java
@@ -4,17 +4,20 @@
  */
 package org.geoserver.cloud.catalog.client.repository;
 
-import java.util.Optional;
-import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.NonNull;
+
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.ClassMappings;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.StoreRepository;
 import org.springframework.lang.Nullable;
+
 import reactor.core.publisher.Flux;
+
+import java.util.Optional;
+import java.util.stream.Stream;
 
 public class CatalogClientStoreRepository extends CatalogClientRepository<StoreInfo>
         implements StoreRepository {

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientStyleRepository.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientStyleRepository.java
@@ -4,13 +4,15 @@
  */
 package org.geoserver.cloud.catalog.client.repository;
 
-import java.util.Optional;
-import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.NonNull;
+
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.StyleRepository;
+
+import java.util.Optional;
+import java.util.stream.Stream;
 
 public class CatalogClientStyleRepository extends CatalogClientRepository<StyleInfo>
         implements StyleRepository {

--- a/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientWorkspaceRepository.java
+++ b/catalog-support/catalog-client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientWorkspaceRepository.java
@@ -4,13 +4,15 @@
  */
 package org.geoserver.cloud.catalog.client.repository;
 
-import java.util.Objects;
-import java.util.Optional;
 import lombok.Getter;
 import lombok.NonNull;
+
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.WorkspaceRepository;
 import org.springframework.lang.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
 
 public class CatalogClientWorkspaceRepository extends CatalogClientRepository<WorkspaceInfo>
         implements WorkspaceRepository {

--- a/catalog-support/catalog-client/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/ReactiveCatalogApiClientConfigurationTest.java
+++ b/catalog-support/catalog-client/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/ReactiveCatalogApiClientConfigurationTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.autoconfigure.web.reactive.function.client.WebCl
 import org.springframework.boot.context.annotation.UserConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration;
+
 import reactivefeign.spring.config.ReactiveFeignAutoConfiguration;
 
 public class ReactiveCatalogApiClientConfigurationTest {

--- a/catalog-support/catalog-client/src/test/java/org/geoserver/cloud/catalog/client/repository/CatalogClientRepositoryConfigurationTest.java
+++ b/catalog-support/catalog-client/src/test/java/org/geoserver/cloud/catalog/client/repository/CatalogClientRepositoryConfigurationTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
 import org.springframework.boot.context.annotation.UserConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
 import reactivefeign.spring.config.ReactiveFeignAutoConfiguration;
 
 public class CatalogClientRepositoryConfigurationTest {

--- a/catalog-support/catalog-client/src/test/java/org/geoserver/cloud/catalog/client/repository/CatalogClientRepositoryTest.java
+++ b/catalog-support/catalog-client/src/test/java/org/geoserver/cloud/catalog/client/repository/CatalogClientRepositoryTest.java
@@ -21,10 +21,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
 import lombok.NonNull;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.CatalogTestData;
@@ -61,8 +59,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 
 @SpringBootTest(classes = CatalogClientRepositoryConfiguration.class)
 @RunWith(SpringRunner.class)

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/autoconfigure/bus/ConditionalOnGeoServerRemoteEventsDisabled.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/autoconfigure/bus/ConditionalOnGeoServerRemoteEventsDisabled.java
@@ -4,13 +4,14 @@
  */
 package org.geoserver.cloud.autoconfigure.bus;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.bus.ServiceMatcher;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.cloud.bus.ServiceMatcher;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/autoconfigure/bus/ConditionalOnGeoServerRemoteEventsEnabled.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/autoconfigure/bus/ConditionalOnGeoServerRemoteEventsEnabled.java
@@ -4,13 +4,14 @@
  */
 package org.geoserver.cloud.autoconfigure.bus;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.bus.ConditionalOnBusEnabled;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.cloud.bus.ConditionalOnBusEnabled;
 
 /**
  * GeoServer remote events enablement checks base on {@link

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/autoconfigure/bus/RemoteApplicationEventsDisabledAutoConfiguration.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/autoconfigure/bus/RemoteApplicationEventsDisabledAutoConfiguration.java
@@ -4,19 +4,20 @@
  */
 package org.geoserver.cloud.autoconfigure.bus;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.bus.ConditionalOnBusEnabled;
 import org.springframework.context.annotation.Configuration;
 
+import javax.annotation.PostConstruct;
+
 /** Log a message if spring-cloud-bus is explicitly disables */
 @Configuration
 @ConditionalOnProperty(
-    value = ConditionalOnBusEnabled.SPRING_CLOUD_BUS_ENABLED,
-    matchIfMissing = false,
-    havingValue = "false"
-)
+        value = ConditionalOnBusEnabled.SPRING_CLOUD_BUS_ENABLED,
+        matchIfMissing = false,
+        havingValue = "false")
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.bus")
 public class RemoteApplicationEventsDisabledAutoConfiguration {
 

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/autoconfigure/bus/RemoteInfoEventInboundResolver.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/autoconfigure/bus/RemoteInfoEventInboundResolver.java
@@ -6,7 +6,6 @@ package org.geoserver.cloud.autoconfigure.bus;
 
 import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
 
-import java.util.function.Function;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.Info;
@@ -24,6 +23,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cloud.bus.ServiceMatcher;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.Order;
+
+import java.util.function.Function;
 
 /**
  * Highest priority listener for incoming {@link RemoteInfoEvent} events to resolve the payload

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/autoconfigure/event/LocalApplicationEventsAutoConfiguration.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/autoconfigure/event/LocalApplicationEventsAutoConfiguration.java
@@ -16,9 +16,8 @@ import org.springframework.context.annotation.Import;
  */
 @Configuration
 @ConditionalOnProperty(
-    value = "geoserver.catalog.events.enabled",
-    havingValue = "true",
-    matchIfMissing = true
-)
+        value = "geoserver.catalog.events.enabled",
+        havingValue = "true",
+        matchIfMissing = true)
 @Import({LocalApplicationEventsConfiguration.class})
 public class LocalApplicationEventsAutoConfiguration {}

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/GeoServerRemoteEventBroadcaster.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/GeoServerRemoteEventBroadcaster.java
@@ -4,9 +4,9 @@
  */
 package org.geoserver.cloud.bus;
 
-import java.util.Optional;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogException;
 import org.geoserver.catalog.DataStoreInfo;
@@ -60,6 +60,8 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
+
+import java.util.Optional;
 
 /**
  * Listens to local catalog change {@link ApplicationEvent}s produced by this service instance and

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/RemoteApplicationEventsConfiguration.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/RemoteApplicationEventsConfiguration.java
@@ -4,8 +4,8 @@
  */
 package org.geoserver.cloud.bus;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.cloud.bus.event.catalog.RemoteCatalogEvent;
 import org.geoserver.cloud.bus.event.config.RemoteConfigEvent;
@@ -18,6 +18,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
+import javax.annotation.PostConstruct;
+
 /**
  * Configuration to enable sending and receiving remote application events related to configuration
  * changes in the {@link Catalog} and {@link GeoServer}
@@ -25,8 +27,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConditionalOnBusEnabled
 @RemoteApplicationEventScan(
-    basePackageClasses = {RemoteCatalogEvent.class, RemoteConfigEvent.class}
-)
+        basePackageClasses = {RemoteCatalogEvent.class, RemoteConfigEvent.class})
 @ComponentScan(basePackageClasses = {RemoteCatalogEvent.class, RemoteConfigEvent.class})
 @Slf4j(topic = "org.geoserver.cloud.bus")
 public class RemoteApplicationEventsConfiguration {

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/RemoteEventResourcePoolProcessor.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/RemoteEventResourcePoolProcessor.java
@@ -4,8 +4,8 @@
  */
 package org.geoserver.cloud.bus;
 
-import java.lang.reflect.Proxy;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.CoverageStoreInfo;
@@ -26,6 +26,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.bus.BusAutoConfiguration;
 import org.springframework.cloud.bus.event.RemoteApplicationEvent;
 import org.springframework.context.event.EventListener;
+
+import java.lang.reflect.Proxy;
 
 /**
  * Listens to {@link RemoteCatalogEvent}s and acts accordingly

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/RemoteAddEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/RemoteAddEvent.java
@@ -4,11 +4,13 @@
  */
 package org.geoserver.cloud.bus.event;
 
-import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
+
 import org.geoserver.catalog.Info;
 import org.geoserver.cloud.event.ConfigInfoInfoType;
+
+import java.util.Optional;
 
 @EqualsAndHashCode(callSuper = true)
 public abstract class RemoteAddEvent<S, I extends Info> extends RemoteInfoEvent<S, I> {

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/RemoteInfoEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/RemoteInfoEvent.java
@@ -5,10 +5,12 @@
 package org.geoserver.cloud.bus.event;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.Info;
 import org.geoserver.cloud.event.ConfigInfoInfoType;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/RemoteModifyEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/RemoteModifyEvent.java
@@ -4,16 +4,18 @@
  */
 package org.geoserver.cloud.bus.event;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.cloud.event.ConfigInfoInfoType;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @EqualsAndHashCode(callSuper = true)
 // @JsonIgnoreProperties(value = {"object", "diff", "payloadCodec"})

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/RemoteRemoveEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/RemoteRemoveEvent.java
@@ -4,11 +4,13 @@
  */
 package org.geoserver.cloud.bus.event;
 
-import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
+
 import org.geoserver.catalog.Info;
 import org.geoserver.cloud.event.ConfigInfoInfoType;
+
+import java.util.Optional;
 
 @EqualsAndHashCode(callSuper = true)
 public abstract class RemoteRemoveEvent<S, I extends Info> extends RemoteInfoEvent<S, I> {

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/catalog/AbstractRemoteCatalogModifyEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/catalog/AbstractRemoteCatalogModifyEvent.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.bus.event.catalog;
 
 import lombok.NonNull;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.plugin.Patch;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/catalog/RemoteCatalogInfoAddEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/catalog/RemoteCatalogInfoAddEvent.java
@@ -8,6 +8,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.cloud.bus.event.RemoteAddEvent;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/catalog/RemoteCatalogInfoModifyEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/catalog/RemoteCatalogInfoModifyEvent.java
@@ -6,6 +6,7 @@ package org.geoserver.cloud.bus.event.catalog;
 
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.plugin.Patch;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/catalog/RemoteCatalogInfoRemoveEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/catalog/RemoteCatalogInfoRemoveEvent.java
@@ -8,6 +8,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.cloud.bus.event.RemoteRemoveEvent;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/catalog/RemoteDefaultDataStoreEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/catalog/RemoteDefaultDataStoreEvent.java
@@ -8,6 +8,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/catalog/RemoteDefaultNamespaceEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/catalog/RemoteDefaultNamespaceEvent.java
@@ -8,6 +8,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.plugin.Patch;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/catalog/RemoteDefaultWorkspaceEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/catalog/RemoteDefaultWorkspaceEvent.java
@@ -8,6 +8,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.Patch;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/AbstractRemoteConfigInfoAddEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/AbstractRemoteConfigInfoAddEvent.java
@@ -6,6 +6,7 @@ package org.geoserver.cloud.bus.event.config;
 
 import lombok.Getter;
 import lombok.Setter;
+
 import org.geoserver.catalog.Info;
 import org.geoserver.cloud.bus.event.RemoteAddEvent;
 import org.geoserver.cloud.event.ConfigInfoInfoType;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/AbstractRemoteConfigInfoRemoveEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/AbstractRemoteConfigInfoRemoveEvent.java
@@ -6,6 +6,7 @@ package org.geoserver.cloud.bus.event.config;
 
 import lombok.Getter;
 import lombok.Setter;
+
 import org.geoserver.catalog.Info;
 import org.geoserver.cloud.bus.event.RemoteRemoveEvent;
 import org.geoserver.cloud.event.ConfigInfoInfoType;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/RemoteGeoServerInfoModifyEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/RemoteGeoServerInfoModifyEvent.java
@@ -6,6 +6,7 @@ package org.geoserver.cloud.bus.event.config;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+
 import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerInfo;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/RemoteGeoServerInfoSetEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/RemoteGeoServerInfoSetEvent.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.bus.event.config;
 
 import lombok.EqualsAndHashCode;
+
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerInfo;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/RemoteLoggingInfoModifyEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/RemoteLoggingInfoModifyEvent.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.bus.event.config;
 
 import lombok.EqualsAndHashCode;
+
 import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.LoggingInfo;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/RemoteLoggingInfoSetEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/RemoteLoggingInfoSetEvent.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.bus.event.config;
 
 import lombok.EqualsAndHashCode;
+
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.LoggingInfo;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/RemoteServiceInfoAddEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/RemoteServiceInfoAddEvent.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.bus.event.config;
 
 import lombok.EqualsAndHashCode;
+
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.ServiceInfo;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/RemoteServiceInfoModifyEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/RemoteServiceInfoModifyEvent.java
@@ -7,6 +7,7 @@ package org.geoserver.cloud.bus.event.config;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
+
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.config.GeoServer;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/RemoteServiceInfoRemoveEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/RemoteServiceInfoRemoveEvent.java
@@ -7,6 +7,7 @@ package org.geoserver.cloud.bus.event.config;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
+
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.ServiceInfo;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/RemoteSettingsInfoAddEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/RemoteSettingsInfoAddEvent.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.bus.event.config;
 
 import lombok.EqualsAndHashCode;
+
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.SettingsInfo;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/RemoteSettingsInfoModifyEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/RemoteSettingsInfoModifyEvent.java
@@ -7,6 +7,7 @@ package org.geoserver.cloud.bus.event.config;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
+
 import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.SettingsInfo;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/RemoteSettingsInfoRemoveEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/bus/event/config/RemoteSettingsInfoRemoveEvent.java
@@ -7,6 +7,7 @@ package org.geoserver.cloud.bus.event.config;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
+
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.SettingsInfo;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/ConfigInfoInfoType.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/ConfigInfoInfoType.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.CoverageStoreInfo;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/LocalAddEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/LocalAddEvent.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.event;
 
 import lombok.NonNull;
+
 import org.geoserver.catalog.Info;
 
 public abstract class LocalAddEvent<S, I extends Info> extends LocalInfoEvent<S, I> {

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/LocalApplicationEventPublisher.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/LocalApplicationEventPublisher.java
@@ -5,16 +5,12 @@
 package org.geoserver.cloud.event;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import javax.annotation.PostConstruct;
+
 import lombok.AccessLevel;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogException;
 import org.geoserver.catalog.Info;
@@ -46,6 +42,14 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.annotation.PostConstruct;
 
 /**
  * Adapts the listener pattern used by {@link Catalog#addListener Catalog} and {@link

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/LocalInfoEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/LocalInfoEvent.java
@@ -6,6 +6,7 @@ package org.geoserver.cloud.event;
 
 import lombok.Getter;
 import lombok.NonNull;
+
 import org.geoserver.catalog.Info;
 import org.springframework.context.ApplicationEvent;
 

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/LocalModifyEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/LocalModifyEvent.java
@@ -4,11 +4,13 @@
  */
 package org.geoserver.cloud.event;
 
-import java.util.List;
 import lombok.Getter;
 import lombok.NonNull;
+
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.plugin.PropertyDiff;
+
+import java.util.List;
 
 public abstract class LocalModifyEvent<S, I extends Info> extends LocalInfoEvent<S, I> {
     private static final long serialVersionUID = 1L;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/LocalPostModifyEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/LocalPostModifyEvent.java
@@ -4,10 +4,12 @@
  */
 package org.geoserver.cloud.event;
 
-import java.util.List;
 import lombok.NonNull;
+
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.plugin.PropertyDiff;
+
+import java.util.List;
 
 public abstract class LocalPostModifyEvent<S, I extends Info> extends LocalModifyEvent<S, I> {
 

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/LocalPreModifyEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/LocalPreModifyEvent.java
@@ -4,10 +4,12 @@
  */
 package org.geoserver.cloud.event;
 
-import java.util.List;
 import lombok.NonNull;
+
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.plugin.PropertyDiff;
+
+import java.util.List;
 
 public abstract class LocalPreModifyEvent<S, I extends Info> extends LocalModifyEvent<S, I> {
 

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/LocalRemoveEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/LocalRemoveEvent.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.event;
 
 import lombok.NonNull;
+
 import org.geoserver.catalog.Info;
 
 public abstract class LocalRemoveEvent<S, I extends Info> extends LocalInfoEvent<S, I> {

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/catalog/LocalCatalogAddEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/catalog/LocalCatalogAddEvent.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.event.catalog;
 
 import lombok.NonNull;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.event.CatalogAddEvent;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/catalog/LocalCatalogPostModifyEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/catalog/LocalCatalogPostModifyEvent.java
@@ -4,12 +4,14 @@
  */
 package org.geoserver.cloud.event.catalog;
 
-import java.util.List;
 import lombok.NonNull;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.event.CatalogPostModifyEvent;
 import org.geoserver.cloud.event.LocalPostModifyEvent;
+
+import java.util.List;
 
 public class LocalCatalogPostModifyEvent extends LocalPostModifyEvent<Catalog, CatalogInfo> {
     private static final long serialVersionUID = 1L;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/catalog/LocalCatalogPreModifyEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/catalog/LocalCatalogPreModifyEvent.java
@@ -4,12 +4,14 @@
  */
 package org.geoserver.cloud.event.catalog;
 
-import java.util.List;
 import lombok.NonNull;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.event.CatalogModifyEvent;
 import org.geoserver.cloud.event.LocalPreModifyEvent;
+
+import java.util.List;
 
 public class LocalCatalogPreModifyEvent extends LocalPreModifyEvent<Catalog, CatalogInfo> {
     private static final long serialVersionUID = 1L;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/catalog/LocalCatalogRemoveEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/catalog/LocalCatalogRemoveEvent.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.event.catalog;
 
 import lombok.NonNull;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.event.CatalogRemoveEvent;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/config/LocalConfigAddEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/config/LocalConfigAddEvent.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.event.config;
 
 import lombok.NonNull;
+
 import org.geoserver.catalog.Info;
 import org.geoserver.cloud.event.LocalAddEvent;
 import org.geoserver.config.GeoServer;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/config/LocalConfigPostModifyEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/config/LocalConfigPostModifyEvent.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.event.config;
 
 import lombok.NonNull;
+
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.plugin.PropertyDiff;
 import org.geoserver.cloud.event.LocalPostModifyEvent;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/config/LocalConfigPreModifyEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/config/LocalConfigPreModifyEvent.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.event.config;
 
 import lombok.NonNull;
+
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.plugin.PropertyDiff;
 import org.geoserver.cloud.event.LocalPreModifyEvent;

--- a/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/config/LocalConfigRemoveEvent.java
+++ b/catalog-support/catalog-event-bus/src/main/java/org/geoserver/cloud/event/config/LocalConfigRemoveEvent.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.event.config;
 
 import lombok.NonNull;
+
 import org.geoserver.catalog.Info;
 import org.geoserver.cloud.event.LocalRemoveEvent;
 import org.geoserver.config.GeoServer;

--- a/catalog-support/catalog-event-bus/src/test/java/org/geoserver/cloud/bus/event/RemoteApplicationEventsAutoConfigurationDisabledTest.java
+++ b/catalog-support/catalog-event-bus/src/test/java/org/geoserver/cloud/bus/event/RemoteApplicationEventsAutoConfigurationDisabledTest.java
@@ -18,9 +18,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 
 @SpringBootTest(
-    classes = {TestConfigurationAutoConfiguration.class, ApplicationEventCapturingListener.class},
-    properties = {"spring.cloud.bus.enabled=true", "geoserver.bus.enabled=false"}
-)
+        classes = {
+            TestConfigurationAutoConfiguration.class,
+            ApplicationEventCapturingListener.class
+        },
+        properties = {"spring.cloud.bus.enabled=true", "geoserver.bus.enabled=false"})
 @EnableAutoConfiguration
 public class RemoteApplicationEventsAutoConfigurationDisabledTest {
     private @Autowired ApplicationContext context;

--- a/catalog-support/catalog-event-bus/src/test/java/org/geoserver/cloud/bus/integration/BusAmqpIntegrationTests.java
+++ b/catalog-support/catalog-event-bus/src/test/java/org/geoserver/cloud/bus/integration/BusAmqpIntegrationTests.java
@@ -23,13 +23,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
-import java.lang.reflect.Proxy;
-import java.util.List;
-import java.util.function.Consumer;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogTestData;
 import org.geoserver.catalog.Info;
@@ -63,17 +61,20 @@ import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.function.Consumer;
+
 @SpringBootTest(
-    webEnvironment = RANDOM_PORT,
-    classes = {TestConfigurationAutoConfiguration.class, BusEventCollector.class},
-    properties = {
-        "spring.cloud.bus.id=app:1",
-        "spring.cloud.stream.bindings.springCloudBusOutput.producer.errorChannelEnabled=true",
-        "spring.autoconfigure.exclude=org.springframework.cloud.stream.test.binder.TestSupportBinderAutoConfiguration",
-        "logging.level.root=WARN",
-        "logging.level.org.springframework.cloud.bus.BusConsumer=INFO"
-    }
-)
+        webEnvironment = RANDOM_PORT,
+        classes = {TestConfigurationAutoConfiguration.class, BusEventCollector.class},
+        properties = {
+            "spring.cloud.bus.id=app:1",
+            "spring.cloud.stream.bindings.springCloudBusOutput.producer.errorChannelEnabled=true",
+            "spring.autoconfigure.exclude=org.springframework.cloud.stream.test.binder.TestSupportBinderAutoConfiguration",
+            "logging.level.root=WARN",
+            "logging.level.org.springframework.cloud.bus.BusConsumer=INFO"
+        })
 @Testcontainers
 public abstract class BusAmqpIntegrationTests {
 

--- a/catalog-support/catalog-event-bus/src/test/java/org/geoserver/cloud/bus/integration/BusEventCollector.java
+++ b/catalog-support/catalog-event-bus/src/test/java/org/geoserver/cloud/bus/integration/BusEventCollector.java
@@ -6,6 +6,16 @@ package org.geoserver.cloud.bus.integration;
 
 import static org.junit.Assert.assertEquals;
 
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+import org.geoserver.cloud.bus.event.RemoteInfoEvent;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.bus.event.RemoteApplicationEvent;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.EventListener;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
@@ -13,14 +23,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
-import org.geoserver.cloud.bus.event.RemoteInfoEvent;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cloud.bus.event.RemoteApplicationEvent;
-import org.springframework.context.ApplicationEvent;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.event.EventListener;
 
 @Configuration
 @Slf4j

--- a/catalog-support/catalog-event-bus/src/test/java/org/geoserver/cloud/bus/integration/CatalogRemoteApplicationEventsTest.java
+++ b/catalog-support/catalog-event-bus/src/test/java/org/geoserver/cloud/bus/integration/CatalogRemoteApplicationEventsTest.java
@@ -10,8 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.util.Collections;
-import java.util.function.Consumer;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.DataStoreInfo;
@@ -27,6 +25,9 @@ import org.geoserver.cloud.bus.event.catalog.RemoteDefaultWorkspaceEvent;
 import org.geoserver.cloud.event.PropertyDiffTestSupport;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.function.Consumer;
 
 public class CatalogRemoteApplicationEventsTest extends BusAmqpIntegrationTests {
 

--- a/catalog-support/catalog-event-bus/src/test/java/org/geoserver/cloud/bus/integration/ConfigRemoteApplicationEventsTest.java
+++ b/catalog-support/catalog-event-bus/src/test/java/org/geoserver/cloud/bus/integration/ConfigRemoteApplicationEventsTest.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.cloud.bus.integration;
 
-import java.util.Locale;
 import org.geoserver.cloud.bus.event.config.RemoteGeoServerInfoModifyEvent;
 import org.geoserver.cloud.bus.event.config.RemoteLoggingInfoModifyEvent;
 import org.geoserver.cloud.bus.event.config.RemoteServiceInfoAddEvent;
@@ -26,6 +25,8 @@ import org.geoserver.wms.WMSInfo;
 import org.geoserver.wms.WMSInfoImpl;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
 
 public class ConfigRemoteApplicationEventsTest extends BusAmqpIntegrationTests {
 

--- a/catalog-support/catalog-event-bus/src/test/java/org/geoserver/cloud/event/LocalApplicationEventsAutoConfigurationTest.java
+++ b/catalog-support/catalog-event-bus/src/test/java/org/geoserver/cloud/event/LocalApplicationEventsAutoConfigurationTest.java
@@ -9,9 +9,6 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Consumer;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.CatalogTestData;
@@ -51,10 +48,16 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
 @SpringBootTest(
-    classes = {TestConfigurationAutoConfiguration.class, ApplicationEventCapturingListener.class},
-    properties = {"spring.cloud.bus.enabled=false"}
-)
+        classes = {
+            TestConfigurationAutoConfiguration.class,
+            ApplicationEventCapturingListener.class
+        },
+        properties = {"spring.cloud.bus.enabled=false"})
 @RunWith(SpringRunner.class)
 @EnableAutoConfiguration
 public class LocalApplicationEventsAutoConfigurationTest {
@@ -74,8 +77,7 @@ public class LocalApplicationEventsAutoConfigurationTest {
 
     public @Test void testCatalogEventBroadcasterHasSetUpItself() {
         Optional<CatalogListener> publiherListener =
-                catalog.getListeners()
-                        .stream()
+                catalog.getListeners().stream()
                         .filter(
                                 l ->
                                         l
@@ -88,9 +90,7 @@ public class LocalApplicationEventsAutoConfigurationTest {
 
     public @Test void testConfigEventBroadcasterHasSetUpItself() {
         Optional<ConfigurationListener> publiherListener =
-                geoserver
-                        .getListeners()
-                        .stream()
+                geoserver.getListeners().stream()
                         .filter(
                                 l ->
                                         l

--- a/catalog-support/catalog-event-bus/src/test/java/org/geoserver/cloud/event/PropertyDiffTestSupport.java
+++ b/catalog-support/catalog-event-bus/src/test/java/org/geoserver/cloud/event/PropertyDiffTestSupport.java
@@ -6,9 +6,10 @@ package org.geoserver.cloud.event;
 
 import static org.junit.Assert.assertTrue;
 
+import org.geoserver.catalog.plugin.PropertyDiff;
+
 import java.util.ArrayList;
 import java.util.List;
-import org.geoserver.catalog.plugin.PropertyDiff;
 
 public class PropertyDiffTestSupport {
 

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/CatalogInfoDeserializer.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/CatalogInfoDeserializer.java
@@ -8,11 +8,13 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import java.io.IOException;
+
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.jackson.databind.catalog.dto.CatalogInfoDto;
 import org.geoserver.jackson.databind.catalog.mapper.CatalogInfoMapper;
 import org.mapstruct.factory.Mappers;
+
+import java.io.IOException;
 
 public class CatalogInfoDeserializer<I extends CatalogInfo> extends JsonDeserializer<I> {
 

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/CatalogInfoSerializer.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/CatalogInfoSerializer.java
@@ -10,11 +10,13 @@ import com.fasterxml.jackson.core.type.WritableTypeId;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import java.io.IOException;
+
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.jackson.databind.catalog.dto.CatalogInfoDto;
 import org.geoserver.jackson.databind.catalog.mapper.CatalogInfoMapper;
 import org.mapstruct.factory.Mappers;
+
+import java.io.IOException;
 
 public class CatalogInfoSerializer<I extends CatalogInfo> extends StdSerializer<I> {
     private static final long serialVersionUID = -4772839273787523779L;

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModule.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModule.java
@@ -7,11 +7,9 @@ package org.geoserver.jackson.databind.catalog;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import java.util.Arrays;
-import java.util.Locale;
-import java.util.Map;
-import java.util.function.Function;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.AuthorityURLInfo;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.CoverageDimensionInfo;
@@ -54,6 +52,11 @@ import org.mapstruct.factory.Mappers;
 import org.opengis.coverage.grid.GridGeometry;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.util.InternationalString;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Jackson {@link com.fasterxml.jackson.databind.Module} to handle GeoServer {@link CatalogInfo}

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/ProxyUtils.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/ProxyUtils.java
@@ -4,16 +4,11 @@
  */
 package org.geoserver.jackson.databind.catalog;
 
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Proxy;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.Info;
@@ -37,6 +32,13 @@ import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.LoggingInfo;
 import org.geoserver.config.ServiceInfo;
 import org.geoserver.config.SettingsInfo;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 /** */
 @Slf4j

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/VersionDeserializer.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/VersionDeserializer.java
@@ -8,9 +8,11 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import java.io.IOException;
+
 import org.geoserver.jackson.databind.catalog.dto.VersionDto;
 import org.geotools.util.Version;
+
+import java.io.IOException;
 
 public class VersionDeserializer extends JsonDeserializer<Version> {
 

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/VersionSerializer.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/VersionSerializer.java
@@ -10,11 +10,13 @@ import com.fasterxml.jackson.core.type.WritableTypeId;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import java.io.IOException;
+
 import org.geoserver.jackson.databind.catalog.dto.VersionDto;
 import org.geoserver.jackson.databind.mapper.SharedMappers;
 import org.geotools.util.Version;
 import org.mapstruct.factory.Mappers;
+
+import java.io.IOException;
 
 public class VersionSerializer extends StdSerializer<Version> {
     private static final long serialVersionUID = 1400927583579278680L;

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/AttributeType.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/AttributeType.java
@@ -4,9 +4,10 @@
  */
 package org.geoserver.jackson.databind.catalog.dto;
 
+import lombok.Data;
+
 import java.io.Serializable;
 import java.util.Map;
-import lombok.Data;
 
 @Data
 public class AttributeType {

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/CatalogInfoDto.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/CatalogInfoDto.java
@@ -6,9 +6,11 @@ package org.geoserver.jackson.databind.catalog.dto;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import java.util.Date;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
+import java.util.Date;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonSubTypes({

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Coverage.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Coverage.java
@@ -4,11 +4,12 @@
  */
 package org.geoserver.jackson.databind.catalog.dto;
 
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/CoverageDimension.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/CoverageDimension.java
@@ -4,11 +4,15 @@
  */
 package org.geoserver.jackson.databind.catalog.dto;
 
-import java.util.List;
 import lombok.Data;
+
 import org.geoserver.catalog.impl.CoverageDimensionImpl;
 
-/** @see CoverageDimensionImpl */
+import java.util.List;
+
+/**
+ * @see CoverageDimensionImpl
+ */
 public @Data class CoverageDimension {
     private String id;
     private String name;

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Dimension.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Dimension.java
@@ -4,11 +4,13 @@
  */
 package org.geoserver.jackson.databind.catalog.dto;
 
-import java.math.BigDecimal;
 import lombok.Data;
+
 import org.geoserver.catalog.DimensionDefaultValueSetting;
 import org.geoserver.catalog.DimensionInfo;
 import org.geoserver.catalog.DimensionPresentation;
+
+import java.math.BigDecimal;
 
 /** DTO for {@link DimensionInfo} */
 public @Data class Dimension {

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/FeatureType.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/FeatureType.java
@@ -4,9 +4,10 @@
  */
 package org.geoserver.jackson.databind.catalog.dto;
 
-import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
+import java.util.List;
 
 @Data
 @EqualsAndHashCode(callSuper = true)

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/GridGeometryDto.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/GridGeometryDto.java
@@ -5,6 +5,7 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
+
 import org.geoserver.config.util.XStreamPersister;
 import org.geotools.coverage.grid.GridGeometry2D;
 

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/HTTPStore.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/HTTPStore.java
@@ -6,6 +6,7 @@ package org.geoserver.jackson.databind.catalog.dto;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/InfoDto.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/InfoDto.java
@@ -6,7 +6,9 @@ package org.geoserver.jackson.databind.catalog.dto;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import lombok.Data;
+
 import org.geoserver.jackson.databind.config.dto.ConfigInfoDto;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/InfoReference.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/InfoReference.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+
 import org.geoserver.catalog.impl.ClassMappings;
 
 @Data

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Layer.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Layer.java
@@ -4,9 +4,10 @@
  */
 package org.geoserver.jackson.databind.catalog.dto;
 
-import java.util.Set;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
+import java.util.Set;
 
 @Data
 @EqualsAndHashCode(callSuper = true)

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/LayerGroup.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/LayerGroup.java
@@ -4,10 +4,11 @@
  */
 package org.geoserver.jackson.databind.catalog.dto;
 
-import java.util.List;
-import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
+import java.util.List;
+import java.util.Map;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -31,10 +32,16 @@ public class LayerGroup extends Published {
     protected List<MetadataLink> metadataLinks;
     protected Envelope bounds;
     private List<Keyword> keywords;
-    /** @since geoserver 2.20.0 */
+    /**
+     * @since geoserver 2.20.0
+     */
     private Map<String, String> internationalTitle;
-    /** @since geoserver 2.20.0 */
+    /**
+     * @since geoserver 2.20.0
+     */
     private Map<String, String> internationalAbstract;
-    /** @since geoserver 2.21.0 */
+    /**
+     * @since geoserver 2.21.0
+     */
     private List<LayerGroupStyle> layerGroupStyles;
 }

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/LayerGroupStyle.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/LayerGroupStyle.java
@@ -4,9 +4,10 @@
  */
 package org.geoserver.jackson.databind.catalog.dto;
 
+import lombok.Data;
+
 import java.util.List;
 import java.util.Map;
-import lombok.Data;
 
 /**
  * DTO for {@link org.geoserver.catalog.impl.LayerGroupStyle}

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Map.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Map.java
@@ -4,9 +4,10 @@
  */
 package org.geoserver.jackson.databind.catalog.dto;
 
-import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
+import java.util.List;
 
 @Data
 @EqualsAndHashCode(callSuper = true)

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Namespace.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Namespace.java
@@ -4,10 +4,11 @@
  */
 package org.geoserver.jackson.databind.catalog.dto;
 
-import java.io.Serializable;
-import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+import java.util.Map;
 
 @Data
 @EqualsAndHashCode(callSuper = true)

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/NumberRangeDto.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/NumberRangeDto.java
@@ -5,6 +5,7 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
+
 import org.geoserver.config.util.XStreamPersister;
 import org.geotools.util.NumberRange;
 

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/PatchDto.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/PatchDto.java
@@ -6,10 +6,13 @@ package org.geoserver.jackson.databind.catalog.dto;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import lombok.Data;
+
+import org.geotools.jackson.databind.filter.dto.Expression.Literal;
+
 import java.util.Map;
 import java.util.TreeMap;
-import lombok.Data;
-import org.geotools.jackson.databind.filter.dto.Expression.Literal;
 
 /** DTO for {@link org.geoserver.catalog.plugin.Patch} */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Published.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Published.java
@@ -6,11 +6,13 @@ package org.geoserver.jackson.databind.catalog.dto;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonSubTypes({

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/QueryDto.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/QueryDto.java
@@ -4,15 +4,17 @@
  */
 package org.geoserver.jackson.databind.catalog.dto;
 
-import java.util.ArrayList;
-import java.util.List;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+
 import org.geoserver.catalog.plugin.Query;
 import org.opengis.filter.Filter;
 import org.opengis.filter.sort.SortBy;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /** DTO for {@link Query} */
 @NoArgsConstructor

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Resource.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Resource.java
@@ -6,11 +6,13 @@ package org.geoserver.jackson.databind.catalog.dto;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonSubTypes({
@@ -51,8 +53,12 @@ public abstract class Resource extends CatalogInfoDto {
     private List<String> disabledServices;
     private Boolean simpleConversionEnabled;
 
-    /** @since geoserver 2.20.0 */
+    /**
+     * @since geoserver 2.20.0
+     */
     private Map<String, String> internationalTitle;
-    /** @since geoserver 2.20.0 */
+    /**
+     * @since geoserver 2.20.0
+     */
     private Map<String, String> internationalAbstract;
 }

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Store.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Store.java
@@ -6,10 +6,12 @@ package org.geoserver.jackson.databind.catalog.dto;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import java.io.Serializable;
-import java.util.Map;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+import java.util.Map;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonSubTypes({

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Style.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Style.java
@@ -4,10 +4,11 @@
  */
 package org.geoserver.jackson.databind.catalog.dto;
 
-import java.io.Serializable;
-import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+import java.util.Map;
 
 @Data
 @EqualsAndHashCode(callSuper = true)

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/VirtualTableDto.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/VirtualTableDto.java
@@ -5,6 +5,7 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
+
 import org.geotools.jdbc.VirtualTable;
 
 /** DTO type for {@link VirtualTable} */

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/WMSLayer.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/WMSLayer.java
@@ -4,9 +4,10 @@
  */
 package org.geoserver.jackson.databind.catalog.dto;
 
-import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
+import java.util.List;
 
 @Data
 @EqualsAndHashCode(callSuper = true)

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Workspace.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/dto/Workspace.java
@@ -6,10 +6,12 @@ package org.geoserver.jackson.databind.catalog.dto;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import java.io.Serializable;
-import java.util.Map;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+import java.util.Map;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonTypeName("WorkspaceInfo")

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/mapper/CatalogInfoMapperConfig.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/mapper/CatalogInfoMapperConfig.java
@@ -9,8 +9,7 @@ import org.mapstruct.MapperConfig;
 import org.mapstruct.ReportingPolicy;
 
 @MapperConfig(
-    componentModel = "default",
-    unmappedTargetPolicy = ReportingPolicy.ERROR,
-    uses = {SharedMappers.class, ObjectFacotries.class, ValueMappers.class}
-)
+        componentModel = "default",
+        unmappedTargetPolicy = ReportingPolicy.ERROR,
+        uses = {SharedMappers.class, ObjectFacotries.class, ValueMappers.class})
 public class CatalogInfoMapperConfig {}

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/mapper/ObjectFacotries.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/mapper/ObjectFacotries.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.jackson.databind.catalog.mapper;
 
-import java.util.function.Supplier;
 import org.geoserver.catalog.AttributeTypeInfo;
 import org.geoserver.catalog.AttributionInfo;
 import org.geoserver.catalog.Catalog;
@@ -68,6 +67,8 @@ import org.geoserver.jackson.databind.catalog.dto.Workspace;
 import org.geoserver.ows.util.OwsUtils;
 import org.mapstruct.ObjectFactory;
 import org.mapstruct.TargetType;
+
+import java.util.function.Supplier;
 
 /**
  * Auto-wired object factory for Catalog info interfaces, so the mapstruct code-generated mappers

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/mapper/ValueMappers.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/catalog/mapper/ValueMappers.java
@@ -4,12 +4,6 @@
  */
 package org.geoserver.jackson.databind.catalog.mapper;
 
-import java.awt.geom.AffineTransform;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
 import org.geoserver.catalog.AttributeTypeInfo;
 import org.geoserver.catalog.AttributionInfo;
 import org.geoserver.catalog.AuthorityURLInfo;
@@ -58,6 +52,13 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.MathTransform;
 import org.opengis.util.InternationalString;
 import org.slf4j.LoggerFactory;
+
+import java.awt.geom.AffineTransform;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
 @Mapper(config = CatalogInfoMapperConfig.class)
 public interface ValueMappers {
@@ -137,7 +138,9 @@ public interface ValueMappers {
         }
     }
 
-    /** @see XStreamPersister#GridGeometry2DConverter */
+    /**
+     * @see XStreamPersister#GridGeometry2DConverter
+     */
     default GridGeometry dtoToGridGeometry2D(GridGeometryDto value) {
         if (value == null) return null;
         CoordinateReferenceSystem crs = Mappers.getMapper(SharedMappers.class).crs(value.getCrs());

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/ConfigInfoDeserializer.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/ConfigInfoDeserializer.java
@@ -5,6 +5,7 @@
 package org.geoserver.jackson.databind.config;
 
 import lombok.NonNull;
+
 import org.geoserver.catalog.Info;
 import org.geoserver.jackson.databind.catalog.dto.InfoDto;
 import org.geoserver.jackson.databind.config.dto.mapper.GeoServerConfigMapper;

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/GeoServerConfigModule.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/GeoServerConfigModule.java
@@ -7,7 +7,9 @@ package org.geoserver.jackson.databind.config;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.Info;
 import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.LoggingInfo;

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/ConfigInfoDto.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/ConfigInfoDto.java
@@ -6,8 +6,10 @@ package org.geoserver.jackson.databind.config.dto;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
 import org.geoserver.jackson.databind.catalog.dto.InfoDto;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/Contact.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/Contact.java
@@ -4,9 +4,11 @@
  */
 package org.geoserver.jackson.databind.config.dto;
 
-import java.util.Map;
 import lombok.Data;
+
 import org.geoserver.config.ContactInfo;
+
+import java.util.Map;
 
 /** DTO for {@link ContactInfo} */
 public @Data class Contact {
@@ -26,32 +28,60 @@ public @Data class Contact {
     private String contactVoice;
     private String onlineResource;
 
-    /** @since geoserver 2.20.0 */
+    /**
+     * @since geoserver 2.20.0
+     */
     private Map<String, String> internationalAddress;
-    /** @since geoserver 2.20.0 */
+    /**
+     * @since geoserver 2.20.0
+     */
     private Map<String, String> internationalContactFacsimile;
-    /** @since geoserver 2.20.0 */
+    /**
+     * @since geoserver 2.20.0
+     */
     private Map<String, String> internationalContactOrganization;
-    /** @since geoserver 2.20.0 */
+    /**
+     * @since geoserver 2.20.0
+     */
     private Map<String, String> internationalContactPerson;
-    /** @since geoserver 2.20.0 */
+    /**
+     * @since geoserver 2.20.0
+     */
     private Map<String, String> internationalContactPosition;
-    /** @since geoserver 2.20.0 */
+    /**
+     * @since geoserver 2.20.0
+     */
     private Map<String, String> internationalContactVoice;
-    /** @since geoserver 2.20.0 */
+    /**
+     * @since geoserver 2.20.0
+     */
     private Map<String, String> internationalOnlineResource;
-    /** @since geoserver 2.20.0 */
+    /**
+     * @since geoserver 2.20.0
+     */
     private Map<String, String> internationalAddressCity;
-    /** @since geoserver 2.20.0 */
+    /**
+     * @since geoserver 2.20.0
+     */
     private Map<String, String> internationalAddressCountry;
-    /** @since geoserver 2.20.0 */
+    /**
+     * @since geoserver 2.20.0
+     */
     private Map<String, String> internationalAddressDeliveryPoint;
-    /** @since geoserver 2.20.0 */
+    /**
+     * @since geoserver 2.20.0
+     */
     private Map<String, String> internationalAddressPostalCode;
-    /** @since geoserver 2.20.0 */
+    /**
+     * @since geoserver 2.20.0
+     */
     private Map<String, String> internationalAddressState;
-    /** @since geoserver 2.20.0 */
+    /**
+     * @since geoserver 2.20.0
+     */
     private Map<String, String> internationalAddressType;
-    /** @since geoserver 2.20.0 */
+    /**
+     * @since geoserver 2.20.0
+     */
     private Map<String, String> internationalContactEmail;
 }

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/CoverageAccess.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/CoverageAccess.java
@@ -5,6 +5,7 @@
 package org.geoserver.jackson.databind.config.dto;
 
 import lombok.Data;
+
 import org.geoserver.config.CoverageAccessInfo;
 
 /** DTO for {@link CoverageAccessInfo} */

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/GeoServer.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/GeoServer.java
@@ -4,11 +4,13 @@
  */
 package org.geoserver.jackson.databind.config.dto;
 
-import java.io.Serializable;
-import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
 import org.geoserver.config.GeoServerInfo;
+
+import java.io.Serializable;
+import java.util.Map;
 
 /** DTO for {@link GeoServerInfo} */
 @EqualsAndHashCode(callSuper = true)

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/JaiDto.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/JaiDto.java
@@ -4,9 +4,11 @@
  */
 package org.geoserver.jackson.databind.config.dto;
 
-import java.util.Set;
 import lombok.Data;
+
 import org.geoserver.config.JAIInfo;
+
+import java.util.Set;
 
 /** DTO for {@link JAIInfo} */
 public @Data class JaiDto {

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/Logging.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/Logging.java
@@ -6,6 +6,7 @@ package org.geoserver.jackson.databind.config.dto;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
 import org.geoserver.config.LoggingInfo;
 
 /** DTO for {@link LoggingInfo} */

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/Service.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/Service.java
@@ -6,13 +6,10 @@ package org.geoserver.jackson.databind.config.dto;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import java.io.Serializable;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
 import org.geoserver.catalog.LayerInfo.WMSInterpolation;
 import org.geoserver.catalog.impl.AuthorityURL;
 import org.geoserver.catalog.impl.LayerIdentifier;
@@ -30,6 +27,12 @@ import org.geoserver.wms.WatermarkInfoImpl;
 import org.geoserver.wps.ProcessGroupInfo;
 import org.geoserver.wps.ProcessInfo;
 import org.geotools.coverage.grid.io.OverviewPolicy;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
 /** DTO for {@link ServiceInfo} */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
@@ -63,11 +66,17 @@ public abstract @Data class Service extends ConfigInfoDto {
     // not used
     // Map<Object, Object> clientProperties;
 
-    /** @since geoserver 2.20.0 */
+    /**
+     * @since geoserver 2.20.0
+     */
     private Locale defaultLocale;
-    /** @since geoserver 2.20.0 */
+    /**
+     * @since geoserver 2.20.0
+     */
     private Map<String, String> internationalTitle;
-    /** @since geoserver 2.20.0 */
+    /**
+     * @since geoserver 2.20.0
+     */
     private Map<String, String> internationalAbstract;
 
     @EqualsAndHashCode(callSuper = true)
@@ -98,12 +107,18 @@ public abstract @Data class Service extends ConfigInfoDto {
         private int remoteStyleMaxRequestTime;
         private int remoteStyleTimeout;
 
-        /** @since geoserver 2.19.2 */
+        /**
+         * @since geoserver 2.19.2
+         */
         private boolean defaultGroupStyleEnabled;
 
-        /** @since geoserver 2.20.0 */
+        /**
+         * @since geoserver 2.20.0
+         */
         private Map<String, String> internationalRootLayerTitle;
-        /** @since geoserver 2.20.0 */
+        /**
+         * @since geoserver 2.20.0
+         */
         private Map<String, String> internationalRootLayerAbstract;
     }
 

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/Settings.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/Settings.java
@@ -4,13 +4,15 @@
  */
 package org.geoserver.jackson.databind.config.dto;
 
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import org.geoserver.config.SettingsInfo;
+import org.geoserver.jackson.databind.catalog.dto.InfoReference;
+
 import java.io.Serializable;
 import java.util.Locale;
 import java.util.Map;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import org.geoserver.config.SettingsInfo;
-import org.geoserver.jackson.databind.catalog.dto.InfoReference;
 
 /** DTO for {@link SettingsInfo} */
 @EqualsAndHashCode(callSuper = true)
@@ -32,6 +34,8 @@ public @Data class Settings extends ConfigInfoDto {
     private boolean showCreatedTimeColumnsInAdminList;
     private boolean showModifiedTimeColumnsInAdminList;
 
-    /** @since geoserver 2.20.0 */
+    /**
+     * @since geoserver 2.20.0
+     */
     private Locale defaultLocale;
 }

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/ConfigInfoMapperConfig.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/ConfigInfoMapperConfig.java
@@ -10,8 +10,7 @@ import org.mapstruct.MapperConfig;
 import org.mapstruct.ReportingPolicy;
 
 @MapperConfig(
-    componentModel = "default",
-    unmappedTargetPolicy = ReportingPolicy.ERROR,
-    uses = {SharedMappers.class, ObjectFacotries.class, WPSMapper.class, ValueMappers.class}
-)
+        componentModel = "default",
+        unmappedTargetPolicy = ReportingPolicy.ERROR,
+        uses = {SharedMappers.class, ObjectFacotries.class, WPSMapper.class, ValueMappers.class})
 public class ConfigInfoMapperConfig {}

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/GeoServerConfigMapper.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/GeoServerConfigMapper.java
@@ -4,8 +4,6 @@
  */
 package org.geoserver.jackson.databind.config.dto.mapper;
 
-import java.util.List;
-import java.util.stream.Collectors;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.Info;
 import org.geoserver.config.ContactInfo;
@@ -41,6 +39,9 @@ import org.geotools.util.Version;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 /** Mapper to/from GeoServer config objects and their respective DTO representations */
 @Mapper(config = ConfigInfoMapperConfig.class)

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/ObjectFacotries.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/ObjectFacotries.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.jackson.databind.config.dto.mapper;
 
-import java.util.function.Supplier;
 import org.geoserver.catalog.Info;
 import org.geoserver.config.CoverageAccessInfo;
 import org.geoserver.config.GeoServerInfo;
@@ -24,6 +23,8 @@ import org.geoserver.jackson.databind.config.dto.Settings;
 import org.geoserver.ows.util.OwsUtils;
 import org.mapstruct.ObjectFactory;
 import org.springframework.stereotype.Component;
+
+import java.util.function.Supplier;
 
 /**
  * Auto-wired object factory for config info interfaces, so the mapstruct code-generated mappers

--- a/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/mapper/SharedMappers.java
+++ b/catalog-support/geoserver-jackson-bindings/src/main/java/org/geoserver/jackson/databind/mapper/SharedMappers.java
@@ -4,17 +4,9 @@
  */
 package org.geoserver.jackson.databind.mapper;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.AuthorityURLInfo;
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.KeywordInfo;
@@ -51,6 +43,16 @@ import org.mapstruct.factory.Mappers;
 import org.opengis.feature.type.Name;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 
 @Mapper
 @Slf4j
@@ -219,7 +221,8 @@ public abstract class SharedMappers {
         if (prop == null) return null;
         Object value = patchPropertyValueToDto(prop.getValue());
         return value;
-    };
+    }
+    ;
 
     private Object patchPropertyValueToDto(Object value) {
         if (value instanceof Info) {
@@ -245,7 +248,8 @@ public abstract class SharedMappers {
             return this.infoToReference((Info) value);
         }
         return value;
-    };
+    }
+    ;
 
     private ClassMappings resolveType(@NonNull Info value) {
         value = ModificationProxy.unwrap(value);

--- a/catalog-support/geoserver-jackson-bindings/src/test/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModuleTest.java
+++ b/catalog-support/geoserver-jackson-bindings/src/test/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModuleTest.java
@@ -6,6 +6,7 @@ package org.geoserver.jackson.databind.catalog;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newLinkedHashSet;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
@@ -17,14 +18,9 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import java.lang.reflect.Proxy;
-import java.math.BigDecimal;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.AttributeTypeInfo;
 import org.geoserver.catalog.AuthorityURLInfo;
 import org.geoserver.catalog.Catalog;
@@ -109,7 +105,16 @@ import org.opengis.filter.expression.Literal;
 import org.opengis.filter.sort.SortOrder;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.util.InternationalString;
+
 import si.uom.SI;
+
+import java.lang.reflect.Proxy;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 /**
  * Verifies that all {@link CatalogInfo} can be sent over the wire and parsed back using jackson,

--- a/catalog-support/geoserver-jackson-bindings/src/test/java/org/geoserver/jackson/databind/config/GeoServerConfigModuleTest.java
+++ b/catalog-support/geoserver-jackson-bindings/src/test/java/org/geoserver/jackson/databind/config/GeoServerConfigModuleTest.java
@@ -10,7 +10,9 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+
 import lombok.NonNull;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogTestData;
 import org.geoserver.catalog.Info;

--- a/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/filter/GeoToolsFilterModule.java
+++ b/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/filter/GeoToolsFilterModule.java
@@ -7,7 +7,9 @@ package org.geotools.jackson.databind.filter;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.geotools.jackson.databind.filter.mapper.ExpressionMapper;
 import org.geotools.jackson.databind.filter.mapper.FilterMapper;
 import org.geotools.jackson.databind.geojson.GeoToolsGeoJsonModule;

--- a/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/filter/dto/Expression.java
+++ b/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/filter/dto/Expression.java
@@ -7,16 +7,18 @@ package org.geotools.jackson.databind.filter.dto;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
-import lombok.experimental.Accessors;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonSubTypes({
@@ -35,10 +37,9 @@ public @Data abstract class Expression {
          * property to the {@code Literal} object, without messing with the value representation.
          */
         @JsonTypeInfo(
-            use = JsonTypeInfo.Id.CLASS,
-            include = JsonTypeInfo.As.EXTERNAL_PROPERTY,
-            property = "@type"
-        )
+                use = JsonTypeInfo.Id.CLASS,
+                include = JsonTypeInfo.As.EXTERNAL_PROPERTY,
+                property = "@type")
         private Object value;
 
         private List<Literal> list;
@@ -49,14 +50,14 @@ public @Data abstract class Expression {
                 list =
                         ((List<?>) value)
                                 .stream()
-                                .map(v -> new Literal().setValue(v))
-                                .collect(Collectors.toList());
+                                        .map(v -> new Literal().setValue(v))
+                                        .collect(Collectors.toList());
             else if (value instanceof Set)
                 set =
                         ((Set<?>) value)
                                 .stream()
-                                .map(v -> new Literal().setValue(v))
-                                .collect(Collectors.toCollection(LinkedHashSet::new));
+                                        .map(v -> new Literal().setValue(v))
+                                        .collect(Collectors.toCollection(LinkedHashSet::new));
             else this.value = value;
             return this;
         }

--- a/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/filter/dto/Filter.java
+++ b/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/filter/dto/Filter.java
@@ -6,13 +6,15 @@ package org.geotools.jackson.databind.filter.dto;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.Accessors;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonSubTypes({
@@ -158,29 +160,23 @@ public @Data class Filter {
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
     @JsonSubTypes({
         @JsonSubTypes.Type(
-            value = BinaryComparisonOperator.PropertyIsEqualTo.class,
-            name = "PropertyIsEqualTo"
-        ),
+                value = BinaryComparisonOperator.PropertyIsEqualTo.class,
+                name = "PropertyIsEqualTo"),
         @JsonSubTypes.Type(
-            value = BinaryComparisonOperator.PropertyIsNotEqualTo.class,
-            name = "PropertyIsNotEqualTo"
-        ),
+                value = BinaryComparisonOperator.PropertyIsNotEqualTo.class,
+                name = "PropertyIsNotEqualTo"),
         @JsonSubTypes.Type(
-            value = BinaryComparisonOperator.PropertyIsGreaterThan.class,
-            name = "PropertyIsGreaterThan"
-        ),
+                value = BinaryComparisonOperator.PropertyIsGreaterThan.class,
+                name = "PropertyIsGreaterThan"),
         @JsonSubTypes.Type(
-            value = BinaryComparisonOperator.PropertyIsGreaterThanOrEqualTo.class,
-            name = "PropertyIsGreaterThanOrEqualTo"
-        ),
+                value = BinaryComparisonOperator.PropertyIsGreaterThanOrEqualTo.class,
+                name = "PropertyIsGreaterThanOrEqualTo"),
         @JsonSubTypes.Type(
-            value = BinaryComparisonOperator.PropertyIsLessThan.class,
-            name = "PropertyIsLessThan"
-        ),
+                value = BinaryComparisonOperator.PropertyIsLessThan.class,
+                name = "PropertyIsLessThan"),
         @JsonSubTypes.Type(
-            value = BinaryComparisonOperator.PropertyIsLessThanOrEqualTo.class,
-            name = "PropertyIsLessThanOrEqualTo"
-        )
+                value = BinaryComparisonOperator.PropertyIsLessThanOrEqualTo.class,
+                name = "PropertyIsLessThanOrEqualTo")
     })
     @Accessors(chain = true)
     @EqualsAndHashCode(callSuper = true)
@@ -214,9 +210,8 @@ public @Data class Filter {
         @JsonSubTypes.Type(value = Filter.BinarySpatialOperator.Disjoint.class, name = "Disjoint"),
         @JsonSubTypes.Type(value = Filter.BinarySpatialOperator.Equals.class, name = "Equals"),
         @JsonSubTypes.Type(
-            value = Filter.BinarySpatialOperator.Intersects.class,
-            name = "Intersects"
-        ),
+                value = Filter.BinarySpatialOperator.Intersects.class,
+                name = "Intersects"),
         @JsonSubTypes.Type(value = Filter.BinarySpatialOperator.Overlaps.class, name = "Overlaps"),
         @JsonSubTypes.Type(value = Filter.BinarySpatialOperator.Touches.class, name = "Touches"),
         @JsonSubTypes.Type(value = Filter.BinarySpatialOperator.Within.class, name = "Within"),
@@ -256,9 +251,8 @@ public @Data class Filter {
         @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
         @JsonSubTypes({
             @JsonSubTypes.Type(
-                value = Filter.BinarySpatialOperator.DWithin.class,
-                name = "DWithin"
-            ),
+                    value = Filter.BinarySpatialOperator.DWithin.class,
+                    name = "DWithin"),
             @JsonSubTypes.Type(value = Filter.BinarySpatialOperator.Beyond.class, name = "Beyond")
         })
         @EqualsAndHashCode(callSuper = true)
@@ -278,9 +272,8 @@ public @Data class Filter {
     @JsonSubTypes({
         @JsonSubTypes.Type(value = Filter.BinaryTemporalOperator.After.class, name = "After"),
         @JsonSubTypes.Type(
-            value = Filter.BinaryTemporalOperator.AnyInteracts.class,
-            name = "AnyInteracts"
-        ),
+                value = Filter.BinaryTemporalOperator.AnyInteracts.class,
+                name = "AnyInteracts"),
         @JsonSubTypes.Type(value = BinaryTemporalOperator.Before.class, name = "Before"),
         @JsonSubTypes.Type(value = BinaryTemporalOperator.Begins.class, name = "Begins"),
         @JsonSubTypes.Type(value = BinaryTemporalOperator.BegunBy.class, name = "BegunBy"),
@@ -290,9 +283,8 @@ public @Data class Filter {
         @JsonSubTypes.Type(value = BinaryTemporalOperator.Meets.class, name = "Meets"),
         @JsonSubTypes.Type(value = BinaryTemporalOperator.MetBy.class, name = "MetBy"),
         @JsonSubTypes.Type(
-            value = BinaryTemporalOperator.OverlappedBy.class,
-            name = "OverlappedBy"
-        ),
+                value = BinaryTemporalOperator.OverlappedBy.class,
+                name = "OverlappedBy"),
         @JsonSubTypes.Type(value = BinaryTemporalOperator.TContains.class, name = "TContains"),
         @JsonSubTypes.Type(value = BinaryTemporalOperator.TOverlaps.class, name = "TOverlaps"),
         @JsonSubTypes.Type(value = BinaryTemporalOperator.TEquals.class, name = "TEquals")

--- a/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/filter/dto/LiteralValueDeserializer.java
+++ b/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/filter/dto/LiteralValueDeserializer.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.io.IOException;
 
 public class LiteralValueDeserializer extends JsonDeserializer<Object> {

--- a/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/filter/dto/LiteralValueSerializer.java
+++ b/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/filter/dto/LiteralValueSerializer.java
@@ -7,6 +7,7 @@ package org.geotools.jackson.databind.filter.dto;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
 import java.io.IOException;
 
 public class LiteralValueSerializer extends StdSerializer<Object> {

--- a/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/filter/mapper/DtoToFilterMapper.java
+++ b/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/filter/mapper/DtoToFilterMapper.java
@@ -4,12 +4,6 @@
  */
 package org.geotools.jackson.databind.filter.mapper;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.IsEqualsToImpl;
 import org.geotools.filter.IsGreaterThanImpl;
@@ -93,6 +87,13 @@ import org.opengis.filter.temporal.OverlappedBy;
 import org.opengis.filter.temporal.TContains;
 import org.opengis.filter.temporal.TEquals;
 import org.opengis.filter.temporal.TOverlaps;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Mapper(config = FilterMapperConfig.class)
 abstract class DtoToFilterMapper {

--- a/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/filter/mapper/ExpressionMapper.java
+++ b/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/filter/mapper/ExpressionMapper.java
@@ -4,7 +4,6 @@
  */
 package org.geotools.jackson.databind.filter.mapper;
 
-import java.util.List;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.FunctionFinder;
 import org.geotools.filter.capability.FunctionNameImpl;
@@ -22,6 +21,8 @@ import org.mapstruct.ObjectFactory;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.expression.ExpressionVisitor;
 import org.opengis.filter.expression.NilExpression;
+
+import java.util.List;
 
 @Mapper(config = FilterMapperConfig.class)
 public abstract class ExpressionMapper {

--- a/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/filter/mapper/FilterMapperConfig.java
+++ b/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/filter/mapper/FilterMapperConfig.java
@@ -8,13 +8,12 @@ import org.mapstruct.MapperConfig;
 import org.mapstruct.ReportingPolicy;
 
 @MapperConfig(
-    componentModel = "default",
-    unmappedTargetPolicy = ReportingPolicy.ERROR,
-    uses = {
-        ExpressionFactory.class,
-        FilterFactory.class,
-        ValueMappers.class,
-        ExpressionMapper.class
-    }
-)
+        componentModel = "default",
+        unmappedTargetPolicy = ReportingPolicy.ERROR,
+        uses = {
+            ExpressionFactory.class,
+            FilterFactory.class,
+            ValueMappers.class,
+            ExpressionMapper.class
+        })
 public class FilterMapperConfig {}

--- a/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/filter/mapper/MappingFilterVisitor.java
+++ b/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/filter/mapper/MappingFilterVisitor.java
@@ -5,6 +5,7 @@
 package org.geotools.jackson.databind.filter.mapper;
 
 import lombok.NonNull;
+
 import org.opengis.filter.And;
 import org.opengis.filter.ExcludeFilter;
 import org.opengis.filter.FilterVisitor;

--- a/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/filter/mapper/ValueMappers.java
+++ b/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/filter/mapper/ValueMappers.java
@@ -4,15 +4,16 @@
  */
 package org.geotools.jackson.databind.filter.mapper;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Function;
 import org.geotools.jackson.databind.filter.dto.Filter.MultiValuedFilter.MatchAction;
 import org.geotools.util.SimpleInternationalString;
 import org.mapstruct.Mapper;
 import org.opengis.util.InternationalString;
 import org.xml.sax.helpers.NamespaceSupport;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
 
 @Mapper(config = FilterMapperConfig.class)
 public abstract class ValueMappers {

--- a/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/geojson/GeoToolsGeoJsonModule.java
+++ b/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/geojson/GeoToolsGeoJsonModule.java
@@ -7,7 +7,9 @@ package org.geotools.jackson.databind.geojson;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.geotools.jackson.databind.geojson.geometry.GeometryDeserializer;
 import org.geotools.jackson.databind.geojson.geometry.GeometrySerializer;
 import org.locationtech.jts.geom.Geometry;

--- a/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/geojson/geometry/GeometryDeserializer.java
+++ b/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/geojson/geometry/GeometryDeserializer.java
@@ -14,11 +14,7 @@ import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.NumericNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.stream.IntStream;
+
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.CoordinateSequenceFactory;
 import org.locationtech.jts.geom.Geometry;
@@ -32,6 +28,12 @@ import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequenceFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.IntStream;
 
 public class GeometryDeserializer<T extends Geometry> extends JsonDeserializer<T> {
 

--- a/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/geojson/geometry/GeometrySerializer.java
+++ b/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/geojson/geometry/GeometrySerializer.java
@@ -10,8 +10,7 @@ import com.fasterxml.jackson.core.type.WritableTypeId;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import java.io.IOException;
-import java.util.concurrent.atomic.AtomicReference;
+
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.CoordinateSequenceFilter;
 import org.locationtech.jts.geom.Geometry;
@@ -22,6 +21,9 @@ import org.locationtech.jts.geom.MultiPoint;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class GeometrySerializer extends StdSerializer<Geometry> {
     private static final long serialVersionUID = 1L;

--- a/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/util/MapperDeserializer.java
+++ b/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/util/MapperDeserializer.java
@@ -8,11 +8,13 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import java.io.IOException;
-import java.util.function.Function;
+
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.function.Function;
 
 /**
  * Generic {@link JsonDeserializer} that applies a function from an for-the-wire POJO type to the

--- a/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/util/MapperSerializer.java
+++ b/catalog-support/geotools-jackson-bindings/src/main/java/org/geotools/jackson/databind/util/MapperSerializer.java
@@ -11,9 +11,11 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import lombok.extern.slf4j.Slf4j;
+
 import java.io.IOException;
 import java.util.function.Function;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Generic {@link JsonSerializer} that applies a function from the original object type to the

--- a/catalog-support/geotools-jackson-bindings/src/test/java/org/geotools/jackson/databind/filter/ExpressionRoundtripTest.java
+++ b/catalog-support/geotools-jackson-bindings/src/test/java/org/geotools/jackson/databind/filter/ExpressionRoundtripTest.java
@@ -8,22 +8,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-import java.awt.Color;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.sql.Date;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geotools.filter.FunctionFinder;
 import org.geotools.geometry.jts.Geometries;
 import org.geotools.jackson.databind.filter.dto.Expression;
@@ -44,7 +30,24 @@ import org.locationtech.jts.io.WKTReader;
 import org.opengis.feature.type.Name;
 import org.opengis.filter.capability.FunctionName;
 import org.opengis.parameter.Parameter;
+
 import si.uom.SI;
+
+import java.awt.Color;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Date;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Abstract test suite for {@link Expression} Data Transfer Objects or POJOS; to be used both for
@@ -244,8 +247,7 @@ public abstract class ExpressionRoundtripTest {
     public @Test void allAvailableFunctionNames() throws Exception {
         FunctionFinder finder = new FunctionFinder(null);
         List<FunctionName> allFunctionDescriptions =
-                finder.getAllFunctionDescriptions()
-                        .stream()
+                finder.getAllFunctionDescriptions().stream()
                         .sorted((f1, f2) -> f1.getName().compareTo(f2.getName()))
                         .collect(Collectors.toList());
         for (FunctionName functionName : allFunctionDescriptions) {

--- a/catalog-support/geotools-jackson-bindings/src/test/java/org/geotools/jackson/databind/filter/FilterRoundtripTest.java
+++ b/catalog-support/geotools-jackson-bindings/src/test/java/org/geotools/jackson/databind/filter/FilterRoundtripTest.java
@@ -4,13 +4,6 @@
  */
 package org.geotools.jackson.databind.filter;
 
-import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.function.Supplier;
 import org.geotools.jackson.databind.filter.dto.Expression;
 import org.geotools.jackson.databind.filter.dto.Expression.Literal;
 import org.geotools.jackson.databind.filter.dto.Filter;
@@ -30,6 +23,14 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequenceFactory;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Abstract test suite for {@link Filter} Data Transfer Objects or POJOS; to be used both for

--- a/catalog-support/geotools-jackson-bindings/src/test/java/org/geotools/jackson/databind/filter/GeoToolsFilterModuleExpressionsTest.java
+++ b/catalog-support/geotools-jackson-bindings/src/test/java/org/geotools/jackson/databind/filter/GeoToolsFilterModuleExpressionsTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.geotools.jackson.databind.filter.dto.Expression;
 import org.geotools.jackson.databind.filter.dto.Expression.FunctionName;
 import org.geotools.jackson.databind.filter.mapper.ExpressionMapper;

--- a/catalog-support/geotools-jackson-bindings/src/test/java/org/geotools/jackson/databind/filter/GeoToolsFilterModuleFiltersTest.java
+++ b/catalog-support/geotools-jackson-bindings/src/test/java/org/geotools/jackson/databind/filter/GeoToolsFilterModuleFiltersTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.geotools.jackson.databind.filter.dto.Filter;
 import org.geotools.jackson.databind.filter.dto.SortBy;
 import org.geotools.jackson.databind.filter.mapper.FilterMapper;

--- a/catalog-support/geotools-jackson-bindings/src/test/java/org/geotools/jackson/databind/filter/dto/ExpressionSerializationTest.java
+++ b/catalog-support/geotools-jackson-bindings/src/test/java/org/geotools/jackson/databind/filter/dto/ExpressionSerializationTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.geotools.jackson.databind.filter.ExpressionRoundtripTest;
 import org.geotools.jackson.databind.filter.dto.Expression.FunctionName;
 import org.junit.Before;

--- a/catalog-support/geotools-jackson-bindings/src/test/java/org/geotools/jackson/databind/filter/dto/FilterSerializationTest.java
+++ b/catalog-support/geotools-jackson-bindings/src/test/java/org/geotools/jackson/databind/filter/dto/FilterSerializationTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.geotools.jackson.databind.filter.FilterRoundtripTest;
 import org.junit.Before;
 

--- a/catalog-support/geotools-jackson-bindings/src/test/java/org/geotools/jackson/databind/geojson/GeoToolsGeoJsonModuleTest.java
+++ b/catalog-support/geotools-jackson-bindings/src/test/java/org/geotools/jackson/databind/geojson/GeoToolsGeoJsonModuleTest.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.assertTrue;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.EnumSet;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
@@ -27,6 +27,8 @@ import org.locationtech.jts.io.Ordinate;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 import org.locationtech.jts.io.WKTWriter;
+
+import java.util.EnumSet;
 
 /**
  * Test suite for {@link GeoToolsGeoJsonModule}, assuming it's registered to an {@link ObjectMapper}

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/CatalogFacadeExtensionAdapter.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/CatalogFacadeExtensionAdapter.java
@@ -9,13 +9,6 @@ import static java.util.Spliterator.IMMUTABLE;
 import static java.util.Spliterator.NONNULL;
 import static java.util.Spliterator.ORDERED;
 
-import java.util.List;
-import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.function.Consumer;
-import java.util.logging.Logger;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.CatalogInfo;
@@ -37,6 +30,14 @@ import org.geoserver.catalog.util.CloseableIterator;
 import org.geotools.util.logging.Logging;
 import org.opengis.filter.Filter;
 import org.opengis.filter.sort.SortBy;
+
+import java.util.List;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * Adapts a regular {@link CatalogFacade} to a {@link ExtendedCatalogFacade}

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/CatalogInfoLookup.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/CatalogInfoLookup.java
@@ -7,24 +7,7 @@ package org.geoserver.catalog.plugin;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.Ordering;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ConcurrentNavigableMap;
-import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.logging.Logger;
-import java.util.stream.Stream;
+
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.LayerGroupInfo;
@@ -45,6 +28,25 @@ import org.opengis.filter.Filter;
 import org.opengis.filter.sort.SortBy;
 import org.opengis.filter.sort.SortOrder;
 import org.springframework.lang.Nullable;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
 
 /**
  * A support index for {@link DefaultMemoryCatalogFacade}, can perform fast lookups of {@link
@@ -282,9 +284,7 @@ abstract class CatalogInfoLookup<T extends CatalogInfo> implements CatalogInfoRe
 
     public @Override <U extends T> long count(Class<U> type, Filter filter) {
         return Filter.INCLUDE.equals(filter)
-                ? idMultiMap
-                        .entrySet()
-                        .stream()
+                ? idMultiMap.entrySet().stream()
                         .filter(k -> type.isAssignableFrom(k.getKey()))
                         .map(Map.Entry::getValue)
                         .mapToLong(Map::size)

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/CatalogInfoRepository.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/CatalogInfoRepository.java
@@ -4,9 +4,8 @@
  */
 package org.geoserver.catalog.plugin;
 
-import java.util.Optional;
-import java.util.stream.Stream;
 import lombok.NonNull;
+
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.LayerGroupInfo;
@@ -19,6 +18,9 @@ import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.opengis.filter.Filter;
 import org.springframework.lang.Nullable;
+
+import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * Raw data access API for {@link CatalogInfo} back-end implementations.

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/CatalogInfoTypeRegistry.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/CatalogInfoTypeRegistry.java
@@ -6,10 +6,6 @@ package org.geoserver.catalog.plugin;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Arrays;
-import java.util.EnumMap;
-import java.util.List;
-import java.util.function.Consumer;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.CoverageStoreInfo;
@@ -30,6 +26,11 @@ import org.geoserver.catalog.WMTSLayerInfo;
 import org.geoserver.catalog.WMTSStoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.ClassMappings;
+
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * Utility class to register providers of any kind based on {@link CatalogInfo} subtypes.

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/CatalogPlugin.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/CatalogPlugin.java
@@ -6,19 +6,6 @@ package org.geoserver.catalog.plugin;
 
 import static java.util.Collections.unmodifiableList;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.stream.Stream;
-import javax.annotation.Nullable;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogCapabilities;
 import org.geoserver.catalog.CatalogException;
@@ -76,6 +63,21 @@ import org.geotools.util.logging.Logging;
 import org.opengis.feature.type.Name;
 import org.opengis.filter.Filter;
 import org.opengis.filter.sort.SortBy;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
 
 /**
  * Alternative to {@link org.geoserver.catalog.impl.CatalogImpl} to improve separation of concerns
@@ -1060,8 +1062,8 @@ public class CatalogPlugin extends CatalogImpl implements Catalog {
     public @Override void removeListeners(Class listenerClass) {
         new ArrayList<>(listeners)
                 .stream()
-                .filter(l -> listenerClass.isInstance(l))
-                .forEach(l -> listeners.remove(l));
+                        .filter(l -> listenerClass.isInstance(l))
+                        .forEach(l -> listeners.remove(l));
     }
 
     public @Override ResourcePool getResourcePool() {

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/DefaultMemoryCatalogFacade.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/DefaultMemoryCatalogFacade.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.catalog.plugin;
 
-import java.util.function.Supplier;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.CatalogInfo;
@@ -17,6 +16,8 @@ import org.geoserver.catalog.plugin.CatalogInfoLookup.ResourceInfoLookup;
 import org.geoserver.catalog.plugin.CatalogInfoLookup.StoreInfoLookup;
 import org.geoserver.catalog.plugin.CatalogInfoLookup.StyleInfoLookup;
 import org.geoserver.catalog.plugin.CatalogInfoLookup.WorkspaceInfoLookup;
+
+import java.util.function.Supplier;
 
 /**
  * Default catalog facade implementation using in-memory {@link CatalogRepository repositories} to

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/ExtendedCatalogFacade.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/ExtendedCatalogFacade.java
@@ -4,10 +4,6 @@
  */
 package org.geoserver.catalog.plugin;
 
-import java.io.Closeable;
-import java.util.Objects;
-import java.util.stream.Stream;
-import javax.annotation.Nullable;
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.LayerGroupInfo;
@@ -22,6 +18,12 @@ import org.geoserver.catalog.util.CloseableIterator;
 import org.geoserver.catalog.util.CloseableIteratorAdapter;
 import org.opengis.filter.Filter;
 import org.opengis.filter.sort.SortBy;
+
+import java.io.Closeable;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
 
 /**
  * {@link CatalogFacade} with additional methods
@@ -45,7 +47,9 @@ public interface ExtendedCatalogFacade extends CatalogFacade {
      */
     <T extends CatalogInfo> Stream<T> query(Query<T> query);
 
-    /** @deprecated use {@link #query(Query)} instead */
+    /**
+     * @deprecated use {@link #query(Query)} instead
+     */
     @Deprecated
     default @Override <T extends CatalogInfo> CloseableIterator<T> list(
             final Class<T> of,

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/IsolatedCatalogFacade.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/IsolatedCatalogFacade.java
@@ -5,15 +5,7 @@
 package org.geoserver.catalog.plugin;
 
 import com.google.common.collect.Iterators;
-import java.io.Closeable;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Objects;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import javax.annotation.Nullable;
+
 import org.geoserver.catalog.CatalogCapabilities;
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.CatalogInfo;
@@ -33,6 +25,17 @@ import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.LocalWorkspace;
 import org.opengis.filter.Filter;
 import org.opengis.filter.sort.SortBy;
+
+import java.io.Closeable;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
 
 /** Copy of package private {@code org.geoserver.catalog.impl.IsolatedCatalogFacade} */
 public final class IsolatedCatalogFacade extends ForwardingExtendedCatalogFacade {

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/Patch.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/Patch.java
@@ -4,6 +4,15 @@
  */
 package org.geoserver.catalog.plugin;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.Value;
+
+import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.ows.util.OwsUtils;
+
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -14,13 +23,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeMap;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.Value;
-import org.geoserver.catalog.impl.ModificationProxy;
-import org.geoserver.ows.util.OwsUtils;
 
 @NoArgsConstructor
 public @Value class Patch implements Serializable {

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/PropertyDiff.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/PropertyDiff.java
@@ -4,6 +4,17 @@
  */
 package org.geoserver.catalog.plugin;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+import org.geoserver.catalog.Info;
+import org.geoserver.catalog.impl.ClassMappings;
+import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.ows.util.ClassProperties;
+import org.geoserver.ows.util.OwsUtils;
+
 import java.io.Serializable;
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
@@ -15,15 +26,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import org.geoserver.catalog.Info;
-import org.geoserver.catalog.impl.ClassMappings;
-import org.geoserver.catalog.impl.ModificationProxy;
-import org.geoserver.ows.util.ClassProperties;
-import org.geoserver.ows.util.OwsUtils;
 
 public @Data class PropertyDiff implements Serializable {
     private static final long serialVersionUID = 1L;
@@ -67,7 +69,9 @@ public @Data class PropertyDiff implements Serializable {
         return changes.stream().filter(c -> propertyName.equals(c.getPropertyName())).findFirst();
     }
 
-    /** @return a "clean copy", where no-op changes are ignored */
+    /**
+     * @return a "clean copy", where no-op changes are ignored
+     */
     public PropertyDiff clean() {
         return new PropertyDiff(
                 changes.stream().filter(c -> !c.isNoChange()).collect(Collectors.toList()));

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/Query.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/Query.java
@@ -4,21 +4,23 @@
  */
 package org.geoserver.catalog.plugin;
 
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.Info;
+import org.opengis.filter.Filter;
+import org.opengis.filter.sort.SortBy;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.OptionalInt;
 import java.util.stream.Collectors;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.experimental.Accessors;
-import org.geoserver.catalog.CatalogInfo;
-import org.geoserver.catalog.Info;
-import org.opengis.filter.Filter;
-import org.opengis.filter.sort.SortBy;
 
 /** */
 @NoArgsConstructor
@@ -81,8 +83,7 @@ public @Data class Query<T extends Info> {
         List<SortBy> sortBy =
                 sortOrder == null
                         ? Collections.emptyList()
-                        : Arrays.asList(sortOrder)
-                                .stream()
+                        : Arrays.asList(sortOrder).stream()
                                 .filter(s -> s != null)
                                 .collect(Collectors.toList());
 

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/RepositoryCatalogFacadeImpl.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/RepositoryCatalogFacadeImpl.java
@@ -6,17 +6,6 @@ package org.geoserver.catalog.plugin;
 
 import static java.lang.String.format;
 
-import java.lang.reflect.Proxy;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogCapabilities;
 import org.geoserver.catalog.CatalogFacade;
@@ -37,6 +26,18 @@ import org.geotools.util.logging.Logging;
 import org.opengis.filter.Filter;
 import org.opengis.filter.sort.SortBy;
 import org.springframework.util.Assert;
+
+import java.lang.reflect.Proxy;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class RepositoryCatalogFacadeImpl extends CatalogInfoRepositoryHolderImpl
         implements RepositoryCatalogFacade {
@@ -68,7 +69,8 @@ public class RepositoryCatalogFacadeImpl extends CatalogInfoRepositoryHolderImpl
 
     public @Override void resolve() {
         // no-op, override as appropriate
-    };
+    }
+    ;
 
     protected <I extends CatalogInfo> I add(
             I info, Class<I> type, CatalogInfoRepository<I> repository) {

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingCatalog.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingCatalog.java
@@ -4,11 +4,6 @@
  */
 package org.geoserver.catalog.plugin.forwarding;
 
-import java.io.Serializable;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Objects;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogCapabilities;
 import org.geoserver.catalog.CatalogFacade;
@@ -36,6 +31,12 @@ import org.opengis.feature.type.Name;
 import org.opengis.filter.Filter;
 import org.opengis.filter.sort.SortBy;
 
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+
 /**
  * {@link Catalog} which forwards all its method calls to another {@code Catalog} aiding in
  * implementing a decorator.
@@ -56,7 +57,9 @@ public class ForwardingCatalog implements Catalog {
         this.catalog = catalog;
     }
 
-    /** @return this decorator's subject */
+    /**
+     * @return this decorator's subject
+     */
     public Catalog getSubject() {
         // if you're wondering, I refuse to derive from org.geotools.util.decorate.AbstractDecorator
         // and by extension from java.sql.Wrapper

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingCatalogFacade.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingCatalogFacade.java
@@ -4,8 +4,6 @@
  */
 package org.geoserver.catalog.plugin.forwarding;
 
-import java.util.List;
-import javax.annotation.Nullable;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogCapabilities;
 import org.geoserver.catalog.CatalogFacade;
@@ -23,6 +21,10 @@ import org.geoserver.catalog.util.CloseableIterator;
 import org.opengis.filter.Filter;
 import org.opengis.filter.sort.SortBy;
 
+import java.util.List;
+
+import javax.annotation.Nullable;
+
 /**
  * {@link CatalogFacade} which forwards all its method calls to another {@code CatalogFacade} aiding
  * in implementing a decorator.
@@ -39,7 +41,9 @@ public class ForwardingCatalogFacade implements CatalogFacade {
         this.facade = facade;
     }
 
-    /** @return this decorator's subject */
+    /**
+     * @return this decorator's subject
+     */
     public CatalogFacade getSubject() {
         // if you're wondering, I refuse to derive from org.geotools.util.decorate.AbstractDecorator
         // and by extension from java.sql.Wrapper

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingCatalogRepository.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingCatalogRepository.java
@@ -4,14 +4,16 @@
  */
 package org.geoserver.catalog.plugin.forwarding;
 
-import java.util.Optional;
-import java.util.stream.Stream;
 import lombok.NonNull;
+
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository;
 import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.catalog.plugin.Query;
 import org.opengis.filter.Filter;
+
+import java.util.Optional;
+import java.util.stream.Stream;
 
 public abstract class ForwardingCatalogRepository<
                 I extends CatalogInfo, S extends CatalogInfoRepository<I>>

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingExtendedCatalogFacade.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingExtendedCatalogFacade.java
@@ -4,12 +4,13 @@
  */
 package org.geoserver.catalog.plugin.forwarding;
 
-import java.util.stream.Stream;
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
 import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.catalog.plugin.Query;
+
+import java.util.stream.Stream;
 
 /** Adapts a regular {@link CatalogFacade} to a {@link ExtendedCatalogFacade} */
 public class ForwardingExtendedCatalogFacade extends ForwardingCatalogFacade

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingLayerGroupRepository.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingLayerGroupRepository.java
@@ -4,12 +4,14 @@
  */
 package org.geoserver.catalog.plugin.forwarding;
 
-import java.util.Optional;
-import java.util.stream.Stream;
 import lombok.NonNull;
+
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.LayerGroupRepository;
+
+import java.util.Optional;
+import java.util.stream.Stream;
 
 public class ForwardingLayerGroupRepository
         extends ForwardingCatalogRepository<LayerGroupInfo, LayerGroupRepository>

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingLayerRepository.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingLayerRepository.java
@@ -4,12 +4,13 @@
  */
 package org.geoserver.catalog.plugin.forwarding;
 
-import java.util.Optional;
-import java.util.stream.Stream;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.LayerRepository;
+
+import java.util.Optional;
+import java.util.stream.Stream;
 
 public class ForwardingLayerRepository
         extends ForwardingCatalogRepository<LayerInfo, LayerRepository> implements LayerRepository {

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingNamespaceRepository.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingNamespaceRepository.java
@@ -4,10 +4,11 @@
  */
 package org.geoserver.catalog.plugin.forwarding;
 
-import java.util.Optional;
-import java.util.stream.Stream;
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.NamespaceRepository;
+
+import java.util.Optional;
+import java.util.stream.Stream;
 
 public class ForwardingNamespaceRepository
         extends ForwardingCatalogRepository<NamespaceInfo, NamespaceRepository>

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingResourceRepository.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingResourceRepository.java
@@ -4,13 +4,15 @@
  */
 package org.geoserver.catalog.plugin.forwarding;
 
-import java.util.Optional;
-import java.util.stream.Stream;
 import lombok.NonNull;
+
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.ResourceRepository;
+
+import java.util.Optional;
+import java.util.stream.Stream;
 
 public class ForwardingResourceRepository
         extends ForwardingCatalogRepository<ResourceInfo, ResourceRepository>

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingStoreRepository.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingStoreRepository.java
@@ -4,13 +4,15 @@
  */
 package org.geoserver.catalog.plugin.forwarding;
 
-import java.util.Optional;
-import java.util.stream.Stream;
 import lombok.NonNull;
+
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.StoreRepository;
+
+import java.util.Optional;
+import java.util.stream.Stream;
 
 public class ForwardingStoreRepository
         extends ForwardingCatalogRepository<StoreInfo, StoreRepository> implements StoreRepository {

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingStyleRepository.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingStyleRepository.java
@@ -4,11 +4,12 @@
  */
 package org.geoserver.catalog.plugin.forwarding;
 
-import java.util.Optional;
-import java.util.stream.Stream;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.StyleRepository;
+
+import java.util.Optional;
+import java.util.stream.Stream;
 
 public class ForwardingStyleRepository
         extends ForwardingCatalogRepository<StyleInfo, StyleRepository> implements StyleRepository {

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingWorkspaceRepository.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingWorkspaceRepository.java
@@ -4,9 +4,10 @@
  */
 package org.geoserver.catalog.plugin.forwarding;
 
-import java.util.Optional;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.WorkspaceRepository;
+
+import java.util.Optional;
 
 public class ForwardingWorkspaceRepository
         extends ForwardingCatalogRepository<WorkspaceInfo, WorkspaceRepository>

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ResolvingCatalogFacadeDecorator.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/forwarding/ResolvingCatalogFacadeDecorator.java
@@ -5,10 +5,7 @@
 package org.geoserver.catalog.plugin.forwarding;
 
 import com.google.common.collect.Lists;
-import java.util.List;
-import java.util.Objects;
-import java.util.function.Function;
-import java.util.stream.Stream;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.CatalogInfo;
@@ -31,6 +28,11 @@ import org.geoserver.catalog.util.CloseableIterator;
 import org.geoserver.catalog.util.CloseableIteratorAdapter;
 import org.opengis.filter.Filter;
 import org.opengis.filter.sort.SortBy;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * {@link ExtendedCatalogFacade} decorator that applies a possibly side-effect producing

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/resolving/CatalogPropertyResolver.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/resolving/CatalogPropertyResolver.java
@@ -4,8 +4,6 @@
  */
 package org.geoserver.catalog.plugin.resolving;
 
-import java.util.Objects;
-import java.util.function.UnaryOperator;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.Info;
@@ -15,6 +13,9 @@ import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.impl.StoreInfoImpl;
 import org.geoserver.catalog.impl.StyleInfoImpl;
 import org.geoserver.catalog.plugin.forwarding.ResolvingCatalogFacadeDecorator;
+
+import java.util.Objects;
+import java.util.function.UnaryOperator;
 
 /**
  * {@link ResolvingCatalogFacadeDecorator#setObjectResolver resolving function} to set the {@link

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/resolving/CollectionPropertiesInitializer.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/resolving/CollectionPropertiesInitializer.java
@@ -4,10 +4,11 @@
  */
 package org.geoserver.catalog.plugin.resolving;
 
-import java.util.function.UnaryOperator;
 import org.geoserver.catalog.impl.ModificationProxy;
 import org.geoserver.catalog.plugin.forwarding.ResolvingCatalogFacadeDecorator;
 import org.geoserver.ows.util.OwsUtils;
+
+import java.util.function.UnaryOperator;
 
 /**
  * {@link ResolvingCatalogFacadeDecorator#setObjectResolver resolving function} that returns the

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/resolving/ModificationProxyDecorator.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/resolving/ModificationProxyDecorator.java
@@ -4,12 +4,13 @@
  */
 package org.geoserver.catalog.plugin.resolving;
 
-import java.util.function.Function;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.impl.ClassMappings;
 import org.geoserver.catalog.impl.ModificationProxy;
 import org.geoserver.catalog.impl.ProxyUtils;
 import org.geoserver.catalog.plugin.forwarding.ResolvingCatalogFacadeDecorator;
+
+import java.util.function.Function;
 
 /**
  * {@link ResolvingCatalogFacadeDecorator#setObjectResolver resolving function} that returns the

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/resolving/ResolvingCatalogFacade.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/resolving/ResolvingCatalogFacade.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.catalog.plugin.resolving;
 
-import java.util.function.Function;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.CatalogInfo;
@@ -13,6 +12,8 @@ import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.impl.ModificationProxy;
 import org.geoserver.catalog.impl.ResolvingProxy;
 import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
+
+import java.util.function.Function;
 
 /**
  * {@link ExtendedCatalogFacade} extension that applies a possibly side-effect producing

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/resolving/ResolvingFacade.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/resolving/ResolvingFacade.java
@@ -4,13 +4,14 @@
  */
 package org.geoserver.catalog.plugin.resolving;
 
-import java.util.function.Function;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.impl.ModificationProxy;
 import org.geoserver.catalog.impl.ResolvingProxy;
+
+import java.util.function.Function;
 
 /**
  * Facade trait that applies a possibly side-effect producing {@link Function} to each outgoing

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/resolving/ResolvingProxyResolver.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/resolving/ResolvingProxyResolver.java
@@ -6,16 +6,8 @@ package org.geoserver.catalog.plugin.resolving;
 
 import static java.util.Objects.requireNonNull;
 
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Proxy;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.BiConsumer;
-import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.Info;
@@ -31,6 +23,16 @@ import org.geoserver.catalog.impl.ResolvingProxy;
 import org.geoserver.catalog.plugin.forwarding.ResolvingCatalogFacadeDecorator;
 import org.geoserver.config.ServiceInfo;
 import org.geoserver.config.SettingsInfo;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 
 /**
  * {@link ResolvingCatalogFacadeDecorator#setObjectResolver resolving function} that resolves {@link
@@ -177,8 +179,7 @@ public class ResolvingProxyResolver<T extends Info> implements UnaryOperator<T> 
 
             LinkedHashSet<StyleInfo> resolvedStyles;
             resolvedStyles =
-                    layer.getStyles()
-                            .stream()
+                    layer.getStyles().stream()
                             .map(this::resolve)
                             .collect(Collectors.toCollection(LinkedHashSet::new));
 

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/rules/CatalogBusinessRules.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/rules/CatalogBusinessRules.java
@@ -4,13 +4,14 @@
  */
 package org.geoserver.catalog.plugin.rules;
 
-import java.util.EnumMap;
-import java.util.Objects;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.MapInfo;
 import org.geoserver.catalog.impl.ClassMappings;
 import org.geoserver.catalog.impl.ModificationProxy;
+
+import java.util.EnumMap;
+import java.util.Objects;
 
 /** */
 public class CatalogBusinessRules {

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/rules/CatalogOpContext.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/rules/CatalogOpContext.java
@@ -6,13 +6,14 @@ package org.geoserver.catalog.plugin.rules;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.BooleanSupplier;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.plugin.CatalogInfoTypeRegistry;
 import org.geoserver.catalog.plugin.PropertyDiff;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BooleanSupplier;
 
 /**
  * Encapsulates the context on which a catalog add/save/remove operation is being executed,
@@ -53,12 +54,16 @@ public class CatalogOpContext<T extends CatalogInfo> {
         this.diff = diff;
     }
 
-    /** @return the catalog on which the operation is being executed */
+    /**
+     * @return the catalog on which the operation is being executed
+     */
     public Catalog getCatalog() {
         return catalog;
     }
 
-    /** @return the {@link CatalogInfo} object subject of the add,save, or remove operation. */
+    /**
+     * @return the {@link CatalogInfo} object subject of the add,save, or remove operation.
+     */
     public T getObject() {
         return object;
     }
@@ -116,7 +121,9 @@ public class CatalogOpContext<T extends CatalogInfo> {
         return value == null ? false : value;
     }
 
-    /** @return {@code this} type narrowed to a sub type of {@code <T>} */
+    /**
+     * @return {@code this} type narrowed to a sub type of {@code <T>}
+     */
     @SuppressWarnings("unchecked")
     public <S extends T> CatalogOpContext<S> as(Class<S> subtype) {
         if (subtype.isInstance(object)) return (CatalogOpContext<S>) this;

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/rules/DefaultNamespaceInfoRules.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/rules/DefaultNamespaceInfoRules.java
@@ -4,10 +4,11 @@
  */
 package org.geoserver.catalog.plugin.rules;
 
-import java.util.List;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.WorkspaceInfo;
+
+import java.util.List;
 
 /** Encapsulates default {@link Catalog} business rules for {@link NamespaceInfo} objects */
 public class DefaultNamespaceInfoRules implements CatalogInfoBusinessRules<NamespaceInfo> {

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/rules/DefaultStoreInfoRules.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/rules/DefaultStoreInfoRules.java
@@ -4,11 +4,12 @@
  */
 package org.geoserver.catalog.plugin.rules;
 
-import java.util.List;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
+
+import java.util.List;
 
 /** Encapsulates default {@link Catalog} business rules for {@link StoreInfo} objects */
 public class DefaultStoreInfoRules implements CatalogInfoBusinessRules<StoreInfo> {

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/rules/DefaultStyleInfoRules.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/rules/DefaultStyleInfoRules.java
@@ -4,10 +4,6 @@
  */
 package org.geoserver.catalog.plugin.rules;
 
-import java.io.IOException;
-import java.util.Optional;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.apache.commons.io.FilenameUtils;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.SLDHandler;
@@ -22,6 +18,11 @@ import org.geoserver.platform.resource.Resource;
 import org.geoserver.platform.resource.Resource.Type;
 import org.geoserver.platform.resource.Resources;
 import org.geotools.util.logging.Logging;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** Encapsulates default {@link Catalog} business rules for {@link StyleInfo} objects */
 public class DefaultStyleInfoRules implements CatalogInfoBusinessRules<StyleInfo> {

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/rules/DefaultWorkspaceInfoRules.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/rules/DefaultWorkspaceInfoRules.java
@@ -4,10 +4,11 @@
  */
 package org.geoserver.catalog.plugin.rules;
 
-import java.util.List;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.WorkspaceInfo;
+
+import java.util.List;
 
 /** Encapsulates default {@link Catalog} business rules for {@link WorkspaceInfo} objects */
 public class DefaultWorkspaceInfoRules implements CatalogInfoBusinessRules<WorkspaceInfo> {

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/validation/CatalogValidationRules.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/validation/CatalogValidationRules.java
@@ -7,9 +7,6 @@ package org.geoserver.catalog.plugin.validation;
 import static org.geoserver.catalog.plugin.validation.DefaultCatalogValidator.checkArgument;
 import static org.geoserver.catalog.plugin.validation.DefaultCatalogValidator.isDefaultStyle;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.CatalogValidator;
@@ -33,6 +30,10 @@ import org.geoserver.catalog.WMTSStoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.ModificationProxy;
 import org.geoserver.platform.GeoServerExtensions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Support class implementing the {@link Catalog} state validation rules for {@link CatalogInfo}

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/validation/DefaultCatalogValidator.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/validation/DefaultCatalogValidator.java
@@ -6,17 +6,6 @@ package org.geoserver.catalog.plugin.validation;
 
 import static java.lang.String.format;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.Stack;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.regex.Matcher;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogBuilder;
 import org.geoserver.catalog.CatalogInfo;
@@ -37,6 +26,18 @@ import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.CatalogPlugin;
 import org.geotools.styling.StyledLayerDescriptor;
 import org.geotools.util.logging.Logging;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.Stack;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
 
 /** Default validation rules for {@link CatalogInfo} pre-add and pre-modify states */
 public class DefaultCatalogValidator implements CatalogValidator {

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/validation/DefaultPropertyValuesResolver.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/catalog/plugin/validation/DefaultPropertyValuesResolver.java
@@ -4,8 +4,6 @@
  */
 package org.geoserver.catalog.plugin.validation;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.CoverageDimensionInfo;
@@ -31,6 +29,9 @@ import org.geoserver.catalog.impl.StyleInfoImpl;
 import org.geoserver.catalog.impl.WMSLayerInfoImpl;
 import org.geoserver.catalog.impl.WMTSLayerInfoImpl;
 import org.geoserver.ows.util.OwsUtils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /** */
 public class DefaultPropertyValuesResolver {

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/config/plugin/ConfigRepository.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/config/plugin/ConfigRepository.java
@@ -4,8 +4,6 @@
  */
 package org.geoserver.config.plugin;
 
-import java.util.Optional;
-import java.util.stream.Stream;
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.Patch;
@@ -13,6 +11,9 @@ import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.LoggingInfo;
 import org.geoserver.config.ServiceInfo;
 import org.geoserver.config.SettingsInfo;
+
+import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * Raw data access API for GeoServer global configuration and per-workspace settings and services

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/config/plugin/GeoServerImpl.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/config/plugin/GeoServerImpl.java
@@ -6,11 +6,6 @@ package org.geoserver.config.plugin;
 
 import static org.geoserver.ows.util.OwsUtils.resolveCollections;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.WorkspaceInfo;
@@ -38,6 +33,12 @@ import org.geotools.util.logging.Logging;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Default implementation of GeoServer global and service configuration manager.

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/config/plugin/MemoryConfigRepository.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/config/plugin/MemoryConfigRepository.java
@@ -6,11 +6,6 @@ package org.geoserver.config.plugin;
 
 import static java.util.Objects.requireNonNull;
 
-import java.lang.reflect.Proxy;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Stream;
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.Patch;
@@ -18,6 +13,12 @@ import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.LoggingInfo;
 import org.geoserver.config.ServiceInfo;
 import org.geoserver.config.SettingsInfo;
+
+import java.lang.reflect.Proxy;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Stream;
 
 /**
  * Purely in-memory {@link ConfigRepository} implementation holding live-objects (no serialization
@@ -54,8 +55,7 @@ public class MemoryConfigRepository implements ConfigRepository {
     public @Override Optional<SettingsInfo> getSettingsByWorkspace(WorkspaceInfo workspace) {
         requireNonNull(workspace);
         requireNonNull(workspace.getId());
-        return settings.values()
-                .stream()
+        return settings.values().stream()
                 .filter(s -> s.getWorkspace().getId().equals(workspace.getId()))
                 .findFirst();
     }
@@ -132,9 +132,7 @@ public class MemoryConfigRepository implements ConfigRepository {
     public @Override Stream<? extends ServiceInfo> getServicesByWorkspace(WorkspaceInfo workspace) {
         requireNonNull(workspace);
         requireNonNull(workspace.getId());
-        return this.services
-                .values()
-                .stream()
+        return this.services.values().stream()
                 .filter(
                         s ->
                                 s.getWorkspace() != null
@@ -143,9 +141,7 @@ public class MemoryConfigRepository implements ConfigRepository {
 
     public @Override <T extends ServiceInfo> Optional<T> getGlobalService(Class<T> clazz) {
         requireNonNull(clazz);
-        return this.services
-                .values()
-                .stream()
+        return this.services.values().stream()
                 .filter(clazz::isInstance)
                 .filter(s -> s.getWorkspace() == null)
                 .map(clazz::cast)
@@ -157,9 +153,7 @@ public class MemoryConfigRepository implements ConfigRepository {
         requireNonNull(workspace);
         requireNonNull(workspace.getId());
         requireNonNull(clazz);
-        return this.services
-                .values()
-                .stream()
+        return this.services.values().stream()
                 .filter(clazz::isInstance)
                 .filter(
                         s ->
@@ -180,9 +174,7 @@ public class MemoryConfigRepository implements ConfigRepository {
             String name, Class<T> clazz) {
         requireNonNull(name);
         requireNonNull(clazz);
-        return this.services
-                .values()
-                .stream()
+        return this.services.values().stream()
                 .filter(clazz::isInstance)
                 .filter(s -> name.equals(s.getName()))
                 .map(clazz::cast)
@@ -195,9 +187,7 @@ public class MemoryConfigRepository implements ConfigRepository {
         requireNonNull(workspace);
         requireNonNull(workspace.getId());
         requireNonNull(clazz);
-        return this.services
-                .values()
-                .stream()
+        return this.services.values().stream()
                 .filter(clazz::isInstance)
                 .filter(
                         s ->

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/config/plugin/RepositoryGeoServerFacadeImpl.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/config/plugin/RepositoryGeoServerFacadeImpl.java
@@ -6,17 +6,6 @@ package org.geoserver.config.plugin;
 
 import static java.util.Objects.requireNonNull;
 
-import java.lang.reflect.Proxy;
-import java.rmi.server.UID;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.MetadataMap;
 import org.geoserver.catalog.WorkspaceInfo;
@@ -34,6 +23,19 @@ import org.geoserver.config.impl.CoverageAccessInfoImpl;
 import org.geoserver.config.impl.GeoServerInfoImpl;
 import org.geoserver.ows.util.OwsUtils;
 import org.geotools.util.logging.Logging;
+
+import java.lang.reflect.Proxy;
+import java.rmi.server.UID;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
 
 /**
  * Default implementation of {@link GeoServerFacade} backed by a pluggable {@link ConfigRepository}

--- a/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/config/plugin/forwarding/ForwardingGeoServerFacade.java
+++ b/catalog-support/pluggable-catalog-support/src/main/java/org/geoserver/config/plugin/forwarding/ForwardingGeoServerFacade.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.config.plugin.forwarding;
 
-import java.util.Collection;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerFacade;
@@ -15,6 +14,8 @@ import org.geoserver.config.SettingsInfo;
 import org.geoserver.config.plugin.ConfigRepository;
 import org.geoserver.config.plugin.RepositoryGeoServerFacade;
 
+import java.util.Collection;
+
 /** */
 public class ForwardingGeoServerFacade implements RepositoryGeoServerFacade {
 
@@ -24,7 +25,9 @@ public class ForwardingGeoServerFacade implements RepositoryGeoServerFacade {
         this.facade = facade;
     }
 
-    /** @return this decorator's subject */
+    /**
+     * @return this decorator's subject
+     */
     public GeoServerFacade getSubject() {
         // if you're wondering, I refuse to derive from org.geotools.util.decorate.AbstractDecorator
         // and by extension from java.sql.Wrapper

--- a/catalog-support/pluggable-catalog-support/src/test/java/org/geoserver/catalog/CatalogConformanceTest.java
+++ b/catalog-support/pluggable-catalog-support/src/test/java/org/geoserver/catalog/CatalogConformanceTest.java
@@ -5,6 +5,7 @@
 package org.geoserver.catalog;
 
 import static com.google.common.collect.Sets.newHashSet;
+
 import static org.geoserver.catalog.Predicates.acceptAll;
 import static org.geoserver.catalog.Predicates.asc;
 import static org.geoserver.catalog.Predicates.contains;
@@ -26,24 +27,7 @@ import static org.junit.Assert.fail;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import java.io.IOException;
-import java.lang.reflect.Proxy;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorCompletionService;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+
 import org.geoserver.catalog.event.CatalogAddEvent;
 import org.geoserver.catalog.event.CatalogListener;
 import org.geoserver.catalog.event.CatalogModifyEvent;
@@ -77,6 +61,25 @@ import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
 import org.opengis.filter.MultiValuedFilter.MatchAction;
 import org.opengis.filter.sort.SortBy;
+
+import java.io.IOException;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Initially a verbatim copy of {@code gs-main}'s {@code
@@ -2583,7 +2586,8 @@ public abstract class CatalogConformanceTest {
                 rawCatalog.add(layer);
             }
         }
-    };
+    }
+    ;
 
     @Test
     public void testGet() {
@@ -3311,9 +3315,7 @@ public abstract class CatalogConformanceTest {
                             for (TestListener testListener : listeners) {
                                 assertTrue(
                                         "Did not find the expected even in the listener",
-                                        testListener
-                                                .removed
-                                                .stream()
+                                        testListener.removed.stream()
                                                 .anyMatch(
                                                         event -> event.getSource() == catalogInfo));
                             }

--- a/catalog-support/pluggable-catalog-support/src/test/java/org/geoserver/catalog/CatalogTestData.java
+++ b/catalog-support/pluggable-catalog-support/src/test/java/org/geoserver/catalog/CatalogTestData.java
@@ -6,18 +6,8 @@ package org.geoserver.catalog;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import lombok.NonNull;
+
 import org.geoserver.catalog.impl.AuthorityURL;
 import org.geoserver.catalog.impl.DataStoreInfoImpl;
 import org.geoserver.catalog.impl.LayerGroupInfoImpl;
@@ -67,6 +57,18 @@ import org.geotools.util.Version;
 import org.junit.rules.ExternalResource;
 import org.opengis.util.InternationalString;
 import org.springframework.util.Assert;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Junit {@code @Rule} to provide or populate a catalog; use {@link CatalogTestData#empty
@@ -558,8 +560,7 @@ public class CatalogTestData extends ExternalResource {
     public void assertInternationalStringPropertiesEqual(Info info1, Info info2) {
         ClassProperties props = new ClassProperties(info1.getClass());
         List<String> istringProps =
-                props.properties()
-                        .stream()
+                props.properties().stream()
                         .filter(p -> props.getter(p, InternationalString.class) != null)
                         .collect(Collectors.toList());
         for (String isp : istringProps) {

--- a/catalog-support/pluggable-catalog-support/src/test/java/org/geoserver/catalog/plugin/PropertyDiffTest.java
+++ b/catalog-support/pluggable-catalog-support/src/test/java/org/geoserver/catalog/plugin/PropertyDiffTest.java
@@ -4,19 +4,14 @@
  */
 package org.geoserver.catalog.plugin;
 
-import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
+import static java.util.Collections.singletonList;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogTestData;
 import org.geoserver.catalog.MetadataMap;
@@ -25,6 +20,13 @@ import org.geoserver.catalog.impl.WorkspaceInfoImpl;
 import org.geoserver.catalog.plugin.PropertyDiff.Change;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
 
 public class PropertyDiffTest {
     private PropertyDiffTestSupport support = new PropertyDiffTestSupport();

--- a/catalog-support/pluggable-catalog-support/src/test/java/org/geoserver/catalog/plugin/XmlCatalogInfoLookup.java
+++ b/catalog-support/pluggable-catalog-support/src/test/java/org/geoserver/catalog/plugin/XmlCatalogInfoLookup.java
@@ -5,20 +5,7 @@
 package org.geoserver.catalog.plugin;
 
 import com.google.common.collect.Ordering;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.lang.reflect.Proxy;
-import java.nio.charset.StandardCharsets;
-import java.util.Comparator;
-import java.util.NoSuchElementException;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.function.Predicate;
-import java.util.logging.Logger;
-import java.util.stream.Stream;
+
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.Info;
@@ -37,6 +24,21 @@ import org.geotools.util.logging.Logging;
 import org.opengis.filter.Filter;
 import org.opengis.filter.sort.SortBy;
 import org.opengis.filter.sort.SortOrder;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Predicate;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
 
 /**
  * Exemplar alternative implementations of {@link CatalogInfoRepository} that store serialized
@@ -526,8 +528,7 @@ abstract class XmlCatalogInfoLookup<T extends CatalogInfo> implements CatalogInf
                     li ->
                             (li.getDefaultStyle() != null
                                             && id.equals(li.getDefaultStyle().getId()))
-                                    || li.getStyles()
-                                            .stream()
+                                    || li.getStyles().stream()
                                             .map(s -> s.getId())
                                             .anyMatch(id::equals);
             return all().filter(predicate);

--- a/catalog-support/pluggable-catalog-support/src/test/java/org/geoserver/cloud/test/ApplicationEventCapturingListener.java
+++ b/catalog-support/pluggable-catalog-support/src/test/java/org/geoserver/cloud/test/ApplicationEventCapturingListener.java
@@ -7,13 +7,14 @@ package org.geoserver.cloud.test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.springframework.context.ApplicationEvent;
-import org.springframework.context.event.EventListener;
-import org.springframework.stereotype.Component;
 
 @Component
 public class ApplicationEventCapturingListener {

--- a/catalog-support/pluggable-catalog-support/src/test/java/org/geoserver/config/GeoServerConfigConformanceTest.java
+++ b/catalog-support/pluggable-catalog-support/src/test/java/org/geoserver/config/GeoServerConfigConformanceTest.java
@@ -18,12 +18,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.lang.reflect.Proxy;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.config.impl.GeoServerImpl;
 import org.geoserver.config.impl.GeoServerInfoImpl;
@@ -31,6 +25,13 @@ import org.geoserver.config.impl.ServiceInfoImpl;
 import org.geoserver.ows.LocalWorkspace;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public abstract class GeoServerConfigConformanceTest {
 

--- a/catalog-support/pluggable-catalog-support/src/test/java/org/geoserver/config/plugin/XmlSerializedConfigRepository.java
+++ b/catalog-support/pluggable-catalog-support/src/test/java/org/geoserver/config/plugin/XmlSerializedConfigRepository.java
@@ -4,6 +4,16 @@
  */
 package org.geoserver.config.plugin;
 
+import org.geoserver.catalog.Info;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.plugin.Patch;
+import org.geoserver.config.GeoServerInfo;
+import org.geoserver.config.LoggingInfo;
+import org.geoserver.config.ServiceInfo;
+import org.geoserver.config.SettingsInfo;
+import org.geoserver.config.util.XStreamPersister;
+import org.geoserver.ows.util.OwsUtils;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -14,15 +24,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Stream;
-import org.geoserver.catalog.Info;
-import org.geoserver.catalog.WorkspaceInfo;
-import org.geoserver.catalog.plugin.Patch;
-import org.geoserver.config.GeoServerInfo;
-import org.geoserver.config.LoggingInfo;
-import org.geoserver.config.ServiceInfo;
-import org.geoserver.config.SettingsInfo;
-import org.geoserver.config.util.XStreamPersister;
-import org.geoserver.ows.util.OwsUtils;
 
 /**
  * Example {@link ConfigRepository} alternative that serializes to XML using {@link
@@ -94,8 +95,7 @@ class XmlSerializedConfigRepository implements ConfigRepository {
     }
 
     public @Override Optional<SettingsInfo> getSettingsByWorkspace(WorkspaceInfo workspace) {
-        return settings.values()
-                .stream()
+        return settings.values().stream()
                 .map(this::toSettings)
                 .filter(s -> s.getWorkspace().getId().equals(workspace.getId()))
                 .findFirst();

--- a/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/AbstractCatalogServiceClientRepositoryTest.java
+++ b/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/AbstractCatalogServiceClientRepositoryTest.java
@@ -11,17 +11,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.IOException;
-import java.lang.reflect.Proxy;
-import java.util.Arrays;
-import java.util.Set;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.NonNull;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.CatalogTestData;
@@ -50,20 +41,30 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.io.IOException;
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 @SpringBootTest(
-    classes = { //
-        CatalogServiceApplication.class, //
-        CatalogClientConfiguration.class //
-    },
-    webEnvironment = WebEnvironment.DEFINED_PORT,
-    properties = {
-        "reactive.feign.hystrix.enabled=false",
-        "spring.cloud.circuitbreaker.hystrix.enabled=false",
-        "spring.main.web-application-type=reactive",
-        "server.port=15556",
-        "geoserver.backend.catalog-service.uri=http://localhost:${server.port}"
-    }
-)
+        classes = { //
+            CatalogServiceApplication.class, //
+            CatalogClientConfiguration.class //
+        },
+        webEnvironment = WebEnvironment.DEFINED_PORT,
+        properties = {
+            "reactive.feign.hystrix.enabled=false",
+            "spring.cloud.circuitbreaker.hystrix.enabled=false",
+            "spring.main.web-application-type=reactive",
+            "server.port=15556",
+            "geoserver.backend.catalog-service.uri=http://localhost:${server.port}"
+        })
 @RunWith(SpringRunner.class)
 @ActiveProfiles("it.catalog-service")
 @EnableAutoConfiguration

--- a/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/LayerGroupRepositoryTest.java
+++ b/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/LayerGroupRepositoryTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertTrue;
 
 import lombok.Getter;
 import lombok.experimental.Accessors;
+
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.StyleInfo;

--- a/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/LayerRepositoryTest.java
+++ b/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/LayerRepositoryTest.java
@@ -8,9 +8,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.Sets;
-import java.util.Set;
+
 import lombok.Getter;
 import lombok.experimental.Accessors;
+
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.StyleInfo;
@@ -19,6 +20,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+
+import java.util.Set;
 
 @EnableAutoConfiguration
 @Accessors(fluent = true)

--- a/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/NamespaceRepositoryTest.java
+++ b/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/NamespaceRepositoryTest.java
@@ -10,16 +10,18 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.experimental.Accessors;
+
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.NamespaceRepository;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @EnableAutoConfiguration
 @Accessors(fluent = true)

--- a/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/ResourceRepositoryTest.java
+++ b/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/ResourceRepositoryTest.java
@@ -8,11 +8,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.experimental.Accessors;
+
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.CoverageStoreInfo;
 import org.geoserver.catalog.DataStoreInfo;
@@ -30,6 +28,10 @@ import org.junit.Test;
 import org.opengis.filter.Filter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @EnableAutoConfiguration
 @Accessors(fluent = true)

--- a/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/StoreRepositoryTest.java
+++ b/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/StoreRepositoryTest.java
@@ -10,16 +10,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.experimental.Accessors;
+
 import org.geoserver.catalog.CascadeDeleteVisitor;
 import org.geoserver.catalog.CoverageStoreInfo;
 import org.geoserver.catalog.DataStoreInfo;
@@ -34,6 +27,15 @@ import org.junit.Test;
 import org.opengis.filter.Filter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @EnableAutoConfiguration
 @Accessors(fluent = true)

--- a/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/StyleRepositoryTest.java
+++ b/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/StyleRepositoryTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertTrue;
 
 import lombok.Getter;
 import lombok.experimental.Accessors;
+
 import org.geoserver.catalog.LegendInfo;
 import org.geoserver.catalog.SLDHandler;
 import org.geoserver.catalog.StyleInfo;

--- a/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/WorkspaceRepositoryTest.java
+++ b/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/WorkspaceRepositoryTest.java
@@ -4,15 +4,17 @@
  */
 package org.geoserver.cloud.catalog.client.reactivefeign;
 
-import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import static java.lang.String.format;
+
 import lombok.Getter;
 import lombok.experimental.Accessors;
+
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.WorkspaceRepository;
 import org.junit.Test;

--- a/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/integration/catalog/AbstractCatalogBackendIT.java
+++ b/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/integration/catalog/AbstractCatalogBackendIT.java
@@ -8,8 +8,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
-import java.io.IOException;
-import java.util.List;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogConformanceTest;
 import org.geoserver.catalog.LayerInfo;
@@ -24,6 +22,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opengis.util.ProgressListener;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.IOException;
+import java.util.List;
 
 @RunWith(SpringRunner.class)
 public abstract class AbstractCatalogBackendIT extends CatalogConformanceTest {

--- a/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/integration/catalog/IntegrationTestConfiguration.java
+++ b/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/integration/catalog/IntegrationTestConfiguration.java
@@ -16,10 +16,9 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @EnableAutoConfiguration(
-    exclude = {
-        SecurityAutoConfiguration.class,
-        UserDetailsServiceAutoConfiguration.class,
-        ManagementWebSecurityAutoConfiguration.class
-    }
-)
+        exclude = {
+            SecurityAutoConfiguration.class,
+            UserDetailsServiceAutoConfiguration.class,
+            ManagementWebSecurityAutoConfiguration.class
+        })
 public class IntegrationTestConfiguration {}

--- a/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/integration/catalogservice/CatalogClientBackendIntegrationTest.java
+++ b/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/integration/catalogservice/CatalogClientBackendIntegrationTest.java
@@ -9,7 +9,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.Lists;
-import java.util.ArrayList;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.CoverageStoreInfo;
@@ -33,6 +33,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.ArrayList;
+
 /**
  * {@link Catalog} integration and conformance tests for a {@link CatalogFacade} running off
  * catalog-service's client {@link CatalogClientRepository repositories} hitting a real back-end
@@ -45,18 +47,17 @@ import org.springframework.test.context.ActiveProfiles;
  * HTTP.
  */
 @SpringBootTest(
-    classes = { //
-        CatalogServiceApplication.class, //
-        CatalogClientConfiguration.class //
-    },
-    webEnvironment = WebEnvironment.DEFINED_PORT,
-    properties = {
-        "spring.cloud.circuitbreaker.hystrix.enabled=false",
-        "spring.main.web-application-type=reactive",
-        "server.port=16666",
-        "geoserver.backend.catalog-service.uri=http://localhost:${server.port}"
-    }
-)
+        classes = { //
+            CatalogServiceApplication.class, //
+            CatalogClientConfiguration.class //
+        },
+        webEnvironment = WebEnvironment.DEFINED_PORT,
+        properties = {
+            "spring.cloud.circuitbreaker.hystrix.enabled=false",
+            "spring.main.web-application-type=reactive",
+            "server.port=16666",
+            "geoserver.backend.catalog-service.uri=http://localhost:${server.port}"
+        })
 @ActiveProfiles("it.catalog-service")
 // REVISIT: fails if run with failsafe "ClassNotFoundException:
 // org.geoserver.cloud.catalog.client.reactivefeign.ReactiveCatalogClient"

--- a/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/integration/catalogservice/CatalogClientGeoServerFacadeConformanceTest.java
+++ b/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/integration/catalogservice/CatalogClientGeoServerFacadeConformanceTest.java
@@ -36,18 +36,17 @@ import org.springframework.test.context.junit4.SpringRunner;
  * hitting a live {@code catalog-service} instance.
  */
 @SpringBootTest(
-    classes = { //
-        CatalogServiceApplication.class, //
-        CatalogClientConfiguration.class //
-    },
-    webEnvironment = WebEnvironment.DEFINED_PORT,
-    properties = {
-        "spring.cloud.circuitbreaker.hystrix.enabled=false",
-        "spring.main.web-application-type=reactive",
-        "server.port=15555",
-        "geoserver.backend.catalog-service.uri=http://localhost:${server.port}"
-    }
-)
+        classes = { //
+            CatalogServiceApplication.class, //
+            CatalogClientConfiguration.class //
+        },
+        webEnvironment = WebEnvironment.DEFINED_PORT,
+        properties = {
+            "spring.cloud.circuitbreaker.hystrix.enabled=false",
+            "spring.main.web-application-type=reactive",
+            "server.port=15555",
+            "geoserver.backend.catalog-service.uri=http://localhost:${server.port}"
+        })
 @RunWith(SpringRunner.class)
 @ActiveProfiles("it.catalog-service")
 public class CatalogClientGeoServerFacadeConformanceTest extends GeoServerConfigConformanceTest {

--- a/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/integration/datadirectory/DataDirectoryCatalogIT.java
+++ b/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/integration/datadirectory/DataDirectoryCatalogIT.java
@@ -16,13 +16,12 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(
-    classes = IntegrationTestConfiguration.class,
-    properties = {
-        "geoserver.backend.data-directory.enabled=true",
-        "spring.cloud.circuitbreaker.hystrix.enabled=false",
-        "spring.cloud.config.retry.max-attempts=1"
-    }
-)
+        classes = IntegrationTestConfiguration.class,
+        properties = {
+            "geoserver.backend.data-directory.enabled=true",
+            "spring.cloud.circuitbreaker.hystrix.enabled=false",
+            "spring.cloud.config.retry.max-attempts=1"
+        })
 public class DataDirectoryCatalogIT extends AbstractCatalogBackendIT {
 
     private @Autowired @Qualifier("catalogFacade") CatalogFacade rawCatalogFacade;

--- a/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/integration/jdbcconfig/JDBCConfigCatalogIT.java
+++ b/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/integration/jdbcconfig/JDBCConfigCatalogIT.java
@@ -16,12 +16,11 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(
-    classes = IntegrationTestConfiguration.class,
-    properties = {
-        "geoserver.backend.jdbcconfig.enabled=true",
-        "logging.level.org.geoserver.cloud.autoconfigure.bus=ERROR"
-    }
-)
+        classes = IntegrationTestConfiguration.class,
+        properties = {
+            "geoserver.backend.jdbcconfig.enabled=true",
+            "logging.level.org.geoserver.cloud.autoconfigure.bus=ERROR"
+        })
 public class JDBCConfigCatalogIT extends AbstractCatalogBackendIT {
 
     private @Autowired @Qualifier("catalogFacade") ExtendedCatalogFacade jdbcCatalogFacade;

--- a/pom.xml
+++ b/pom.xml
@@ -669,9 +669,26 @@
       <url>https://maven.geo-solutions.it/</url>
     </repository>
     <repository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
       <id>spring-releases</id>
       <name>Spring Releases</name>
       <url>https://repo.spring.io/release</url>
+    </repository>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>maven-central</id>
+      <name>Maven Central</name>
+      <url>https://repo.maven.apache.org/maven2</url>
     </repository>
   </repositories>
   <pluginRepositories>
@@ -726,7 +743,7 @@
         <plugin>
           <groupId>com.spotify.fmt</groupId>
           <artifactId>fmt-maven-plugin</artifactId>
-          <version>2.14</version>
+          <version>2.15</version>
         </plugin>
         <plugin>
           <groupId>com.spotify</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -724,9 +724,9 @@
           <version>1.2.2</version>
         </plugin>
         <plugin>
-          <groupId>com.coveo</groupId>
+          <groupId>com.spotify.fmt</groupId>
           <artifactId>fmt-maven-plugin</artifactId>
-          <version>2.4.0</version>
+          <version>2.14</version>
         </plugin>
         <plugin>
           <groupId>com.spotify</groupId>
@@ -866,7 +866,7 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>com.coveo</groupId>
+        <groupId>com.spotify.fmt</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/api/v1/ApiExceptionHandler.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/api/v1/ApiExceptionHandler.java
@@ -4,12 +4,13 @@
  */
 package org.geoserver.cloud.catalog.api.v1;
 
-import java.util.NoSuchElementException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.util.NoSuchElementException;
 
 @RestControllerAdvice
 public class ApiExceptionHandler {

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/api/v1/ReactiveCatalogController.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/api/v1/ReactiveCatalogController.java
@@ -9,6 +9,7 @@ import static org.geoserver.catalog.impl.ClassMappings.STORE;
 import static org.springframework.http.MediaType.APPLICATION_STREAM_JSON_VALUE;
 
 import lombok.NonNull;
+
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.DataStoreInfo;
@@ -38,6 +39,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -329,9 +331,8 @@ public class ReactiveCatalogController {
     }
 
     @GetMapping(
-        path = "/workspaces/{workspaceId}/layergroups",
-        produces = APPLICATION_STREAM_JSON_VALUE
-    )
+            path = "/workspaces/{workspaceId}/layergroups",
+            produces = APPLICATION_STREAM_JSON_VALUE)
     public Flux<LayerGroupInfo> findLayerGroupsByWoskspaceId(
             @PathVariable("workspaceId") String workspaceId) {
 

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/api/v1/ReactiveConfigController.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/api/v1/ReactiveConfigController.java
@@ -7,6 +7,7 @@ package org.geoserver.cloud.catalog.api.v1;
 import static org.springframework.http.MediaType.APPLICATION_STREAM_JSON_VALUE;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.cloud.catalog.service.ReactiveCatalog;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -172,9 +174,8 @@ public class ReactiveConfigController {
 
     /** GeoServer services specific to the specified workspace. */
     @GetMapping(
-        path = "/workspaces/{workspaceId}/services",
-        produces = APPLICATION_STREAM_JSON_VALUE
-    )
+            path = "/workspaces/{workspaceId}/services",
+            produces = APPLICATION_STREAM_JSON_VALUE)
     public Flux<ServiceInfo> getServicesByWorkspace(
             @PathVariable("workspaceId") String workspaceId) {
 

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/api/v1/ReactiveResourceStoreController.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/api/v1/ReactiveResourceStoreController.java
@@ -10,11 +10,11 @@ import static org.springframework.http.MediaType.APPLICATION_STREAM_JSON_VALUE;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.nio.ByteBuffer;
-import java.util.Objects;
+
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+
 import org.geoserver.cloud.catalog.service.ReactiveResourceStore;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.platform.resource.Resource.Type;
@@ -31,8 +31,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.nio.ByteBuffer;
+import java.util.Objects;
 
 /** */
 @RestController
@@ -86,9 +90,8 @@ public class ReactiveResourceStoreController {
     }
 
     @GetMapping(
-        path = "/{*path}",
-        produces = {APPLICATION_STREAM_JSON_VALUE}
-    )
+            path = "/{*path}",
+            produces = {APPLICATION_STREAM_JSON_VALUE})
     public Flux<WebResource> list(@PathVariable("path") String path) {
         return store.get(path).flatMapMany(store::list).map(this::toWebResource);
     }
@@ -99,10 +102,9 @@ public class ReactiveResourceStoreController {
     }
 
     @PutMapping(
-        path = "/{*path}",
-        consumes = APPLICATION_OCTET_STREAM_VALUE,
-        produces = APPLICATION_JSON_VALUE
-    )
+            path = "/{*path}",
+            consumes = APPLICATION_OCTET_STREAM_VALUE,
+            produces = APPLICATION_JSON_VALUE)
     public Mono<WebResource> put(
             @PathVariable("path") String path, @RequestBody ByteBuffer contents) {
 
@@ -110,9 +112,8 @@ public class ReactiveResourceStoreController {
     }
 
     @GetMapping(
-        path = "/{*path}",
-        produces = {APPLICATION_OCTET_STREAM_VALUE}
-    )
+            path = "/{*path}",
+            produces = {APPLICATION_OCTET_STREAM_VALUE})
     public Mono<org.springframework.core.io.Resource> getFileContent(
             @PathVariable("path") String path) {
         return store.get(path).map(this::toSpringResource);

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/app/CatalogServiceApplicationConfiguration.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/app/CatalogServiceApplicationConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.catalog.app;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.catalog.api.v1.ReactiveCatalogController;
 import org.geoserver.cloud.catalog.app.CatalogServiceApplicationProperties.SchedulerConfig;
 import org.geoserver.cloud.catalog.service.ReactiveCatalog;
@@ -14,6 +15,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.config.WebFluxConfigurer;
+
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/service/BlockingCatalog.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/service/BlockingCatalog.java
@@ -4,12 +4,9 @@
  */
 package org.geoserver.cloud.catalog.service;
 
-import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogCapabilities;
 import org.geoserver.catalog.CatalogFacade;
@@ -33,6 +30,11 @@ import org.opengis.filter.Filter;
 import org.opengis.filter.sort.SortBy;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
+
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /** */
 @Component

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/service/CatalogInfoRepositoryProvider.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/service/CatalogInfoRepositoryProvider.java
@@ -13,14 +13,13 @@ import static org.geoserver.catalog.impl.ClassMappings.STORE;
 import static org.geoserver.catalog.impl.ClassMappings.STYLE;
 import static org.geoserver.catalog.impl.ClassMappings.WORKSPACE;
 
-import java.util.EnumMap;
-import java.util.function.Supplier;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.impl.ClassMappings;
@@ -33,6 +32,9 @@ import org.geoserver.catalog.plugin.CatalogInfoRepository.ResourceRepository;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.StoreRepository;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.StyleRepository;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.WorkspaceRepository;
+
+import java.util.EnumMap;
+import java.util.function.Supplier;
 
 // revisit, replaced by BlockingCatalog
 // @Component

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/service/ProxyResolver.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/service/ProxyResolver.java
@@ -10,6 +10,7 @@ import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.config.GeoServer;
 import org.geoserver.jackson.databind.catalog.ProxyUtils;
 import org.springframework.stereotype.Service;
+
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/service/ReactiveCatalog.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/service/ReactiveCatalog.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.catalog.service;
 
 import lombok.NonNull;
+
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.LayerGroupInfo;
@@ -18,6 +19,7 @@ import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.catalog.plugin.Query;
 import org.opengis.filter.Filter;
 import org.opengis.filter.capability.FunctionName;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/service/ReactiveCatalogImpl.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/service/ReactiveCatalogImpl.java
@@ -4,15 +4,9 @@
  */
 package org.geoserver.cloud.catalog.service;
 
-import java.util.Arrays;
-import java.util.Date;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.DataStoreInfo;
@@ -35,9 +29,18 @@ import org.opengis.parameter.Parameter;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /** */
 @Service
@@ -48,7 +51,9 @@ public class ReactiveCatalogImpl implements ReactiveCatalog {
 
     private BlockingCatalog blockingCatalog;
 
-    /** @see #getSupportedFunctionNames() */
+    /**
+     * @see #getSupportedFunctionNames()
+     */
     private List<FunctionName> supportedFilterFunctionNames;
 
     public ReactiveCatalogImpl(
@@ -121,11 +126,10 @@ public class ReactiveCatalogImpl implements ReactiveCatalog {
         if (supportedFilterFunctionNames == null) {
             List<FunctionName> names =
                     new FunctionFinder(null)
-                            .getAllFunctionDescriptions()
-                            .stream()
-                            .filter(this::supportsdArgumentTypes)
-                            .sorted((f1, f2) -> f1.getName().compareTo(f2.getName()))
-                            .collect(Collectors.toCollection(LinkedList::new));
+                            .getAllFunctionDescriptions().stream()
+                                    .filter(this::supportsdArgumentTypes)
+                                    .sorted((f1, f2) -> f1.getName().compareTo(f2.getName()))
+                                    .collect(Collectors.toCollection(LinkedList::new));
             if (!names.contains(IsInstanceOf.NAME)) {
                 names.add(0, IsInstanceOf.NAME);
             }

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/service/ReactiveGeoServer.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/service/ReactiveGeoServer.java
@@ -4,9 +4,6 @@
  */
 package org.geoserver.cloud.catalog.service;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.Callable;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.config.GeoServer;
@@ -21,9 +18,14 @@ import org.geoserver.wms.WMSInfo;
 import org.geoserver.wps.WPSInfo;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.Callable;
 
 /** */
 @Service

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/service/ReactiveResourceStore.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/service/ReactiveResourceStore.java
@@ -4,11 +4,14 @@
  */
 package org.geoserver.cloud.catalog.service;
 
-import java.nio.ByteBuffer;
 import lombok.NonNull;
+
 import org.geoserver.platform.resource.Resource;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.nio.ByteBuffer;
 
 /** */
 public interface ReactiveResourceStore {

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/service/ReactiveResourceStoreImpl.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/service/ReactiveResourceStoreImpl.java
@@ -4,19 +4,22 @@
  */
 package org.geoserver.cloud.catalog.service;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.ByteBuffer;
 import lombok.NonNull;
+
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.platform.resource.Resource.Type;
 import org.geoserver.platform.resource.ResourceStore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
 
 /** */
 @Service
@@ -62,7 +65,9 @@ public class ReactiveResourceStoreImpl implements ReactiveResourceStore {
         return Mono.just(path).subscribeOn(catalogScheduler).map(blockingStore::remove);
     }
 
-    /** @return the new resource, or empty if it couldn't be moved */
+    /**
+     * @return the new resource, or empty if it couldn't be moved
+     */
     public @Override Mono<Resource> move(String path, String target) {
         return Mono.just(path)
                 .subscribeOn(catalogScheduler)

--- a/services/catalog/src/test/java/org/geoserver/cloud/catalog/api/v1/AbstractReactiveCatalogControllerTest.java
+++ b/services/catalog/src/test/java/org/geoserver/cloud/catalog/api/v1/AbstractReactiveCatalogControllerTest.java
@@ -9,16 +9,8 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import lombok.NonNull;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.CatalogTestData;
@@ -46,12 +38,22 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
 @SpringBootTest(
-    classes = {
-        CatalogServiceApplicationConfiguration.class,
-        WebTestClientSupportConfiguration.class
-    }
-)
+        classes = {
+            CatalogServiceApplicationConfiguration.class,
+            WebTestClientSupportConfiguration.class
+        })
 @ActiveProfiles("test") // see bootstrap-test.yml
 @RunWith(SpringRunner.class)
 public abstract class AbstractReactiveCatalogControllerTest<C extends CatalogInfo> {
@@ -98,8 +100,7 @@ public abstract class AbstractReactiveCatalogControllerTest<C extends CatalogInf
                 Arrays.stream(expected).map(CatalogInfo::getId).collect(Collectors.toSet());
         ClassMappings classMappings = ClassMappings.fromInterface(type);
         Set<String> actual =
-                this.findAll(classMappings)
-                        .stream()
+                this.findAll(classMappings).stream()
                         .map(CatalogInfo::getId)
                         .collect(Collectors.toSet());
         assertEquals(expectedIds, actual);
@@ -142,8 +143,7 @@ public abstract class AbstractReactiveCatalogControllerTest<C extends CatalogInf
                                             .map(CatalogInfo::getId)
                                             .collect(Collectors.toSet());
                             Set<String> returnedIds =
-                                    responseBody
-                                            .stream()
+                                    responseBody.stream()
                                             .map(CatalogInfo::getId)
                                             .collect(Collectors.toSet());
                             assertEquals(expectedIds, returnedIds);

--- a/services/catalog/src/test/java/org/geoserver/cloud/catalog/api/v1/LayerControllerTest.java
+++ b/services/catalog/src/test/java/org/geoserver/cloud/catalog/api/v1/LayerControllerTest.java
@@ -8,16 +8,18 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.Sets;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.http.MediaType;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @AutoConfigureWebTestClient(timeout = "360000")
 public class LayerControllerTest extends AbstractReactiveCatalogControllerTest<LayerInfo> {
@@ -205,8 +207,7 @@ public class LayerControllerTest extends AbstractReactiveCatalogControllerTest<L
                                     Arrays.stream(expectedLayers)
                                             .map(LayerInfo::getId)
                                             .collect(Collectors.toSet()),
-                                    responseBody
-                                            .stream()
+                                    responseBody.stream()
                                             .map(LayerInfo::getId)
                                             .collect(Collectors.toSet()));
                         });

--- a/services/catalog/src/test/java/org/geoserver/cloud/catalog/api/v1/NamespaceControllerTest.java
+++ b/services/catalog/src/test/java/org/geoserver/cloud/catalog/api/v1/NamespaceControllerTest.java
@@ -9,11 +9,12 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.http.MediaType.*;
 
-import java.io.IOException;
-import java.util.List;
 import org.geoserver.catalog.NamespaceInfo;
 import org.junit.Test;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+
+import java.io.IOException;
+import java.util.List;
 
 @AutoConfigureWebTestClient(timeout = "360000")
 public class NamespaceControllerTest extends AbstractReactiveCatalogControllerTest<NamespaceInfo> {

--- a/services/catalog/src/test/java/org/geoserver/cloud/catalog/api/v1/ReactiveConfigControllerTest.java
+++ b/services/catalog/src/test/java/org/geoserver/cloud/catalog/api/v1/ReactiveConfigControllerTest.java
@@ -13,9 +13,6 @@ import static org.junit.Assert.assertNull;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.APPLICATION_STREAM_JSON;
 
-import java.util.Arrays;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.geoserver.catalog.CatalogTestData;
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.WorkspaceInfo;
@@ -50,12 +47,15 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec;
 
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 @SpringBootTest(
-    classes = {
-        CatalogServiceApplicationConfiguration.class,
-        WebTestClientSupportConfiguration.class
-    }
-)
+        classes = {
+            CatalogServiceApplicationConfiguration.class,
+            WebTestClientSupportConfiguration.class
+        })
 @ActiveProfiles("test") // see bootstrap-test.yml
 @RunWith(SpringRunner.class)
 @AutoConfigureWebTestClient(timeout = "360000")

--- a/services/catalog/src/test/java/org/geoserver/cloud/catalog/api/v1/ResourceInfoControllerTest.java
+++ b/services/catalog/src/test/java/org/geoserver/cloud/catalog/api/v1/ResourceInfoControllerTest.java
@@ -7,8 +7,6 @@ package org.geoserver.cloud.catalog.api.v1;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-import java.io.IOException;
-import java.util.List;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.NamespaceInfo;
@@ -24,6 +22,9 @@ import org.junit.Test;
 import org.opengis.filter.Filter;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.http.MediaType;
+
+import java.io.IOException;
+import java.util.List;
 
 @AutoConfigureWebTestClient(timeout = "360000")
 public class ResourceInfoControllerTest

--- a/services/catalog/src/test/java/org/geoserver/cloud/catalog/api/v1/StoreControllerTest.java
+++ b/services/catalog/src/test/java/org/geoserver/cloud/catalog/api/v1/StoreControllerTest.java
@@ -7,14 +7,6 @@ package org.geoserver.cloud.catalog.api.v1;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.geoserver.catalog.CoverageStoreInfo;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.HTTPStoreInfo;
@@ -30,6 +22,15 @@ import org.opengis.filter.Filter;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.http.MediaType;
 import org.springframework.lang.Nullable;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @AutoConfigureWebTestClient(timeout = "360000")
 public class StoreControllerTest extends AbstractReactiveCatalogControllerTest<StoreInfo> {

--- a/services/catalog/src/test/java/org/geoserver/cloud/catalog/api/v1/StyleControllerTest.java
+++ b/services/catalog/src/test/java/org/geoserver/cloud/catalog/api/v1/StyleControllerTest.java
@@ -6,10 +6,6 @@ package org.geoserver.cloud.catalog.api.v1;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.geoserver.catalog.LegendInfo;
 import org.geoserver.catalog.SLDHandler;
 import org.geoserver.catalog.StyleInfo;
@@ -20,6 +16,11 @@ import org.junit.Test;
 import org.opengis.filter.Filter;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.http.MediaType;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @AutoConfigureWebTestClient(timeout = "360000")
 public class StyleControllerTest extends AbstractReactiveCatalogControllerTest<StyleInfo> {
@@ -223,8 +224,7 @@ public class StyleControllerTest extends AbstractReactiveCatalogControllerTest<S
                                             .map(StyleInfo::getId)
                                             .collect(Collectors.toSet());
                             Set<String> returnedIds =
-                                    response.getResponseBody()
-                                            .stream()
+                                    response.getResponseBody().stream()
                                             .map(StyleInfo::getId)
                                             .collect(Collectors.toSet());
                             assertEquals(expectedIds, returnedIds);
@@ -263,8 +263,7 @@ public class StyleControllerTest extends AbstractReactiveCatalogControllerTest<S
                                             .map(StyleInfo::getId)
                                             .collect(Collectors.toSet());
                             Set<String> returnedIds =
-                                    response.getResponseBody()
-                                            .stream()
+                                    response.getResponseBody().stream()
                                             .map(StyleInfo::getId)
                                             .collect(Collectors.toSet());
                             assertEquals(expectedIds, returnedIds);

--- a/services/catalog/src/test/java/org/geoserver/cloud/catalog/api/v1/WorkspaceControllerTest.java
+++ b/services/catalog/src/test/java/org/geoserver/cloud/catalog/api/v1/WorkspaceControllerTest.java
@@ -4,11 +4,12 @@
  */
 package org.geoserver.cloud.catalog.api.v1;
 
-import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
+import static java.lang.String.format;
 
 import org.geoserver.catalog.WorkspaceInfo;
 import org.junit.Test;

--- a/services/catalog/src/test/java/org/geoserver/cloud/catalog/test/CatalogTestClient.java
+++ b/services/catalog/src/test/java/org/geoserver/cloud/catalog/test/CatalogTestClient.java
@@ -6,11 +6,9 @@ package org.geoserver.cloud.catalog.test;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
-import java.lang.reflect.Proxy;
-import java.util.function.Consumer;
-import javax.annotation.Nullable;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.impl.ClassMappings;
 import org.geoserver.catalog.impl.ModificationProxy;
@@ -20,6 +18,11 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.test.web.reactive.server.WebTestClient.RequestBodySpec;
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec;
+
+import java.lang.reflect.Proxy;
+import java.util.function.Consumer;
+
+import javax.annotation.Nullable;
 
 @RequiredArgsConstructor
 public class CatalogTestClient<C extends CatalogInfo> {

--- a/services/catalog/src/test/java/org/geoserver/cloud/catalog/test/TestConfiguration.java
+++ b/services/catalog/src/test/java/org/geoserver/cloud/catalog/test/TestConfiguration.java
@@ -12,10 +12,9 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @EnableAutoConfiguration(
-    exclude = { //
-        ReactiveSecurityAutoConfiguration.class, //
-        ReactiveUserDetailsServiceAutoConfiguration.class, //
-        ReactiveManagementWebSecurityAutoConfiguration.class //
-    }
-)
+        exclude = { //
+            ReactiveSecurityAutoConfiguration.class, //
+            ReactiveUserDetailsServiceAutoConfiguration.class, //
+            ReactiveManagementWebSecurityAutoConfiguration.class //
+        })
 public class TestConfiguration {}

--- a/services/catalog/src/test/java/org/geoserver/cloud/catalog/test/WebTestClientSupport.java
+++ b/services/catalog/src/test/java/org/geoserver/cloud/catalog/test/WebTestClientSupport.java
@@ -4,9 +4,8 @@
  */
 package org.geoserver.cloud.catalog.test;
 
-import java.util.function.Supplier;
-import javax.annotation.PostConstruct;
 import lombok.NonNull;
+
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
@@ -18,6 +17,10 @@ import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.cloud.catalog.api.v1.ReactiveCatalogController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.util.function.Supplier;
+
+import javax.annotation.PostConstruct;
 
 /**
  * Configures the {@link WebTestClient} to be able of encoding and decoding {@link CatalogInfo}

--- a/services/gwc/src/main/java/org/geoserver/cloud/gwc/app/RootRedirectController.java
+++ b/services/gwc/src/main/java/org/geoserver/cloud/gwc/app/RootRedirectController.java
@@ -8,7 +8,9 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.servlet.view.RedirectView;
 
-/** @since 1.0 */
+/**
+ * @since 1.0
+ */
 @Controller
 public class RootRedirectController {
 

--- a/services/restconfig/src/main/java/org/geoserver/cloud/restconfig/RestConfigApplicationConfiguration.java
+++ b/services/restconfig/src/main/java/org/geoserver/cloud/restconfig/RestConfigApplicationConfiguration.java
@@ -8,8 +8,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.APPLICATION_XML;
 import static org.springframework.http.MediaType.TEXT_HTML;
 
-import java.util.List;
-import javax.servlet.http.HttpServletRequest;
 import org.geoserver.rest.CallbackInterceptor;
 import org.geoserver.rest.PutIgnoringExtensionContentNegotiationStrategy;
 import org.geoserver.rest.RestInterceptor;
@@ -30,6 +28,10 @@ import org.springframework.web.servlet.mvc.condition.PatternsRequestCondition;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 import org.springframework.web.servlet.resource.ResourceUrlProvider;
 import org.springframework.web.util.UrlPathHelper;
+
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
 
 @Configuration
 @ComponentScan(basePackageClasses = org.geoserver.rest.AbstractGeoServerController.class)

--- a/services/wcs/src/main/java/org/geoserver/cloud/wcs/WCSController.java
+++ b/services/wcs/src/main/java/org/geoserver/cloud/wcs/WCSController.java
@@ -7,8 +7,6 @@ package org.geoserver.cloud.wcs;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.geoserver.ows.Dispatcher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -16,6 +14,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.view.RedirectView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 public @Controller class WCSController {
 
@@ -36,16 +37,15 @@ public @Controller class WCSController {
     }
 
     @RequestMapping(
-        method = {GET, POST},
-        path = {
-            "/wcs",
-            "/{workspace}/wcs",
-            "/{workspace}/{layer}/wcs",
-            "/ows",
-            "/{workspace}/ows",
-            "/{workspace}/{layer}/ows"
-        }
-    )
+            method = {GET, POST},
+            path = {
+                "/wcs",
+                "/{workspace}/wcs",
+                "/{workspace}/{layer}/wcs",
+                "/ows",
+                "/{workspace}/ows",
+                "/{workspace}/{layer}/ows"
+            })
     public void handle(HttpServletRequest request, HttpServletResponse response) throws Exception {
         geoserverDispatcher.handleRequest(request, response);
     }

--- a/services/wcs/src/main/java/org/geoserver/cloud/wcs/WcsApplicationConfiguration.java
+++ b/services/wcs/src/main/java/org/geoserver/cloud/wcs/WcsApplicationConfiguration.java
@@ -10,12 +10,11 @@ import org.springframework.context.annotation.ImportResource;
 
 @Configuration
 @ImportResource( //
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = { //
-        "jar:gs-wcs-.*!/applicationContext.xml", //
-        "jar:gs-wcs1_0-.*!/applicationContext.xml", //
-        "jar:gs-wcs1_1-.*!/applicationContext.xml", //
-        "jar:gs-wcs2_0-.*!/applicationContext.xml" //
-    }
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = { //
+            "jar:gs-wcs-.*!/applicationContext.xml", //
+            "jar:gs-wcs1_0-.*!/applicationContext.xml", //
+            "jar:gs-wcs1_1-.*!/applicationContext.xml", //
+            "jar:gs-wcs2_0-.*!/applicationContext.xml" //
+        })
 public class WcsApplicationConfiguration {}

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/cloudnative/CloudNativeUIAutoConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/cloudnative/CloudNativeUIAutoConfiguration.java
@@ -4,13 +4,17 @@
  */
 package org.geoserver.cloud.autoconfigure.web.cloudnative;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.web.service.WebUiCloudServicesConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-/** @since 1.0 */
+import javax.annotation.PostConstruct;
+
+/**
+ * @since 1.0
+ */
 @Configuration(proxyBeanMethods = false)
 @Import(WebUiCloudServicesConfiguration.class)
 @Slf4j

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/AbstractWebUIAutoConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/AbstractWebUIAutoConfiguration.java
@@ -4,8 +4,9 @@
  */
 package org.geoserver.cloud.autoconfigure.web.core;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.PostConstruct;
 
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.web")
 public abstract class AbstractWebUIAutoConfiguration {

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebCoreConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebCoreConfiguration.java
@@ -16,12 +16,11 @@ import org.springframework.context.annotation.ImportResource;
 
 @Configuration(proxyBeanMethods = true)
 @ImportResource( //
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = { //
-        "jar:gs-web-core-.*!/applicationContext.xml#name="
-                + WebCoreConfiguration.EXCLUDED_BEANS_PATTERN //
-    }
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = { //
+            "jar:gs-web-core-.*!/applicationContext.xml#name="
+                    + WebCoreConfiguration.EXCLUDED_BEANS_PATTERN //
+        })
 public class WebCoreConfiguration {
 
     static final String EXCLUDED_BEANS_PATTERN = "^(?!logsPage).*$";

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebUIApplicationAutoConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebUIApplicationAutoConfiguration.java
@@ -4,8 +4,8 @@
  */
 package org.geoserver.cloud.autoconfigure.web.core;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.autoconfigure.core.GeoServerWebMvcMainAutoConfiguration;
 import org.geoserver.cloud.autoconfigure.web.demo.DemosAutoConfiguration;
 import org.geoserver.cloud.autoconfigure.web.extension.ExtensionsAutoConfiguration;
@@ -23,6 +23,8 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
+
+import javax.annotation.PostConstruct;
 
 @Configuration
 @AutoConfigureAfter({GeoServerWebMvcMainAutoConfiguration.class})

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/DemoRequestsConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/DemoRequestsConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.autoconfigure.web.demo;
 
 import lombok.Getter;
+
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -15,15 +16,13 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration
 @ConditionalOnClass(name = "org.geoserver.web.demo.SRSListPage")
 @ConditionalOnProperty( // enabled by default
-    prefix = DemosAutoConfiguration.CONFIG_PREFIX,
-    name = "demo-requests",
-    havingValue = "true",
-    matchIfMissing = true
-)
+        prefix = DemosAutoConfiguration.CONFIG_PREFIX,
+        name = "demo-requests",
+        havingValue = "true",
+        matchIfMissing = true)
 @ImportResource( //
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=demoRequests"}
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=demoRequests"})
 public class DemoRequestsConfiguration extends AbstractWebUIAutoConfiguration {
 
     static final String CONFIG_PREFIX = DemosAutoConfiguration.CONFIG_PREFIX + ".demo-requests";

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/DemosAutoConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/DemosAutoConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.autoconfigure.web.demo;
 
 import lombok.Getter;
+
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -14,11 +15,10 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @ConditionalOnClass(name = "org.geoserver.web.demo.DemoRequest")
 @ConditionalOnProperty( // enabled by default
-    prefix = DemosAutoConfiguration.CONFIG_PREFIX,
-    name = "enabled",
-    havingValue = "true",
-    matchIfMissing = true
-)
+        prefix = DemosAutoConfiguration.CONFIG_PREFIX,
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true)
 @Import({
     LayerPreviewConfiguration.class,
     DemoRequestsConfiguration.class,

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/LayerPreviewConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/LayerPreviewConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.autoconfigure.web.demo;
 
 import lombok.Getter;
+
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
 import org.geoserver.cloud.autoconfigure.web.demo.LayerPreviewConfiguration.GmlCommonFormatsConfiguration;
 import org.geoserver.cloud.autoconfigure.web.demo.LayerPreviewConfiguration.KmlCommonFormatsConfiguration;
@@ -19,15 +20,13 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration
 @ConditionalOnClass(name = "org.geoserver.web.demo.MapPreviewPage")
 @ConditionalOnProperty( // enabled by default
-    prefix = LayerPreviewConfiguration.CONFIG_PREFIX,
-    name = "enabled",
-    havingValue = "true",
-    matchIfMissing = true
-)
+        prefix = LayerPreviewConfiguration.CONFIG_PREFIX,
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true)
 @ImportResource( //
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=layerListDemo2"}
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=layerListDemo2"})
 @Import({
     OpenLayersCommonFormatsConfiguration.class,
     GmlCommonFormatsConfiguration.class,
@@ -42,15 +41,13 @@ public class LayerPreviewConfiguration extends AbstractWebUIAutoConfiguration {
 
     @Configuration
     @ConditionalOnProperty(
-        prefix = LayerPreviewConfiguration.COMMON_FORMATS_PREFIX,
-        name = "open-layers",
-        havingValue = "true",
-        matchIfMissing = true
-    )
+            prefix = LayerPreviewConfiguration.COMMON_FORMATS_PREFIX,
+            name = "open-layers",
+            havingValue = "true",
+            matchIfMissing = true)
     @ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=openLayersPreview"}
-    )
+            reader = FilteringXmlBeanDefinitionReader.class, //
+            locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=openLayersPreview"})
     public class OpenLayersCommonFormatsConfiguration extends AbstractWebUIAutoConfiguration {
 
         static final String CONFIG_PREFIX =
@@ -61,15 +58,13 @@ public class LayerPreviewConfiguration extends AbstractWebUIAutoConfiguration {
 
     @Configuration
     @ConditionalOnProperty(
-        prefix = LayerPreviewConfiguration.COMMON_FORMATS_PREFIX,
-        name = "gml",
-        havingValue = "true",
-        matchIfMissing = true
-    )
+            prefix = LayerPreviewConfiguration.COMMON_FORMATS_PREFIX,
+            name = "gml",
+            havingValue = "true",
+            matchIfMissing = true)
     @ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=gMLPreview"}
-    )
+            reader = FilteringXmlBeanDefinitionReader.class, //
+            locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=gMLPreview"})
     public class GmlCommonFormatsConfiguration extends AbstractWebUIAutoConfiguration {
 
         static final String CONFIG_PREFIX =
@@ -80,15 +75,13 @@ public class LayerPreviewConfiguration extends AbstractWebUIAutoConfiguration {
 
     @Configuration
     @ConditionalOnProperty(
-        prefix = LayerPreviewConfiguration.COMMON_FORMATS_PREFIX,
-        name = "kml",
-        havingValue = "true",
-        matchIfMissing = true
-    )
+            prefix = LayerPreviewConfiguration.COMMON_FORMATS_PREFIX,
+            name = "kml",
+            havingValue = "true",
+            matchIfMissing = true)
     @ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=kMLPreview"}
-    )
+            reader = FilteringXmlBeanDefinitionReader.class, //
+            locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=kMLPreview"})
     public class KmlCommonFormatsConfiguration extends AbstractWebUIAutoConfiguration {
 
         static final String CONFIG_PREFIX =

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/ReprojectionConsoleConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/ReprojectionConsoleConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.autoconfigure.web.demo;
 
 import lombok.Getter;
+
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -15,15 +16,13 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration
 @ConditionalOnClass(name = "org.geoserver.web.demo.SRSListPage")
 @ConditionalOnProperty( // enabled by default
-    prefix = DemosAutoConfiguration.CONFIG_PREFIX,
-    name = "reprojection-console",
-    havingValue = "true",
-    matchIfMissing = true
-)
+        prefix = DemosAutoConfiguration.CONFIG_PREFIX,
+        name = "reprojection-console",
+        havingValue = "true",
+        matchIfMissing = true)
 @ImportResource( //
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=reprojectionConsole"}
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=reprojectionConsole"})
 public class ReprojectionConsoleConfiguration extends AbstractWebUIAutoConfiguration {
 
     static final String CONFIG_PREFIX =

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/SrsListConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/SrsListConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.autoconfigure.web.demo;
 
 import lombok.Getter;
+
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -15,15 +16,13 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration
 @ConditionalOnClass(name = "org.geoserver.web.demo.SRSListPage")
 @ConditionalOnProperty( // enabled by default
-    prefix = DemosAutoConfiguration.CONFIG_PREFIX,
-    name = "srs-list",
-    havingValue = "true",
-    matchIfMissing = true
-)
+        prefix = DemosAutoConfiguration.CONFIG_PREFIX,
+        name = "srs-list",
+        havingValue = "true",
+        matchIfMissing = true)
 @ImportResource( //
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=srsList"}
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=srsList"})
 public class SrsListConfiguration extends AbstractWebUIAutoConfiguration {
 
     static final String CONFIG_PREFIX = DemosAutoConfiguration.CONFIG_PREFIX + ".srs-list";

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/WcsRequestBuilderConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/WcsRequestBuilderConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.autoconfigure.web.demo;
 
 import lombok.Getter;
+
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -15,17 +16,16 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration(proxyBeanMethods = true)
 @ConditionalOnClass(name = "org.geoserver.wcs.web.demo.WCSRequestBuilder")
 @ConditionalOnProperty( // enabled by default
-    prefix = DemosAutoConfiguration.CONFIG_PREFIX,
-    name = "wcs-request-builder",
-    havingValue = "true",
-    matchIfMissing = true
-)
+        prefix = DemosAutoConfiguration.CONFIG_PREFIX,
+        name = "wcs-request-builder",
+        havingValue = "true",
+        matchIfMissing = true)
 @ImportResource( //
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = { //
-        "jar:gs-web-wcs-.*!/applicationContext.xml#name=wcsRequestBuilder"
-    } //
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = { //
+            "jar:gs-web-wcs-.*!/applicationContext.xml#name=wcsRequestBuilder"
+        } //
+        )
 public class WcsRequestBuilderConfiguration extends AbstractWebUIAutoConfiguration {
 
     static final String CONFIG_PREFIX =

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/WpsRequestBuilderConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/WpsRequestBuilderConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.autoconfigure.web.demo;
 
 import lombok.Getter;
+
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -15,15 +16,13 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration(proxyBeanMethods = true)
 @ConditionalOnClass(name = "org.geoserver.wps.web.WPSRequestBuilder")
 @ConditionalOnProperty( // enabled by default
-    prefix = DemosAutoConfiguration.CONFIG_PREFIX,
-    name = "wps-request-builder",
-    havingValue = "true",
-    matchIfMissing = true
-)
+        prefix = DemosAutoConfiguration.CONFIG_PREFIX,
+        name = "wps-request-builder",
+        havingValue = "true",
+        matchIfMissing = true)
 @ImportResource( //
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = "jar:gs-web-wps-.*!/applicationContext.xml#name=wpsRequestBuilder"
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = "jar:gs-web-wps-.*!/applicationContext.xml#name=wpsRequestBuilder")
 public class WpsRequestBuilderConfiguration extends AbstractWebUIAutoConfiguration {
 
     static final String CONFIG_PREFIX =

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/extension/geostyler/GeoStylerAutoConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/extension/geostyler/GeoStylerAutoConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.autoconfigure.web.extension.geostyler;
 
 import lombok.Getter;
+
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.geoserver.wms.web.data.GeoStyler;
@@ -16,17 +17,16 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration
 @ConditionalOnClass(value = GeoStyler.class)
 @ConditionalOnProperty( //
-    prefix = GeoStylerAutoConfiguration.CONFIG_PREFIX,
-    name = "enabled",
-    havingValue = "true",
-    matchIfMissing = false
-)
+        prefix = GeoStylerAutoConfiguration.CONFIG_PREFIX,
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = false)
 @ImportResource( //
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = { //
-        "jar:gs-geostyler-.*!/applicationContext.xml" //
-    } //
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = { //
+            "jar:gs-geostyler-.*!/applicationContext.xml" //
+        } //
+        )
 public class GeoStylerAutoConfiguration extends AbstractWebUIAutoConfiguration {
 
     static final String CONFIG_PREFIX = "geoserver.web-ui.extensions.geostyler";

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/extension/importer/ImporterAutoConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/extension/importer/ImporterAutoConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.autoconfigure.web.extension.importer;
 
 import lombok.Getter;
+
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -14,11 +15,10 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @ConditionalOnClass(name = "org.geoserver.importer.web.ImporterConfigPage")
 @ConditionalOnProperty( // enabled by default
-    prefix = ImporterAutoConfiguration.CONFIG_PREFIX,
-    name = "enabled",
-    havingValue = "true",
-    matchIfMissing = true
-)
+        prefix = ImporterAutoConfiguration.CONFIG_PREFIX,
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true)
 @Import(ImporterConfiguration.class)
 public class ImporterAutoConfiguration extends AbstractWebUIAutoConfiguration {
 

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/extension/importer/ImporterConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/extension/importer/ImporterConfiguration.java
@@ -10,10 +10,10 @@ import org.springframework.context.annotation.ImportResource;
 
 @Configuration(proxyBeanMethods = true)
 @ImportResource( //
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = { //
-        "jar:gs-importer-core-.*!/applicationContext.xml", //
-        "jar:gs-importer-web-.*!/applicationContext.xml" //
-    } //
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = { //
+            "jar:gs-importer-core-.*!/applicationContext.xml", //
+            "jar:gs-importer-web-.*!/applicationContext.xml" //
+        } //
+        )
 public class ImporterConfiguration {}

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/security/SecurityAutoConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/security/SecurityAutoConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.autoconfigure.web.security;
 
 import lombok.Getter;
+
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -14,11 +15,10 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @ConditionalOnClass(name = "org.geoserver.security.web.SecuritySettingsPage")
 @ConditionalOnProperty( // enabled by default
-    prefix = SecurityAutoConfiguration.CONFIG_PREFIX,
-    name = "enabled",
-    havingValue = "true",
-    matchIfMissing = true
-)
+        prefix = SecurityAutoConfiguration.CONFIG_PREFIX,
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true)
 @Import(SecurityConfiguration.class)
 public class SecurityAutoConfiguration extends AbstractWebUIAutoConfiguration {
 

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/security/SecurityConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/security/SecurityConfiguration.java
@@ -10,11 +10,11 @@ import org.springframework.context.annotation.ImportResource;
 
 @Configuration(proxyBeanMethods = true)
 @ImportResource( //
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = { //
-        "jar:gs-web-sec-core-.*!/applicationContext.xml", //
-        "jar:gs-web-sec-jdbc-.*!/applicationContext.xml", //
-        "jar:gs-web-sec-ldap-.*!/applicationContext.xml" //
-    } //
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = { //
+            "jar:gs-web-sec-core-.*!/applicationContext.xml", //
+            "jar:gs-web-sec-jdbc-.*!/applicationContext.xml", //
+            "jar:gs-web-sec-ldap-.*!/applicationContext.xml" //
+        } //
+        )
 public class SecurityConfiguration {}

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/tools/CatalogBulkLoadToolConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/tools/CatalogBulkLoadToolConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.autoconfigure.web.tools;
 
 import lombok.Getter;
+
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -15,15 +16,13 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration
 @ConditionalOnClass(name = "org.geoserver.web.catalogstresstool.CatalogStressTester")
 @ConditionalOnProperty( // enabled by default
-    prefix = ToolsAutoConfiguration.CONFIG_PREFIX,
-    name = "catalog-bulk-load",
-    havingValue = "true",
-    matchIfMissing = true
-)
+        prefix = ToolsAutoConfiguration.CONFIG_PREFIX,
+        name = "catalog-bulk-load",
+        havingValue = "true",
+        matchIfMissing = true)
 @ImportResource(
-    reader = FilteringXmlBeanDefinitionReader.class,
-    locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=CatalogStresser"}
-)
+        reader = FilteringXmlBeanDefinitionReader.class,
+        locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=CatalogStresser"})
 public class CatalogBulkLoadToolConfiguration extends AbstractWebUIAutoConfiguration {
 
     static final String CONFIG_PREFIX = ToolsAutoConfiguration.CONFIG_PREFIX + ".catalog-bulk-load";

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/tools/ReprojectionConsoleConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/tools/ReprojectionConsoleConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.autoconfigure.web.tools;
 
 import lombok.Getter;
+
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -15,15 +16,13 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration
 @ConditionalOnClass(name = "org.geoserver.web.catalogstresstool.CatalogStressTester")
 @ConditionalOnProperty( // enabled by default
-    prefix = ToolsAutoConfiguration.CONFIG_PREFIX,
-    name = "reprojection-console",
-    havingValue = "true",
-    matchIfMissing = true
-)
+        prefix = ToolsAutoConfiguration.CONFIG_PREFIX,
+        name = "reprojection-console",
+        havingValue = "true",
+        matchIfMissing = true)
 @ImportResource(
-    reader = FilteringXmlBeanDefinitionReader.class,
-    locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=reprojectionConsole"}
-)
+        reader = FilteringXmlBeanDefinitionReader.class,
+        locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=reprojectionConsole"})
 public class ReprojectionConsoleConfiguration extends AbstractWebUIAutoConfiguration {
 
     static final String CONFIG_PREFIX =

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/tools/ResourceBrowserConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/tools/ResourceBrowserConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.autoconfigure.web.tools;
 
 import lombok.Getter;
+
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -22,15 +23,13 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration
 @ConditionalOnClass(name = "org.geoserver.web.resources.PageResourceBrowser")
 @ConditionalOnProperty( // enabled by default
-    prefix = ToolsAutoConfiguration.CONFIG_PREFIX,
-    name = "resource-browser",
-    havingValue = "true",
-    matchIfMissing = true
-)
+        prefix = ToolsAutoConfiguration.CONFIG_PREFIX,
+        name = "resource-browser",
+        havingValue = "true",
+        matchIfMissing = true)
 @ImportResource(
-    reader = FilteringXmlBeanDefinitionReader.class,
-    locations = {"jar:gs-web-resource-.*!/applicationContext.xml"}
-)
+        reader = FilteringXmlBeanDefinitionReader.class,
+        locations = {"jar:gs-web-resource-.*!/applicationContext.xml"})
 public class ResourceBrowserConfiguration extends AbstractWebUIAutoConfiguration {
 
     static final String CONFIG_PREFIX = ToolsAutoConfiguration.CONFIG_PREFIX + ".resource-browser";

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/tools/ToolsAutoConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/tools/ToolsAutoConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.autoconfigure.web.tools;
 
 import lombok.Getter;
+
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
@@ -12,11 +13,10 @@ import org.springframework.context.annotation.Import;
 
 @Configuration
 @ConditionalOnProperty(
-    prefix = ToolsAutoConfiguration.CONFIG_PREFIX,
-    name = "enabled",
-    havingValue = "true",
-    matchIfMissing = true
-)
+        prefix = ToolsAutoConfiguration.CONFIG_PREFIX,
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true)
 @Import({
     ResourceBrowserConfiguration.class,
     CatalogBulkLoadToolConfiguration.class,

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/wcs/WcsAutoConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/wcs/WcsAutoConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.autoconfigure.web.wcs;
 
 import lombok.Getter;
+
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -14,11 +15,10 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @ConditionalOnClass(name = "org.geoserver.wcs.web.WCSAdminPage")
 @ConditionalOnProperty( // enabled by default
-    prefix = WcsAutoConfiguration.CONFIG_PREFIX,
-    name = "enabled",
-    havingValue = "true",
-    matchIfMissing = true
-)
+        prefix = WcsAutoConfiguration.CONFIG_PREFIX,
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true)
 @Import(WcsConfiguration.class)
 public class WcsAutoConfiguration extends AbstractWebUIAutoConfiguration {
 

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/wcs/WcsConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/wcs/WcsConfiguration.java
@@ -10,14 +10,14 @@ import org.springframework.context.annotation.ImportResource;
 
 @Configuration(proxyBeanMethods = true)
 @ImportResource( //
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = { //
-        "jar:gs-wcs-.*!/applicationContext.xml", //
-        "jar:gs-wcs1_0-.*!/applicationContext.xml", //
-        "jar:gs-wcs1_1-.*!/applicationContext.xml", //
-        "jar:gs-wcs2_0-.*!/applicationContext.xml", //
-        // exclude wcs request builder, the DemosAutoConfiguration takes care of it
-        "jar:gs-web-wcs-.*!/applicationContext.xml#name=^(?!wcsRequestBuilder).*$"
-    } //
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = { //
+            "jar:gs-wcs-.*!/applicationContext.xml", //
+            "jar:gs-wcs1_0-.*!/applicationContext.xml", //
+            "jar:gs-wcs1_1-.*!/applicationContext.xml", //
+            "jar:gs-wcs2_0-.*!/applicationContext.xml", //
+            // exclude wcs request builder, the DemosAutoConfiguration takes care of it
+            "jar:gs-web-wcs-.*!/applicationContext.xml#name=^(?!wcsRequestBuilder).*$"
+        } //
+        )
 public class WcsConfiguration {}

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/wfs/WfsAutoConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/wfs/WfsAutoConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.autoconfigure.web.wfs;
 
 import lombok.Getter;
+
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -14,11 +15,10 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @ConditionalOnClass(name = "org.geoserver.wfs.web.WFSAdminPage")
 @ConditionalOnProperty( // enabled by default
-    prefix = WfsAutoConfiguration.CONFIG_PREFIX,
-    name = "enabled",
-    havingValue = "true",
-    matchIfMissing = true
-)
+        prefix = WfsAutoConfiguration.CONFIG_PREFIX,
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true)
 @Import(WfsConfiguration.class)
 public class WfsAutoConfiguration extends AbstractWebUIAutoConfiguration {
 

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/wfs/WfsConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/wfs/WfsConfiguration.java
@@ -10,10 +10,10 @@ import org.springframework.context.annotation.ImportResource;
 
 @Configuration(proxyBeanMethods = true)
 @ImportResource( //
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = { //
-        "jar:gs-web-wfs-.*!/applicationContext.xml", //
-        "jar:gs-wfs-.*!/applicationContext.xml"
-    } //
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = { //
+            "jar:gs-web-wfs-.*!/applicationContext.xml", //
+            "jar:gs-wfs-.*!/applicationContext.xml"
+        } //
+        )
 public class WfsConfiguration {}

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/wms/WmsAutoConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/wms/WmsAutoConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.autoconfigure.web.wms;
 
 import lombok.Getter;
+
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -14,11 +15,10 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @ConditionalOnClass(name = "org.geoserver.wms.web.WMSAdminPage")
 @ConditionalOnProperty( // enabled by default
-    prefix = WmsAutoConfiguration.CONFIG_PREFIX,
-    name = "enabled",
-    havingValue = "true",
-    matchIfMissing = true
-)
+        prefix = WmsAutoConfiguration.CONFIG_PREFIX,
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true)
 @Import(WmsConfiguration.class)
 public class WmsAutoConfiguration extends AbstractWebUIAutoConfiguration {
 

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/wms/WmsConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/wms/WmsConfiguration.java
@@ -10,13 +10,12 @@ import org.springframework.context.annotation.ImportResource;
 
 @Configuration(proxyBeanMethods = true)
 @ImportResource( //
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = {
-        "jar:gs-web-wms-.*!/applicationContext.xml", //
-        "jar:gs-wms-.*!/applicationContext.xml", //
-        "jar:gs-wfs-.*!/applicationContext.xml#name=" + WmsConfiguration.WFS_BEANS_REGEX
-    }
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = {
+            "jar:gs-web-wms-.*!/applicationContext.xml", //
+            "jar:gs-wms-.*!/applicationContext.xml", //
+            "jar:gs-wfs-.*!/applicationContext.xml#name=" + WmsConfiguration.WFS_BEANS_REGEX
+        })
 public class WmsConfiguration {
 
     static final String WFS_BEANS_REGEX =

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/wps/WpsAutoConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/wps/WpsAutoConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.autoconfigure.web.wps;
 
 import lombok.Getter;
+
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -14,11 +15,10 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @ConditionalOnClass(name = "org.geoserver.wps.web.WPSAdminPage")
 @ConditionalOnProperty( // enabled by default
-    prefix = WpsAutoConfiguration.CONFIG_PREFIX,
-    name = "enabled",
-    havingValue = "true",
-    matchIfMissing = true
-)
+        prefix = WpsAutoConfiguration.CONFIG_PREFIX,
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true)
 @Import(WpsConfiguration.class)
 public class WpsAutoConfiguration extends AbstractWebUIAutoConfiguration {
 

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/wps/WpsConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/wps/WpsConfiguration.java
@@ -10,12 +10,11 @@ import org.springframework.context.annotation.ImportResource;
 
 @Configuration(proxyBeanMethods = true)
 @ImportResource( //
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = {
-        // exclude wpsRequestBuilder, DemosAutoConfiguration takes care of it
-        "jar:gs-web-wps-.*!/applicationContext.xml#name=^(?!wpsRequestBuilder).*$",
-        "jar:gs-wps-.*!/applicationContext.xml",
-        "jar:gs-wcs-.*!/applicationContext.xml"
-    }
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = {
+            // exclude wpsRequestBuilder, DemosAutoConfiguration takes care of it
+            "jar:gs-web-wps-.*!/applicationContext.xml#name=^(?!wpsRequestBuilder).*$",
+            "jar:gs-wps-.*!/applicationContext.xml",
+            "jar:gs-wcs-.*!/applicationContext.xml"
+        })
 public class WpsConfiguration {}

--- a/services/web-ui/src/main/java/org/geoserver/cloud/web/service/ServiceInstance.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/web/service/ServiceInstance.java
@@ -4,10 +4,13 @@
  */
 package org.geoserver.cloud.web.service;
 
-import java.io.Serializable;
 import lombok.Data;
 
-/** @since 1.0 */
+import java.io.Serializable;
+
+/**
+ * @since 1.0
+ */
 public @Data class ServiceInstance implements Serializable, Comparable<ServiceInstance> {
     private static final long serialVersionUID = 1L;
 

--- a/services/web-ui/src/main/java/org/geoserver/cloud/web/service/ServiceInstanceRegistry.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/web/service/ServiceInstanceRegistry.java
@@ -6,29 +6,35 @@ package org.geoserver.cloud.web.service;
 
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.appinfo.InstanceInfo.InstanceStatus;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.netflix.eureka.EurekaServiceInstance;
+
 import java.net.URI;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import org.springframework.cloud.client.discovery.DiscoveryClient;
-import org.springframework.cloud.netflix.eureka.EurekaServiceInstance;
 
-/** @since 1.0 */
+/**
+ * @since 1.0
+ */
 @RequiredArgsConstructor
 public class ServiceInstanceRegistry {
 
     private final @NonNull DiscoveryClient client;
 
-    /** @return All known service IDs */
+    /**
+     * @return All known service IDs
+     */
     public List<String> getServiceNames() {
         return client.getServices();
     }
 
     public Stream<ServiceInstance> getServices() {
-        return client.getServices()
-                .stream()
+        return client.getServices().stream()
                 .map(client::getInstances)
                 .map(List::stream)
                 .flatMap(Function.identity())

--- a/services/web-ui/src/main/java/org/geoserver/cloud/web/service/WebUiCloudServicesConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/web/service/WebUiCloudServicesConfiguration.java
@@ -13,7 +13,9 @@ import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/** @since 1.0 */
+/**
+ * @since 1.0
+ */
 @Configuration(proxyBeanMethods = true)
 public class WebUiCloudServicesConfiguration {
 

--- a/services/web-ui/src/main/java/org/geoserver/cloud/web/ui/ServiceProvider.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/web/ui/ServiceProvider.java
@@ -4,14 +4,17 @@
  */
 package org.geoserver.cloud.web.ui;
 
-import java.util.List;
-import java.util.stream.Collectors;
 import org.geoserver.cloud.web.service.ServiceInstance;
 import org.geoserver.cloud.web.service.ServiceInstanceRegistry;
 import org.geoserver.web.GeoServerApplication;
 import org.geoserver.web.wicket.GeoServerDataProvider;
 
-/** @since 1.0 */
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @since 1.0
+ */
 class ServiceProvider extends GeoServerDataProvider<ServiceInstance> {
     private static final long serialVersionUID = 1L;
 

--- a/services/web-ui/src/main/java/org/geoserver/cloud/web/ui/ServiceRegistryPage.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/web/ui/ServiceRegistryPage.java
@@ -14,7 +14,9 @@ import org.geoserver.web.wicket.GeoServerDataProvider.Property;
 import org.geoserver.web.wicket.GeoServerTablePanel;
 import org.geoserver.web.wicket.SimpleExternalLink;
 
-/** @since 1.0 */
+/**
+ * @since 1.0
+ */
 public class ServiceRegistryPage extends GeoServerSecuredPage {
 
     private static final long serialVersionUID = 1L;

--- a/services/wfs/src/main/java/org/geoserver/cloud/wfs/app/WFSController.java
+++ b/services/wfs/src/main/java/org/geoserver/cloud/wfs/app/WFSController.java
@@ -7,8 +7,6 @@ package org.geoserver.cloud.wfs.app;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.geoserver.ows.Dispatcher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -16,6 +14,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.view.RedirectView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 @Controller
 public class WFSController {
@@ -37,16 +38,15 @@ public class WFSController {
     }
 
     @RequestMapping(
-        method = {GET, POST},
-        path = {
-            "/wfs",
-            "/{workspace}/wfs",
-            "/{workspace}/{layer}/wfs",
-            "/ows",
-            "/{workspace}/ows",
-            "/{workspace}/{layer}/ows"
-        }
-    )
+            method = {GET, POST},
+            path = {
+                "/wfs",
+                "/{workspace}/wfs",
+                "/{workspace}/{layer}/wfs",
+                "/ows",
+                "/{workspace}/ows",
+                "/{workspace}/{layer}/ows"
+            })
     public void serviceRequest(HttpServletRequest request, HttpServletResponse response)
             throws Exception {
         geoserverDispatcher.handleRequest(request, response);

--- a/services/wfs/src/main/java/org/geoserver/cloud/wfs/config/WfsAutoConfiguration.java
+++ b/services/wfs/src/main/java/org/geoserver/cloud/wfs/config/WfsAutoConfiguration.java
@@ -13,10 +13,10 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration(proxyBeanMethods = true)
 @AutoConfigureAfter({GeoServerWebMvcMainAutoConfiguration.class})
 @ImportResource( //
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = {
-        "jar:gs-wfs-.*!/applicationContext.xml#name=.*",
-        "jar:gs-flatgeobuf-.*!/applicationContext.xml#name=.*"
-    } //
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = {
+            "jar:gs-wfs-.*!/applicationContext.xml#name=.*",
+            "jar:gs-flatgeobuf-.*!/applicationContext.xml#name=.*"
+        } //
+        )
 public class WfsAutoConfiguration {}

--- a/services/wms/src/main/java/org/geoserver/cloud/wms/app/WmsApplicationConfiguration.java
+++ b/services/wms/src/main/java/org/geoserver/cloud/wms/app/WmsApplicationConfiguration.java
@@ -18,13 +18,12 @@ import org.springframework.context.annotation.ImportResource;
 
 @Configuration
 @ImportResource( //
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = { //
-        "jar:gs-wms-.*!/applicationContext.xml", //
-        "jar:gs-wfs-.*!/applicationContext.xml#name="
-                + WmsApplicationConfiguration.WFS_INCLUDED_BEANS_REGEX //
-    }
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = { //
+            "jar:gs-wms-.*!/applicationContext.xml", //
+            "jar:gs-wfs-.*!/applicationContext.xml#name="
+                    + WmsApplicationConfiguration.WFS_INCLUDED_BEANS_REGEX //
+        })
 public class WmsApplicationConfiguration {
 
     static final String WFS_INCLUDED_BEANS_REGEX =
@@ -51,11 +50,10 @@ public class WmsApplicationConfiguration {
     }
 
     @ConditionalOnProperty(
-        prefix = "geoserver.wms",
-        name = "reflector.enabled",
-        havingValue = "true",
-        matchIfMissing = false
-    )
+            prefix = "geoserver.wms",
+            name = "reflector.enabled",
+            havingValue = "true",
+            matchIfMissing = false)
     public @Bean GetMapReflectorController getMapReflectorController() {
         return new GetMapReflectorController();
     }

--- a/services/wms/src/main/java/org/geoserver/cloud/wms/controller/GetMapReflectorController.java
+++ b/services/wms/src/main/java/org/geoserver/cloud/wms/controller/GetMapReflectorController.java
@@ -6,21 +6,21 @@ package org.geoserver.cloud.wms.controller;
 
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.geoserver.ows.Dispatcher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 public @Controller class GetMapReflectorController {
 
     private @Autowired Dispatcher geoserverDispatcher;
 
     @RequestMapping(
-        method = {GET},
-        path = {"/wms/reflect", "/{workspace}/wms/reflect"}
-    )
+            method = {GET},
+            path = {"/wms/reflect", "/{workspace}/wms/reflect"})
     public void getMapReflect(HttpServletRequest request, HttpServletResponse response)
             throws Exception {
         geoserverDispatcher.handleRequest(request, response);

--- a/services/wms/src/main/java/org/geoserver/cloud/wms/controller/WMSController.java
+++ b/services/wms/src/main/java/org/geoserver/cloud/wms/controller/WMSController.java
@@ -7,8 +7,6 @@ package org.geoserver.cloud.wms.controller;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.geoserver.ows.Dispatcher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -16,6 +14,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.view.RedirectView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 public @Controller class WMSController {
 
@@ -39,9 +40,8 @@ public @Controller class WMSController {
      * </ul>
      */
     @RequestMapping(
-        method = RequestMethod.GET,
-        path = {"/schemas/wms/**"}
-    )
+            method = RequestMethod.GET,
+            path = {"/schemas/wms/**"})
     public void getWmsSchema(HttpServletRequest request, HttpServletResponse response)
             throws Exception {
         classPathPublisher.handleRequest(request, response);
@@ -58,25 +58,23 @@ public @Controller class WMSController {
      * </ul>
      */
     @RequestMapping(
-        method = RequestMethod.GET,
-        path = {"/openlayers/**", "/openlayers3/**"}
-    )
+            method = RequestMethod.GET,
+            path = {"/openlayers/**", "/openlayers3/**"})
     public void getStaticResource(HttpServletRequest request, HttpServletResponse response)
             throws Exception {
         classPathPublisher.handleRequest(request, response);
     }
 
     @RequestMapping(
-        method = {GET, POST},
-        path = {
-            "/wms",
-            "/{workspace}/wms",
-            "/{workspace}/{layer}/wms",
-            "/ows",
-            "/{workspace}/ows",
-            "/{workspace}/{layer}/ows"
-        }
-    )
+            method = {GET, POST},
+            path = {
+                "/wms",
+                "/{workspace}/wms",
+                "/{workspace}/{layer}/wms",
+                "/ows",
+                "/{workspace}/ows",
+                "/{workspace}/{layer}/ows"
+            })
     public void handle(HttpServletRequest request, HttpServletResponse response) throws Exception {
         geoserverDispatcher.handleRequest(request, response);
     }

--- a/services/wps/src/main/java/org/geoserver/cloud/wps/WPSController.java
+++ b/services/wps/src/main/java/org/geoserver/cloud/wps/WPSController.java
@@ -7,8 +7,6 @@ package org.geoserver.cloud.wps;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.geoserver.ows.Dispatcher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -16,6 +14,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.view.RedirectView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 public @Controller class WPSController {
 
@@ -36,9 +37,8 @@ public @Controller class WPSController {
     }
 
     @RequestMapping(
-        method = {GET, POST},
-        path = {"/wps", "/{workspace}/wps", "/ows", "/{workspace}/ows"}
-    )
+            method = {GET, POST},
+            path = {"/wps", "/{workspace}/wps", "/ows", "/{workspace}/ows"})
     public void handle(HttpServletRequest request, HttpServletResponse response) throws Exception {
         geoserverDispatcher.handleRequest(request, response);
     }

--- a/services/wps/src/main/java/org/geoserver/cloud/wps/WpsApplicationConfiguration.java
+++ b/services/wps/src/main/java/org/geoserver/cloud/wps/WpsApplicationConfiguration.java
@@ -10,12 +10,11 @@ import org.springframework.context.annotation.ImportResource;
 
 @Configuration
 @ImportResource( //
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = { //
-        "jar:gs-wps-.*!/applicationContext.xml" // , //
-        // // REVISIT: wps won't start without the web components! see note in pom.xml
-        // "jar:gs-web-core-.*!/applicationContext.xml", //
-        // "jar:gs-web-wps-.*!/applicationContext.xml", //
-    }
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = { //
+            "jar:gs-wps-.*!/applicationContext.xml" // , //
+            // // REVISIT: wps won't start without the web components! see note in pom.xml
+            // "jar:gs-web-core-.*!/applicationContext.xml", //
+            // "jar:gs-web-wps-.*!/applicationContext.xml", //
+        })
 public class WpsApplicationConfiguration {}

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/catalog/ConditionalOnBackendCacheEnabled.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/catalog/ConditionalOnBackendCacheEnabled.java
@@ -4,22 +4,22 @@
  */
 package org.geoserver.cloud.autoconfigure.catalog;
 
+import org.geoserver.cloud.catalog.caching.GeoServerBackendCacheConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.geoserver.cloud.catalog.caching.GeoServerBackendCacheConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Documented
 @ConditionalOnClass(GeoServerBackendCacheConfiguration.class)
 @ConditionalOnProperty(
-    name = "geoserver.catalog.caching.enabled",
-    havingValue = "true",
-    matchIfMissing = false
-)
+        name = "geoserver.catalog.caching.enabled",
+        havingValue = "true",
+        matchIfMissing = false)
 public @interface ConditionalOnBackendCacheEnabled {}

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/catalog/ConditionalOnCatalogServiceClientEnabled.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/catalog/ConditionalOnCatalogServiceClientEnabled.java
@@ -4,22 +4,22 @@
  */
 package org.geoserver.cloud.autoconfigure.catalog;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Documented
 @ConditionalOnClass(org.geoserver.cloud.catalog.client.impl.CatalogClientConfiguration.class)
 @ConditionalOnProperty(
-    prefix = "geoserver.backend.catalog-service",
-    name = "enabled",
-    havingValue = "true",
-    matchIfMissing = false
-)
+        prefix = "geoserver.backend.catalog-service",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = false)
 public @interface ConditionalOnCatalogServiceClientEnabled {}

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/catalog/ConditionalOnDataDirectoryEnabled.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/catalog/ConditionalOnDataDirectoryEnabled.java
@@ -4,20 +4,20 @@
  */
 package org.geoserver.cloud.autoconfigure.catalog;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Documented
 @ConditionalOnProperty(
-    prefix = "geoserver.backend.data-directory",
-    name = "enabled",
-    havingValue = "true",
-    matchIfMissing = false
-)
+        prefix = "geoserver.backend.data-directory",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = false)
 public @interface ConditionalOnDataDirectoryEnabled {}

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/catalog/ConditionalOnJdbcConfigEnabled.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/catalog/ConditionalOnJdbcConfigEnabled.java
@@ -4,24 +4,24 @@
  */
 package org.geoserver.cloud.autoconfigure.catalog;
 
+import org.geoserver.jdbcconfig.catalog.JDBCCatalogFacade;
+import org.geoserver.jdbcconfig.config.JDBCGeoServerFacade;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.geoserver.jdbcconfig.catalog.JDBCCatalogFacade;
-import org.geoserver.jdbcconfig.config.JDBCGeoServerFacade;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Documented
 @ConditionalOnClass({JDBCCatalogFacade.class, JDBCGeoServerFacade.class})
 @ConditionalOnProperty(
-    prefix = "geoserver.backend.jdbcconfig",
-    name = "enabled",
-    havingValue = "true",
-    matchIfMissing = false
-)
+        prefix = "geoserver.backend.jdbcconfig",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = false)
 public @interface ConditionalOnJdbcConfigEnabled {}

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/catalog/JDBCConfigWebAutoConfiguration.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/catalog/JDBCConfigWebAutoConfiguration.java
@@ -13,10 +13,9 @@ import org.springframework.context.annotation.Import;
 @ConditionalOnClass(name = "org.geoserver.web.GeoServerHomePageContentProvider")
 @ConditionalOnJdbcConfigEnabled
 @ConditionalOnProperty(
-    prefix = "geoserver.backend.jdbcconfig.web",
-    name = "enabled",
-    havingValue = "true",
-    matchIfMissing = false
-)
+        prefix = "geoserver.backend.jdbcconfig.web",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = false)
 @Import({JDBCConfigWebConfiguration.class})
 public class JDBCConfigWebAutoConfiguration {}

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/security/ConditionalOnGeoServerSecurityDisabled.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/security/ConditionalOnGeoServerSecurityDisabled.java
@@ -4,20 +4,20 @@
  */
 package org.geoserver.cloud.autoconfigure.security;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Documented
 @ConditionalOnProperty(
-    prefix = "geoserver.security",
-    name = "enabled",
-    havingValue = "false",
-    matchIfMissing = false
-)
+        prefix = "geoserver.security",
+        name = "enabled",
+        havingValue = "false",
+        matchIfMissing = false)
 public @interface ConditionalOnGeoServerSecurityDisabled {}

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/security/ConditionalOnGeoServerSecurityEnabled.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/security/ConditionalOnGeoServerSecurityEnabled.java
@@ -4,20 +4,20 @@
  */
 package org.geoserver.cloud.autoconfigure.security;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Documented
 @ConditionalOnProperty(
-    prefix = "geoserver.security",
-    name = "enabled",
-    havingValue = "true",
-    matchIfMissing = true
-)
+        prefix = "geoserver.security",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true)
 public @interface ConditionalOnGeoServerSecurityEnabled {}

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/security/GeoServerSecurityDisabledAutoConfiguration.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/security/GeoServerSecurityDisabledAutoConfiguration.java
@@ -4,13 +4,15 @@
  */
 package org.geoserver.cloud.autoconfigure.security;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.security.GeoServerSecurityConfigChangeEvent;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.bus.jackson.RemoteApplicationEventScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.EventListener;
+
+import javax.annotation.PostConstruct;
 
 @Configuration
 @ConditionalOnGeoServerSecurityDisabled

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/security/GeoServerSecurityEnabledAutoConfiguration.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/security/GeoServerSecurityEnabledAutoConfiguration.java
@@ -4,14 +4,16 @@
  */
 package org.geoserver.cloud.autoconfigure.security;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.autoconfigure.bus.RemoteApplicationEventsAutoConfiguration;
 import org.geoserver.cloud.config.security.GeoServerSecurityConfiguration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+
+import javax.annotation.PostConstruct;
 
 @ConditionalOnGeoServerSecurityEnabled
 @Import(GeoServerSecurityConfiguration.class)

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/bus/incoming/caching/RemoteEventCacheEvictor.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/bus/incoming/caching/RemoteEventCacheEvictor.java
@@ -8,9 +8,9 @@ import static org.geoserver.cloud.catalog.caching.CachingCatalogFacade.DEFAULT_N
 import static org.geoserver.cloud.catalog.caching.CachingCatalogFacade.DEFAULT_WORKSPACE_CACHE_KEY;
 import static org.geoserver.cloud.catalog.caching.CachingCatalogFacade.generateDefaultDataStoreKey;
 
-import java.util.function.BooleanSupplier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.WorkspaceInfo;
@@ -35,6 +35,8 @@ import org.geoserver.cloud.event.ConfigInfoInfoType;
 import org.geoserver.config.GeoServerInfo;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
+
+import java.util.function.BooleanSupplier;
 
 /**
  * Component to listen to {@link RemoteInfoEvent} based hierarchy of events and evict entries from

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalog/CatalogProperties.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalog/CatalogProperties.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.config.catalog;
 
 import lombok.Data;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "geoserver.catalog")

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalog/DataDirectoryProperties.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalog/DataDirectoryProperties.java
@@ -4,9 +4,11 @@
  */
 package org.geoserver.cloud.config.catalog;
 
-import java.nio.file.Path;
 import lombok.Data;
+
 import org.geoserver.cloud.autoconfigure.catalog.DataDirectoryAutoConfiguration;
+
+import java.nio.file.Path;
 
 /**
  * Configuration properties to use GeoServer's traditional, file-system based data-directory as the

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalog/GeoServerBackendProperties.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalog/GeoServerBackendProperties.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.config.catalog;
 
 import lombok.Data;
+
 import org.geoserver.cloud.catalog.client.impl.CatalogClientProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalog/JdbcconfigProperties.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalog/JdbcconfigProperties.java
@@ -4,10 +4,12 @@
  */
 package org.geoserver.cloud.config.catalog;
 
-import java.nio.file.Path;
 import lombok.Data;
+
 import org.geoserver.cloud.autoconfigure.catalog.JDBCConfigAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+
+import java.nio.file.Path;
 
 /**
  * Configuration properties to use GeoServer's {@code jdbcconfig} and {@code jdbcstore} community

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalog/XstreamServiceLoadersConfiguration.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalog/XstreamServiceLoadersConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.config.catalog;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.config.util.XStreamServiceLoader;
 import org.geoserver.gwc.wmts.WMTSXStreamLoader;
 import org.geoserver.platform.GeoServerResourceLoader;

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalogclient/CatalogClientBackendConfigurer.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalogclient/CatalogClientBackendConfigurer.java
@@ -4,8 +4,8 @@
  */
 package org.geoserver.cloud.config.catalogclient;
 
-import java.io.File;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
 import org.geoserver.cloud.catalog.client.impl.CatalogClientCatalogFacade;
 import org.geoserver.cloud.catalog.client.impl.CatalogClientConfiguration;
@@ -24,6 +24,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
+
+import java.io.File;
 
 @Configuration(proxyBeanMethods = true)
 @Import(CatalogClientConfiguration.class)

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalogclient/CatalogClientGeoServerLoader.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalogclient/CatalogClientGeoServerLoader.java
@@ -4,8 +4,8 @@
  */
 package org.geoserver.cloud.config.catalogclient;
 
-import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.config.GeoServer;
@@ -14,6 +14,8 @@ import org.geoserver.config.GeoServerLoader;
 import org.geoserver.config.util.XStreamPersister;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.opengis.filter.Filter;
+
+import java.io.IOException;
 
 /** */
 @Slf4j

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/datadirectory/DataDirectoryBackendConfigurer.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/datadirectory/DataDirectoryBackendConfigurer.java
@@ -4,11 +4,9 @@
  */
 package org.geoserver.cloud.config.datadirectory;
 
-import java.io.File;
-import java.nio.file.Path;
-import java.util.Objects;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.plugin.DefaultMemoryCatalogFacade;
 import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
 import org.geoserver.cloud.autoconfigure.bus.ConditionalOnGeoServerRemoteEventsEnabled;
@@ -24,6 +22,10 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Objects;
 
 /** */
 @Configuration(proxyBeanMethods = true)

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/datadirectory/DataDirectoryGeoServerLoader.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/datadirectory/DataDirectoryGeoServerLoader.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.cloud.config.datadirectory;
 
-import java.util.List;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.Info;
@@ -25,6 +24,8 @@ import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.platform.resource.Resource.Lock;
 
+import java.util.List;
+
 /** */
 public class DataDirectoryGeoServerLoader extends DefaultGeoServerLoader {
 
@@ -41,9 +42,7 @@ public class DataDirectoryGeoServerLoader extends DefaultGeoServerLoader {
                         geoServer.getCatalog().getResourceLoader(), xp);
 
         ConfigurationListener configPersister =
-                geoServer
-                        .getListeners()
-                        .stream()
+                geoServer.getListeners().stream()
                         .filter(GeoServerConfigPersister.class::isInstance)
                         .findFirst()
                         .orElse(null);

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/datadirectory/DataDirectoryRemoteEventProcessor.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/datadirectory/DataDirectoryRemoteEventProcessor.java
@@ -4,12 +4,10 @@
  */
 package org.geoserver.cloud.config.datadirectory;
 
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.Info;
@@ -35,6 +33,10 @@ import org.geoserver.config.ServiceInfo;
 import org.geoserver.config.SettingsInfo;
 import org.geoserver.config.plugin.RepositoryGeoServerFacade;
 import org.springframework.context.event.EventListener;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /** Listens to {@link RemoteCatalogEvent}s and updates the local catalog */
 @Slf4j(topic = "org.geoserver.cloud.bus.incoming.datadirectory")

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/datadirectory/NoServletContextDataDirectoryResourceStore.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/datadirectory/NoServletContextDataDirectoryResourceStore.java
@@ -4,12 +4,15 @@
  */
 package org.geoserver.cloud.config.datadirectory;
 
-import java.io.File;
-import java.util.Objects;
-import javax.servlet.ServletContext;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.platform.resource.DataDirectoryResourceStore;
 import org.geoserver.platform.resource.FileSystemResourceStore;
+
+import java.io.File;
+import java.util.Objects;
+
+import javax.servlet.ServletContext;
 
 /**
  * {@link DataDirectoryResourceStore} that works both for webmvc (servlet) and reactive (WebFlux)

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/datadirectory/NoServletContextFileLockProvider.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/datadirectory/NoServletContextFileLockProvider.java
@@ -4,11 +4,14 @@
  */
 package org.geoserver.cloud.config.datadirectory;
 
-import java.io.File;
-import javax.servlet.ServletContext;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.platform.resource.FileLockProvider;
+
+import java.io.File;
+
+import javax.servlet.ServletContext;
 
 /**
  * {@link FileLockProvider} that expects the data directory file at its constructor, overriding

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/jdbcconfig/CloudJdbcConfigDatabase.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/jdbcconfig/CloudJdbcConfigDatabase.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.cloud.config.jdbcconfig;
 
-import javax.sql.DataSource;
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.impl.CatalogImpl;
 import org.geoserver.catalog.impl.ModificationProxy;
@@ -12,6 +11,8 @@ import org.geoserver.jdbcconfig.internal.ConfigDatabase;
 import org.geoserver.jdbcconfig.internal.XStreamInfoSerialBinding;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.sql.DataSource;
 
 /**
  * Overrides {@link #save} and {@link #remove} to {@link #clearCache(Info) dispose the internal
@@ -33,10 +34,9 @@ class CloudJdbcConfigDatabase extends ConfigDatabase {
      */
     @Override
     @Transactional(
-        transactionManager = "jdbcConfigTransactionManager",
-        propagation = Propagation.REQUIRED,
-        rollbackFor = Exception.class
-    )
+            transactionManager = "jdbcConfigTransactionManager",
+            propagation = Propagation.REQUIRED,
+            rollbackFor = Exception.class)
     public <T extends Info> T save(T info) {
         clearCache(ModificationProxy.unwrap(info));
         T saved = super.save(info);
@@ -49,10 +49,9 @@ class CloudJdbcConfigDatabase extends ConfigDatabase {
      */
     @Override
     @Transactional(
-        transactionManager = "jdbcConfigTransactionManager",
-        propagation = Propagation.REQUIRED,
-        rollbackFor = Exception.class
-    )
+            transactionManager = "jdbcConfigTransactionManager",
+            propagation = Propagation.REQUIRED,
+            rollbackFor = Exception.class)
     public void remove(Info info) {
         clearCache(ModificationProxy.unwrap(info));
         super.remove(info);

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/jdbcconfig/CloudJdbcConfigProperties.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/jdbcconfig/CloudJdbcConfigProperties.java
@@ -6,17 +6,20 @@ package org.geoserver.cloud.config.jdbcconfig;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
-import java.io.IOException;
-import java.net.URL;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
-import javax.sql.DataSource;
+
 import org.geoserver.jdbcconfig.internal.ConfigDatabase;
 import org.geoserver.jdbcconfig.internal.JDBCConfigProperties;
 import org.geoserver.jdbcconfig.internal.JDBCConfigPropertiesFactoryBean;
 import org.geoserver.jdbcloader.DataSourceFactoryBean;
 import org.geoserver.platform.resource.Resource;
+
+import java.io.IOException;
+import java.net.URL;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import javax.sql.DataSource;
 
 /** Extends {@link JDBCConfigProperties} to not need a {@link JDBCConfigPropertiesFactoryBean} */
 public class CloudJdbcConfigProperties extends JDBCConfigProperties {

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/jdbcconfig/CloudJdbcGeoServerLoader.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/jdbcconfig/CloudJdbcGeoServerLoader.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.cloud.config.jdbcconfig;
 
-import java.util.List;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.plugin.CatalogPlugin;
 import org.geoserver.config.DefaultGeoServerLoader;
@@ -20,6 +19,8 @@ import org.geoserver.jdbcconfig.internal.JDBCConfigProperties;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.platform.resource.Resource.Lock;
+
+import java.util.List;
 
 /**
  * Overrides {@link #loadGeoServer(GeoServer, XStreamPersister)} to avoid a class cast exception on

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/jdbcconfig/CloudJdbcGeoserverFacade.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/jdbcconfig/CloudJdbcGeoserverFacade.java
@@ -10,13 +10,7 @@ import static org.geoserver.catalog.Predicates.equal;
 import static org.geoserver.catalog.Predicates.isNull;
 
 import com.google.common.base.Preconditions;
-import java.lang.reflect.Proxy;
-import java.rmi.server.UID;
-import java.util.Collection;
-import java.util.List;
-import java.util.logging.Logger;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.ModificationProxy;
@@ -31,6 +25,15 @@ import org.geoserver.jdbcconfig.internal.ConfigDatabase;
 import org.geoserver.ows.util.OwsUtils;
 import org.geotools.util.logging.Logging;
 import org.opengis.filter.Filter;
+
+import java.lang.reflect.Proxy;
+import java.rmi.server.UID;
+import java.util.Collection;
+import java.util.List;
+import java.util.logging.Logger;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Copy of {@link JDBCGeoServerFacade} that does not try reinitialize logging, can't extend it

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/jdbcconfig/CloudJdbcStoreProperties.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/jdbcconfig/CloudJdbcStoreProperties.java
@@ -6,17 +6,20 @@ package org.geoserver.cloud.config.jdbcconfig;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+
+import org.geoserver.jdbcloader.DataSourceFactoryBean;
+import org.geoserver.jdbcstore.internal.JDBCResourceStoreProperties;
+import org.geoserver.jdbcstore.internal.JDBCResourceStorePropertiesFactoryBean;
+import org.geoserver.platform.resource.Resource;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+
 import javax.sql.DataSource;
-import org.geoserver.jdbcloader.DataSourceFactoryBean;
-import org.geoserver.jdbcstore.internal.JDBCResourceStoreProperties;
-import org.geoserver.jdbcstore.internal.JDBCResourceStorePropertiesFactoryBean;
-import org.geoserver.platform.resource.Resource;
 
 /**
  * Extends {@link JDBCResourceStoreProperties} to not need a {@link

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/jdbcconfig/JDBCConfigBackendConfigurer.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/jdbcconfig/JDBCConfigBackendConfigurer.java
@@ -7,14 +7,10 @@ package org.geoserver.cloud.config.jdbcconfig;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.zaxxer.hikari.HikariDataSource;
-import java.io.File;
-import java.io.IOException;
-import java.io.Serializable;
-import java.nio.file.Path;
-import java.sql.Driver;
-import javax.sql.DataSource;
+
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.plugin.CatalogFacadeExtensionAdapter;
 import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
 import org.geoserver.cloud.autoconfigure.bus.ConditionalOnGeoServerRemoteEventsEnabled;
@@ -58,6 +54,14 @@ import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.jdbc.support.DatabaseStartupValidator;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.util.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Path;
+import java.sql.Driver;
+
+import javax.sql.DataSource;
 
 /**
  * Configure JDBC Config catalog

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/jdbcconfig/bus/JdbcConfigRemoteEventProcessor.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/jdbcconfig/bus/JdbcConfigRemoteEventProcessor.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.config.jdbcconfig.bus;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.Info;
 import org.geoserver.cloud.bus.event.RemoteInfoEvent;

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/security/GeoServerSecurityConfiguration.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/security/GeoServerSecurityConfiguration.java
@@ -4,8 +4,8 @@
  */
 package org.geoserver.cloud.config.security;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.autoconfigure.bus.ConditionalOnGeoServerRemoteEventsDisabled;
 import org.geoserver.cloud.autoconfigure.bus.ConditionalOnGeoServerRemoteEventsEnabled;
 import org.geoserver.cloud.autoconfigure.security.ConditionalOnGeoServerSecurityEnabled;
@@ -22,6 +22,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.ImportResource;
+
+import javax.annotation.PostConstruct;
 
 /**
  * Loads geoserver security bean definitions from {@code
@@ -40,10 +42,11 @@ import org.springframework.context.annotation.ImportResource;
  */
 @Configuration
 @ImportResource(
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    // exclude authenticationManager from applicationSecurityContext.xml
-    locations = {"classpath*:/applicationSecurityContext.xml#name=^(?!authenticationManager).*$"}
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        // exclude authenticationManager from applicationSecurityContext.xml
+        locations = {
+            "classpath*:/applicationSecurityContext.xml#name=^(?!authenticationManager).*$"
+        })
 @Slf4j(topic = "org.geoserver.cloud.config.security")
 @ConditionalOnGeoServerSecurityEnabled
 @RemoteApplicationEventScan(basePackageClasses = {GeoServerSecurityConfigChangeEvent.class})

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/security/CloudGeoServerSecurityManager.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/security/CloudGeoServerSecurityManager.java
@@ -4,9 +4,9 @@
  */
 package org.geoserver.cloud.security;
 
-import java.io.IOException;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.security.GeoServerSecurityManager;
 import org.geoserver.security.config.PasswordPolicyConfig;
@@ -22,6 +22,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.bus.ServiceMatcher;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
+
+import java.io.IOException;
 
 /**
  * Extends {@link GeoServerSecurityManager} to {@link #fireRemoteChangedEvent(String) notify} other

--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/security/GeoServerSecurityConfigChangeEvent.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/security/GeoServerSecurityConfigChangeEvent.java
@@ -7,6 +7,7 @@ package org.geoserver.cloud.security;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
+
 import org.geoserver.security.GeoServerSecurityManager;
 import org.springframework.cloud.bus.event.RemoteApplicationEvent;
 

--- a/starters/starter-catalog-backend/src/main/java/org/geotools/autoconfigure/httpclient/GeoToolsHttpClientAutoConfiguration.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geotools/autoconfigure/httpclient/GeoToolsHttpClientAutoConfiguration.java
@@ -5,6 +5,7 @@
 package org.geotools.autoconfigure.httpclient;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.geotools.autoconfigure.httpclient.ProxyConfig.ProxyHostConfig;
 import org.geotools.http.HTTPClientFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -69,11 +70,10 @@ import org.springframework.context.annotation.Configuration;
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties
 @ConditionalOnProperty(
-    prefix = "geotools.httpclient.proxy",
-    name = "enabled",
-    havingValue = "true",
-    matchIfMissing = true
-)
+        prefix = "geotools.httpclient.proxy",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true)
 @Slf4j(topic = "org.geotools.autoconfigure.httpclient")
 public class GeoToolsHttpClientAutoConfiguration {
 

--- a/starters/starter-catalog-backend/src/main/java/org/geotools/autoconfigure/httpclient/ProxyConfig.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geotools/autoconfigure/httpclient/ProxyConfig.java
@@ -4,12 +4,14 @@
  */
 package org.geotools.autoconfigure.httpclient;
 
+import lombok.Data;
+import lombok.NonNull;
+
+import org.springframework.util.StringUtils;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
-import lombok.Data;
-import lombok.NonNull;
-import org.springframework.util.StringUtils;
 
 /** */
 public @Data class ProxyConfig {

--- a/starters/starter-catalog-backend/src/main/java/org/geotools/autoconfigure/httpclient/SpringEnvironmentAwareGeoToolsHttpClient.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geotools/autoconfigure/httpclient/SpringEnvironmentAwareGeoToolsHttpClient.java
@@ -20,17 +20,8 @@ package org.geotools.autoconfigure.httpclient;
 import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofSeconds;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.zip.GZIPInputStream;
 import lombok.NonNull;
+
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpException;
@@ -59,6 +50,17 @@ import org.geotools.http.HTTPProxy;
 import org.geotools.http.HTTPResponse;
 import org.geotools.util.factory.GeoTools;
 import org.springframework.core.env.PropertyResolver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
 
 /**
  * Copy of GeoTools' {@link org.geotools.http.commons.MultithreadedHttpClient} due to its lack of
@@ -212,7 +214,9 @@ class SpringEnvironmentAwareGeoToolsHttpClient
         return response;
     }
 
-    /** @return the http status code of the execution */
+    /**
+     * @return the http status code of the execution
+     */
     private HttpMethodResponse executeMethod(HttpRequestBase method)
             throws IOException, HttpException {
 

--- a/starters/starter-catalog-backend/src/main/java/org/geotools/autoconfigure/httpclient/SpringEnvironmentAwareGeoToolsHttpClientFactory.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geotools/autoconfigure/httpclient/SpringEnvironmentAwareGeoToolsHttpClientFactory.java
@@ -4,14 +4,16 @@
  */
 package org.geotools.autoconfigure.httpclient;
 
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Setter;
+
 import org.geotools.http.AbstractHTTPClientFactory;
 import org.geotools.http.HTTPBehavior;
 import org.geotools.http.HTTPClient;
 import org.geotools.http.HTTPConnectionPooling;
 import org.geotools.http.LoggingHTTPClient;
+
+import java.util.List;
 
 /** */
 public class SpringEnvironmentAwareGeoToolsHttpClientFactory extends AbstractHTTPClientFactory {

--- a/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/test/backend/CatalogClientBackendAutoConfigurationTest.java
+++ b/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/test/backend/CatalogClientBackendAutoConfigurationTest.java
@@ -25,6 +25,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
 import reactivefeign.spring.config.ReactiveFeignAutoConfiguration;
 
 /**

--- a/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/test/backend/DataDirectoryAutoConfigurationTest.java
+++ b/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/test/backend/DataDirectoryAutoConfigurationTest.java
@@ -27,13 +27,12 @@ import org.springframework.boot.test.context.SpringBootTest;
  * {@code geoserver.backend.data-directory.enabled=true}
  */
 @SpringBootTest(
-    classes = AutoConfigurationTestConfiguration.class //
-    ,
-    properties = {
-        "geoserver.backend.dataDirectory.enabled=true",
-        "geoserver.backend.dataDirectory.location=/tmp/data_dir_autoconfiguration_test"
-    }
-)
+        classes = AutoConfigurationTestConfiguration.class //
+        ,
+        properties = {
+            "geoserver.backend.dataDirectory.enabled=true",
+            "geoserver.backend.dataDirectory.location=/tmp/data_dir_autoconfiguration_test"
+        })
 public class DataDirectoryAutoConfigurationTest extends GeoServerBackendConfigurerTest {
 
     private @Autowired GeoServerBackendProperties configProperties;

--- a/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/test/backend/JDBCConfigAutoConfigurationTest.java
+++ b/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/test/backend/JDBCConfigAutoConfigurationTest.java
@@ -33,9 +33,8 @@ import org.springframework.test.context.junit4.SpringRunner;
  * geoserver.backend.jdbcconfig.enabled=true}
  */
 @SpringBootTest(
-    classes = AutoConfigurationTestConfiguration.class,
-    properties = "geoserver.backend.jdbcconfig.enabled=true"
-)
+        classes = AutoConfigurationTestConfiguration.class,
+        properties = "geoserver.backend.jdbcconfig.enabled=true")
 @RunWith(SpringRunner.class)
 public class JDBCConfigAutoConfigurationTest extends JDBCConfigTest {
 

--- a/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/test/backend/JDBCConfigAutoConfigurationWebDisabledTest.java
+++ b/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/test/backend/JDBCConfigAutoConfigurationWebDisabledTest.java
@@ -18,12 +18,11 @@ import org.springframework.boot.test.context.SpringBootTest;
  * (default behavior)
  */
 @SpringBootTest(
-    classes = AutoConfigurationTestConfiguration.class,
-    properties = {
-        "geoserver.backend.jdbcconfig.enabled=true",
-        "geoserver.backend.jdbcconfig.web.enabled=false"
-    }
-)
+        classes = AutoConfigurationTestConfiguration.class,
+        properties = {
+            "geoserver.backend.jdbcconfig.enabled=true",
+            "geoserver.backend.jdbcconfig.web.enabled=false"
+        })
 public class JDBCConfigAutoConfigurationWebDisabledTest extends JDBCConfigTest {
 
     @Test(expected = NoSuchBeanDefinitionException.class)

--- a/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/test/backend/JDBCConfigAutoConfigurationWebEnabledTest.java
+++ b/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/test/backend/JDBCConfigAutoConfigurationWebEnabledTest.java
@@ -20,12 +20,11 @@ import org.springframework.test.context.ActiveProfiles;
  * geoserver.backend.jdbcconfig.enabled=true} and {@code geoserver.backend.jdbcconfig.web=true}
  */
 @SpringBootTest(
-    classes = AutoConfigurationTestConfiguration.class,
-    properties = {
-        "geoserver.backend.jdbcconfig.enabled=true",
-        "geoserver.backend.jdbcconfig.web.enabled=true"
-    }
-)
+        classes = AutoConfigurationTestConfiguration.class,
+        properties = {
+            "geoserver.backend.jdbcconfig.enabled=true",
+            "geoserver.backend.jdbcconfig.web.enabled=true"
+        })
 @ActiveProfiles("test")
 public class JDBCConfigAutoConfigurationWebEnabledTest extends JDBCConfigTest {
 

--- a/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/test/backend/JDBCConfigTest.java
+++ b/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/test/backend/JDBCConfigTest.java
@@ -5,10 +5,12 @@
 package org.geoserver.cloud.autoconfigure.test.backend;
 
 import com.zaxxer.hikari.HikariDataSource;
-import javax.sql.DataSource;
+
 import org.junit.After;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+
+import javax.sql.DataSource;
 
 /**
  * Closes the {@link DataSource} after each test run, otherwise, being an in-memory H2 db (as

--- a/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/test/security/GeoServerSecurityDisabledAutoConfigurationTest.java
+++ b/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/test/security/GeoServerSecurityDisabledAutoConfigurationTest.java
@@ -36,16 +36,14 @@ import org.springframework.test.context.junit4.SpringRunner;
  */
 @SpringBootTest(classes = AutoConfigurationTestConfiguration.class)
 @EnableAutoConfiguration(
-    exclude = {SecurityAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class}
-)
+        exclude = {SecurityAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class})
 @RunWith(SpringRunner.class)
 @ActiveProfiles("test")
 @TestPropertySource(
-    properties = {
-        "geoserver.backend.data-directory.enabled=true",
-        "geoserver.security.enabled=false"
-    }
-)
+        properties = {
+            "geoserver.backend.data-directory.enabled=true",
+            "geoserver.security.enabled=false"
+        })
 public class GeoServerSecurityDisabledAutoConfigurationTest {
 
     private @Autowired @Qualifier("rawCatalog") Catalog rawCatalog;

--- a/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/test/security/GeoServerSecurityEnabledAutoConfigurationTest.java
+++ b/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/test/security/GeoServerSecurityEnabledAutoConfigurationTest.java
@@ -31,16 +31,14 @@ import org.springframework.test.context.junit4.SpringRunner;
 /** Smoke test for {@link GeoServerSecurityEnabledAutoConfiguration} enabled */
 @SpringBootTest(classes = AutoConfigurationTestConfiguration.class)
 @EnableAutoConfiguration(
-    exclude = {SecurityAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class}
-)
+        exclude = {SecurityAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class})
 @RunWith(SpringRunner.class)
 @ActiveProfiles("test")
 @TestPropertySource(
-    properties = {
-        "geoserver.backend.data-directory.enabled=true",
-        "geoserver.security.enabled=true"
-    }
-)
+        properties = {
+            "geoserver.backend.data-directory.enabled=true",
+            "geoserver.security.enabled=true"
+        })
 public class GeoServerSecurityEnabledAutoConfigurationTest {
 
     private @Autowired @Qualifier("rawCatalog") Catalog rawCatalog;

--- a/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/testconfiguration/AutoConfigurationTestConfiguration.java
+++ b/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/testconfiguration/AutoConfigurationTestConfiguration.java
@@ -11,6 +11,5 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @EnableAutoConfiguration(
-    exclude = {SecurityAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class}
-)
+        exclude = {SecurityAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class})
 public class AutoConfigurationTestConfiguration {}

--- a/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/bus/incoming/caching/RemoteEventCacheEvictorTest.java
+++ b/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/bus/incoming/caching/RemoteEventCacheEvictorTest.java
@@ -14,9 +14,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.times;
 
-import java.util.Date;
-import java.util.function.Function;
-import javax.annotation.Nullable;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.CatalogTestData;
@@ -69,6 +66,11 @@ import org.springframework.cache.CacheManager;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.util.Date;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
 /**
  * Test {@link org.geoserver.cloud.bus.incoming.caching.RemoteEventCacheEvictor} functionality when
  * {@code geoserver.catalog.caching.enabled=true}.
@@ -78,20 +80,19 @@ import org.springframework.test.context.junit4.SpringRunner;
  * locally cached {@link Info} objects
  */
 @SpringBootTest(
-    classes = AutoConfigurationTestConfiguration.class,
-    properties = { //
-        "eureka.client.enabled=false",
-        "spring.cloud.bus.enabled=true",
-        "geoserver.catalog.caching.enabled=true",
-        "geoserver.bus.enabled=true",
-        // disable automatic publishing of remote events,
-        // we're publishing them directly in test cases
-        "geoserver.bus.send-events=false",
-        "geoserver.backend.data-directory.enabled=true",
-        "geoserver.backend.data-directory.location=/tmp/data_dir_autoconfiguration_test",
-        "logging.level.org.springframework.cache=DEBUG"
-    }
-)
+        classes = AutoConfigurationTestConfiguration.class,
+        properties = { //
+            "eureka.client.enabled=false",
+            "spring.cloud.bus.enabled=true",
+            "geoserver.catalog.caching.enabled=true",
+            "geoserver.bus.enabled=true",
+            // disable automatic publishing of remote events,
+            // we're publishing them directly in test cases
+            "geoserver.bus.send-events=false",
+            "geoserver.backend.data-directory.enabled=true",
+            "geoserver.backend.data-directory.location=/tmp/data_dir_autoconfiguration_test",
+            "logging.level.org.springframework.cache=DEBUG"
+        })
 @RunWith(SpringRunner.class)
 public class RemoteEventCacheEvictorTest {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/ConditionalOnAzureBlobstoreEnabled.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/ConditionalOnAzureBlobstoreEnabled.java
@@ -4,14 +4,15 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc;
 
+import org.geowebcache.azure.AzureBlobStoreConfigProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.geowebcache.azure.AzureBlobStoreConfigProvider;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 /**
  * Conditionals:
@@ -30,8 +31,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 @ConditionalOnGeoWebCacheEnabled
 @ConditionalOnClass(AzureBlobStoreConfigProvider.class)
 @ConditionalOnProperty(
-    name = GeoWebCacheConfigurationProperties.BLOBSTORE_AZURE_ENABLED,
-    havingValue = "true",
-    matchIfMissing = false
-)
+        name = GeoWebCacheConfigurationProperties.BLOBSTORE_AZURE_ENABLED,
+        havingValue = "true",
+        matchIfMissing = false)
 public @interface ConditionalOnAzureBlobstoreEnabled {}

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/ConditionalOnDiskQuotaEnabled.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/ConditionalOnDiskQuotaEnabled.java
@@ -4,14 +4,15 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc;
 
+import org.geowebcache.diskquota.DiskQuotaConfig;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.geowebcache.diskquota.DiskQuotaConfig;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 /**
  * Disk Quota conditional, disabled by default
@@ -24,8 +25,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 @ConditionalOnGeoWebCacheEnabled
 @ConditionalOnClass(DiskQuotaConfig.class) // i.e. gwc-diskquota.jar is in the classpath
 @ConditionalOnProperty(
-    name = GeoWebCacheConfigurationProperties.DISKQUOTA_ENABLED,
-    havingValue = "true",
-    matchIfMissing = false
-)
+        name = GeoWebCacheConfigurationProperties.DISKQUOTA_ENABLED,
+        havingValue = "true",
+        matchIfMissing = false)
 public @interface ConditionalOnDiskQuotaEnabled {}

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/ConditionalOnGeoServerWebUIEnabled.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/ConditionalOnGeoServerWebUIEnabled.java
@@ -4,14 +4,15 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc;
 
+import org.geoserver.gwc.web.GWCSettingsPage;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.geoserver.gwc.web.GWCSettingsPage;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 /**
  * Conditionals:
@@ -30,8 +31,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 @ConditionalOnGeoWebCacheEnabled
 @ConditionalOnClass(GWCSettingsPage.class)
 @ConditionalOnProperty(
-    name = GoServerWebUIConfigurationProperties.ENABLED,
-    havingValue = "true",
-    matchIfMissing = false
-)
+        name = GoServerWebUIConfigurationProperties.ENABLED,
+        havingValue = "true",
+        matchIfMissing = false)
 public @interface ConditionalOnGeoServerWebUIEnabled {}

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/ConditionalOnGeoWebCacheEnabled.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/ConditionalOnGeoWebCacheEnabled.java
@@ -4,22 +4,22 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc;
 
+import org.geoserver.gwc.GWC;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.geoserver.gwc.GWC;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Documented
 @ConditionalOnClass(GWC.class)
 @ConditionalOnProperty(
-    name = GeoWebCacheConfigurationProperties.ENABLED,
-    havingValue = "true",
-    matchIfMissing = true
-)
+        name = GeoWebCacheConfigurationProperties.ENABLED,
+        havingValue = "true",
+        matchIfMissing = true)
 public @interface ConditionalOnGeoWebCacheEnabled {}

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/ConditionalOnGeoWebCacheRestConfigEnabled.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/ConditionalOnGeoWebCacheRestConfigEnabled.java
@@ -4,13 +4,14 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
@@ -18,8 +19,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 @ConditionalOnGeoWebCacheEnabled
 @ConditionalOnClass(org.geowebcache.rest.controller.GWCController.class)
 @ConditionalOnProperty(
-    name = GeoWebCacheConfigurationProperties.RESTCONFIG_ENABLED,
-    havingValue = "true",
-    matchIfMissing = false
-)
+        name = GeoWebCacheConfigurationProperties.RESTCONFIG_ENABLED,
+        havingValue = "true",
+        matchIfMissing = false)
 public @interface ConditionalOnGeoWebCacheRestConfigEnabled {}

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/ConditionalOnS3BlobstoreEnabled.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/ConditionalOnS3BlobstoreEnabled.java
@@ -4,14 +4,15 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc;
 
+import org.geowebcache.s3.S3BlobStoreConfigProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.geowebcache.s3.S3BlobStoreConfigProvider;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 /**
  * Conditionals:
@@ -30,8 +31,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 @ConditionalOnGeoWebCacheEnabled
 @ConditionalOnClass(S3BlobStoreConfigProvider.class)
 @ConditionalOnProperty(
-    name = GeoWebCacheConfigurationProperties.BLOBSTORE_S3_ENABLED,
-    havingValue = "true",
-    matchIfMissing = false
-)
+        name = GeoWebCacheConfigurationProperties.BLOBSTORE_S3_ENABLED,
+        havingValue = "true",
+        matchIfMissing = false)
 public @interface ConditionalOnS3BlobstoreEnabled {}

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/ConditionalOnWebUIEnabled.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/ConditionalOnWebUIEnabled.java
@@ -4,12 +4,13 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 /**
  * Conditionals:
@@ -26,8 +27,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 @Documented
 @ConditionalOnGeoWebCacheEnabled
 @ConditionalOnProperty(
-    name = GeoWebCacheConfigurationProperties.WEBUI_ENABLED,
-    havingValue = "true",
-    matchIfMissing = false
-)
+        name = GeoWebCacheConfigurationProperties.WEBUI_ENABLED,
+        havingValue = "true",
+        matchIfMissing = false)
 public @interface ConditionalOnWebUIEnabled {}

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/GeoWebCacheConfigurationProperties.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/GeoWebCacheConfigurationProperties.java
@@ -4,10 +4,12 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc;
 
-import java.nio.file.Path;
 import lombok.Data;
+
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.nio.file.Path;
 
 /**
  * Configuration properties for GeoWebcache

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/GoServerWebUIConfigurationProperties.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/GoServerWebUIConfigurationProperties.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.autoconfigure.gwc;
 
 import lombok.Data;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/blobstore/AzureBlobstoreAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/blobstore/AzureBlobstoreAutoConfiguration.java
@@ -4,14 +4,16 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc.blobstore;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnAzureBlobstoreEnabled;
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoServerWebUIEnabled;
 import org.geoserver.gwc.web.blob.AzureBlobStoreType;
 import org.geowebcache.azure.AzureBlobStoreConfigProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
 
 /**
  * Original:

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/blobstore/S3BlobstoreAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/blobstore/S3BlobstoreAutoConfiguration.java
@@ -4,8 +4,8 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc.blobstore;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoServerWebUIEnabled;
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnS3BlobstoreEnabled;
 import org.geoserver.gwc.web.blob.S3BlobStoreType;
@@ -13,6 +13,8 @@ import org.geoserver.platform.ModuleStatusImpl;
 import org.geowebcache.s3.S3BlobStoreConfigProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
 
 /**
  * Original:

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/DiskQuotaAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/DiskQuotaAutoConfiguration.java
@@ -28,11 +28,10 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration(proxyBeanMethods = true)
 @Import(DisquotaRestAutoConfiguration.class)
 @ImportResource(
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = {
-        "jar:gs-gwc-.*!/geowebcache-diskquota-context.xml#name=^(?!DiskQuotaConfigLoader).*$"
-    }
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = {
+            "jar:gs-gwc-.*!/geowebcache-diskquota-context.xml#name=^(?!DiskQuotaConfigLoader).*$"
+        })
 public class DiskQuotaAutoConfiguration {
 
     static {

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/GeoServerIntegrationAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/GeoServerIntegrationAutoConfiguration.java
@@ -4,8 +4,8 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc.core;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoWebCacheEnabled;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
@@ -25,16 +25,19 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 import org.springframework.context.annotation.Primary;
 
-/** @since 1.0 */
+import javax.annotation.PostConstruct;
+
+/**
+ * @since 1.0
+ */
 @Configuration(proxyBeanMethods = true)
 @ConditionalOnGeoWebCacheEnabled
 @AutoConfigureAfter(GwcCoreAutoConfiguration.class)
 @ImportResource(
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = {
-        "jar:gs-gwc-.*!/geowebcache-geoserver-context.xml#name=^(?!GeoSeverTileLayerCatalog|gwcCatalogConfiguration).*$"
-    }
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = {
+            "jar:gs-gwc-.*!/geowebcache-geoserver-context.xml#name=^(?!GeoSeverTileLayerCatalog|gwcCatalogConfiguration).*$"
+        })
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.core")
 public class GeoServerIntegrationAutoConfiguration {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/GwcCoreAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/GwcCoreAutoConfiguration.java
@@ -6,20 +6,8 @@ package org.geoserver.cloud.autoconfigure.gwc.core;
 
 import static org.geowebcache.storage.DefaultStorageFinder.GWC_CACHE_DIR;
 
-import java.io.IOException;
-import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.function.Supplier;
-import javax.annotation.PostConstruct;
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoWebCacheEnabled;
 import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheConfigurationProperties;
 import org.geoserver.cloud.autoconfigure.gwc.integration.SeedingWMSAutoConfiguration;
@@ -49,17 +37,33 @@ import org.springframework.context.annotation.ImportResource;
 import org.springframework.core.env.Environment;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
-/** @since 1.0 */
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Supplier;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+/**
+ * @since 1.0
+ */
 @Configuration(proxyBeanMethods = true)
 @ConditionalOnGeoWebCacheEnabled
 @Import(DiskQuotaAutoConfiguration.class)
 @AutoConfigureAfter(SeedingWMSAutoConfiguration.class)
 @ImportResource(
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = {
-        "jar:gs-gwc-.*!/geowebcache-core-context.xml#name=^(?!gwcXmlConfig|gwcDefaultStorageFinder|gwcGeoServervConfigPersister|metastoreRemover).*$"
-    }
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = {
+            "jar:gs-gwc-.*!/geowebcache-core-context.xml#name=^(?!gwcXmlConfig|gwcDefaultStorageFinder|gwcGeoServervConfigPersister|metastoreRemover).*$"
+        })
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.core")
 public class GwcCoreAutoConfiguration {
 
@@ -215,7 +219,9 @@ public class GwcCoreAutoConfiguration {
         return new CloudDefaultStorageFinder(defaultCacheDirectory, environment);
     }
 
-    /** @param directory */
+    /**
+     * @param directory
+     */
     private void validateDirectory(Path directory, String configPropertyName) {
         if (!directory.isAbsolute()) {
             throw new BeanInitializationException(

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/LocalEventsAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/LocalEventsAutoConfiguration.java
@@ -4,14 +4,18 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc.integration;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoWebCacheEnabled;
 import org.geoserver.cloud.gwc.event.TileLayerEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/** @since 1.0 */
+import javax.annotation.PostConstruct;
+
+/**
+ * @since 1.0
+ */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnGeoWebCacheEnabled
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.integration")

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/RemoteEventsAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/RemoteEventsAutoConfiguration.java
@@ -4,11 +4,8 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc.integration;
 
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.autoconfigure.bus.ConditionalOnGeoServerRemoteEventsEnabled;
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoWebCacheEnabled;
 import org.geoserver.cloud.gwc.bus.GeoWebCacheRemoteEventsBroker;
@@ -22,7 +19,15 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/** @since 1.0 */
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * @since 1.0
+ */
 @Configuration(proxyBeanMethods = false)
 @AutoConfigureAfter(BusAutoConfiguration.class)
 @ConditionalOnGeoWebCacheEnabled

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/SeedingWMSAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/SeedingWMSAutoConfiguration.java
@@ -6,9 +6,8 @@ package org.geoserver.cloud.autoconfigure.gwc.integration;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.util.Map;
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -31,6 +30,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.ImportResource;
 
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+
 /**
  * Autoconfiguration to create a minimal {@link WebMapService} bean and its collaborators, to be
  * used by GeoWebCache for creating tile images.
@@ -40,13 +43,12 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration
 @ConditionalOnGeoWebCacheEnabled
 @ImportResource( //
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = { //
-        "jar:gs-wms-.*!/applicationContext.xml#name=^(?!getMapKvpReader).*$", //
-        "jar:gs-wfs-.*!/applicationContext.xml#name="
-                + SeedingWMSAutoConfiguration.WFS_BEANS_REGEX //
-    }
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = { //
+            "jar:gs-wms-.*!/applicationContext.xml#name=^(?!getMapKvpReader).*$", //
+            "jar:gs-wfs-.*!/applicationContext.xml#name="
+                    + SeedingWMSAutoConfiguration.WFS_BEANS_REGEX //
+        })
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.integration")
 public class SeedingWMSAutoConfiguration {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/WMTSIntegrationAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/WMTSIntegrationAutoConfiguration.java
@@ -4,8 +4,8 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc.integration;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoWebCacheEnabled;
 import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheConfigurationProperties;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
@@ -13,18 +13,20 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
-/** @since 1.0 */
+import javax.annotation.PostConstruct;
+
+/**
+ * @since 1.0
+ */
 @Configuration(proxyBeanMethods = true)
 @ConditionalOnGeoWebCacheEnabled
 @ConditionalOnProperty(
-    name = GeoWebCacheConfigurationProperties.SERVICE_WMTS_ENABLED,
-    havingValue = "true",
-    matchIfMissing = false
-)
+        name = GeoWebCacheConfigurationProperties.SERVICE_WMTS_ENABLED,
+        havingValue = "true",
+        matchIfMissing = false)
 @ImportResource(
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = {"jar:gs-gwc-.*!/geowebcache-geoserver-wmts-integration.xml"}
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = {"jar:gs-gwc-.*!/geowebcache-geoserver-wmts-integration.xml"})
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.integration")
 public class WMTSIntegrationAutoConfiguration {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/GoogleMapsAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/GoogleMapsAutoConfiguration.java
@@ -4,8 +4,8 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc.service;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheConfigurationProperties;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.gwc.web.gmaps.GoogleMapsController;
@@ -14,18 +14,20 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
-/** @since 1.0 */
+import javax.annotation.PostConstruct;
+
+/**
+ * @since 1.0
+ */
 @Configuration
 @ConditionalOnProperty(
-    name = GeoWebCacheConfigurationProperties.SERVICE_GMAPS_ENABLED,
-    havingValue = "true",
-    matchIfMissing = false
-)
+        name = GeoWebCacheConfigurationProperties.SERVICE_GMAPS_ENABLED,
+        havingValue = "true",
+        matchIfMissing = false)
 @ComponentScan(basePackageClasses = GoogleMapsController.class)
 @ImportResource(
-    reader = FilteringXmlBeanDefinitionReader.class,
-    locations = "jar:gs-gwc-.*!/geowebcache-gmaps-context.xml#name=gwcServiceGMapsTarget"
-)
+        reader = FilteringXmlBeanDefinitionReader.class,
+        locations = "jar:gs-gwc-.*!/geowebcache-gmaps-context.xml#name=gwcServiceGMapsTarget")
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.service")
 public class GoogleMapsAutoConfiguration {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/KMLAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/KMLAutoConfiguration.java
@@ -4,8 +4,8 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc.service;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheConfigurationProperties;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.gwc.web.kml.KMLController;
@@ -14,18 +14,20 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
-/** @since 1.0 */
+import javax.annotation.PostConstruct;
+
+/**
+ * @since 1.0
+ */
 @Configuration
 @ConditionalOnProperty(
-    name = GeoWebCacheConfigurationProperties.SERVICE_KML_ENABLED,
-    havingValue = "true",
-    matchIfMissing = false
-)
+        name = GeoWebCacheConfigurationProperties.SERVICE_KML_ENABLED,
+        havingValue = "true",
+        matchIfMissing = false)
 @ComponentScan(basePackageClasses = KMLController.class)
 @ImportResource(
-    reader = FilteringXmlBeanDefinitionReader.class,
-    locations = "jar:gs-gwc-.*!/geowebcache-kmlservice-context.xml#name=gwcServiceKMLTarget"
-)
+        reader = FilteringXmlBeanDefinitionReader.class,
+        locations = "jar:gs-gwc-.*!/geowebcache-kmlservice-context.xml#name=gwcServiceKMLTarget")
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.service")
 public class KMLAutoConfiguration {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/MGMapsAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/MGMapsAutoConfiguration.java
@@ -4,8 +4,8 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc.service;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheConfigurationProperties;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.gwc.web.mgmaps.MGMapsController;
@@ -14,18 +14,20 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
-/** @since 1.0 */
+import javax.annotation.PostConstruct;
+
+/**
+ * @since 1.0
+ */
 @Configuration
 @ConditionalOnProperty(
-    name = GeoWebCacheConfigurationProperties.SERVICE_MGMAPS_ENABLED,
-    havingValue = "true",
-    matchIfMissing = false
-)
+        name = GeoWebCacheConfigurationProperties.SERVICE_MGMAPS_ENABLED,
+        havingValue = "true",
+        matchIfMissing = false)
 @ComponentScan(basePackageClasses = MGMapsController.class)
 @ImportResource(
-    reader = FilteringXmlBeanDefinitionReader.class,
-    locations = "jar:gs-gwc-.*!/geowebcache-gmaps-context.xml#name=gwcServiceMGMapsTarget"
-)
+        reader = FilteringXmlBeanDefinitionReader.class,
+        locations = "jar:gs-gwc-.*!/geowebcache-gmaps-context.xml#name=gwcServiceMGMapsTarget")
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.service")
 public class MGMapsAutoConfiguration {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/RESTConfigAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/RESTConfigAutoConfiguration.java
@@ -4,13 +4,15 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc.service;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoWebCacheRestConfigEnabled;
 import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheConfigurationProperties;
 import org.geoserver.cloud.autoconfigure.gwc.core.DiskQuotaAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
 
 /**
  * The original {@literal geowebcache-rest-context.xml}:

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/TileMapServiceAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/TileMapServiceAutoConfiguration.java
@@ -4,8 +4,8 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc.service;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheConfigurationProperties;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.gwc.web.tms.TMSController;
@@ -14,19 +14,21 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
-/** @since 1.0 */
+import javax.annotation.PostConstruct;
+
+/**
+ * @since 1.0
+ */
 @Configuration
 @ConditionalOnProperty(
-    name = GeoWebCacheConfigurationProperties.SERVICE_TMS_ENABLED,
-    havingValue = "true",
-    matchIfMissing = false
-)
+        name = GeoWebCacheConfigurationProperties.SERVICE_TMS_ENABLED,
+        havingValue = "true",
+        matchIfMissing = false)
 @ComponentScan(basePackageClasses = TMSController.class)
 @ImportResource(
-    reader = FilteringXmlBeanDefinitionReader.class,
-    // locations = "jar:gs-gwc-.*!/geowebcache-tmsservice-context.xml#name=gwcServiceTMSTarget"
-    locations = "jar:gs-gwc-.*!/geowebcache-tmsservice-context.xml"
-)
+        reader = FilteringXmlBeanDefinitionReader.class,
+        // locations = "jar:gs-gwc-.*!/geowebcache-tmsservice-context.xml#name=gwcServiceTMSTarget"
+        locations = "jar:gs-gwc-.*!/geowebcache-tmsservice-context.xml")
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.service")
 public class TileMapServiceAutoConfiguration {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/WebMapServiceAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/WebMapServiceAutoConfiguration.java
@@ -4,8 +4,8 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc.service;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheConfigurationProperties;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.gwc.web.wms.WMSController;
@@ -14,18 +14,20 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
-/** @since 1.0 */
+import javax.annotation.PostConstruct;
+
+/**
+ * @since 1.0
+ */
 @Configuration
 @ConditionalOnProperty(
-    name = GeoWebCacheConfigurationProperties.SERVICE_WMS_ENABLED,
-    havingValue = "true",
-    matchIfMissing = false
-)
+        name = GeoWebCacheConfigurationProperties.SERVICE_WMS_ENABLED,
+        havingValue = "true",
+        matchIfMissing = false)
 @ComponentScan(basePackageClasses = WMSController.class)
 @ImportResource(
-    reader = FilteringXmlBeanDefinitionReader.class,
-    locations = "jar:gs-gwc-.*!/geowebcache-wmsservice-context.xml"
-)
+        reader = FilteringXmlBeanDefinitionReader.class,
+        locations = "jar:gs-gwc-.*!/geowebcache-wmsservice-context.xml")
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.service")
 public class WebMapServiceAutoConfiguration {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/WebMapTileServiceAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/WebMapTileServiceAutoConfiguration.java
@@ -4,8 +4,8 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc.service;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheConfigurationProperties;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.gwc.web.wmts.WMTSController;
@@ -14,18 +14,20 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
-/** @since 1.0 */
+import javax.annotation.PostConstruct;
+
+/**
+ * @since 1.0
+ */
 @Configuration
 @ConditionalOnProperty(
-    name = GeoWebCacheConfigurationProperties.SERVICE_WMTS_ENABLED,
-    havingValue = "true",
-    matchIfMissing = false
-)
+        name = GeoWebCacheConfigurationProperties.SERVICE_WMTS_ENABLED,
+        havingValue = "true",
+        matchIfMissing = false)
 @ComponentScan(basePackageClasses = WMTSController.class)
 @ImportResource(
-    reader = FilteringXmlBeanDefinitionReader.class,
-    locations = "jar:gs-gwc-.*!/geowebcache-wmtsservice-context.xml"
-)
+        reader = FilteringXmlBeanDefinitionReader.class,
+        locations = "jar:gs-gwc-.*!/geowebcache-wmtsservice-context.xml")
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.service")
 public class WebMapTileServiceAutoConfiguration {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/web/gwc/GeoServerWebUIAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/web/gwc/GeoServerWebUIAutoConfiguration.java
@@ -4,12 +4,10 @@
  */
 package org.geoserver.cloud.autoconfigure.web.gwc;
 
-import java.util.ArrayList;
-import java.util.List;
-import javax.annotation.PostConstruct;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.apache.wicket.Component;
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoServerWebUIEnabled;
 import org.geoserver.cloud.autoconfigure.gwc.GoServerWebUIConfigurationProperties;
@@ -29,6 +27,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+
 /**
  * Auto configuration to enabled GWC Wicket Web UI components.
  *
@@ -46,13 +49,12 @@ import org.springframework.context.annotation.ImportResource;
 @ConditionalOnGeoServerWebUIEnabled
 @EnableConfigurationProperties(GoServerWebUIConfigurationProperties.class)
 @ImportResource( //
-    reader = FilteringXmlBeanDefinitionReader.class,
-    locations = {
-        "jar:gs-web-gwc-.*!/applicationContext.xml#name=^(?!"
-                + GeoServerWebUIAutoConfiguration.EXCLUDED_BEANS
-                + ").*$"
-    }
-)
+        reader = FilteringXmlBeanDefinitionReader.class,
+        locations = {
+            "jar:gs-web-gwc-.*!/applicationContext.xml#name=^(?!"
+                    + GeoServerWebUIAutoConfiguration.EXCLUDED_BEANS
+                    + ").*$"
+        })
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.web.gwc")
 public class GeoServerWebUIAutoConfiguration {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/web/gwc/GeoWebCacheUIAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/web/gwc/GeoWebCacheUIAutoConfiguration.java
@@ -4,8 +4,8 @@
  */
 package org.geoserver.cloud.autoconfigure.web.gwc;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoWebCacheRestConfigEnabled;
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnWebUIEnabled;
 import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheConfigurationProperties;
@@ -14,6 +14,8 @@ import org.gwc.web.rest.GeoWebCacheController;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
 
 @Configuration
 @ConditionalOnWebUIEnabled

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/bus/GeoWebCacheRemoteEventsBroker.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/bus/GeoWebCacheRemoteEventsBroker.java
@@ -4,18 +4,20 @@
  */
 package org.geoserver.cloud.gwc.bus;
 
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Supplier;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.catalog.CatalogException;
 import org.geoserver.cloud.gwc.event.GeoWebCacheEvent;
 import org.mapstruct.factory.Mappers;
 import org.springframework.cloud.bus.event.RemoteApplicationEvent;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.event.EventListener;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Listens to local {@link GeoWebCacheEvent}s produced by this service instance and broadcasts them

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/bus/RemoteBlobStoreEvent.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/bus/RemoteBlobStoreEvent.java
@@ -9,7 +9,9 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
 
-/** @since 1.0 */
+/**
+ * @since 1.0
+ */
 @NoArgsConstructor
 public class RemoteBlobStoreEvent extends RemoteGeoWebCacheEvent {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/bus/RemoteEventMapper.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/bus/RemoteEventMapper.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.gwc.bus;
 
 import lombok.NonNull;
+
 import org.geoserver.cloud.gwc.event.BlobStoreEvent;
 import org.geoserver.cloud.gwc.event.GeoWebCacheEvent;
 import org.geoserver.cloud.gwc.event.GridsetEvent;
@@ -14,7 +15,9 @@ import org.mapstruct.Mapper;
 import org.mapstruct.ObjectFactory;
 import org.mapstruct.ReportingPolicy;
 
-/** @since 1.0 */
+/**
+ * @since 1.0
+ */
 @Mapper(componentModel = "default", unmappedTargetPolicy = ReportingPolicy.ERROR)
 interface RemoteEventMapper {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/bus/RemoteGeoWebCacheEvent.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/bus/RemoteGeoWebCacheEvent.java
@@ -8,10 +8,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+
 import org.springframework.cloud.bus.event.Destination;
 import org.springframework.cloud.bus.event.RemoteApplicationEvent;
 
-/** @since 1.0 */
+/**
+ * @since 1.0
+ */
 @NoArgsConstructor
 public abstract class RemoteGeoWebCacheEvent extends RemoteApplicationEvent {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/bus/RemoteGridsetEvent.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/bus/RemoteGridsetEvent.java
@@ -9,7 +9,9 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
 
-/** @since 1.0 */
+/**
+ * @since 1.0
+ */
 @NoArgsConstructor
 public class RemoteGridsetEvent extends RemoteGeoWebCacheEvent {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/bus/RemoteTileLayerEvent.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/bus/RemoteTileLayerEvent.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+
 import org.geoserver.gwc.layer.TileLayerCatalogListener;
 import org.springframework.context.ApplicationContext;
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/event/BlobStoreEvent.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/event/BlobStoreEvent.java
@@ -8,7 +8,9 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 
-/** @since 1.0 */
+/**
+ * @since 1.0
+ */
 public class BlobStoreEvent extends GeoWebCacheEvent {
     private static final long serialVersionUID = 1L;
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/event/GeoWebCacheEvent.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/event/GeoWebCacheEvent.java
@@ -6,6 +6,7 @@ package org.geoserver.cloud.gwc.event;
 
 import lombok.Getter;
 import lombok.Setter;
+
 import org.geoserver.gwc.layer.TileLayerCatalogListener;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEvent;

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/event/GridsetEvent.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/event/GridsetEvent.java
@@ -8,7 +8,9 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 
-/** @since 1.0 */
+/**
+ * @since 1.0
+ */
 public class GridsetEvent extends GeoWebCacheEvent {
     private static final long serialVersionUID = 1L;
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/event/TileLayerEvent.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/event/TileLayerEvent.java
@@ -7,6 +7,7 @@ package org.geoserver.cloud.gwc.event;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+
 import org.geoserver.gwc.layer.TileLayerCatalogListener;
 import org.springframework.context.ApplicationContext;
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/event/TileLayerEventPublisher.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/event/TileLayerEventPublisher.java
@@ -5,11 +5,12 @@
 package org.geoserver.cloud.gwc.event;
 
 import com.google.common.annotations.VisibleForTesting;
-import javax.annotation.PostConstruct;
+
 import lombok.AccessLevel;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+
 import org.geoserver.gwc.layer.TileLayerCatalog;
 import org.geoserver.gwc.layer.TileLayerCatalogListener;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +18,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
+
+import javax.annotation.PostConstruct;
 
 /**
  * Adapts the listener pattern used by {@link TileLayerCatalog#addListener} and {@link

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/CachingTileLayerCatalog.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/CachingTileLayerCatalog.java
@@ -4,13 +4,9 @@
  */
 package org.geoserver.cloud.gwc.repository;
 
-import java.util.HashSet;
-import java.util.NoSuchElementException;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+
 import org.geoserver.cloud.gwc.event.TileLayerEvent;
 import org.geoserver.gwc.layer.GeoServerTileLayerInfo;
 import org.geoserver.gwc.layer.TileLayerCatalog;
@@ -20,7 +16,15 @@ import org.springframework.cache.Cache.ValueRetrievalException;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.event.EventListener;
 
-/** @since 1.0 */
+import java.util.HashSet;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * @since 1.0
+ */
 @RequiredArgsConstructor
 public class CachingTileLayerCatalog implements TileLayerCatalog {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/CloudCatalogConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/CloudCatalogConfiguration.java
@@ -5,7 +5,9 @@
 package org.geoserver.cloud.gwc.repository;
 
 import com.google.common.cache.LoadingCache;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.cloud.gwc.event.TileLayerEvent;
@@ -15,7 +17,9 @@ import org.geoserver.gwc.layer.TileLayerCatalog;
 import org.geowebcache.grid.GridSetBroker;
 import org.springframework.context.event.EventListener;
 
-/** @since 1.0 */
+/**
+ * @since 1.0
+ */
 @Slf4j(topic = "org.geoserver.cloud.gwc.repository")
 public class CloudCatalogConfiguration extends CatalogConfiguration {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/CloudDefaultStorageFinder.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/CloudDefaultStorageFinder.java
@@ -4,14 +4,17 @@
  */
 package org.geoserver.cloud.gwc.repository;
 
-import java.nio.file.Path;
 import org.geowebcache.config.ConfigurationException;
 import org.geowebcache.storage.DefaultStorageFinder;
 import org.geowebcache.util.ApplicationContextProvider;
 import org.springframework.core.env.Environment;
 import org.springframework.web.context.WebApplicationContext;
 
-/** @since 1.0 */
+import java.nio.file.Path;
+
+/**
+ * @since 1.0
+ */
 public class CloudDefaultStorageFinder extends DefaultStorageFinder {
 
     private Environment environment;

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/CloudGwcXmlConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/CloudGwcXmlConfiguration.java
@@ -9,17 +9,10 @@ import static org.geoserver.cloud.gwc.event.GeoWebCacheEvent.Type.DELETED;
 import static org.geoserver.cloud.gwc.event.GeoWebCacheEvent.Type.MODIFIED;
 
 import com.google.common.base.Supplier;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.function.Consumer;
+
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.geoserver.cloud.gwc.event.BlobStoreEvent;
 import org.geoserver.cloud.gwc.event.GeoWebCacheEvent;
@@ -36,6 +29,16 @@ import org.geowebcache.layer.TileLayer;
 import org.geowebcache.locks.LockProvider;
 import org.geowebcache.util.ApplicationContextProvider;
 import org.springframework.context.event.EventListener;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
 
 /**
  * @implNote there is a {@link BlobStoreConfigurationListener} abstraction, but no homologous one to

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/CloudXMLResourceProvider.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/CloudXMLResourceProvider.java
@@ -4,6 +4,16 @@
  */
 package org.geoserver.cloud.gwc.repository;
 
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.ResourceStore;
+import org.geoserver.platform.resource.Resources;
+import org.geoserver.util.IOUtils;
+import org.geowebcache.config.ConfigurationException;
+import org.geowebcache.config.ConfigurationResourceProvider;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -13,16 +23,10 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
-import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
-import org.geoserver.platform.resource.Resource;
-import org.geoserver.platform.resource.ResourceStore;
-import org.geoserver.platform.resource.Resources;
-import org.geoserver.util.IOUtils;
-import org.geowebcache.config.ConfigurationException;
-import org.geowebcache.config.ConfigurationResourceProvider;
 
-/** @since 1.0 */
+/**
+ * @since 1.0
+ */
 @Slf4j(topic = "org.geoserver.cloud.gwc.repository")
 public class CloudXMLResourceProvider implements ConfigurationResourceProvider {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/ResourceStoreTileLayerCatalog.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/ResourceStoreTileLayerCatalog.java
@@ -7,6 +7,28 @@ package org.geoserver.cloud.gwc.repository;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Streams;
 import com.thoughtworks.xstream.XStream;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.configuration.DefaultConfigurationBuilder.XMLConfigurationProvider;
+import org.geoserver.config.util.SecureXStream;
+import org.geoserver.gwc.layer.GeoServerTileLayerInfo;
+import org.geoserver.gwc.layer.TileLayerCatalog;
+import org.geoserver.gwc.layer.TileLayerCatalogListener;
+import org.geoserver.gwc.layer.TileLayerCatalogListener.Type;
+import org.geoserver.platform.resource.FileSystemResourceStore;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.ResourceStore;
+import org.geoserver.platform.resource.Resources;
+import org.geoserver.util.DimensionWarning;
+import org.geowebcache.config.ContextualConfigurationProvider.Context;
+import org.geowebcache.config.XMLConfiguration;
+import org.geowebcache.storage.blobstore.file.FilePathUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.context.WebApplicationContext;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -31,27 +53,10 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.configuration.DefaultConfigurationBuilder.XMLConfigurationProvider;
-import org.geoserver.config.util.SecureXStream;
-import org.geoserver.gwc.layer.GeoServerTileLayerInfo;
-import org.geoserver.gwc.layer.TileLayerCatalog;
-import org.geoserver.gwc.layer.TileLayerCatalogListener;
-import org.geoserver.gwc.layer.TileLayerCatalogListener.Type;
-import org.geoserver.platform.resource.FileSystemResourceStore;
-import org.geoserver.platform.resource.Resource;
-import org.geoserver.platform.resource.ResourceStore;
-import org.geoserver.platform.resource.Resources;
-import org.geoserver.util.DimensionWarning;
-import org.geowebcache.config.ContextualConfigurationProvider.Context;
-import org.geowebcache.config.XMLConfiguration;
-import org.geowebcache.storage.blobstore.file.FilePathUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.context.WebApplicationContext;
 
-/** @since 1.0 */
+/**
+ * @since 1.0
+ */
 @Slf4j(topic = "org.geoserver.cloud.gwc.repository")
 @RequiredArgsConstructor
 public class ResourceStoreTileLayerCatalog implements TileLayerCatalog {

--- a/starters/starter-gwc/src/main/java/org/gwc/web/gmaps/GoogleMapsController.java
+++ b/starters/starter-gwc/src/main/java/org/gwc/web/gmaps/GoogleMapsController.java
@@ -4,13 +4,14 @@
  */
 package org.gwc.web.gmaps;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.geoserver.ows.Dispatcher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 @Controller
 @RequestMapping("/gwc/service/gmaps")

--- a/starters/starter-gwc/src/main/java/org/gwc/web/kml/KMLController.java
+++ b/starters/starter-gwc/src/main/java/org/gwc/web/kml/KMLController.java
@@ -4,13 +4,14 @@
  */
 package org.gwc.web.kml;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.geoserver.ows.Dispatcher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 @Controller
 @RequestMapping("/gwc/service/kml")

--- a/starters/starter-gwc/src/main/java/org/gwc/web/mgmaps/MGMapsController.java
+++ b/starters/starter-gwc/src/main/java/org/gwc/web/mgmaps/MGMapsController.java
@@ -4,13 +4,14 @@
  */
 package org.gwc.web.mgmaps;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.geoserver.ows.Dispatcher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 @Controller
 @RequestMapping("/gwc/service/mgmaps")

--- a/starters/starter-gwc/src/main/java/org/gwc/web/rest/GeoWebCacheController.java
+++ b/starters/starter-gwc/src/main/java/org/gwc/web/rest/GeoWebCacheController.java
@@ -4,14 +4,15 @@
  */
 package org.gwc.web.rest;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.geoserver.gwc.dispatch.GeoServerGWCDispatcherController;
 import org.geowebcache.GeoWebCacheDispatcher;
 import org.geowebcache.controller.GeoWebCacheDispatcherController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * Modified top-level dispatcher controller for use by GeoServer. Same as {@link
@@ -27,13 +28,12 @@ public class GeoWebCacheController {
     private @Autowired GeoWebCacheDispatcher gwcDispatcher;
 
     @RequestMapping(
-        path = {
-            "",
-            "/home",
-            "/demo/**",
-            "/proxy/**",
-        }
-    )
+            path = {
+                "",
+                "/home",
+                "/demo/**",
+                "/proxy/**",
+            })
     public void handle(HttpServletRequest request, HttpServletResponse response) throws Exception {
         gwcDispatcher.handleRequest(request, response);
     }

--- a/starters/starter-gwc/src/main/java/org/gwc/web/tms/TMSController.java
+++ b/starters/starter-gwc/src/main/java/org/gwc/web/tms/TMSController.java
@@ -4,13 +4,14 @@
  */
 package org.gwc.web.tms;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.geoserver.ows.Dispatcher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 @Controller
 @RequestMapping("/gwc/service/tms")

--- a/starters/starter-gwc/src/main/java/org/gwc/web/wms/WMSController.java
+++ b/starters/starter-gwc/src/main/java/org/gwc/web/wms/WMSController.java
@@ -4,13 +4,14 @@
  */
 package org.gwc.web.wms;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.geoserver.ows.Dispatcher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 @Controller
 @RequestMapping("/gwc/service/wms")

--- a/starters/starter-gwc/src/main/java/org/gwc/web/wmts/WMTSController.java
+++ b/starters/starter-gwc/src/main/java/org/gwc/web/wmts/WMTSController.java
@@ -4,13 +4,14 @@
  */
 package org.gwc.web.wmts;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.geoserver.ows.Dispatcher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 @Controller
 @RequestMapping("/gwc/service/wmts")

--- a/starters/starter-gwc/src/test/java/org/geoserver/cloud/autoconfigure/gwc/GeoWebCacheContextRunner.java
+++ b/starters/starter-gwc/src/test/java/org/geoserver/cloud/autoconfigure/gwc/GeoWebCacheContextRunner.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc;
 
-import java.io.File;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.plugin.CatalogPlugin;
 import org.geoserver.cloud.autoconfigure.gwc.core.GeoWebCacheAutoConfiguration;
@@ -21,7 +20,11 @@ import org.geoserver.security.GeoServerSecurityManager;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 
-/** @since 1.0 */
+import java.io.File;
+
+/**
+ * @since 1.0
+ */
 public class GeoWebCacheContextRunner {
 
     public static WebApplicationContextRunner newMinimalGeoWebCacheContextRunner(File tmpDir) {

--- a/starters/starter-gwc/src/test/java/org/geoserver/cloud/autoconfigure/gwc/blobstore/AzureBlobstoreAutoConfigurationTest.java
+++ b/starters/starter-gwc/src/test/java/org/geoserver/cloud/autoconfigure/gwc/blobstore/AzureBlobstoreAutoConfigurationTest.java
@@ -7,7 +7,6 @@ package org.geoserver.cloud.autoconfigure.gwc.blobstore;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheContextRunner;
 import org.geoserver.gwc.web.blob.AzureBlobStoreType;
 import org.geowebcache.azure.AzureBlobStoreConfigProvider;
@@ -16,6 +15,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+
+import java.io.File;
 
 /**
  * {@link AzureBlobstoreAutoConfiguration} tests

--- a/starters/starter-gwc/src/test/java/org/geoserver/cloud/autoconfigure/gwc/blobstore/S3BlobstoreAutoConfigurationTest.java
+++ b/starters/starter-gwc/src/test/java/org/geoserver/cloud/autoconfigure/gwc/blobstore/S3BlobstoreAutoConfigurationTest.java
@@ -7,7 +7,6 @@ package org.geoserver.cloud.autoconfigure.gwc.blobstore;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheContextRunner;
 import org.geoserver.gwc.web.blob.S3BlobStoreType;
 import org.geoserver.platform.ModuleStatusImpl;
@@ -17,6 +16,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+
+import java.io.File;
 
 /**
  * {@link S3BlobstoreAutoConfiguration} tests

--- a/starters/starter-gwc/src/test/java/org/geoserver/cloud/autoconfigure/gwc/core/GwcCoreAutoConfigurationTest.java
+++ b/starters/starter-gwc/src/test/java/org/geoserver/cloud/autoconfigure/gwc/core/GwcCoreAutoConfigurationTest.java
@@ -11,8 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Throwables;
-import java.io.File;
-import java.io.IOException;
+
 import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheContextRunner;
 import org.geoserver.cloud.gwc.repository.CloudDefaultStorageFinder;
 import org.geoserver.cloud.gwc.repository.CloudGwcXmlConfiguration;
@@ -24,13 +23,20 @@ import org.springframework.beans.InvalidPropertyException;
 import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 
-/** @since 1.0 */
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * @since 1.0
+ */
 class GwcCoreAutoConfigurationTest {
 
     @TempDir File tmpDir;
     WebApplicationContextRunner runner;
 
-    /** @throws java.lang.Exception */
+    /**
+     * @throws java.lang.Exception
+     */
     @BeforeEach
     void setUp() throws Exception {
         runner = GeoWebCacheContextRunner.newMinimalGeoWebCacheContextRunner(tmpDir);

--- a/starters/starter-gwc/src/test/java/org/geoserver/cloud/gwc/repository/CloudGwcXmlConfigurationTest.java
+++ b/starters/starter-gwc/src/test/java/org/geoserver/cloud/gwc/repository/CloudGwcXmlConfigurationTest.java
@@ -17,11 +17,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
 import org.geoserver.cloud.gwc.event.BlobStoreEvent;
 import org.geoserver.cloud.gwc.event.GeoWebCacheEvent;
 import org.geoserver.cloud.gwc.event.GridsetEvent;
@@ -40,7 +35,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-/** @since 1.0 */
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * @since 1.0
+ */
 class CloudGwcXmlConfigurationTest {
 
     private CloudGwcXmlConfiguration config;

--- a/starters/starter-gwc/src/test/java/org/geoserver/cloud/gwc/repository/ResourceStoreTileLayerCatalogTest.java
+++ b/starters/starter-gwc/src/test/java/org/geoserver/cloud/gwc/repository/ResourceStoreTileLayerCatalogTest.java
@@ -12,14 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableSet;
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.apache.commons.io.FileUtils;
 import org.geoserver.catalog.impl.ModificationProxy;
 import org.geoserver.gwc.layer.GeoServerTileLayerInfo;
@@ -32,7 +25,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-/** @since 1.0 */
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @since 1.0
+ */
 class ResourceStoreTileLayerCatalogTest {
 
     private @TempDir File baseDirectory;

--- a/starters/starter-jackson/src/main/java/org/geoserver/cloud/autoconfigure/jackson/GeoServerJacksonBindingsAutoConfiguration.java
+++ b/starters/starter-jackson/src/main/java/org/geoserver/cloud/autoconfigure/jackson/GeoServerJacksonBindingsAutoConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.autoconfigure.jackson;
 
 import com.fasterxml.jackson.databind.Module;
+
 import org.geoserver.jackson.databind.catalog.GeoServerCatalogModule;
 import org.geoserver.jackson.databind.config.GeoServerConfigModule;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;

--- a/starters/starter-jackson/src/main/java/org/geoserver/cloud/autoconfigure/jackson/GeoToolsJacksonBindingsAutoConfiguration.java
+++ b/starters/starter-jackson/src/main/java/org/geoserver/cloud/autoconfigure/jackson/GeoToolsJacksonBindingsAutoConfiguration.java
@@ -6,6 +6,7 @@ package org.geoserver.cloud.autoconfigure.jackson;
 
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
 import org.geotools.jackson.databind.filter.GeoToolsFilterModule;
 import org.geotools.jackson.databind.geojson.GeoToolsGeoJsonModule;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;

--- a/starters/starter-jackson/src/test/java/org/geoserver/cloud/autoconfigure/jackson/GeoServerJacksonBindingsAutoConfigurationTest.java
+++ b/starters/starter-jackson/src/test/java/org/geoserver/cloud/autoconfigure/jackson/GeoServerJacksonBindingsAutoConfigurationTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.HamcrestCondition.matching;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Set;
+
 import org.assertj.core.api.Condition;
 import org.geoserver.jackson.databind.catalog.GeoServerCatalogModule;
 import org.geoserver.jackson.databind.config.GeoServerConfigModule;
@@ -17,6 +17,8 @@ import org.junit.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.util.Set;
 
 public class GeoServerJacksonBindingsAutoConfigurationTest {
 

--- a/starters/starter-jackson/src/test/java/org/geoserver/cloud/autoconfigure/jackson/GeoToolsJacksonBindingsAutoConfigurationTest.java
+++ b/starters/starter-jackson/src/test/java/org/geoserver/cloud/autoconfigure/jackson/GeoToolsJacksonBindingsAutoConfigurationTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.HamcrestCondition.matching;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import java.util.Set;
+
 import org.assertj.core.api.Condition;
 import org.geotools.jackson.databind.filter.GeoToolsFilterModule;
 import org.geotools.jackson.databind.geojson.GeoToolsGeoJsonModule;
@@ -19,6 +19,8 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.util.Set;
 
 public class GeoToolsJacksonBindingsAutoConfigurationTest {
 

--- a/starters/starter-reactive/src/test/java/org/geoserver/cloud/test/TestConfiguration.java
+++ b/starters/starter-reactive/src/test/java/org/geoserver/cloud/test/TestConfiguration.java
@@ -16,13 +16,12 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 @EnableAutoConfiguration(
-    exclude = {
-        ReactiveSecurityAutoConfiguration.class,
-        ReactiveManagementWebSecurityAutoConfiguration.class,
-        ReactiveUserDetailsServiceAutoConfiguration.class,
-        LoadBalancerBeanPostProcessorAutoConfiguration.class
-    }
-)
+        exclude = {
+            ReactiveSecurityAutoConfiguration.class,
+            ReactiveManagementWebSecurityAutoConfiguration.class,
+            ReactiveUserDetailsServiceAutoConfiguration.class,
+            LoadBalancerBeanPostProcessorAutoConfiguration.class
+        })
 public class TestConfiguration {
 
     @Bean

--- a/starters/starter-security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/AuthKeyAutoConfiguration.java
+++ b/starters/starter-security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/AuthKeyAutoConfiguration.java
@@ -4,8 +4,8 @@
  */
 package org.geoserver.cloud.autoconfigure.authzn;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.geoserver.platform.ModuleStatus;
 import org.geoserver.platform.ModuleStatusImpl;
@@ -17,7 +17,11 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportResource;
 
-/** @since 1.0 */
+import javax.annotation.PostConstruct;
+
+/**
+ * @since 1.0
+ */
 @Configuration(proxyBeanMethods = false)
 @Import({AuthKeyAutoConfiguration.Enabled.class, AuthKeyAutoConfiguration.WebUI.class})
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.authzn")
@@ -53,9 +57,8 @@ public class AuthKeyAutoConfiguration {
 
     @ConditionalOnAuthKeyEnabled
     @ImportResource(
-        reader = FilteringXmlBeanDefinitionReader.class,
-        locations = {Enabled.INCLUDE}
-    )
+            reader = FilteringXmlBeanDefinitionReader.class,
+            locations = {Enabled.INCLUDE})
     static @Configuration class Enabled {
         static final String EXCLUDE = "authKeyExtension|" + WEB_UI_BEANS;
         static final String INCLUDE =
@@ -69,9 +72,8 @@ public class AuthKeyAutoConfiguration {
     @ConditionalOnAuthKeyEnabled
     @ConditionalOnClass(AuthenticationFilterPanel.class)
     @ImportResource(
-        reader = FilteringXmlBeanDefinitionReader.class,
-        locations = {WebUI.INCLUDE}
-    )
+            reader = FilteringXmlBeanDefinitionReader.class,
+            locations = {WebUI.INCLUDE})
     static @Configuration class WebUI {
         static final String INCLUDE =
                 "jar:gs-authkey-.*!/applicationContext.xml#name=^(" + WEB_UI_BEANS + ").*$";

--- a/starters/starter-security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/ConditionalOnAuthKeyEnabled.java
+++ b/starters/starter-security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/ConditionalOnAuthKeyEnabled.java
@@ -4,16 +4,17 @@
  */
 package org.geoserver.cloud.autoconfigure.authzn;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
 import org.geoserver.security.GeoServerAuthenticationKeyProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Conditionals:
@@ -32,10 +33,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplicat
 @ConditionalOnWebApplication(type = Type.SERVLET)
 @ConditionalOnClass(GeoServerAuthenticationKeyProvider.class)
 @ConditionalOnProperty(
-    name = AuthKeyAutoConfiguration.GEOSERVER_SECURITY_AUTHKEY,
-    havingValue = "true",
-    matchIfMissing = ConditionalOnAuthKeyEnabled.enabledByDefault
-)
+        name = AuthKeyAutoConfiguration.GEOSERVER_SECURITY_AUTHKEY,
+        havingValue = "true",
+        matchIfMissing = ConditionalOnAuthKeyEnabled.enabledByDefault)
 public @interface ConditionalOnAuthKeyEnabled {
     boolean enabledByDefault = false;
 }

--- a/starters/starter-spring-boot/src/main/java/org/geoserver/cloud/app/ServiceIdFilterAutoConfiguration.java
+++ b/starters/starter-spring-boot/src/main/java/org/geoserver/cloud/app/ServiceIdFilterAutoConfiguration.java
@@ -4,12 +4,6 @@
  */
 package org.geoserver.cloud.app;
 
-import java.io.IOException;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -18,6 +12,14 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * Auto configuration to log basic application info at {@link ApplicationReadyEvent app startup}
@@ -31,10 +33,9 @@ import org.springframework.core.env.Environment;
 @ConditionalOnWebApplication
 @ConditionalOnClass(javax.servlet.Filter.class)
 @ConditionalOnProperty(
-    name = "geoserver.debug.instanceId",
-    havingValue = "true",
-    matchIfMissing = false
-)
+        name = "geoserver.debug.instanceId",
+        havingValue = "true",
+        matchIfMissing = false)
 public class ServiceIdFilterAutoConfiguration {
 
     static class ServiceIdFilter implements javax.servlet.Filter {

--- a/starters/starter-spring-boot/src/main/java/org/geoserver/cloud/app/StartupLogger.java
+++ b/starters/starter-spring-boot/src/main/java/org/geoserver/cloud/app/StartupLogger.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.app;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.env.ConfigurableEnvironment;

--- a/starters/starter-spring-boot/src/main/java/org/geoserver/cloud/config/factory/FilteringXmlBeanDefinitionReader.java
+++ b/starters/starter-spring-boot/src/main/java/org/geoserver/cloud/config/factory/FilteringXmlBeanDefinitionReader.java
@@ -7,18 +7,8 @@ package org.geoserver.cloud.config.factory;
 import static org.springframework.util.StringUtils.hasText;
 import static org.springframework.util.StringUtils.tokenizeToStringArray;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.function.Predicate;
-import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
@@ -32,6 +22,18 @@ import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
 import org.w3c.dom.Element;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 /**
  * Spring xml bean definition reader that uses a regular expression to include or exclude beans by

--- a/starters/starter-spring-boot/src/test/java/org/geoserver/cloud/app/ServiceIdFilterAutoConfigurationTest.java
+++ b/starters/starter-spring-boot/src/test/java/org/geoserver/cloud/app/ServiceIdFilterAutoConfigurationTest.java
@@ -9,9 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletRequest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
@@ -20,7 +17,13 @@ import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-/** @since 1.0 */
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletRequest;
+
+/**
+ * @since 1.0
+ */
 class ServiceIdFilterAutoConfigurationTest {
 
     WebApplicationContextRunner webappRunner =

--- a/starters/starter-spring-boot/src/test/java/org/geoserver/cloud/config/factory/FilteringXmlBeanDefinitionReaderTest.java
+++ b/starters/starter-spring-boot/src/test/java/org/geoserver/cloud/config/factory/FilteringXmlBeanDefinitionReaderTest.java
@@ -4,16 +4,17 @@
  */
 package org.geoserver.cloud.config.factory;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 
 public class FilteringXmlBeanDefinitionReaderTest {
 

--- a/starters/starter-webmvc/src/main/java/org/geoserver/cloud/autoconfigure/servlet/GeoServerServletContextAutoConfiguration.java
+++ b/starters/starter-webmvc/src/main/java/org/geoserver/cloud/autoconfigure/servlet/GeoServerServletContextAutoConfiguration.java
@@ -4,8 +4,8 @@
  */
 package org.geoserver.cloud.autoconfigure.servlet;
 
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.cloud.autoconfigure.core.GeoServerWebMvcMainAutoConfiguration;
 import org.geoserver.cloud.config.servlet.GeoServerServletContextConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -13,24 +13,24 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+import javax.annotation.PostConstruct;
+
 @Configuration
 @AutoConfigureAfter(GeoServerWebMvcMainAutoConfiguration.class)
 @ConditionalOnProperty(
-    prefix = "geoserver.servlet",
-    name = "enabled",
-    havingValue = "true",
-    matchIfMissing = true
-)
+        prefix = "geoserver.servlet",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true)
 @Import(GeoServerServletContextConfiguration.class)
 @Slf4j
 public class GeoServerServletContextAutoConfiguration {
 
     @ConditionalOnProperty(
-        prefix = "geoserver.servlet",
-        name = "enabled",
-        havingValue = "false",
-        matchIfMissing = false
-    )
+            prefix = "geoserver.servlet",
+            name = "enabled",
+            havingValue = "false",
+            matchIfMissing = false)
     public static class Disabled {
         public @PostConstruct void log() {
             log.info(

--- a/starters/starter-webmvc/src/main/java/org/geoserver/cloud/config/main/GeoServerMainModuleConfiguration.java
+++ b/starters/starter-webmvc/src/main/java/org/geoserver/cloud/config/main/GeoServerMainModuleConfiguration.java
@@ -55,12 +55,11 @@ import org.springframework.context.annotation.ImportResource;
  */
 @Configuration(proxyBeanMethods = true)
 @ImportResource( //
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    // exclude beans
-    locations =
-            "jar:gs-main-.*!/applicationContext.xml#name="
-                    + GeoServerMainModuleConfiguration.EXCLUDE_BEANS_REGEX
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        // exclude beans
+        locations =
+                "jar:gs-main-.*!/applicationContext.xml#name="
+                        + GeoServerMainModuleConfiguration.EXCLUDE_BEANS_REGEX)
 public class GeoServerMainModuleConfiguration {
 
     private static final String UNUSED_BEAN_NAMES =

--- a/starters/starter-webmvc/src/main/java/org/geoserver/cloud/config/main/UpdateSequenceListener.java
+++ b/starters/starter-webmvc/src/main/java/org/geoserver/cloud/config/main/UpdateSequenceListener.java
@@ -5,7 +5,6 @@
  */
 package org.geoserver.cloud.config.main;
 
-import java.util.List;
 import org.geoserver.catalog.CatalogException;
 import org.geoserver.catalog.event.CatalogAddEvent;
 import org.geoserver.catalog.event.CatalogListener;
@@ -18,6 +17,8 @@ import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.LoggingInfo;
 import org.geoserver.config.ServiceInfo;
 import org.geoserver.config.SettingsInfo;
+
+import java.util.List;
 
 /**
  * REVISIT: verbatim copy of org.geoserver.config.UpdateSequenceListener cause it's package private.

--- a/starters/starter-webmvc/src/main/java/org/geoserver/cloud/config/servlet/GeoServerServletContextConfiguration.java
+++ b/starters/starter-webmvc/src/main/java/org/geoserver/cloud/config/servlet/GeoServerServletContextConfiguration.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.cloud.config.servlet;
 
-import javax.servlet.Filter;
 import org.geoserver.GeoserverInitStartupListener;
 import org.geoserver.filters.FlushSafeFilter;
 import org.geoserver.filters.SessionDebugFilter;
@@ -17,6 +16,8 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.context.request.RequestContextListener;
+
+import javax.servlet.Filter;
 
 @Configuration
 public class GeoServerServletContextConfiguration {
@@ -47,41 +48,37 @@ public class GeoServerServletContextConfiguration {
      * after close() has been called (https://osgeo-org.atlassian.net/browse/GEOS-5985)
      */
     @ConditionalOnProperty(
-        prefix = "geoserver.servlet.filter.flush-safe",
-        name = "enabled",
-        havingValue = "true",
-        matchIfMissing = true
-    )
+            prefix = "geoserver.servlet.filter.flush-safe",
+            name = "enabled",
+            havingValue = "true",
+            matchIfMissing = true)
     public @Bean FlushSafeFilter flushSafeFilter() {
         return new FlushSafeFilter();
     }
 
     @ConditionalOnProperty(
-        prefix = "geoserver.servlet.filter.flush-safe",
-        name = "enabled",
-        havingValue = "true",
-        matchIfMissing = true
-    )
+            prefix = "geoserver.servlet.filter.flush-safe",
+            name = "enabled",
+            havingValue = "true",
+            matchIfMissing = true)
     public @Bean FilterRegistrationBean<FlushSafeFilter> flushSafeFilterReg() {
         return newRegistration(flushSafeFilter(), FLUSH_SAFE_FILTER_ORDER);
     }
 
     @ConditionalOnProperty(
-        prefix = "geoserver.servlet.filter.session-debug",
-        name = "enabled",
-        havingValue = "true",
-        matchIfMissing = true
-    )
+            prefix = "geoserver.servlet.filter.session-debug",
+            name = "enabled",
+            havingValue = "true",
+            matchIfMissing = true)
     public @Bean SessionDebugFilter sessionDebugFilter() {
         return new SessionDebugFilter();
     }
 
     @ConditionalOnProperty(
-        prefix = "geoserver.servlet.filter.session-debug",
-        name = "enabled",
-        havingValue = "true",
-        matchIfMissing = true
-    )
+            prefix = "geoserver.servlet.filter.session-debug",
+            name = "enabled",
+            havingValue = "true",
+            matchIfMissing = true)
     public @Bean FilterRegistrationBean<SessionDebugFilter> sessionDebugFilterFilterReg() {
         return newRegistration(sessionDebugFilter(), SESSION_DEBUG_FILTER_ORDER);
     }

--- a/starters/starter-webmvc/src/test/java/org/geoserver/cloud/autoconfigure/servlet/ServletContextConditionalFiltersTest.java
+++ b/starters/starter-webmvc/src/test/java/org/geoserver/cloud/autoconfigure/servlet/ServletContextConditionalFiltersTest.java
@@ -31,12 +31,11 @@ import org.springframework.web.context.request.RequestContextListener;
 @EnableAutoConfiguration(exclude = {SecurityAutoConfiguration.class})
 @RunWith(SpringRunner.class)
 @TestPropertySource(
-    properties = {
-        "reactive.feign.loadbalancer.enabled=false",
-        "geoserver.servlet.filter.session-debug.enabled=false",
-        "geoserver.servlet.filter.flush-safe.enabled=false"
-    }
-)
+        properties = {
+            "reactive.feign.loadbalancer.enabled=false",
+            "geoserver.servlet.filter.session-debug.enabled=false",
+            "geoserver.servlet.filter.flush-safe.enabled=false"
+        })
 @ActiveProfiles("test")
 public class ServletContextConditionalFiltersTest {
 

--- a/starters/starter-webmvc/src/test/java/org/geoserver/cloud/autoconfigure/servlet/ServletContextDisabledSmokeTest.java
+++ b/starters/starter-webmvc/src/test/java/org/geoserver/cloud/autoconfigure/servlet/ServletContextDisabledSmokeTest.java
@@ -29,9 +29,11 @@ import org.springframework.web.context.request.RequestContextListener;
  * auto-configuration is disabled through {@code geoserver.servlet.enabled=false}
  */
 @SpringBootTest(
-    classes = TestConfiguration.class,
-    properties = {"reactive.feign.loadbalancer.enabled=false", "geoserver.servlet.enabled=false"}
-)
+        classes = TestConfiguration.class,
+        properties = {
+            "reactive.feign.loadbalancer.enabled=false",
+            "geoserver.servlet.enabled=false"
+        })
 @EnableAutoConfiguration(exclude = SecurityAutoConfiguration.class)
 @RunWith(SpringRunner.class)
 @ActiveProfiles("test")

--- a/starters/starter-webmvc/src/test/java/org/geoserver/cloud/autoconfigure/servlet/ServletContextEnabledSmokeTest.java
+++ b/starters/starter-webmvc/src/test/java/org/geoserver/cloud/autoconfigure/servlet/ServletContextEnabledSmokeTest.java
@@ -27,9 +27,8 @@ import org.springframework.web.context.request.RequestContextListener;
 
 /** Smoke test to load the servlet context beans with auto-configuration enabled */
 @SpringBootTest(
-    classes = TestConfiguration.class,
-    properties = "reactive.feign.loadbalancer.enabled=false"
-)
+        classes = TestConfiguration.class,
+        properties = "reactive.feign.loadbalancer.enabled=false")
 @EnableAutoConfiguration(exclude = SecurityAutoConfiguration.class)
 @RunWith(SpringRunner.class)
 @ActiveProfiles("test")

--- a/starters/starter-webmvc/src/test/java/org/geoserver/cloud/config/main/GeoServerMainConfigurationSmokeTest.java
+++ b/starters/starter-webmvc/src/test/java/org/geoserver/cloud/config/main/GeoServerMainConfigurationSmokeTest.java
@@ -21,9 +21,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 /** Smoke test to load the main context without auto-configuration enabled and without security */
 @SpringBootTest(
-    classes = {TestConfiguration.class},
-    properties = "reactive.feign.loadbalancer.enabled=false"
-)
+        classes = {TestConfiguration.class},
+        properties = "reactive.feign.loadbalancer.enabled=false")
 @RunWith(SpringRunner.class)
 @ActiveProfiles("test")
 public class GeoServerMainConfigurationSmokeTest {

--- a/starters/starter-webmvc/src/test/java/org/geoserver/cloud/test/TestConfiguration.java
+++ b/starters/starter-webmvc/src/test/java/org/geoserver/cloud/test/TestConfiguration.java
@@ -23,15 +23,14 @@ import org.springframework.test.context.TestPropertySource;
  */
 @Configuration
 @EnableAutoConfiguration(
-    exclude = { //
-        DataSourceAutoConfiguration.class, //
-        DataSourceTransactionManagerAutoConfiguration.class, //
-        HibernateJpaAutoConfiguration.class, //
-        SecurityAutoConfiguration.class, //
-        UserDetailsServiceAutoConfiguration.class, //
-        ManagementWebSecurityAutoConfiguration.class, //
-        LoadBalancerBeanPostProcessorAutoConfiguration.class
-    }
-)
+        exclude = { //
+            DataSourceAutoConfiguration.class, //
+            DataSourceTransactionManagerAutoConfiguration.class, //
+            HibernateJpaAutoConfiguration.class, //
+            SecurityAutoConfiguration.class, //
+            UserDetailsServiceAutoConfiguration.class, //
+            ManagementWebSecurityAutoConfiguration.class, //
+            LoadBalancerBeanPostProcessorAutoConfiguration.class
+        })
 @TestPropertySource(properties = {"geoserver.backend.data-directory.enabled=true"})
 public class TestConfiguration {}

--- a/starters/starter-wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/CssStylingConfiguration.java
+++ b/starters/starter-wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/CssStylingConfiguration.java
@@ -20,22 +20,22 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportResource;
 
-/** @since 1.0 */
+/**
+ * @since 1.0
+ */
 @Configuration
 @Import(value = {CssStylingConfiguration.Enabled.class, CssStylingConfiguration.Disabled.class})
 class CssStylingConfiguration {
 
     @ConditionalOnBean(name = "sldHandler")
     @ConditionalOnProperty(
-        name = "geoserver.styling.css.enabled",
-        havingValue = "true",
-        matchIfMissing = true
-    )
+            name = "geoserver.styling.css.enabled",
+            havingValue = "true",
+            matchIfMissing = true)
     @ConditionalOnClass(CssHandler.class)
     @ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {"jar:gs-css-.*!/applicationContext.xml"}
-    )
+            reader = FilteringXmlBeanDefinitionReader.class, //
+            locations = {"jar:gs-css-.*!/applicationContext.xml"})
     static class Enabled {}
 
     /**
@@ -47,10 +47,9 @@ class CssStylingConfiguration {
      */
     @ConditionalOnBean(name = "sldHandler")
     @ConditionalOnProperty(
-        name = "geoserver.styling.css.enabled",
-        havingValue = "false",
-        matchIfMissing = false
-    )
+            name = "geoserver.styling.css.enabled",
+            havingValue = "false",
+            matchIfMissing = false)
     static class Disabled {
 
         public @Bean ModuleStatus cssDisabledModuleStatus() {

--- a/starters/starter-wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/MapBoxStylingConfiguration.java
+++ b/starters/starter-wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/MapBoxStylingConfiguration.java
@@ -18,33 +18,34 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportResource;
 
-/** @since 1.0 */
+/**
+ * @since 1.0
+ */
 @Configuration
 @Import(
-    value = {MapBoxStylingConfiguration.Enabled.class, MapBoxStylingConfiguration.Disabled.class}
-)
+        value = {
+            MapBoxStylingConfiguration.Enabled.class,
+            MapBoxStylingConfiguration.Disabled.class
+        })
 class MapBoxStylingConfiguration {
 
     @Configuration
     @ConditionalOnBean(name = "sldHandler") // sldHandler is MBStyleHandler's constructor arg
     @ConditionalOnProperty(
-        name = "geoserver.styling.mapbox.enabled",
-        havingValue = "true",
-        matchIfMissing = true
-    )
+            name = "geoserver.styling.mapbox.enabled",
+            havingValue = "true",
+            matchIfMissing = true)
     @ConditionalOnClass(MBStyleHandler.class)
     @ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {"jar:gs-mbstyle-.*!/applicationContext.xml"}
-    )
+            reader = FilteringXmlBeanDefinitionReader.class, //
+            locations = {"jar:gs-mbstyle-.*!/applicationContext.xml"})
     static class Enabled {}
 
     @Configuration
     @ConditionalOnProperty(
-        name = "geoserver.styling.mapbox.enabled",
-        havingValue = "false",
-        matchIfMissing = false
-    )
+            name = "geoserver.styling.mapbox.enabled",
+            havingValue = "false",
+            matchIfMissing = false)
     @ConditionalOnClass(MBStyleHandler.class)
     static class Disabled {
 

--- a/starters/starter-wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/VectorTilesConfiguration.java
+++ b/starters/starter-wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/VectorTilesConfiguration.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.cloud.autoconfigure.wms;
 
-import javax.annotation.PostConstruct;
 import org.geoserver.cloud.autoconfigure.wms.WmsExtensionsConfigProperties.Wms.WmsOutputFormatsConfigProperties.VectorTilesConfigProperties;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.geoserver.wms.vector.VectorTileMapOutputFormat;
@@ -16,14 +15,17 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
-/** @since 1.0 */
+import javax.annotation.PostConstruct;
+
+/**
+ * @since 1.0
+ */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(VectorTileMapOutputFormat.class)
 @EnableConfigurationProperties(WmsExtensionsConfigProperties.class)
 @ImportResource( //
-    reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = {"jar:gs-vectortiles-.*!/applicationContext.xml#name=(VectorTilesExtension)"}
-)
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = {"jar:gs-vectortiles-.*!/applicationContext.xml#name=(VectorTilesExtension)"})
 class VectorTilesConfiguration {
 
     static final String PREFIX = "geoserver.wms.output-formats.vector-tiles";
@@ -38,44 +40,38 @@ class VectorTilesConfiguration {
     }
 
     @ConditionalOnProperty(
-        prefix = PREFIX + ".mapbox",
-        name = "enabled",
-        havingValue = "true",
-        matchIfMissing = true
-    )
+            prefix = PREFIX + ".mapbox",
+            name = "enabled",
+            havingValue = "true",
+            matchIfMissing = true)
     @ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {
-            "jar:gs-vectortiles-.*!/applicationContext.xml#name=(wmsMapBoxBuilderFactory|wmsMapBoxMapOutputFormat)"
-        }
-    )
+            reader = FilteringXmlBeanDefinitionReader.class, //
+            locations = {
+                "jar:gs-vectortiles-.*!/applicationContext.xml#name=(wmsMapBoxBuilderFactory|wmsMapBoxMapOutputFormat)"
+            })
     static @Configuration class MapBox {}
 
     @ConditionalOnProperty(
-        prefix = PREFIX + ".geojson",
-        name = "enabled",
-        havingValue = "true",
-        matchIfMissing = true
-    )
+            prefix = PREFIX + ".geojson",
+            name = "enabled",
+            havingValue = "true",
+            matchIfMissing = true)
     @ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {
-            "jar:gs-vectortiles-.*!/applicationContext.xml#name=(wmsGeoJsonBuilderFactory|wmsGeoJsonMapOutputFormat)"
-        }
-    )
+            reader = FilteringXmlBeanDefinitionReader.class, //
+            locations = {
+                "jar:gs-vectortiles-.*!/applicationContext.xml#name=(wmsGeoJsonBuilderFactory|wmsGeoJsonMapOutputFormat)"
+            })
     static @Configuration class GeoJson {}
 
     @ConditionalOnProperty(
-        prefix = PREFIX + ".topojson",
-        name = "enabled",
-        havingValue = "true",
-        matchIfMissing = true
-    )
+            prefix = PREFIX + ".topojson",
+            name = "enabled",
+            havingValue = "true",
+            matchIfMissing = true)
     @ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {
-            "jar:gs-vectortiles-.*!/applicationContext.xml#name=(wmsTopoJSONBuilderFactory|wmsTopoJSONMapOutputFormat)"
-        }
-    )
+            reader = FilteringXmlBeanDefinitionReader.class, //
+            locations = {
+                "jar:gs-vectortiles-.*!/applicationContext.xml#name=(wmsTopoJSONBuilderFactory|wmsTopoJSONMapOutputFormat)"
+            })
     static @Configuration class TopoJson {}
 }

--- a/starters/starter-wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/WmsExtensionsAutoConfiguration.java
+++ b/starters/starter-wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/WmsExtensionsAutoConfiguration.java
@@ -8,14 +8,15 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-/** @since 1.0 */
+/**
+ * @since 1.0
+ */
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(WmsExtensionsConfigProperties.class)
 @Import(
-    value = {
-        CssStylingConfiguration.class,
-        MapBoxStylingConfiguration.class,
-        VectorTilesConfiguration.class
-    }
-)
+        value = {
+            CssStylingConfiguration.class,
+            MapBoxStylingConfiguration.class,
+            VectorTilesConfiguration.class
+        })
 public class WmsExtensionsAutoConfiguration {}

--- a/starters/starter-wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/WmsExtensionsConfigProperties.java
+++ b/starters/starter-wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/WmsExtensionsConfigProperties.java
@@ -7,6 +7,7 @@ package org.geoserver.cloud.autoconfigure.wms;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**

--- a/support-services/admin/src/main/java/org/geoserver/cloud/adminserver/SpringBootAdminServerApplication.java
+++ b/support-services/admin/src/main/java/org/geoserver/cloud/adminserver/SpringBootAdminServerApplication.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.adminserver;
 
 import de.codecentric.boot.admin.server.config.EnableAdminServer;
+
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 

--- a/support-services/api-gateway/src/main/java/org/geoserver/cloud/gateway/filter/RouteProfileGatewayFilterFactory.java
+++ b/support-services/api-gateway/src/main/java/org/geoserver/cloud/gateway/filter/RouteProfileGatewayFilterFactory.java
@@ -6,14 +6,11 @@ package org.geoserver.cloud.gateway.filter;
 
 import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import javax.validation.constraints.NotEmpty;
 import lombok.Data;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
@@ -23,7 +20,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.server.ServerWebExchange;
+
 import reactor.core.publisher.Mono;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import javax.validation.constraints.NotEmpty;
 
 /** Allows to enable routes only if a given spring profile is enabled */
 public class RouteProfileGatewayFilterFactory

--- a/support-services/api-gateway/src/main/java/org/geoserver/cloud/gateway/filter/StripBasePathGatewayFilterFactory.java
+++ b/support-services/api-gateway/src/main/java/org/geoserver/cloud/gateway/filter/StripBasePathGatewayFilterFactory.java
@@ -6,14 +6,16 @@ package org.geoserver.cloud.gateway.filter;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.util.List;
 import lombok.Data;
+
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.StripPrefixGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.StripPrefixGatewayFilterFactory.Config;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.util.StringUtils;
+
+import java.util.List;
 
 /**
  * See gateway's issue <a

--- a/support-services/api-gateway/src/main/java/org/geoserver/cloud/gateway/predicate/RegExpQueryRoutePredicateFactory.java
+++ b/support-services/api-gateway/src/main/java/org/geoserver/cloud/gateway/predicate/RegExpQueryRoutePredicateFactory.java
@@ -4,23 +4,26 @@
  */
 package org.geoserver.cloud.gateway.predicate;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Predicate;
-import java.util.regex.Pattern;
-import javax.validation.constraints.NotEmpty;
 import lombok.Data;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
+
 import org.springframework.cloud.gateway.handler.predicate.AbstractRoutePredicateFactory;
 import org.springframework.cloud.gateway.handler.predicate.GatewayPredicate;
 import org.springframework.cloud.gateway.handler.predicate.QueryRoutePredicateFactory;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.server.ServerWebExchange;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+import javax.validation.constraints.NotEmpty;
 
 /**
  * Gateway predicate factory that allows matching by HTTP request query string parameters using

--- a/support-services/config/src/main/java/org/geoserver/cloud/config/ConfigApplication.java
+++ b/support-services/config/src/main/java/org/geoserver/cloud/config/ConfigApplication.java
@@ -15,19 +15,19 @@ import org.springframework.retry.annotation.EnableRetry;
 @EnableConfigServer
 @EnableRetry
 @NativeHint(
-    // these type hints are not needed since we've configured config-service not to fetch the eureka
-    // registry
-    //    types =
-    //            @TypeHint(
-    //                types = {
-    //                    com.netflix.discovery.shared.Application.class, //
-    //                    com.netflix.appinfo.InstanceInfo.class, //
-    //                    com.netflix.appinfo.InstanceInfo.PortWrapper.class, //
-    //                    com.netflix.appinfo.MyDataCenterInfo.class
-    //                }
-    //            ), //
-    resources = @ResourceHint(patterns = "gs_cloud_bootstrap_profiles.yml")
-)
+        // these type hints are not needed since we've configured config-service not to fetch the
+        // eureka
+        // registry
+        //    types =
+        //            @TypeHint(
+        //                types = {
+        //                    com.netflix.discovery.shared.Application.class, //
+        //                    com.netflix.appinfo.InstanceInfo.class, //
+        //                    com.netflix.appinfo.InstanceInfo.PortWrapper.class, //
+        //                    com.netflix.appinfo.MyDataCenterInfo.class
+        //                }
+        //            ), //
+        resources = @ResourceHint(patterns = "gs_cloud_bootstrap_profiles.yml"))
 public class ConfigApplication {
 
     public static void main(String[] args) {

--- a/support-services/config/src/test/java/org/geoserver/cloud/config/ConfigApplicationTest.java
+++ b/support-services/config/src/test/java/org/geoserver/cloud/config/ConfigApplicationTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;


### PR DESCRIPTION
- Update fmt-maven-plugin, moved from com.coveo to com.spotify.fmt

Since the JDK is more restrictive since version 16+,
the following parameters are configured in `.mvn/jvm.config`
to run the Google Java Formatter, as instructed
in https://github.com/spotify/fmt-maven-plugin#using-with-java-16-and-maven

```
--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
```
- Apply updated formatting after upgrading to com.spotify.fmt:fmt-maven-plugin:2.15
- Add maven central repository and upgrade to fmt-maven-plugin:2.15
