### PR TITLE
Wrong reference to docs-file

### DIFF
--- a/src/services/catalog/README.md
+++ b/src/services/catalog/README.md
@@ -4,4 +4,4 @@ Spring Webflux reactive microservice that exposes the GeoServer *catalog*, *glob
 objects through a RESTful API to other microservices, in order to abstract out the microservices that require access
 to the catalog from the actual catalog backend and implementation.
 
-Follow the service [documentation](../../docs/develop/services/catalog-service.md) and keep it up to date .
+Follow the service [documentation](../../../docs/develop/services/catalog-service.md) and keep it up to date .


### PR DESCRIPTION
Update the path to another file in the docs, the used link resulted in a 404 error.