### PR TITLE
Do allow to configure jdbcconfig datasource connection limits

### DIFF
--- a/src/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/test/backend/JdbcConfigDataSourceTest.java
+++ b/src/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/test/backend/JdbcConfigDataSourceTest.java
@@ -1,0 +1,53 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.test.backend;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+import org.geoserver.cloud.autoconfigure.testconfiguration.AutoConfigurationTestConfiguration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLTransientConnectionException;
+
+import javax.sql.DataSource;
+
+@SpringBootTest(
+        classes = AutoConfigurationTestConfiguration.class,
+        properties = {
+            "geoserver.backend.jdbcconfig.enabled=true",
+            "geoserver.backend.jdbcconfig.datasource.maximumPoolSize=2",
+            "geoserver.backend.jdbcconfig.datasource.minimumIdle=1",
+            "geoserver.backend.jdbcconfig.datasource.connectionTimeout=250", // 250ms
+            "geoserver.backend.jdbcconfig.datasource.idleTimeout=10000", // 10 secs
+        })
+@RunWith(SpringRunner.class)
+public class JdbcConfigDataSourceTest extends JDBCConfigTest {
+
+    public @Test void testDataSource() throws SQLException {
+        DataSource ds = context.getBean("jdbcConfigDataSource", DataSource.class);
+        assertSame(ds, context.getBean("jdbcStoreDataSource", DataSource.class));
+        assertThat(ds, instanceOf(HikariDataSource.class));
+        HikariDataSource hds = (HikariDataSource) ds;
+        assertEquals(2, hds.getMaximumPoolSize());
+        assertEquals(1, hds.getMinimumIdle());
+        assertEquals(10_000, hds.getIdleTimeout());
+        assertEquals(250, hds.getConnectionTimeout());
+        try (Connection c1 = hds.getConnection();
+                Connection c2 = hds.getConnection()) {
+            assertThrows(SQLTransientConnectionException.class, () -> hds.getConnection());
+        }
+    }
+}


### PR DESCRIPTION
At some point we lost the ability to configure the connection pool limits, despite what spring-boot's [documentation says](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto.data-access.configure-two-datasources).

Adds the following configuration properties to `geoserver.backend.jdbcconfig.datasource`:

`minimumIdle`: minimum number of connections in the pool
`maximumPoolSize`: maximum number of connection in the pool
`connectionTimeout`: connection time out in milliseconds (defaults to `250`, which is also the minimum value)
`idleTimeout`: time in milliseconds before closing idle connections (defaults to `60000`)