### PR TITLE
Replace GeoServerInitStartupListener by an ApplicationContextInitializer

### DIFF
--- a/src/starters/webmvc/src/main/java/org/geoserver/cloud/autoconfigure/context/GeoServerContextInitializer.java
+++ b/src/starters/webmvc/src/main/java/org/geoserver/cloud/autoconfigure/context/GeoServerContextInitializer.java
@@ -1,0 +1,53 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.context;
+
+import org.geoserver.GeoserverInitStartupListener;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+
+/**
+ * {@link ApplicationContextInitializer} replacing upstream's {@link GeoserverInitStartupListener},
+ * which is a servlet context listener instead, and hence runs too late in spring-boot.
+ *
+ * <p>With an {@code ApplicationContextInitializer} we make sure required initializations run before
+ * even loading the spring beans.
+ *
+ * @since 1.0
+ */
+public class GeoServerContextInitializer
+        implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    @Override
+    public void initialize(ConfigurableApplicationContext applicationContext) {
+        System.setProperty("RELINQUISH_LOG4J_CONTROL", "true");
+        System.setProperty("org.geotools.referencing.forceXY", "true");
+
+        ServletContext source = mockServletContext();
+        ServletContextEvent sce = new ServletContextEvent(source);
+        GeoserverInitStartupListener startupInitializer = new GeoserverInitStartupListener();
+        startupInitializer.contextInitialized(sce);
+    }
+
+    protected ServletContext mockServletContext() {
+        InvocationHandler handler =
+                new InvocationHandler() {
+                    public @Override Object invoke(Object proxy, Method method, Object[] args)
+                            throws Throwable {
+                        return null;
+                    }
+                };
+        return (ServletContext)
+                Proxy.newProxyInstance(
+                        getClass().getClassLoader(), new Class[] {ServletContext.class}, handler);
+    }
+}

--- a/src/starters/webmvc/src/main/java/org/geoserver/cloud/config/servlet/GeoServerServletContextConfiguration.java
+++ b/src/starters/webmvc/src/main/java/org/geoserver/cloud/config/servlet/GeoServerServletContextConfiguration.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.cloud.config.servlet;
 
-import org.geoserver.GeoserverInitStartupListener;
 import org.geoserver.filters.FlushSafeFilter;
 import org.geoserver.filters.SessionDebugFilter;
 import org.geoserver.filters.SpringDelegatingFilter;
@@ -29,11 +28,6 @@ public class GeoServerServletContextConfiguration {
     private static final int THREAD_LOCALS_CLEANUP_FILTER_ORDER = 5;
 
     // Listeners
-    public @Bean GeoserverInitStartupListener initStartupListener() {
-        System.setProperty("RELINQUISH_LOG4J_CONTROL", "true");
-        return new GeoserverInitStartupListener();
-    }
-
     public @Bean GeoServerServletInitializer contextLoaderListener() {
         return new GeoServerServletInitializer();
     }

--- a/src/starters/webmvc/src/main/resources/META-INF/spring.factories
+++ b/src/starters/webmvc/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,8 @@
+# Initializers
+org.springframework.context.ApplicationContextInitializer=\
+org.geoserver.cloud.autoconfigure.context.GeoServerContextInitializer
+
+# Auto Configure
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.geoserver.cloud.autoconfigure.core.GeoServerWebMvcMainAutoConfiguration,\
 org.geoserver.cloud.autoconfigure.servlet.GeoServerServletContextAutoConfiguration,\

--- a/src/starters/webmvc/src/test/java/org/geoserver/cloud/autoconfigure/servlet/ServletContextConditionalFiltersTest.java
+++ b/src/starters/webmvc/src/test/java/org/geoserver/cloud/autoconfigure/servlet/ServletContextConditionalFiltersTest.java
@@ -6,7 +6,6 @@ package org.geoserver.cloud.autoconfigure.servlet;
 
 import static org.junit.Assert.assertNotNull;
 
-import org.geoserver.GeoserverInitStartupListener;
 import org.geoserver.cloud.config.servlet.GeoServerServletInitializer;
 import org.geoserver.cloud.test.TestConfiguration;
 import org.geoserver.filters.FlushSafeFilter;
@@ -49,10 +48,6 @@ public class ServletContextConditionalFiltersTest {
     @Test(expected = NoSuchBeanDefinitionException.class)
     public void sessionDebugFilter() {
         context.getBean(SessionDebugFilter.class);
-    }
-
-    public @Test void initStartupListener() {
-        assertNotNull(context.getBean(GeoserverInitStartupListener.class));
     }
 
     public @Test void contextLoaderListener() {

--- a/src/starters/webmvc/src/test/java/org/geoserver/cloud/autoconfigure/servlet/ServletContextDisabledSmokeTest.java
+++ b/src/starters/webmvc/src/test/java/org/geoserver/cloud/autoconfigure/servlet/ServletContextDisabledSmokeTest.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.cloud.autoconfigure.servlet;
 
-import org.geoserver.GeoserverInitStartupListener;
 import org.geoserver.cloud.config.servlet.GeoServerServletInitializer;
 import org.geoserver.cloud.test.TestConfiguration;
 import org.geoserver.filters.FlushSafeFilter;
@@ -40,11 +39,6 @@ import org.springframework.web.context.request.RequestContextListener;
 public class ServletContextDisabledSmokeTest {
 
     private @Autowired ApplicationContext context;
-
-    @Test(expected = NoSuchBeanDefinitionException.class)
-    public void initStartupListener() {
-        context.getBean(GeoserverInitStartupListener.class);
-    }
 
     @Test(expected = NoSuchBeanDefinitionException.class)
     public void contextLoaderListener() {

--- a/src/starters/webmvc/src/test/java/org/geoserver/cloud/autoconfigure/servlet/ServletContextEnabledSmokeTest.java
+++ b/src/starters/webmvc/src/test/java/org/geoserver/cloud/autoconfigure/servlet/ServletContextEnabledSmokeTest.java
@@ -6,7 +6,6 @@ package org.geoserver.cloud.autoconfigure.servlet;
 
 import static org.junit.Assert.assertNotNull;
 
-import org.geoserver.GeoserverInitStartupListener;
 import org.geoserver.cloud.config.servlet.GeoServerServletInitializer;
 import org.geoserver.cloud.test.TestConfiguration;
 import org.geoserver.filters.FlushSafeFilter;
@@ -35,10 +34,6 @@ import org.springframework.web.context.request.RequestContextListener;
 public class ServletContextEnabledSmokeTest {
 
     private @Autowired ApplicationContext context;
-
-    public @Test void initStartupListener() {
-        assertNotNull(context.getBean(GeoserverInitStartupListener.class));
-    }
 
     public @Test void contextLoaderListener() {
         assertNotNull(context.getBean(GeoServerServletInitializer.class));


### PR DESCRIPTION
Being a `ServletContextListener`, `GeoServerInitStartupListener`
can run when it's too late to set up the static initializations,
GeoServer expects before even loading the catalog and other
spring beans.

Fixes #231
At some point, probably during a recent refactoring,
`GeoServerInitStartupListener` stopped running before GeoServer uses
any CRS GeoTools API, at which point it's too late to set the
`org.geotools.referencing.forceXY=true` system property.

The right way to perform such early initialization in spring-boot is
through an `ApplicationContextInitializer` instead.
