### PR TITLE
Move default workspace/store assignment to CatalogPlugin.add(...)

### DIFF
--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogPlugin.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogPlugin.java
@@ -239,6 +239,9 @@ public class CatalogPlugin extends CatalogImpl implements Catalog {
 
     // Store methods
     public @Override void add(StoreInfo store) {
+        if (store.getWorkspace() == null) {
+            store.setWorkspace(getDefaultWorkspace());
+        }
         doAdd(store, facade::add);
     }
 
@@ -426,6 +429,13 @@ public class CatalogPlugin extends CatalogImpl implements Catalog {
 
     // Resource methods
     public @Override void add(ResourceInfo resource) {
+        if (resource.getNamespace() == null) {
+            // default to default namespace
+            resource.setNamespace(getDefaultNamespace());
+        }
+        if (resource.getNativeName() == null) {
+            resource.setNativeName(resource.getName());
+        }
         doAdd(resource, facade::add);
     }
 

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/validation/DefaultPropertyValuesResolver.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/validation/DefaultPropertyValuesResolver.java
@@ -74,10 +74,6 @@ public class DefaultPropertyValuesResolver {
     }
 
     private void resolve(StoreInfo store) {
-        if (store.getWorkspace() == null) {
-            store.setWorkspace(catalog.getDefaultWorkspace());
-        }
-
         resolveCollections(store);
         StoreInfoImpl s = (StoreInfoImpl) store;
         s.setCatalog(catalog);
@@ -86,14 +82,6 @@ public class DefaultPropertyValuesResolver {
     private void resolve(ResourceInfo resource) {
         ResourceInfoImpl r = (ResourceInfoImpl) resource;
         r.setCatalog(catalog);
-
-        if (resource.getNamespace() == null) {
-            // default to default namespace
-            resource.setNamespace(catalog.getDefaultNamespace());
-        }
-        if (resource.getNativeName() == null) {
-            resource.setNativeName(resource.getName());
-        }
 
         if (resource instanceof FeatureTypeInfo) {
             resolve((FeatureTypeInfo) resource);


### PR DESCRIPTION
Fixes a bug where the restapi calls in catalog validation
before adding a coverage store, but the catalog validation
was assgigning the default workspace/store itself.

# Use case 1: create a coverage store with no workspace in the XML payload

`store_no_ws.xml`:

```
<coverageStore>
  <name>mosaic</name>
  <type>ImageMosaic</type>
  <enabled>true</enabled>
  <url>file:coverages/mosaic/mosaic.shp</url>
</coverageStore>
```

## Expected:

```
curl -v -u admin:geoserver -H "Content-Type: application/xml" "$baseurl/workspaces/test1/coveragestores" -d @store_no_ws.xml
> POST /geoserver/cloud/rest/workspaces/test1/coveragestores HTTP/1.1
> 
< HTTP/1.1 500 Server Error
Store must be part of a workspace
```

## Actual:

```
curl -v -u admin:geoserver -H "Content-Type: application/xml" "$baseurl/workspaces/test1/coveragestores" -d @store_no_ws.xml
> POST /geoserver/cloud/rest/workspaces/test1/coveragestores HTTP/1.1
< HTTP/1.1 201 Created
< Location: http://localhost:9090/geoserver/cloud/rest/workspaces/test1/coveragestores/mosaic
< Content-Type: text/plain
mosaic
```

```
curl -v -u admin:geoserver -H "Accept: application/xml" "$baseurl/workspaces/test1/coveragestores/mosaic"
> GET /geoserver/cloud/rest/workspaces/test1/coveragestores/mosaic HTTP/1.1
< HTTP/1.1 404 Not Found
No such coverage store: test1,mosaic
```

*It was created on the default workspace instead*:

```
curl -v -u admin:geoserver -H "Accept: application/xml" "$baseurl/workspaces/defws/coveragestores/mosaic"
> GET /geoserver/cloud/rest/workspaces/defws/coveragestores/mosaic HTTP/1.1
< HTTP/1.1 200 OK
< Content-Type: application/xml
<coverageStore>
  <name>mosaic</name>
  <type>ImageMosaic</type>
  <enabled>true</enabled>
  <workspace>
    <name>defws</name>
  </workspace>
  <url>file:coverages/mosaic/mosaic.shp</url>
  <coverages>
    <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:9090/geoserver/cloud/rest/workspaces/defws/coveragestores/mosaic/coverages.xml" type="application/xml"/>
  </coverages>
</coverageStore>
```
