### PR TITLE
web-ui: avoid log4j 1.x ClassNotFoundException in GlobalSettingsPage

### DIFF
--- a/src/apps/geoserver/webui/pom.xml
+++ b/src/apps/geoserver/webui/pom.xml
@@ -139,6 +139,17 @@
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-gwc</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <!-- to avoid ClassNotFoundException(org/apache/logging/log4j/core/config/Configuration) at GlobalSettingsPage  -->
+      <artifactId>log4j-core</artifactId>
+    </dependency>
+    <dependency>
+      <!-- Junit4 dependency required by WicketTester -->
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/src/apps/geoserver/webui/src/main/resources/org/geoserver/web/admin/GlobalSettingsPage.html
+++ b/src/apps/geoserver/webui/src/main/resources/org/geoserver/web/admin/GlobalSettingsPage.html
@@ -7,11 +7,11 @@
   <fieldset>
     <legend><span><wicket:message key="serviceSettings">Services Settings</wicket:message></span></legend>
     <ul>
-      <li class="unused">
+      <li class="unused" id="proxyBaseUrlContainer">
         <label for="proxyBaseUrl"><wicket:message key="proxyBaseUrl">Proxy Base URL</wicket:message></label>
         <input id="proxyBaseUrl" class="field text" type="text" wicket:id="proxyBaseUrl" />
       </li>
-      <li class="unused">
+      <li class="unused" id="useHeadersProxyURL">
         <input id="useHeadersProxyURL" type="checkbox" wicket:id="useHeadersProxyURL" />
         <label for="useHeadersProxyURL"><wicket:message key="useHeadersProxyURL">Use headers for Proxy URL</wicket:message></label>
       </li>
@@ -65,7 +65,7 @@
     </ul>
   </fieldset>
   <h3><span><wicket:message key="internalSettings">Internal Settings</wicket:message></span></h3>
-  <fieldset class="unused">
+  <fieldset class="unused" id="loggingSettingsContainer">
     <legend><span><wicket:message key="loggingSettings">Logging Settings</wicket:message></span></legend>
     <ul>
       <li>
@@ -93,13 +93,13 @@
         <label for="featureTypeCacheSize"><wicket:message key="featureTypeCacheSize">Feature Type Cache Size</wicket:message></label>
         <input id="featureTypeCacheSize"class="field text" type="text" wicket:id="featureTypeCacheSize" />
       </li>
-      <li class="unused">
+      <li class="unused" id="lockProviderContainer">
        <label><wicket:message key="lockProvider">lockProvider:</wicket:message></label>
        <select class="select" id="lockProvider" wicket:id="lockProvider"></select>
       </li>
     </ul>
   </fieldset>
-   <fieldset class="unused">
+   <fieldset class="unused" id="webUISettingsContainer">
     <legend><span><wicket:message key="webUISettings">WebUI Settings</wicket:message></span></legend>
     <ul>
       <li>

--- a/src/apps/geoserver/webui/src/test/java/org/geoserver/cloud/web/app/WebUIApplicationTest.java
+++ b/src/apps/geoserver/webui/src/test/java/org/geoserver/cloud/web/app/WebUIApplicationTest.java
@@ -4,14 +4,143 @@
  */
 package org.geoserver.cloud.web.app;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.markup.html.link.BookmarkablePageLink;
+import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.util.tester.TagTester;
+import org.apache.wicket.util.tester.WicketTester;
+import org.geoserver.web.GeoServerApplication;
+import org.geoserver.web.GeoServerHomePage;
+import org.geoserver.web.GeoServerLoginPage;
+import org.geoserver.web.admin.GlobalSettingsPage;
+import org.geoserver.web.wicket.WicketHierarchyPrinter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+@SpringBootTest(
+        properties = {
+            "spring.cloud.bus.enabled: false",
+            "spring.cloud.config.enabled: false",
+            "spring.cloud.config.discovery.enabled: false",
+            "eureka.client.enabled: false"
+        })
 @ActiveProfiles("test") // see bootstrap-test.yml
 public class WebUIApplicationTest {
 
+    private @Autowired GeoServerApplication app;
+    private WicketTester tester;
+
+    static @BeforeAll void beforeAll() {
+        System.setProperty("wicket.configuration", "deployment");
+        // Disable CSRF protection for tests, since the test framework doesn't set the Referer
+        System.setProperty(GeoServerApplication.GEOSERVER_CSRF_DISABLED, "true");
+        // make sure that we check the english i18n when needed
+        Locale.setDefault(Locale.ENGLISH);
+    }
+
+    @BeforeEach
+    void setUpWicketTester() {
+        boolean init = true;
+        tester = new WicketTester(app, init);
+    }
+
+    @AfterEach
+    void tearDownWicketTester() {
+        if (null != tester) tester.destroy();
+        logout();
+    }
+
+    void login() {
+        login("admin", "geoserver", "ROLE_ADMINISTRATOR");
+    }
+
+    void logout() {
+        login("anonymousUser", "", "ROLE_ANONYMOUS");
+    }
+
+    protected void login(String username, String password, String... roles) {
+        SecurityContextHolder.setContext(new SecurityContextImpl());
+        List<GrantedAuthority> l = new ArrayList<>();
+        for (String role : roles) {
+            l.add(new SimpleGrantedAuthority(role));
+        }
+
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken(username, password, l));
+    }
+
+    private void print(Component component) {
+        boolean dumpClass = true;
+        boolean dumpValue = false;
+        boolean dumpPath = true;
+        WicketHierarchyPrinter.print(component, dumpClass, dumpValue, dumpPath);
+    }
+
     @Test
-    public void contextLoads() {}
+    public void GeoServerHomePage_smoke_test_anonymous() {
+        GeoServerHomePage page = tester.startPage(GeoServerHomePage.class);
+        assertNotNull(page);
+        // print(page);
+        tester.assertInvisible("catalogLinks");
+        tester.assertComponent("providedCaps", ListView.class);
+    }
+
+    @Test
+    public void GeoServerHomePage_smoke_test_logged_in() {
+        login();
+        GeoServerHomePage page = tester.startPage(GeoServerHomePage.class);
+        assertNotNull(page);
+        // print(page);
+        tester.assertComponent("catalogLinks:layersLink", BookmarkablePageLink.class);
+        tester.assertComponent("catalogLinks:storesLink", BookmarkablePageLink.class);
+        tester.assertComponent("catalogLinks:workspacesLink", BookmarkablePageLink.class);
+        tester.assertComponent("providedCaps", ListView.class);
+    }
+
+    @Test
+    public void GlobalSettingsPage_smoke_test_loggedout() {
+        logout();
+        tester.startPage(GlobalSettingsPage.class);
+        tester.assertRenderedPage(GeoServerLoginPage.class);
+    }
+
+    @Test
+    public void GlobalSettingsPage_smoke_test() {
+        login();
+        tester.startPage(GlobalSettingsPage.class);
+        tester.assertRenderedPage(GlobalSettingsPage.class);
+        GlobalSettingsPage page = (GlobalSettingsPage) tester.getLastRenderedPage();
+        // print(page);
+        assertHidden("proxyBaseUrlContainer");
+        assertHidden("useHeadersProxyURL");
+        assertHidden("loggingSettingsContainer");
+        assertHidden("lockProviderContainer");
+        assertHidden("webUISettingsContainer");
+    }
+
+    protected void assertHidden(String id) {
+        TagTester tag = tester.getTagById(id);
+        String msg =
+                "expected custom 'unused' css class to hide the "
+                        + id
+                        + " form inputs in custom GlobalSettingsPage.html";
+        assertEquals(msg, "unused", tag.getAttribute("class"));
+    }
 }


### PR DESCRIPTION
`GlobalSettingsPage`'s `logLevelsAppend()` fails if log4j 1.x `Configuration` is not on the classpath.
Add `WicketTester` based tests to verify it loads correctly.