### PR TITLE
GWC REST API fix to fill in the TileLayerInfo blanks when creating a TileLayer

### DIFF
--- a/src/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/CloudCatalogConfiguration.java
+++ b/src/starters/starter-gwc/src/main/java/org/geoserver/cloud/gwc/repository/CloudCatalogConfiguration.java
@@ -4,18 +4,34 @@
  */
 package org.geoserver.cloud.gwc.repository;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.cache.LoadingCache;
 
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.cloud.gwc.event.TileLayerEvent;
+import org.geoserver.gwc.GWC;
+import org.geoserver.gwc.config.GWCConfig;
 import org.geoserver.gwc.layer.CatalogConfiguration;
 import org.geoserver.gwc.layer.GeoServerTileLayer;
+import org.geoserver.gwc.layer.GeoServerTileLayerInfo;
 import org.geoserver.gwc.layer.TileLayerCatalog;
+import org.geoserver.gwc.layer.TileLayerInfoUtil;
+import org.geoserver.util.DimensionWarning.WarningType;
+import org.geowebcache.config.XMLGridSubset;
+import org.geowebcache.filter.parameters.ParameterFilter;
 import org.geowebcache.grid.GridSetBroker;
+import org.geowebcache.layer.ExpirationRule;
+import org.geowebcache.layer.TileLayer;
 import org.springframework.context.event.EventListener;
+
+import java.util.List;
+import java.util.Set;
 
 /**
  * @since 1.0
@@ -44,5 +60,57 @@ public class CloudCatalogConfiguration extends CatalogConfiguration {
     public void onTileLayerEvent(TileLayerEvent event) {
         log.debug("evicting GeoServerTileLayer cache entry upon {}", event);
         spiedLayerCache.invalidate(event.getLayerId());
+    }
+
+    @Override
+    public void addLayer(final TileLayer tl) {
+        checkNotNull(tl);
+        checkArgument(canSave(tl), "Can't save TileLayer of type ", tl.getClass());
+
+        GeoServerTileLayer tileLayer = (GeoServerTileLayer) tl;
+        GeoServerTileLayerInfo info = tileLayer.getInfo();
+
+        checkNotNull(info, "GeoServerTileLayerInfo is null");
+        checkNotNull(info.getId(), "id is null");
+        checkNotNull(info.getName(), "name is null");
+
+        PublishedInfo publishedInfo = tileLayer.getPublishedInfo();
+        GWCConfig defaults = GWC.get().getConfig();
+        GeoServerTileLayerInfo infoDefaults =
+                TileLayerInfoUtil.loadOrCreate(publishedInfo, defaults);
+        setMissingConfig(info, infoDefaults);
+        super.addLayer(tl);
+    }
+
+    private void setMissingConfig(GeoServerTileLayerInfo info, GeoServerTileLayerInfo defaults) {
+
+        // defaults.isAutoCacheStyles();
+        // defaults.isEnabled();
+        // defaults.isInMemoryCached();
+        String blobStoreId = defaults.getBlobStoreId();
+        Set<WarningType> cacheWarningSkips = defaults.getCacheWarningSkips();
+        int expireCache = defaults.getExpireCache();
+        List<ExpirationRule> expireCacheList = defaults.getExpireCacheList();
+        int expireClients = defaults.getExpireClients();
+        Set<XMLGridSubset> gridSubsets = defaults.getGridSubsets();
+        int gutter = defaults.getGutter();
+        int metaTilingX = defaults.getMetaTilingX();
+        int metaTilingY = defaults.getMetaTilingY();
+        Set<String> mimeFormats = defaults.getMimeFormats();
+        Set<ParameterFilter> parameterFilters = defaults.getParameterFilters();
+
+        if (null == info.getBlobStoreId()) info.setBlobStoreId(blobStoreId);
+        if (null == info.getCacheWarningSkips()) info.setCacheWarningSkips(cacheWarningSkips);
+        if (0 == info.getExpireCache()) info.setExpireCache(expireCache);
+        if (null == info.getExpireCacheList()) info.setExpireCacheList(expireCacheList);
+        if (0 == info.getExpireClients()) info.setExpireClients(expireClients);
+        if (null == info.getGridSubsets() || info.getGridSubsets().isEmpty())
+            info.setGridSubsets(gridSubsets);
+        if (0 == info.getGutter()) info.setGutter(gutter);
+        if (0 == info.getMetaTilingX()) info.setMetaTilingX(metaTilingX);
+        if (0 == info.getMetaTilingY()) info.setMetaTilingY(metaTilingY);
+        if (info.getMimeFormats().isEmpty()) info.getMimeFormats().addAll(mimeFormats);
+        if (null == info.getParameterFilters() || info.getParameterFilters().isEmpty())
+            info.setParameterFilters(parameterFilters);
     }
 }


### PR DESCRIPTION
To be raised as an issue upstream. Work around the behaivor
mismatch between GWC's REST API and GeoServer's GWC web-ui.

When creating a tile layer with the web-ui, the GeoServerTileLayerInfo
is populated with the defaults from GWCConfig (set in GWCSettings page).

When creating a tile layer through the REST API, it allows a minimal
payload but does not fill in the blanks with the defaults from GWConfig.

e.g., the following payload:

```
<GeoServerLayer><enabled>true</enabled><name>topp:states</name></GeoServerLayer>
```

results in an unsusable tile layer:

```
<?xml version="1.0" encoding="UTF-8"?>
<GeoServerLayer>
  <id>LayerInfoImpl-8fbb6079-2ee3-40b0-955a-2ccf1b8c2941</id>
  <enabled>true</enabled>
  <name>topp:states</name>
  <mimeFormats/>
  <gridSubsets/>
  <metaWidthHeight>
    <int>0</int>
    <int>0</int>
  </metaWidthHeight>
  <expireCache>0</expireCache>
  <expireClients>0</expireClients>
  <parameterFilters/>
  <gutter>0</gutter>
  <cacheWarningSkips/>
</GeoServerLayer>
```

where from the default tile layer settings it should be more like:

```
<GeoServerLayer>
  <id>LayerInfoImpl-8fbb6079-2ee3-40b0-955a-2ccf1b8c2941</id>
  <enabled>true</enabled>
  <name>topp:states</name>
  <mimeFormats>
    <string>image/png</string>
    <string>image/jpeg</string>
  </mimeFormats>
  <gridSubsets>
    <gridSubset>
      <gridSetName>EPSG:4326</gridSetName>
    </gridSubset>
    <gridSubset>
      <gridSetName>EPSG:900913</gridSetName>
    </gridSubset>
  </gridSubsets>
  <metaWidthHeight>
    <int>4</int>
    <int>4</int>
  </metaWidthHeight>
  <expireCache>0</expireCache>
  <expireClients>0</expireClients>
  <parameterFilters>
    <styleParameterFilter>
      <key>STYLES</key>
      <defaultValue></defaultValue>
    </styleParameterFilter>
  </parameterFilters>
  <gutter>0</gutter>
  <cacheWarningSkips/>
</GeoServerLayer>
```