### PR TITLE
Contribute known org.geoserver.config.ServiceFactoryExtension implementations

### DIFF
--- a/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalog/XstreamServiceLoadersConfiguration.java
+++ b/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/config/catalog/XstreamServiceLoadersConfiguration.java
@@ -7,11 +7,16 @@ package org.geoserver.cloud.config.catalog;
 import lombok.extern.slf4j.Slf4j;
 
 import org.geoserver.config.util.XStreamServiceLoader;
+import org.geoserver.gwc.wmts.WMTSFactoryExtension;
 import org.geoserver.gwc.wmts.WMTSXStreamLoader;
 import org.geoserver.platform.GeoServerResourceLoader;
+import org.geoserver.wcs.WCSFactoryExtension;
 import org.geoserver.wcs.WCSXStreamLoader;
+import org.geoserver.wfs.WFSFactoryExtension;
 import org.geoserver.wfs.WFSXStreamLoader;
+import org.geoserver.wms.WMSFactoryExtension;
 import org.geoserver.wms.WMSXStreamLoader;
+import org.geoserver.wps.WPSFactoryExtension;
 import org.geoserver.wps.WPSXStreamLoader;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -34,9 +39,21 @@ public class XstreamServiceLoadersConfiguration {
         return log(new WFSXStreamLoader(resourceLoader));
     }
 
+    @ConditionalOnMissingBean(WFSFactoryExtension.class)
+    public @Bean WFSFactoryExtension wfsFactoryExtension(GeoServerResourceLoader resourceLoader) {
+        log.info("Automatically contributing {}", WFSFactoryExtension.class.getSimpleName());
+        return new WFSFactoryExtension() {}; // constructor is protected!
+    }
+
     @ConditionalOnMissingBean(WMSXStreamLoader.class)
     public @Bean WMSXStreamLoader wmsLoader(GeoServerResourceLoader resourceLoader) {
         return log(new WMSXStreamLoader(resourceLoader));
+    }
+
+    @ConditionalOnMissingBean(WMSFactoryExtension.class)
+    public @Bean WMSFactoryExtension wmsFactoryExtension() {
+        log.info("Automatically contributing {}", WMSFactoryExtension.class.getSimpleName());
+        return new WMSFactoryExtension();
     }
 
     @ConditionalOnMissingBean(WCSXStreamLoader.class)
@@ -44,9 +61,21 @@ public class XstreamServiceLoadersConfiguration {
         return log(new WCSXStreamLoader(resourceLoader));
     }
 
+    @ConditionalOnMissingBean(WCSFactoryExtension.class)
+    public @Bean WCSFactoryExtension wcsFactoryExtension() {
+        log.info("Automatically contributing {}", WCSFactoryExtension.class.getSimpleName());
+        return new WCSFactoryExtension();
+    }
+
     @ConditionalOnMissingBean(WMTSXStreamLoader.class)
     public @Bean WMTSXStreamLoader wmtsLoader(GeoServerResourceLoader resourceLoader) {
         return log(new WMTSXStreamLoader(resourceLoader));
+    }
+
+    @ConditionalOnMissingBean(WMTSFactoryExtension.class)
+    public @Bean WMTSFactoryExtension wmtsFactoryExtension() {
+        log.info("Automatically contributing {}", WMTSFactoryExtension.class.getSimpleName());
+        return new WMTSFactoryExtension() {}; // constructor is protected!
     }
 
     @ConditionalOnMissingBean(WPSXStreamLoader.class)
@@ -54,10 +83,14 @@ public class XstreamServiceLoadersConfiguration {
         return log(new WPSXStreamLoader(resourceLoader));
     }
 
-    private <T extends XStreamServiceLoader<?>> T log(T loader) {
-        log.info(
-                "Automatically contributing {} service xstream loader",
-                loader.getClass().getSimpleName());
-        return loader;
+    @ConditionalOnMissingBean(WPSFactoryExtension.class)
+    public @Bean WPSFactoryExtension WPSFactoryExtension() {
+        log.info("Automatically contributing {}", WPSFactoryExtension.class.getSimpleName());
+        return new WPSFactoryExtension() {}; // constructor is protected!
+    }
+
+    private <T> T log(T extension) {
+        log.info("Automatically contributing {}", extension.getClass().getSimpleName());
+        return extension;
     }
 }


### PR DESCRIPTION
Make sure all `ServiceFactoryExtension` are available regardless
of whether the associated service is loaded.

Seems to only be used by web-ui, but its a GeoServerFactory
extension to create concrete ServiceInfo instances, so
better be sure than sorry.