### PR TITLE
Handle virtual services in gwc-service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,6 +142,8 @@ services:
       JAVA_OPTS: ${GATEWAY_JAVA_OPTS}
       SPRING_PROFILES_ACTIVE: dev #exposes the catalog and config API at /api/v1/**
       RETRY_MAX_ATTEMPTS: 100
+      # eat our own dogfood and set a base path
+      GEOSERVER_BASE_PATH: /geoserver/cloud
     ports:
       - 9090:8080
     networks:

--- a/starters/starter-gwc/src/main/java/org/gwc/web/gmaps/GoogleMapsController.java
+++ b/starters/starter-gwc/src/main/java/org/gwc/web/gmaps/GoogleMapsController.java
@@ -14,7 +14,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @Controller
-@RequestMapping("/gwc/service/gmaps")
+@RequestMapping(
+        path = {
+            "/gwc/service/gmaps",
+            "/{virtualservice}/gwc/service/gmaps",
+            "/{virtualservice}/{layer}/gwc/service/gmaps"
+        })
 public class GoogleMapsController {
 
     private @Autowired Dispatcher geoserverDispatcher;

--- a/starters/starter-gwc/src/main/java/org/gwc/web/kml/KMLController.java
+++ b/starters/starter-gwc/src/main/java/org/gwc/web/kml/KMLController.java
@@ -14,7 +14,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @Controller
-@RequestMapping("/gwc/service/kml")
+@RequestMapping(
+        path = {
+            "/gwc/service/kml",
+            "/{virtualservice}/gwc/service/kml",
+            "/{virtualservice}/{layer}/gwc/service/kml"
+        })
 public class KMLController {
 
     private @Autowired Dispatcher geoserverDispatcher;

--- a/starters/starter-gwc/src/main/java/org/gwc/web/mgmaps/MGMapsController.java
+++ b/starters/starter-gwc/src/main/java/org/gwc/web/mgmaps/MGMapsController.java
@@ -14,7 +14,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @Controller
-@RequestMapping("/gwc/service/mgmaps")
+@RequestMapping(
+        path = {
+            "/gwc/service/mgmaps",
+            "/{virtualservice}/gwc/service/mgmaps",
+            "/{virtualservice}/{layer}/gwc/service/mgmaps"
+        })
 public class MGMapsController {
 
     private @Autowired Dispatcher geoserverDispatcher;

--- a/starters/starter-gwc/src/main/java/org/gwc/web/tms/TMSController.java
+++ b/starters/starter-gwc/src/main/java/org/gwc/web/tms/TMSController.java
@@ -14,7 +14,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @Controller
-@RequestMapping("/gwc/service/tms")
+@RequestMapping(
+        path = {
+            "/gwc/service/tms",
+            "/{virtualservice}/gwc/service/tms",
+            "/{virtualservice}/{layer}/gwc/service/tms"
+        })
 public class TMSController {
 
     private @Autowired Dispatcher geoserverDispatcher;

--- a/starters/starter-gwc/src/main/java/org/gwc/web/wms/WMSController.java
+++ b/starters/starter-gwc/src/main/java/org/gwc/web/wms/WMSController.java
@@ -14,7 +14,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @Controller
-@RequestMapping("/gwc/service/wms")
+@RequestMapping(
+        path = {
+            "/gwc/service/wms",
+            "/{virtualservice}/gwc/service/wms",
+            "/{virtualservice}/{layer}/gwc/service/wms"
+        })
 public class WMSController {
 
     private @Autowired Dispatcher geoserverDispatcher;

--- a/starters/starter-gwc/src/main/java/org/gwc/web/wmts/WMTSController.java
+++ b/starters/starter-gwc/src/main/java/org/gwc/web/wmts/WMTSController.java
@@ -14,7 +14,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @Controller
-@RequestMapping("/gwc/service/wmts")
+@RequestMapping(
+        path = {
+            "/gwc/service/wmts",
+            "/{virtualservice}/gwc/service/wmts",
+            "/{virtualservice}/{layer}/gwc/service/wmts"
+        })
 public class WMTSController {
 
     private @Autowired Dispatcher geoserverDispatcher;


### PR DESCRIPTION
Let `gwc-service` handle GeoServer virtual services
(i.e.: `[/{virtualservice}[/{layername}]]/gwc/service/**`,
where `{virtualservice}` is either a workspace or global
layer group name).