### PR TITLE
Expose some basic catalog and config metrics to be exported by micrometer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ webapp
 .flattened-pom.xml
 
 docker-compose_datadir*
+/.metadata/

--- a/src/starters/starter-catalog-backend/pom.xml
+++ b/src/starters/starter-catalog-backend/pom.xml
@@ -15,6 +15,11 @@
       <artifactId>gs-cloud-spring-boot-starter</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-webmvc</artifactId>
       <scope>provided</scope>

--- a/src/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/metrics/catalog/CatalogMetrics.java
+++ b/src/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/metrics/catalog/CatalogMetrics.java
@@ -1,0 +1,80 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.metrics.catalog;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.geoserver.catalog.Catalog;
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.GeoServerInfo;
+
+import java.util.function.Supplier;
+
+/**
+ * Registers GeoServer {@link Catalog catalog} and {@link GeoServer config} metrics to be exported
+ * by micrometer's {@link MeterRegistry}.
+ *
+ * <p>The following metrics are exported:
+ *
+ * <ul>
+ *   <li>{@literal geoserver.config.update_sequence}: the configuration {@link
+ *       GeoServerInfo#getUpdateSequence() update sequence}
+ *   <li>{@literal geoserver.catalog.added}: Number of CatalogInfo objects added to this instance's
+ *       Catalog
+ *   <li>{@literal geoserver.catalog.removed}: Number of CatalogInfo objects removed on this
+ *       instance's Catalog
+ *   <li>{@literal geoserver.catalog.modified}: Number of modifications to CatalogInfo objects on
+ *       this instance's Catalog
+ * </ul>
+ *
+ * <p>All metrics are tagged with the {@literal instance-id} key, whose value is resolved through
+ * <code>${geoserver.metrics.instance-id}</code>, which usually should be the same as <code>
+ * ${info.instance-id}</code>.
+ *
+ * @since 1.0
+ */
+@RequiredArgsConstructor
+@Slf4j(topic = "org.geoserver.cloud.metrics.catalog")
+public class CatalogMetrics implements MeterBinder {
+
+    private final @NonNull GeoSeverMetricsConfigProperties metricsConfig;
+    private final @NonNull Catalog catalog;
+    private final @NonNull GeoServer config;
+
+    private MetricsCatalogListener listener;
+
+    public @Override void bindTo(@NonNull MeterRegistry registry) {
+        if (listener != null) {
+            catalog.removeListener(listener);
+        }
+
+        if (metricsConfig.isEnabled()) {
+            final String instanceIdTag = metricsConfig.getInstanceId();
+            catalog.addListener(listener = new MetricsCatalogListener(registry, instanceIdTag));
+
+            registerUpdateSequence(registry, instanceIdTag);
+
+            log.info("GeoServer Catalog and config metrics enabled.");
+        }
+    }
+
+    private void registerUpdateSequence(MeterRegistry registry, final String instanceIdTag) {
+        Supplier<Number> updateSequence = () -> config.getGlobal().getUpdateSequence();
+        Gauge.Builder<Supplier<Number>> updateSeqBuilder =
+                Gauge.builder("geoserver.config.update_sequence", updateSequence)
+                        .description("GeoServer configuration update sequence")
+                        .baseUnit("sequence");
+
+        if (null != instanceIdTag)
+            updateSeqBuilder = updateSeqBuilder.tag("instance-id", instanceIdTag);
+        updateSeqBuilder.register(registry);
+    }
+}

--- a/src/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/metrics/catalog/CatalogMetricsAutoConfiguration.java
+++ b/src/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/metrics/catalog/CatalogMetricsAutoConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.metrics.catalog;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+import org.geoserver.catalog.Catalog;
+import org.geoserver.config.GeoServer;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for {@link Catalog} and {@link GeoServer}
+ * metrics; depends on the {@literal geoserver.metrics.enabled=true} configuration property.
+ *
+ * @see CatalogMetrics
+ * @since 1.0
+ */
+@Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter({MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
+@ConditionalOnClass(MeterRegistry.class)
+@ConditionalOnBean(MeterRegistry.class)
+@EnableConfigurationProperties(GeoSeverMetricsConfigProperties.class)
+public class CatalogMetricsAutoConfiguration {
+
+    public @Bean CatalogMetrics geoserverCatalogMetrics( //
+            GeoSeverMetricsConfigProperties metricsConfig, //
+            @Qualifier("catalog") Catalog catalog, //
+            @Qualifier("geoServer") GeoServer config) {
+
+        return new CatalogMetrics(metricsConfig, catalog, config);
+    }
+}

--- a/src/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/metrics/catalog/GeoSeverMetricsConfigProperties.java
+++ b/src/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/metrics/catalog/GeoSeverMetricsConfigProperties.java
@@ -1,0 +1,22 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+
+package org.geoserver.cloud.autoconfigure.metrics.catalog;
+
+import lombok.Data;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @since 1.0
+ */
+@Data
+@ConfigurationProperties(prefix = "geoserver.metrics")
+public class GeoSeverMetricsConfigProperties {
+
+    private boolean enabled = true;
+
+    private String instanceId;
+}

--- a/src/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/metrics/catalog/MetricsCatalogListener.java
+++ b/src/starters/starter-catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/metrics/catalog/MetricsCatalogListener.java
@@ -1,0 +1,82 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.metrics.catalog;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Counter.Builder;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.BaseUnits;
+
+import lombok.NonNull;
+
+import org.geoserver.catalog.CatalogException;
+import org.geoserver.catalog.event.CatalogAddEvent;
+import org.geoserver.catalog.event.CatalogListener;
+import org.geoserver.catalog.event.CatalogModifyEvent;
+import org.geoserver.catalog.event.CatalogPostModifyEvent;
+import org.geoserver.catalog.event.CatalogRemoveEvent;
+
+import javax.annotation.Nullable;
+
+class MetricsCatalogListener implements CatalogListener {
+
+    private final Counter added;
+    private final Counter removed;
+    private final Counter modified;
+    private final Counter reloads;
+
+    public MetricsCatalogListener(@NonNull MeterRegistry registry, @Nullable String instanceId) {
+
+        added =
+                counter("geoserver.catalog.added", instanceId, registry)
+                        .description(
+                                "Number of CatalogInfo objects added to this instance's Catalog")
+                        .register(registry);
+        removed =
+                counter("geoserver.catalog.removed", instanceId, registry)
+                        .description(
+                                "Number of CatalogInfo objects removed on this instance's Catalog")
+                        .register(registry);
+        modified =
+                counter("geoserver.catalog.modified", instanceId, registry)
+                        .description(
+                                "Number of modifications to CatalogInfo objects on this instance's Catalog")
+                        .register(registry);
+
+        reloads =
+                Counter.builder("geoserver.catalog.reloads")
+                        .description("Times the Catalog has been reloaded")
+                        .baseUnit(BaseUnits.OPERATIONS)
+                        .register(registry);
+    }
+
+    private Counter.Builder counter(String name, String instanceId, MeterRegistry registry) {
+        Builder builder =
+                Counter.builder(name) //
+                        .baseUnit(BaseUnits.OPERATIONS);
+        if (null != instanceId) builder = builder.tag("instance-id", instanceId);
+        return builder;
+    }
+
+    public @Override void handleAddEvent(CatalogAddEvent event) throws CatalogException {
+        added.increment();
+    }
+
+    public @Override void handleRemoveEvent(CatalogRemoveEvent event) {
+        removed.increment();
+    }
+
+    public @Override void reloaded() {
+        reloads.increment();
+    }
+
+    public @Override void handlePostModifyEvent(CatalogPostModifyEvent event) {
+        modified.increment();
+    }
+
+    public @Override void handleModifyEvent(CatalogModifyEvent event) {
+        // no-op, see #handlePostModifyEvent
+    }
+}

--- a/src/starters/starter-catalog-backend/src/main/resources/META-INF/spring.factories
+++ b/src/starters/starter-catalog-backend/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.geotools.autoconfigure.httpclient.GeoToolsHttpClientAutoConfiguration,\
 org.geoserver.cloud.autoconfigure.catalog.GeoServerBackendAutoConfiguration,\
-org.geoserver.cloud.autoconfigure.security.GeoServerSecurityAutoConfiguration
+org.geoserver.cloud.autoconfigure.security.GeoServerSecurityAutoConfiguration,\
+org.geoserver.cloud.autoconfigure.metrics.catalog.CatalogMetricsAutoConfiguration

--- a/src/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/testconfiguration/AutoConfigurationTestConfiguration.java
+++ b/src/starters/starter-catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/testconfiguration/AutoConfigurationTestConfiguration.java
@@ -4,6 +4,8 @@
  */
 package org.geoserver.cloud.autoconfigure.testconfiguration;
 
+import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementContextAutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
@@ -11,5 +13,10 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @EnableAutoConfiguration(
-        exclude = {SecurityAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class})
+        exclude = {
+            SecurityAutoConfiguration.class,
+            UserDetailsServiceAutoConfiguration.class,
+            ManagementContextAutoConfiguration.class,
+            ManagementWebSecurityAutoConfiguration.class
+        })
 public class AutoConfigurationTestConfiguration {}

--- a/src/starters/starter-spring-boot/src/main/resources/gs_cloud_bootstrap_profiles.yml
+++ b/src/starters/starter-spring-boot/src/main/resources/gs_cloud_bootstrap_profiles.yml
@@ -10,6 +10,15 @@ config.server.url: http://config:8080
 # and the the discovery-service is eureka (discovery_eureka profile is enabled) 
 eureka.server.url: http://discovery:8761/eureka
 
+info:
+  component: Web Map Service
+  instance-id: ${spring.application.name}:${vcap.application.instance_id:${spring.application.instance_id:${spring.cloud.client.ip-address}}:${server.port}}
+
+geoserver:
+  metrics:
+    enabled: true
+    instance-id: ${info.instance-id}
+    
 # This default configuration is the same than applying the config_first profile group
 # defined below.
 spring:


### PR DESCRIPTION
Expose some basic catalog and config metrics to be exported by micrometer.

If `spring-boot-actuator` is present on the (GeoServer) application,
and the config propery `geoserver.metrics.enabled=true` (default),
the following metrics are exported through micrometer, with the
`instance-id` tag matching the `info.instance-id` value to ease
slicing by service when aggregating values on an external system.

* `geoserver.config.update_sequence`: The configuration update sequence.
* `geoserver.catalog.added`: Number of CatalogInfo objects added to
this instance's Catalog
* `geoserver.catalog.removed`: Number of CatalogInfo objects removed
on this instance's Catalog
* `geoserver.catalog.modified`: Number of modifications to CatalogInfo
objects on this instance's Catalog

They can then be monitored at each instance's actuator endpoint. For
example:

```
curl -i http://192.168.0.21:8106/actuator/metrics/geoserver.config.update_sequence
HTTP/1.1 200
Content-Type: application/vnd.spring-boot.actuator.v3+json

{
  "name": "geoserver.config.update_sequence",
  "description": "GeoServer configuration update sequence",
  "baseUnit": "sequence",
  "measurements": [
    {
      "statistic": "VALUE",
      "value": 208.0
    }
  ],
  "availableTags": [
    {
      "tag": "instance-id",
      "values": [
        "web-ui:192.168.0.21:9106"
      ]
    }
  ]
}
```

References:
- [Spring Boot Metrics](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#actuator.metrics)
- [Micrometer](https://micrometer.io/)