### PR TITLE
Fix invalid virtual service endpoints not returning 404

### DIFF
--- a/src/services/wcs/src/main/java/org/geoserver/cloud/wcs/WCSController.java
+++ b/src/services/wcs/src/main/java/org/geoserver/cloud/wcs/WCSController.java
@@ -7,10 +7,12 @@ package org.geoserver.cloud.wcs;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
+import org.geoserver.cloud.virtualservice.VirtualServiceVerifier;
 import org.geoserver.ows.Dispatcher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.view.RedirectView;
@@ -23,6 +25,8 @@ public @Controller class WCSController {
     private @Autowired Dispatcher geoserverDispatcher;
 
     private @Autowired org.geoserver.ows.ClasspathPublisher classPathPublisher;
+
+    private @Autowired VirtualServiceVerifier virtualServiceVerifier;
 
     @GetMapping("/")
     public RedirectView redirectRootToGetCapabilities() {
@@ -38,15 +42,36 @@ public @Controller class WCSController {
 
     @RequestMapping(
             method = {GET, POST},
-            path = {
-                "/wcs",
-                "/{workspace}/wcs",
-                "/{workspace}/{layer}/wcs",
-                "/ows",
-                "/{workspace}/ows",
-                "/{workspace}/{layer}/ows"
-            })
+            path = {"/wcs", "/ows"})
     public void handle(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        geoserverDispatcher.handleRequest(request, response);
+    }
+
+    @RequestMapping(
+            method = {GET, POST},
+            path = {"/{virtualService}/wcs", "/{virtualService}/ows"})
+    public void handleVirtualService(
+            @PathVariable(name = "virtualService") String virtualService,
+            HttpServletRequest request,
+            HttpServletResponse response)
+            throws Exception {
+
+        virtualServiceVerifier.checkVirtualService(virtualService);
+
+        geoserverDispatcher.handleRequest(request, response);
+    }
+
+    @RequestMapping(
+            method = {GET, POST},
+            path = {"/{virtualService}/{layer}/wcs", "/{virtualService}/{layer}/ows"})
+    public void handleVirtualServiceLayer(
+            @PathVariable(name = "virtualService") String virtualService,
+            @PathVariable(name = "layer") String layer,
+            HttpServletRequest request,
+            HttpServletResponse response)
+            throws Exception {
+
+        virtualServiceVerifier.checkVirtualService(virtualService, layer);
         geoserverDispatcher.handleRequest(request, response);
     }
 }

--- a/src/services/wcs/src/main/java/org/geoserver/cloud/wcs/WcsApplicationConfiguration.java
+++ b/src/services/wcs/src/main/java/org/geoserver/cloud/wcs/WcsApplicationConfiguration.java
@@ -5,6 +5,8 @@
 package org.geoserver.cloud.wcs;
 
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.virtualservice.VirtualServiceVerifier;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
@@ -17,4 +19,9 @@ import org.springframework.context.annotation.ImportResource;
             "jar:gs-wcs1_1-.*!/applicationContext.xml", //
             "jar:gs-wcs2_0-.*!/applicationContext.xml" //
         })
-public class WcsApplicationConfiguration {}
+public class WcsApplicationConfiguration {
+
+    public @Bean VirtualServiceVerifier virtualServiceVerifier() {
+        return new VirtualServiceVerifier();
+    }
+}

--- a/src/services/wfs/src/main/java/org/geoserver/cloud/wfs/config/WfsAutoConfiguration.java
+++ b/src/services/wfs/src/main/java/org/geoserver/cloud/wfs/config/WfsAutoConfiguration.java
@@ -6,7 +6,9 @@ package org.geoserver.cloud.wfs.config;
 
 import org.geoserver.cloud.autoconfigure.core.GeoServerWebMvcMainAutoConfiguration;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.virtualservice.VirtualServiceVerifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
@@ -19,4 +21,9 @@ import org.springframework.context.annotation.ImportResource;
             "jar:gs-flatgeobuf-.*!/applicationContext.xml#name=.*"
         } //
         )
-public class WfsAutoConfiguration {}
+public class WfsAutoConfiguration {
+
+    public @Bean VirtualServiceVerifier virtualServiceVerifier() {
+        return new VirtualServiceVerifier();
+    }
+}

--- a/src/services/wms/src/main/java/org/geoserver/cloud/wms/app/WmsApplicationConfiguration.java
+++ b/src/services/wms/src/main/java/org/geoserver/cloud/wms/app/WmsApplicationConfiguration.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.wms.app;
 
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.virtualservice.VirtualServiceVerifier;
 import org.geoserver.cloud.wms.controller.GetMapReflectorController;
 import org.geoserver.cloud.wms.controller.WMSController;
 import org.geoserver.config.GeoServer;
@@ -47,6 +48,10 @@ public class WmsApplicationConfiguration {
 
     public @Bean WMSController webMapServiceController() {
         return new WMSController();
+    }
+
+    public @Bean VirtualServiceVerifier virtualServiceVerifier() {
+        return new VirtualServiceVerifier();
     }
 
     @ConditionalOnProperty(

--- a/src/services/wms/src/main/java/org/geoserver/cloud/wms/controller/WMSController.java
+++ b/src/services/wms/src/main/java/org/geoserver/cloud/wms/controller/WMSController.java
@@ -7,10 +7,12 @@ package org.geoserver.cloud.wms.controller;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
+import org.geoserver.cloud.virtualservice.VirtualServiceVerifier;
 import org.geoserver.ows.Dispatcher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.view.RedirectView;
@@ -23,6 +25,8 @@ public @Controller class WMSController {
     private @Autowired Dispatcher geoserverDispatcher;
 
     private @Autowired org.geoserver.ows.ClasspathPublisher classPathPublisher;
+
+    private @Autowired VirtualServiceVerifier virtualServiceVerifier;
 
     @GetMapping("/")
     public RedirectView redirectRootToGetCapabilities() {
@@ -67,15 +71,36 @@ public @Controller class WMSController {
 
     @RequestMapping(
             method = {GET, POST},
-            path = {
-                "/wms",
-                "/{workspace}/wms",
-                "/{workspace}/{layer}/wms",
-                "/ows",
-                "/{workspace}/ows",
-                "/{workspace}/{layer}/ows"
-            })
+            path = {"/wms", "/ows"})
     public void handle(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        geoserverDispatcher.handleRequest(request, response);
+    }
+
+    @RequestMapping(
+            method = {GET, POST},
+            path = {"/{virtualService}/wms", "/{virtualService}/ows"})
+    public void handleVirtualService(
+            @PathVariable(name = "virtualService") String virtualService,
+            HttpServletRequest request,
+            HttpServletResponse response)
+            throws Exception {
+
+        virtualServiceVerifier.checkVirtualService(virtualService);
+
+        geoserverDispatcher.handleRequest(request, response);
+    }
+
+    @RequestMapping(
+            method = {GET, POST},
+            path = {"/{virtualService}/{layer}/wms", "/{virtualService}/{layer}/ows"})
+    public void handleVirtualServiceLayer(
+            @PathVariable(name = "virtualService") String virtualService,
+            @PathVariable(name = "layer") String layer,
+            HttpServletRequest request,
+            HttpServletResponse response)
+            throws Exception {
+
+        virtualServiceVerifier.checkVirtualService(virtualService, layer);
         geoserverDispatcher.handleRequest(request, response);
     }
 }

--- a/src/services/wms/src/main/resources/bootstrap.yml
+++ b/src/services/wms/src/main/resources/bootstrap.yml
@@ -6,6 +6,11 @@ server:
   # Let spring-boot's ForwardedHeaderFilter take care of reflecting the client-originated protocol and address in the HttpServletRequest  
   forward-headers-strategy: framework
   servlet.context-path: /
+  error:
+    include-message: always
+    include-binding-errors: always
+    whitelabel:
+      enabled: true
 management.server.port: 8081
 spring:
   config:

--- a/src/starters/starter-webmvc/src/main/java/org/geoserver/cloud/virtualservice/VirtualServiceVerifier.java
+++ b/src/starters/starter-webmvc/src/main/java/org/geoserver/cloud/virtualservice/VirtualServiceVerifier.java
@@ -1,0 +1,76 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.virtualservice;
+
+import lombok.NonNull;
+
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.PublishedInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+/**
+ * Helper service for OWS controllers to verify the existence of virtual services before proceeding.
+ *
+ * @since 1.0
+ */
+public class VirtualServiceVerifier {
+
+    private @Autowired Catalog catalog;
+
+    /**
+     * @throws 404 ResponseStatusException if {@code virtualService} can't be mapped to a workspace
+     *     or a root layer group
+     */
+    public void checkVirtualService(@NonNull String virtualService) {
+        findWorkspace(virtualService)
+                .map(WorkspaceInfo::getName)
+                .or(() -> findGlobalLayerGroup(virtualService).map(LayerGroupInfo::getName))
+                .orElseThrow(() -> virtualServiceNotFound(virtualService));
+    }
+
+    /**
+     * @throws 404 ResponseStatusException if {@code virtualService} can't be mapped to a workspace
+     *     and layer to a {@link PublishedInfo} inside it
+     */
+    public void checkVirtualService(String virtualService, String layer) {
+        WorkspaceInfo ws =
+                findWorkspace(virtualService)
+                        .orElseThrow(() -> virtualServiceNotFound(virtualService));
+        findPublished(ws.getName(), layer).orElseThrow(() -> layerNotFound(virtualService, layer));
+    }
+
+    private Optional<WorkspaceInfo> findWorkspace(String workspace) {
+        return Optional.ofNullable(catalog.getWorkspaceByName(workspace));
+    }
+
+    private Optional<LayerGroupInfo> findGlobalLayerGroup(String name) {
+        return Optional.ofNullable(catalog.getLayerGroupByName(name));
+    }
+
+    private Optional<PublishedInfo> findPublished(String workspace, String layer) {
+        PublishedInfo l = catalog.getLayerGroupByName(workspace, layer);
+        if (null == l) {
+            String qualifiedName = workspace + ":" + layer;
+            l = catalog.getLayerByName(qualifiedName);
+        }
+        return Optional.ofNullable(l);
+    }
+
+    private ResponseStatusException virtualServiceNotFound(String service) {
+        return new ResponseStatusException(
+                HttpStatus.NOT_FOUND, "Workspace or global LayerGroup does not exist: " + service);
+    }
+
+    private ResponseStatusException layerNotFound(String workspace, String layer) {
+        return new ResponseStatusException(
+                HttpStatus.NOT_FOUND, "Layer " + layer + " does not exist in " + workspace);
+    }
+}


### PR DESCRIPTION
If an invalid virtual service request is made (e.g.
to a non existing workspace or layer), upstream
GeoServer will return a 404 thanks to `OWSHandlerMapping`
checking for the workspace/layergroup/layer and returning
a `null` request handler.

Spring-boot does not automatically engages the `OWSHandlerMapping`
beans in the request lifecycle.

This patch creates separate controller entry points for
`/{virtualService}/<ows service>` and
`/{virtualService}/{layer}/<ows service>`, using a helper
service bean to verify the existence of the requested
workspace/layergroup and layer, returning a 404 with
an explanatory message if the virtual service is not found,
and hence avoiding to return the full layer list in
getcapabilities requests instead.

Fixes #24