### PR TITLE
Remove dependency on gs-web-gwc from blobstores

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -444,11 +444,23 @@
         <groupId>org.geoserver.extension</groupId>
         <artifactId>gs-gwc-s3</artifactId>
         <version>${gs.version}</version>
+        <exclusions>
+          <exclusion>
+            <artifactId>gs-web-gwc</artifactId>
+            <groupId>org.geoserver.web</groupId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.geoserver.community</groupId>
         <artifactId>gs-gwc-azure-blob</artifactId>
         <version>${gs.community.version}</version>
+        <exclusions>
+          <exclusion>
+            <artifactId>gs-web-gwc</artifactId>
+            <groupId>org.geoserver.web</groupId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.geoserver.community</groupId>

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/blobstore/AzureBlobstoreAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/blobstore/AzureBlobstoreAutoConfiguration.java
@@ -9,9 +9,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnAzureBlobstoreEnabled;
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoServerWebUIEnabled;
 import org.geoserver.gwc.web.blob.AzureBlobStoreType;
+import org.geoserver.platform.ModuleStatusImpl;
 import org.geowebcache.azure.AzureBlobStoreConfigProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 import javax.annotation.PostConstruct;
 
@@ -34,6 +36,7 @@ import javax.annotation.PostConstruct;
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnAzureBlobstoreEnabled
+@Import(AzureBlobstoreAutoConfiguration.AzureBlobstoreGsWebUIConfiguration.class)
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.blobstore")
 public class AzureBlobstoreAutoConfiguration {
 
@@ -46,9 +49,23 @@ public class AzureBlobstoreAutoConfiguration {
         return new AzureBlobStoreConfigProvider();
     }
 
-    @Bean(name = "AzureBlobStoreType")
     @ConditionalOnGeoServerWebUIEnabled
-    public AzureBlobStoreType azureBlobStoreType() {
-        return new AzureBlobStoreType();
+    static @Configuration class AzureBlobstoreGsWebUIConfiguration {
+
+        @Bean(name = "AzureBlobStoreType")
+        public AzureBlobStoreType azureBlobStoreType() {
+            return new AzureBlobStoreType();
+        }
+
+        @Bean(name = "GWC-AzureExtension")
+        public ModuleStatusImpl gwcAzureExtension() {
+            ModuleStatusImpl module = new ModuleStatusImpl();
+            module.setModule("gs-gwc-azure");
+            module.setName("GeoWebCache Azure Extension");
+            module.setComponent("GeoWebCache Azure BlobStore plugin");
+            module.setEnabled(true);
+            module.setAvailable(true);
+            return module;
+        }
     }
 }

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/blobstore/S3BlobstoreAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/blobstore/S3BlobstoreAutoConfiguration.java
@@ -13,6 +13,7 @@ import org.geoserver.platform.ModuleStatusImpl;
 import org.geowebcache.s3.S3BlobStoreConfigProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 import javax.annotation.PostConstruct;
 
@@ -41,6 +42,7 @@ import javax.annotation.PostConstruct;
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnS3BlobstoreEnabled
+@Import(S3BlobstoreAutoConfiguration.S3BlobstoreGsWebUIConfiguration.class)
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.blobstore")
 public class S3BlobstoreAutoConfiguration {
 
@@ -53,21 +55,25 @@ public class S3BlobstoreAutoConfiguration {
         return new S3BlobStoreConfigProvider();
     }
 
-    @Bean(name = "S3BlobStoreType")
     @ConditionalOnGeoServerWebUIEnabled
-    public S3BlobStoreType s3BlobStoreType() {
-        return new S3BlobStoreType();
-    }
+    static @Configuration class S3BlobstoreGsWebUIConfiguration {
 
-    @Bean(name = "GWC-S3Extension")
-    @ConditionalOnGeoServerWebUIEnabled
-    public ModuleStatusImpl gwcS3Extension() {
-        ModuleStatusImpl module = new ModuleStatusImpl();
-        module.setModule("gs-gwc-s3");
-        module.setName("GeoWebCache S3 Extension");
-        module.setComponent("GeoWebCache S3 support plugin");
-        module.setEnabled(true);
-        module.setAvailable(true);
-        return module;
+        @Bean(name = "GWC-S3Extension")
+        @ConditionalOnGeoServerWebUIEnabled
+        public ModuleStatusImpl gwcS3Extension() {
+            ModuleStatusImpl module = new ModuleStatusImpl();
+            module.setModule("gs-gwc-s3");
+            module.setName("GeoWebCache S3 Extension");
+            module.setComponent("GeoWebCache S3 support plugin");
+            module.setEnabled(true);
+            module.setAvailable(true);
+            return module;
+        }
+
+        @Bean(name = "S3BlobStoreType")
+        @ConditionalOnGeoServerWebUIEnabled
+        public S3BlobStoreType s3BlobStoreType() {
+            return new S3BlobStoreType();
+        }
     }
 }


### PR DESCRIPTION
`gs-gwc-s3` and `gs-gwc-azure` were carring over
`gs-web-gwc` as a transitive dependency, and the
wicket web-ui components with them.