### PR TITLE
GeoWebCache direct WMS integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -429,16 +429,6 @@
         <groupId>org.geoserver</groupId>
         <artifactId>gs-gwc</artifactId>
         <version>${gs.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>stax-api</artifactId>
-            <groupId>stax</groupId>
-          </exclusion>
-          <exclusion>
-            <artifactId>stax</artifactId>
-            <groupId>stax</groupId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.geoserver.extension</groupId>

--- a/services/web-ui/pom.xml
+++ b/services/web-ui/pom.xml
@@ -245,6 +245,40 @@
         <dependency>
           <groupId>org.geoserver.cloud</groupId>
           <artifactId>gs-cloud-starter-gwc</artifactId>
+          <exclusions>
+            <exclusion>
+              <artifactId>gwc-georss</artifactId>
+              <groupId>org.geowebcache</groupId>
+            </exclusion>
+            <exclusion>
+              <artifactId>gwc-gmaps</artifactId>
+              <groupId>org.geowebcache</groupId>
+            </exclusion>
+            <exclusion>
+              <artifactId>gwc-kml</artifactId>
+              <groupId>org.geowebcache</groupId>
+            </exclusion>
+            <exclusion>
+              <artifactId>gwc-rest</artifactId>
+              <groupId>org.geowebcache</groupId>
+            </exclusion>
+            <exclusion>
+              <artifactId>gwc-tms</artifactId>
+              <groupId>org.geowebcache</groupId>
+            </exclusion>
+            <exclusion>
+              <artifactId>gwc-ve</artifactId>
+              <groupId>org.geowebcache</groupId>
+            </exclusion>
+            <exclusion>
+              <artifactId>gwc-wms</artifactId>
+              <groupId>org.geowebcache</groupId>
+            </exclusion>
+            <exclusion>
+              <artifactId>gwc-wmts</artifactId>
+              <groupId>org.geowebcache</groupId>
+            </exclusion>
+          </exclusions>
         </dependency>
         <dependency>
           <groupId>org.geoserver.web</groupId>

--- a/services/web-ui/src/main/resources/bootstrap.yml
+++ b/services/web-ui/src/main/resources/bootstrap.yml
@@ -41,14 +41,8 @@ spring:
       - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
       - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
       - org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration
-      # Force disabling GWC services
-      - org.geoserver.cloud.autoconfigure.gwc.service.WebMapTileServiceAutoConfiguration
-      - org.geoserver.cloud.autoconfigure.gwc.service.WebMapServiceAutoConfiguration
-      - org.geoserver.cloud.autoconfigure.gwc.service.TileMapServiceAutoConfiguration
-      - org.geoserver.cloud.autoconfigure.gwc.service.GoogleMapsAutoConfiguration
-      - org.geoserver.cloud.autoconfigure.gwc.service.MGMapsAutoConfiguration
-      - org.geoserver.cloud.autoconfigure.gwc.service.KMLAutoConfiguration
-      - org.geoserver.cloud.autoconfigure.gwc.service.RESTConfigAutoConfiguration
+      - org.springframework.boot.autoconfigure.freemarker.FreeMarkerAutoConfiguration
+      # Force disabling GWC UI, it's embedded in gwc-core, so can't have a ConditionalOnClass
       - org.geoserver.cloud.autoconfigure.web.gwc.GeoWebCacheUIAutoConfiguration
 
 # same as default of true, this service does use the registry (when eureka client is enabled)

--- a/services/wms/pom.xml
+++ b/services/wms/pom.xml
@@ -20,12 +20,54 @@
       <artifactId>gs-cloud-starter-webmvc</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.geoserver.cloud</groupId>
-      <artifactId>gs-cloud-starter-security</artifactId>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-wms</artifactId>
     </dependency>
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-cloud-starter-wms-extensions</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-starter-gwc</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>gwc-georss</artifactId>
+          <groupId>org.geowebcache</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>gwc-gmaps</artifactId>
+          <groupId>org.geowebcache</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>gwc-kml</artifactId>
+          <groupId>org.geowebcache</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>gwc-rest</artifactId>
+          <groupId>org.geowebcache</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>gwc-tms</artifactId>
+          <groupId>org.geowebcache</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>gwc-ve</artifactId>
+          <groupId>org.geowebcache</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>gwc-wms</artifactId>
+          <groupId>org.geowebcache</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>gwc-wmts</artifactId>
+          <groupId>org.geowebcache</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-starter-security</artifactId>
     </dependency>
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
@@ -34,10 +76,6 @@
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-cloud-starter-raster-formats</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.geoserver</groupId>
-      <artifactId>gs-wms</artifactId>
     </dependency>
   </dependencies>
   <profiles>
@@ -131,17 +169,6 @@
           <!-- just to avoid a com.thoughtworks.xstream.mapper.CannotResolveClassException: org.geoserver.wps.WPSInfoImpl -->
           <groupId>org.geoserver.extension</groupId>
           <artifactId>gs-wps-core</artifactId>
-          <exclusions>
-            <exclusion>
-              <artifactId>*</artifactId>
-              <groupId>*</groupId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-        <dependency>
-          <!-- just to avoid a com.thoughtworks.xstream.mapper.CannotResolveClassException: org.geoserver.gwc.WMTSInfoImpl -->
-          <groupId>org.geoserver</groupId>
-          <artifactId>gs-gwc</artifactId>
           <exclusions>
             <exclusion>
               <artifactId>*</artifactId>

--- a/services/wms/src/main/resources/bootstrap.yml
+++ b/services/wms/src/main/resources/bootstrap.yml
@@ -33,6 +33,10 @@ spring:
       - org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
       - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
       - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
+      - org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration
+      - org.springframework.boot.autoconfigure.freemarker.FreeMarkerAutoConfiguration
+      # Force disabling GWC UI, it's embedded in gwc-core, so can't have a ConditionalOnClass
+      - org.geoserver.cloud.autoconfigure.web.gwc.GeoWebCacheUIAutoConfiguration
 
 # override default of true, this service does not use the registry (when eureka client is enabled)
 eureka.client.fetch-registry: false

--- a/services/wms/src/test/resources/bootstrap-test.yml
+++ b/services/wms/src/test/resources/bootstrap-test.yml
@@ -8,6 +8,9 @@ spring:
   cloud.bus.enabled: false
 eureka.client.enabled: false
 
+gwc:
+  cache-directory: ${java.io.tmpdir}/gs-wms-tmp
+
 geoserver:
   backend:
     data-directory:
@@ -27,7 +30,8 @@ geoserver:
 logging:
   level:
     root: WARN
-    org.geoserver.platform: ERROR
-    org.geoserver.cloud: DEBUG
-    org.geoserver.cloud.config.factory: TRACE
-    org.springframework.test: ERROR
+    org.geoserver.platform: error
+    org.geoserver.cloud: info
+    org.geoserver.cloud.config.factory: debug
+    org.springframework.test: error
+

--- a/starters/starter-gwc/README.md
+++ b/starters/starter-gwc/README.md
@@ -35,3 +35,8 @@ classDiagram
         onBlobStoreEvent(BlobStoreEvent event)
     }
 ```
+
+## Usage
+
+
+

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/ConditionalOnDirectWMSIntegrationEnabled.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/ConditionalOnDirectWMSIntegrationEnabled.java
@@ -1,0 +1,26 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.gwc;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @since 1.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Documented
+@ConditionalOnGeoWebCacheEnabled
+@ConditionalOnProperty(
+        name = GeoWebCacheConfigurationProperties.WMS_INTEGRATION_ENABLED,
+        havingValue = "true",
+        matchIfMissing = false)
+public @interface ConditionalOnDirectWMSIntegrationEnabled {}

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/ConditionalOnWMTSIntegrationEnabled.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/ConditionalOnWMTSIntegrationEnabled.java
@@ -1,0 +1,33 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.gwc;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Conditionals:
+ *
+ * <ul>
+ *   <li>{@literal gwc.enabled=true}: Core gwc integration is enabled
+ *   <li>{@literal gwc.services.wmts=true}: GWC WMTS service is enabled
+ * </ul>
+ *
+ * @since 1.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Documented
+@ConditionalOnGeoWebCacheEnabled
+@ConditionalOnProperty(
+        name = GeoWebCacheConfigurationProperties.SERVICE_WMTS_ENABLED,
+        havingValue = "true",
+        matchIfMissing = false)
+public @interface ConditionalOnWMTSIntegrationEnabled {}

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/GeoWebCacheConfigurationProperties.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/GeoWebCacheConfigurationProperties.java
@@ -53,6 +53,7 @@ public @Data class GeoWebCacheConfigurationProperties {
     public static final String CACHE_DIRECTORY = "gwc.cache-directory";
     public static final String CONFIG_DIRECTORY = "gwc.config-directory";
     public static final String WEBUI_ENABLED = "gwc.web-ui";
+    public static final String WMS_INTEGRATION_ENABLED = "gwc.wms-integration";
     public static final String RESTCONFIG_ENABLED = "gwc.rest-config";
     public static final String SERVICE_WMTS_ENABLED = "gwc.services.wmts";
     public static final String SERVICE_TMS_ENABLED = "gwc.services.tms";
@@ -87,6 +88,14 @@ public @Data class GeoWebCacheConfigurationProperties {
 
     /** Enables or disables the GWC user interface */
     private boolean webUi = false;
+
+    /**
+     * Enables or disables the extension to integrate GWC with GeoServer's WMS. This is a
+     * component-level configuration property that, if enabled, the option to activate the
+     * integration needs to be configured in GeoServer's WEB-UI, and if disabled, the Web-UI don't
+     * even show the option
+     */
+    private boolean wmsIntegration = false;
 
     /** Enables or disables the GWC REST API to configure layers, blob stores, etc. */
     private boolean restConfig = false;

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/DiskQuotaAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/DiskQuotaAutoConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.context.annotation.ImportResource;
 @ImportResource(
         reader = FilteringXmlBeanDefinitionReader.class, //
         locations = {
-            "jar:gs-gwc-.*!/geowebcache-diskquota-context.xml#name=^(?!DiskQuotaConfigLoader).*$"
+            "jar:gs-gwc-[0-9]+.*!/geowebcache-diskquota-context.xml#name=^(?!DiskQuotaConfigLoader).*$"
         })
 public class DiskQuotaAutoConfiguration {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/GeoServerIntegrationAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/GeoServerIntegrationAutoConfiguration.java
@@ -36,10 +36,19 @@ import javax.annotation.PostConstruct;
 @ImportResource(
         reader = FilteringXmlBeanDefinitionReader.class, //
         locations = {
-            "jar:gs-gwc-.*!/geowebcache-geoserver-context.xml#name=^(?!GeoSeverTileLayerCatalog|gwcCatalogConfiguration).*$"
+            "jar:gs-gwc-[0-9]+.*!/geowebcache-geoserver-context.xml#name=^(?!"
+                    + GeoServerIntegrationAutoConfiguration.EXCLUDED_BEANS
+                    + ").*$"
         })
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.core")
 public class GeoServerIntegrationAutoConfiguration {
+
+    static final String EXCLUDED_BEANS = //
+            "GeoSeverTileLayerCatalog" //
+                    + "|gwcCatalogConfiguration" //
+                    + "|gwcTransactionListener" //
+                    + "|gwcWMSExtendedCapabilitiesProvider" //
+            ;
 
     public @PostConstruct void log() {
         log.info("GeoWebCache core GeoServer integration enabled");

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/GwcCoreAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/GwcCoreAutoConfiguration.java
@@ -62,7 +62,7 @@ import javax.servlet.http.HttpServletRequestWrapper;
 @ImportResource(
         reader = FilteringXmlBeanDefinitionReader.class, //
         locations = {
-            "jar:gs-gwc-.*!/geowebcache-core-context.xml#name=^(?!gwcXmlConfig|gwcDefaultStorageFinder|gwcGeoServervConfigPersister|metastoreRemover).*$"
+            "jar:gs-gwc-[0-9]+.*!/geowebcache-core-context.xml#name=^(?!gwcXmlConfig|gwcDefaultStorageFinder|gwcGeoServervConfigPersister|metastoreRemover).*$"
         })
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.core")
 public class GwcCoreAutoConfiguration {

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/SeedingWMSAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/SeedingWMSAutoConfiguration.java
@@ -45,15 +45,59 @@ import javax.annotation.PostConstruct;
 @ImportResource( //
         reader = FilteringXmlBeanDefinitionReader.class, //
         locations = { //
-            "jar:gs-wms-.*!/applicationContext.xml#name=^(?!getMapKvpReader).*$", //
-            "jar:gs-wfs-.*!/applicationContext.xml#name="
-                    + SeedingWMSAutoConfiguration.WFS_BEANS_REGEX //
+            SeedingWMSAutoConfiguration.GS_WMS_INCLUDES, //
+            SeedingWMSAutoConfiguration.GS_WFS_INCLUDES //
         })
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.integration")
 public class SeedingWMSAutoConfiguration {
 
-    static final String WFS_BEANS_REGEX =
-            "^(gml.*OutputFormat|bboxKvpParser|xmlConfiguration.*|gml[1-9]*SchemaBuilder|wfsXsd.*|wfsSqlViewKvpParser).*$";
+    // wms beans black-list
+    private static final String WMS_BEANS_REGEX =
+            """
+            ^(?!\
+            getMapKvpReader\
+            |wmsCapabilitiesXmlReader\
+            |getMapXmlReader\
+            |sldXmlReader\
+            |wms_1_1_1_GetCapabilitiesResponse\
+            |wms_1_3_0_GetCapabilitiesResponse\
+            |wmsDescribeLayerXML\
+            |.*DescribeLayerResponse\
+            |.stylesResponse\
+            |.kmlIconService\
+            |.wmsURLMapping\
+            |.wmsXMLTransformerResponse\
+            |.*LegendOutputFormat\
+            |.*LegendGraphicResponse\
+            |.PDFMap.*\
+            |OpenLayers.*\
+            |Atom.*\
+            |RSSGeoRSSMapProducer\
+            |.*SVG.*\
+            |animateURLMapping\
+            |metaTileCache\
+            |wmsClasspathPublisherMapping\
+            ).*$\
+            """;
+
+    // wfs beans white-list
+    private static final String WFS_BEANS_REGEX =
+            """
+            ^(\
+            gml.*OutputFormat\
+            |bboxKvpParser\
+            |xmlConfiguration.*\
+            |gml[1-9]*SchemaBuilder\
+            |wfsXsd.*\
+            |wfsSqlViewKvpParser\
+            ).*$\
+            """;
+
+    static final String GS_WMS_INCLUDES =
+            "jar:gs-wms-[0-9]+.*!/applicationContext.xml#name=" + WMS_BEANS_REGEX;
+
+    static final String GS_WFS_INCLUDES =
+            "jar:gs-wfs-[0-9]+.*!/applicationContext.xml#name=" + WFS_BEANS_REGEX;
 
     public @PostConstruct void log() {
         log.info("GeoWebCache internal WMS for seeding enabled");
@@ -73,7 +117,7 @@ public class SeedingWMSAutoConfiguration {
      *
      * <p>Replaces {@link CacheSeedingWebMapService} declared in {@literal
      * geowebcache-geoserver-wms-integration.xml} for simplicity and because its {@literal
-     * wmsServiceInterceptor_CachingWMS} pointcut advisor forces eager loading of the wms context
+     * wmsServiceInterceptor_SeedingWMS} pointcut advisor forces eager loading of the wms context
      * before the catalog is initialized, making {@link GetMapKvpRequestReader} constructor throw a
      * NPE.
      */

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/WMSIntegrationAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/WMSIntegrationAutoConfiguration.java
@@ -1,0 +1,217 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.gwc.integration;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
+import static org.geowebcache.conveyor.Conveyor.CacheResult.MISS;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnDirectWMSIntegrationEnabled;
+import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoServerWebUIEnabled;
+import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheConfigurationProperties;
+import org.geoserver.cloud.autoconfigure.gwc.core.GeoServerIntegrationAutoConfiguration;
+import org.geoserver.gwc.GWC;
+import org.geoserver.gwc.config.GWCConfig;
+import org.geoserver.gwc.web.GWCSettingsPage;
+import org.geoserver.gwc.wms.CachingExtendedCapabilitiesProvider;
+import org.geoserver.ows.Dispatcher;
+import org.geoserver.ows.HttpErrorCodeException;
+import org.geoserver.web.HeaderContribution;
+import org.geoserver.wms.DefaultWebMapService;
+import org.geoserver.wms.GetMapRequest;
+import org.geoserver.wms.WMSMapContent;
+import org.geoserver.wms.WebMap;
+import org.geoserver.wms.WebMapService;
+import org.geoserver.wms.map.GetMapKvpRequestReader;
+import org.geoserver.wms.map.RawMap;
+import org.geowebcache.conveyor.ConveyorTile;
+import org.geowebcache.io.ByteArrayResource;
+import org.geowebcache.io.Resource;
+import org.geowebcache.layer.TileLayer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.channels.Channels;
+import java.util.LinkedHashMap;
+
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Autoconfiguration to integrate GWC with GeoServer's WMS
+ *
+ * <p>GeoWebCache can be transparently integrated with the GeoServer WMS, effectively converting the
+ * regular WMS in a <a href="https://wiki.osgeo.org/wiki/WMS_Tile_Caching">WMS-C</a>.
+ *
+ * @since 1.0
+ */
+@Configuration(proxyBeanMethods = false)
+@Import({
+    WMSIntegrationAutoConfiguration.Enabled.class,
+    WMSIntegrationAutoConfiguration.Disabled.class
+})
+@Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.integration")
+public class WMSIntegrationAutoConfiguration {
+
+    @ConditionalOnDirectWMSIntegrationEnabled
+    static @Configuration class Enabled {
+
+        /**
+         * Originally declared in {@literal geowebcache-geoserver-context.xml} and excluded by
+         * {@link GeoServerIntegrationAutoConfiguration}. Contributed to the application context
+         * here only if direct-WMS integration is {@link ConditionalOnDirectWMSIntegrationEnabled
+         * enabled}.
+         *
+         * @param gwc
+         */
+        @ConditionalOnBean(name = {"wmsServiceTarget", "wms_1_1_1_GetCapabilitiesResponse"})
+        public @Bean CachingExtendedCapabilitiesProvider gwcWMSExtendedCapabilitiesProvider(
+                GWC gwc) {
+            log.info("GeoWebCache direct WMS integration enabled");
+            return new CachingExtendedCapabilitiesProvider(gwc);
+        }
+
+        /**
+         * AspectJ around advise on {@link DefaultWebMapService#getMap} to serve the WMS GetMap
+         * request through GWC if the parameters match a tile.
+         *
+         * <p>Replaces {@link org.geoserver.gwc.wms.CachingWebMapService} declared in {@literal
+         * geowebcache-geoserver-wms-integration.xml} for simplicity and because its {@literal
+         * wmsServiceInterceptor_SeedingWMS} pointcut advisor forces eager loading of the wms
+         * context before the catalog is initialized, making {@link GetMapKvpRequestReader}
+         * constructor throw a NPE.
+         *
+         * @param gwc
+         */
+        @ConditionalOnBean(name = {"wmsServiceTarget", "wms_1_1_1_GetCapabilitiesResponse"})
+        public @Bean ForwardGetMapToGwcAspect gwcGetMapAdvise(GWC gwc) {
+            return new ForwardGetMapToGwcAspect(gwc);
+        }
+    }
+
+    @ConditionalOnProperty(
+            name = GeoWebCacheConfigurationProperties.WMS_INTEGRATION_ENABLED,
+            havingValue = "false",
+            matchIfMissing = true)
+    @Import(Disabled.GeoServerWebUI.class)
+    static @Configuration class Disabled {
+
+        /**
+         * If direct-WMS integration is disabled, contribute {@literal wms-integration-disabled.css}
+         * to the Wicket {@link GWCSettingsPage} to hide the {@literal Enable direct integration
+         * with GeoServer WMS} and {@literal Explicitly require TILED Parameter} form elements.
+         */
+        @ConditionalOnGeoServerWebUIEnabled
+        static @Configuration class GeoServerWebUI {
+
+            public @Bean HeaderContribution GWCSettingsPage_WMSIntegationDisabledCssContribution() {
+                log.info("GeoWebCache direct WMS integration disabled in GWCSettingsPage");
+                HeaderContribution contribution = new HeaderContribution();
+                contribution.setScope(GWCSettingsPage.class);
+                contribution.setCSSFilename("wms-integration-disabled.css");
+                return contribution;
+            }
+        }
+    }
+
+    @Aspect
+    @Slf4j(topic = "org.geoserver.cloud.gwc.integration.wms")
+    @RequiredArgsConstructor
+    static class ForwardGetMapToGwcAspect {
+
+        private final GWC gwc;
+
+        /**
+         * Wraps {@link WebMapService#getMap(GetMapRequest)}, called by the {@link Dispatcher}
+         *
+         * @see WebMapService#getMap(GetMapRequest)
+         * @see
+         *     org.aopalliance.intercept.MethodInterceptor#invoke(org.aopalliance.intercept.MethodInvocation)
+         */
+        @Around("execution (* org.geoserver.wms.DefaultWebMapService.getMap(..))")
+        public WebMap getMap(ProceedingJoinPoint joinPoint) throws Throwable {
+            final GWCConfig config = gwc.getConfig();
+            final GetMapRequest request = getRequest(joinPoint);
+            final boolean enabled = config.isDirectWMSIntegrationEnabled();
+            final boolean tiled = request.isTiled() || !config.isRequireTiledParameter();
+            if (!(enabled && tiled)) {
+                return (WebMap) joinPoint.proceed();
+            }
+
+            final StringBuilder requestMistmatchTarget = new StringBuilder();
+            ConveyorTile cachedTile = gwc.dispatch(request, requestMistmatchTarget);
+
+            if (cachedTile == null) {
+                WebMap dynamicResult = (WebMap) joinPoint.proceed();
+                dynamicResult.setResponseHeader("geowebcache-cache-result", MISS.toString());
+                dynamicResult.setResponseHeader(
+                        "geowebcache-miss-reason", requestMistmatchTarget.toString());
+                return dynamicResult;
+            }
+            checkState(cachedTile.getTileLayer() != null);
+            final TileLayer layer = cachedTile.getTileLayer();
+
+            log.trace("GetMap request intercepted, serving cached content: {}", request);
+
+            final byte[] tileBytes;
+            {
+                final Resource mapContents = cachedTile.getBlob();
+                if (mapContents instanceof ByteArrayResource) {
+                    tileBytes = ((ByteArrayResource) mapContents).getContents();
+                } else {
+                    ByteArrayOutputStream out = new ByteArrayOutputStream();
+                    mapContents.transferTo(Channels.newChannel(out));
+                    tileBytes = out.toByteArray();
+                }
+            }
+
+            // Handle Etags
+            final String ifNoneMatch = request.getHttpRequestHeader("If-None-Match");
+            final String etag = GWC.getETag(tileBytes);
+            if (etag.equals(ifNoneMatch)) {
+                // Client already has the current version
+                log.trace("ETag matches, returning 304");
+                throw new HttpErrorCodeException(HttpServletResponse.SC_NOT_MODIFIED);
+            }
+
+            log.trace("No matching ETag, returning cached tile");
+            final String mimeType = cachedTile.getMimeType().getMimeType();
+
+            RawMap map = new RawMap((WMSMapContent) null, tileBytes, mimeType);
+
+            map.setContentDispositionHeader(
+                    (WMSMapContent) null, "." + cachedTile.getMimeType().getFileExtension(), false);
+
+            LinkedHashMap<String, String> headers = new LinkedHashMap<>();
+            GWC.setCacheControlHeaders(headers, layer, (int) cachedTile.getTileIndex()[2]);
+            GWC.setConditionalGetHeaders(
+                    headers, cachedTile, etag, request.getHttpRequestHeader("If-Modified-Since"));
+            GWC.setCacheMetadataHeaders(headers, cachedTile, layer);
+            headers.forEach((k, v) -> map.setResponseHeader(k, v));
+
+            return map;
+        }
+
+        private GetMapRequest getRequest(ProceedingJoinPoint joinPoint) {
+
+            final Object[] arguments = joinPoint.getArgs();
+
+            checkArgument(arguments.length == 1);
+            checkArgument(arguments[0] instanceof GetMapRequest);
+
+            return (GetMapRequest) arguments[0];
+        }
+    }
+}

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/WMTSIntegrationAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/WMTSIntegrationAutoConfiguration.java
@@ -6,10 +6,8 @@ package org.geoserver.cloud.autoconfigure.gwc.integration;
 
 import lombok.extern.slf4j.Slf4j;
 
-import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoWebCacheEnabled;
-import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheConfigurationProperties;
+import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnWMTSIntegrationEnabled;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
@@ -19,14 +17,10 @@ import javax.annotation.PostConstruct;
  * @since 1.0
  */
 @Configuration(proxyBeanMethods = true)
-@ConditionalOnGeoWebCacheEnabled
-@ConditionalOnProperty(
-        name = GeoWebCacheConfigurationProperties.SERVICE_WMTS_ENABLED,
-        havingValue = "true",
-        matchIfMissing = false)
+@ConditionalOnWMTSIntegrationEnabled
 @ImportResource(
         reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {"jar:gs-gwc-.*!/geowebcache-geoserver-wmts-integration.xml"})
+        locations = {"jar:gs-gwc-[0-9]+.*!/geowebcache-geoserver-wmts-integration.xml"})
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.integration")
 public class WMTSIntegrationAutoConfiguration {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/WMTSIntegrationAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/WMTSIntegrationAutoConfiguration.java
@@ -8,6 +8,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnWMTSIntegrationEnabled;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geowebcache.service.wmts.WMTSService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
@@ -18,6 +20,7 @@ import javax.annotation.PostConstruct;
  */
 @Configuration(proxyBeanMethods = true)
 @ConditionalOnWMTSIntegrationEnabled
+@ConditionalOnClass(WMTSService.class)
 @ImportResource(
         reader = FilteringXmlBeanDefinitionReader.class, //
         locations = {"jar:gs-gwc-[0-9]+.*!/geowebcache-geoserver-wmts-integration.xml"})

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/GoogleMapsAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/GoogleMapsAutoConfiguration.java
@@ -8,7 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheConfigurationProperties;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geowebcache.service.gmaps.GMapsConverter;
 import org.gwc.web.gmaps.GoogleMapsController;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -20,6 +22,7 @@ import javax.annotation.PostConstruct;
  * @since 1.0
  */
 @Configuration
+@ConditionalOnClass(GMapsConverter.class)
 @ConditionalOnProperty(
         name = GeoWebCacheConfigurationProperties.SERVICE_GMAPS_ENABLED,
         havingValue = "true",

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/GoogleMapsAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/GoogleMapsAutoConfiguration.java
@@ -27,7 +27,7 @@ import javax.annotation.PostConstruct;
 @ComponentScan(basePackageClasses = GoogleMapsController.class)
 @ImportResource(
         reader = FilteringXmlBeanDefinitionReader.class,
-        locations = "jar:gs-gwc-.*!/geowebcache-gmaps-context.xml#name=gwcServiceGMapsTarget")
+        locations = "jar:gs-gwc-[0-9]+.*!/geowebcache-gmaps-context.xml#name=gwcServiceGMapsTarget")
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.service")
 public class GoogleMapsAutoConfiguration {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/KMLAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/KMLAutoConfiguration.java
@@ -8,7 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheConfigurationProperties;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geowebcache.service.kml.KMLService;
 import org.gwc.web.kml.KMLController;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -20,6 +22,7 @@ import javax.annotation.PostConstruct;
  * @since 1.0
  */
 @Configuration
+@ConditionalOnClass(KMLService.class)
 @ConditionalOnProperty(
         name = GeoWebCacheConfigurationProperties.SERVICE_KML_ENABLED,
         havingValue = "true",

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/KMLAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/KMLAutoConfiguration.java
@@ -27,7 +27,8 @@ import javax.annotation.PostConstruct;
 @ComponentScan(basePackageClasses = KMLController.class)
 @ImportResource(
         reader = FilteringXmlBeanDefinitionReader.class,
-        locations = "jar:gs-gwc-.*!/geowebcache-kmlservice-context.xml#name=gwcServiceKMLTarget")
+        locations =
+                "jar:gs-gwc-[0-9]+.*!/geowebcache-kmlservice-context.xml#name=gwcServiceKMLTarget")
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.service")
 public class KMLAutoConfiguration {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/MGMapsAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/MGMapsAutoConfiguration.java
@@ -27,7 +27,8 @@ import javax.annotation.PostConstruct;
 @ComponentScan(basePackageClasses = MGMapsController.class)
 @ImportResource(
         reader = FilteringXmlBeanDefinitionReader.class,
-        locations = "jar:gs-gwc-.*!/geowebcache-gmaps-context.xml#name=gwcServiceMGMapsTarget")
+        locations =
+                "jar:gs-gwc-[0-9]+.*!/geowebcache-gmaps-context.xml#name=gwcServiceMGMapsTarget")
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.service")
 public class MGMapsAutoConfiguration {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/MGMapsAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/MGMapsAutoConfiguration.java
@@ -8,7 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheConfigurationProperties;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geowebcache.service.mgmaps.MGMapsConverter;
 import org.gwc.web.mgmaps.MGMapsController;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -20,6 +22,7 @@ import javax.annotation.PostConstruct;
  * @since 1.0
  */
 @Configuration
+@ConditionalOnClass(MGMapsConverter.class)
 @ConditionalOnProperty(
         name = GeoWebCacheConfigurationProperties.SERVICE_MGMAPS_ENABLED,
         havingValue = "true",

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/TileMapServiceAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/TileMapServiceAutoConfiguration.java
@@ -27,8 +27,7 @@ import javax.annotation.PostConstruct;
 @ComponentScan(basePackageClasses = TMSController.class)
 @ImportResource(
         reader = FilteringXmlBeanDefinitionReader.class,
-        // locations = "jar:gs-gwc-.*!/geowebcache-tmsservice-context.xml#name=gwcServiceTMSTarget"
-        locations = "jar:gs-gwc-.*!/geowebcache-tmsservice-context.xml")
+        locations = "jar:gs-gwc-[0-9]+.*!/geowebcache-tmsservice-context.xml")
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.service")
 public class TileMapServiceAutoConfiguration {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/TileMapServiceAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/TileMapServiceAutoConfiguration.java
@@ -8,7 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheConfigurationProperties;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geowebcache.service.tms.TMSService;
 import org.gwc.web.tms.TMSController;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -20,6 +22,7 @@ import javax.annotation.PostConstruct;
  * @since 1.0
  */
 @Configuration
+@ConditionalOnClass(TMSService.class)
 @ConditionalOnProperty(
         name = GeoWebCacheConfigurationProperties.SERVICE_TMS_ENABLED,
         havingValue = "true",

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/WebMapServiceAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/WebMapServiceAutoConfiguration.java
@@ -27,7 +27,7 @@ import javax.annotation.PostConstruct;
 @ComponentScan(basePackageClasses = WMSController.class)
 @ImportResource(
         reader = FilteringXmlBeanDefinitionReader.class,
-        locations = "jar:gs-gwc-.*!/geowebcache-wmsservice-context.xml")
+        locations = "jar:gs-gwc-[0-9]+.*!/geowebcache-wmsservice-context.xml")
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.service")
 public class WebMapServiceAutoConfiguration {
 

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/WebMapServiceAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/WebMapServiceAutoConfiguration.java
@@ -8,7 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheConfigurationProperties;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geowebcache.service.wms.WMSService;
 import org.gwc.web.wms.WMSController;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -20,6 +22,7 @@ import javax.annotation.PostConstruct;
  * @since 1.0
  */
 @Configuration
+@ConditionalOnClass(WMSService.class)
 @ConditionalOnProperty(
         name = GeoWebCacheConfigurationProperties.SERVICE_WMS_ENABLED,
         havingValue = "true",

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/WebMapTileServiceAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/WebMapTileServiceAutoConfiguration.java
@@ -8,7 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheConfigurationProperties;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geowebcache.service.wmts.WMTSService;
 import org.gwc.web.wmts.WMTSController;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -20,6 +22,7 @@ import javax.annotation.PostConstruct;
  * @since 1.0
  */
 @Configuration
+@ConditionalOnClass(WMTSService.class)
 @ConditionalOnProperty(
         name = GeoWebCacheConfigurationProperties.SERVICE_WMTS_ENABLED,
         havingValue = "true",

--- a/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/WebMapTileServiceAutoConfiguration.java
+++ b/starters/starter-gwc/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/WebMapTileServiceAutoConfiguration.java
@@ -27,7 +27,7 @@ import javax.annotation.PostConstruct;
 @ComponentScan(basePackageClasses = WMTSController.class)
 @ImportResource(
         reader = FilteringXmlBeanDefinitionReader.class,
-        locations = "jar:gs-gwc-.*!/geowebcache-wmtsservice-context.xml")
+        locations = "jar:gs-gwc-[0-9]+.*!/geowebcache-wmtsservice-context.xml")
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.service")
 public class WebMapTileServiceAutoConfiguration {
 

--- a/starters/starter-gwc/src/main/resources/META-INF/spring.factories
+++ b/starters/starter-gwc/src/main/resources/META-INF/spring.factories
@@ -4,6 +4,7 @@ org.geoserver.cloud.autoconfigure.gwc.integration.LocalEventsAutoConfiguration,\
 org.geoserver.cloud.autoconfigure.gwc.integration.RemoteEventsAutoConfiguration,\
 org.geoserver.cloud.autoconfigure.gwc.integration.SeedingWMSAutoConfiguration,\
 org.geoserver.cloud.autoconfigure.gwc.integration.WMTSIntegrationAutoConfiguration,\
+org.geoserver.cloud.autoconfigure.gwc.integration.WMSIntegrationAutoConfiguration,\
 org.geoserver.cloud.autoconfigure.gwc.service.TileMapServiceAutoConfiguration,\
 org.geoserver.cloud.autoconfigure.gwc.service.WebMapTileServiceAutoConfiguration,\
 org.geoserver.cloud.autoconfigure.gwc.service.WebMapServiceAutoConfiguration,\

--- a/starters/starter-gwc/src/main/resources/org/geoserver/gwc/web/wms-integration-disabled.css
+++ b/starters/starter-gwc/src/main/resources/org/geoserver/gwc/web/wms-integration-disabled.css
@@ -1,0 +1,10 @@
+/* direct-WMS integration is disabled, hide the related form elements */
+#enableWMSIntegration,#requireTiledParameter{
+  display: none;
+}
+#page-pane form ul li label[for="enableWMSIntegration"]{
+  display: none;
+}
+#page-pane form ul li label[for="requireTiledParameter"]{
+  display: none;
+}

--- a/starters/starter-gwc/src/test/java/org/geoserver/cloud/autoconfigure/gwc/integration/WMSIntegrationAutoConfigurationTest.java
+++ b/starters/starter-gwc/src/test/java/org/geoserver/cloud/autoconfigure/gwc/integration/WMSIntegrationAutoConfigurationTest.java
@@ -1,0 +1,128 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.gwc.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheContextRunner;
+import org.geoserver.cloud.autoconfigure.gwc.integration.WMSIntegrationAutoConfiguration.ForwardGetMapToGwcAspect;
+import org.geoserver.gwc.web.GWCSettingsPage;
+import org.geoserver.gwc.wms.CachingExtendedCapabilitiesProvider;
+import org.geoserver.web.HeaderContribution;
+import org.geoserver.wms.DefaultWebMapService;
+import org.geoserver.wms.capabilities.GetCapabilitiesResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+
+import java.io.File;
+
+/**
+ * Test suite for {@link WMSIntegrationAutoConfiguration}
+ *
+ * @since 1.0
+ */
+class WMSIntegrationAutoConfigurationTest {
+
+    @TempDir File tmpDir;
+    WebApplicationContextRunner runner;
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @BeforeEach
+    void setUp() throws Exception {
+        runner =
+                GeoWebCacheContextRunner.newMinimalGeoWebCacheContextRunner(tmpDir)
+                        .withConfiguration(
+                                AutoConfigurations.of(WMSIntegrationAutoConfiguration.class));
+    }
+
+    /**
+     * Set up mocked up minimum WMS beans that will satisfy the {@code @ConditionalOnBean(name =
+     * {"wmsServiceTarget", "wms_1_1_1_GetCapabilitiesResponse"})} conditions on {@link
+     * WMSIntegrationAutoConfiguration}
+     */
+    private WebApplicationContextRunner withMockWMS() {
+        DefaultWebMapService mockWms = mock(DefaultWebMapService.class);
+        org.geoserver.wms.capabilities.GetCapabilitiesResponse mockGetCapabilities =
+                mock(GetCapabilitiesResponse.class);
+
+        return runner.withBean("wmsServiceTarget", DefaultWebMapService.class, () -> mockWms)
+                .withBean(
+                        "wms_1_1_1_GetCapabilitiesResponse",
+                        GetCapabilitiesResponse.class,
+                        () -> mockGetCapabilities);
+    }
+
+    @Test
+    void disabledByDefault() {
+        withMockWMS()
+                .run(
+                        context -> {
+                            assertThat(context)
+                                    .doesNotHaveBean(CachingExtendedCapabilitiesProvider.class);
+                            assertThat(context).doesNotHaveBean(ForwardGetMapToGwcAspect.class);
+                            assertThat(context)
+                                    .doesNotHaveBean(
+                                            "GWCSettingsPage_WMSIntegationDisabledCssContribution");
+                        });
+    }
+
+    @Test
+    void enabledByConfigAndGeoServerWebMapServiceNotFound() {
+        runner.withPropertyValues("gwc.wms-integration=true")
+                .run(
+                        context -> {
+                            assertThat(context)
+                                    .doesNotHaveBean(CachingExtendedCapabilitiesProvider.class);
+                            assertThat(context).doesNotHaveBean(ForwardGetMapToGwcAspect.class);
+                            assertThat(context)
+                                    .doesNotHaveBean(
+                                            "GWCSettingsPage_WMSIntegationDisabledCssContribution");
+                        });
+    }
+
+    @Test
+    void enabledByConfigAndGeoServerWebMapServiceFound() {
+        withMockWMS()
+                .withPropertyValues("gwc.wms-integration=true")
+                .run(
+                        context -> {
+                            assertThat(context)
+                                    .hasSingleBean(CachingExtendedCapabilitiesProvider.class);
+                            assertThat(context).hasSingleBean(ForwardGetMapToGwcAspect.class);
+                            assertThat(context)
+                                    .doesNotHaveBean(
+                                            "GWCSettingsPage_WMSIntegationDisabledCssContribution");
+                        });
+    }
+
+    @Test
+    void disabledContributesCssToHideWebUIComponents() {
+        withMockWMS()
+                .withPropertyValues("geoserver.web-ui.gwc.enabled=true")
+                .run(
+                        context -> {
+                            assertThat(context)
+                                    .doesNotHaveBean(CachingExtendedCapabilitiesProvider.class);
+                            assertThat(context).doesNotHaveBean(ForwardGetMapToGwcAspect.class);
+                            assertThat(context)
+                                    .hasBean(
+                                            "GWCSettingsPage_WMSIntegationDisabledCssContribution");
+                            HeaderContribution contrib =
+                                    context.getBean(
+                                            "GWCSettingsPage_WMSIntegationDisabledCssContribution",
+                                            HeaderContribution.class);
+                            assertEquals(GWCSettingsPage.class, contrib.getScope());
+                            assertEquals(
+                                    "wms-integration-disabled.css", contrib.getCSS().getName());
+                        });
+    }
+}


### PR DESCRIPTION
- AutoConfiguration to integrate GWC with GeoServer WMS

Disabled by default, can be enabled with the `gwc.wms-integration=true`
configuration property.

This is a component-level configuration property that, if enabled,
the option to activate the integration needs to be configured in
GeoServer's WEB-UI, and if disabled, the Web-UI don't even show the
checkboxkes in GWCSettingsPage.
- Integrate GWC with wms-service

`wms-service` only depends on the following gwc modules:

Add exclusions on `wms-service` and `web-ui` poms to reduce
the number of gwc module dependencies to just what they need,
and add `@ConditionalOnClass` conditions to `starter-gwc`
auto-configurations where appropriate to support some
gwc jars not being on the classpath.

```
gs-gwc-azure-blob
gs-gwc-s3
gwc-aws-s3
gwc-azure-blob
gwc-core
gwc-diskquota-core
gwc-diskquota-jdbc
```

`webui` only depends on the following gwc modules:

```
gs-gwc-azure-blob
gs-gwc-s3
gwc-aws-s3
gwc-azure-blob
gwc-core
gwc-diskquota-core
gwc-diskquota-jdbc
gs-web-gwc
```

Fixes #194
