### PR TITLE
Bind missing RemoteEventResourcePoolProcessor bean and improve logging

### DIFF
--- a/src/catalog/event-bus/src/main/java/org/geoserver/cloud/autoconfigure/bus/catalog/RemoteCatalogEventsAutoConfiguration.java
+++ b/src/catalog/event-bus/src/main/java/org/geoserver/cloud/autoconfigure/bus/catalog/RemoteCatalogEventsAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * {@link EnableAutoConfiguration auto-configuration} catalog and config events integration with
@@ -87,12 +88,17 @@ public class RemoteCatalogEventsAutoConfiguration {
     }
 
     public @Bean RemoteCatalogEventBridge remoteEventBroadcaster(
-            ApplicationEventPublisher eventPublisher, RemoteCatalogEventMapper eventMapper) {
+            ApplicationEventPublisher eventPublisher,
+            RemoteCatalogEventMapper eventMapper,
+            ServiceMatcher serviceMatcher) {
 
         log.info("Configuring GeoServer Catalog distributed events.");
 
         Consumer<RemoteInfoEvent> remoteEventPublisher = eventPublisher::publishEvent;
-        Consumer<InfoEvent<?, ?, ?>> localEventPublisher = eventPublisher::publishEvent;
-        return new RemoteCatalogEventBridge(remoteEventPublisher, localEventPublisher, eventMapper);
+        @SuppressWarnings("rawtypes")
+        Consumer<InfoEvent> localEventPublisher = eventPublisher::publishEvent;
+        Supplier<String> busId = serviceMatcher::getBusId;
+        return new RemoteCatalogEventBridge(
+                localEventPublisher, remoteEventPublisher, eventMapper, busId);
     }
 }

--- a/src/catalog/event-bus/src/main/java/org/geoserver/cloud/bus/catalog/InfoEventResolver.java
+++ b/src/catalog/event-bus/src/main/java/org/geoserver/cloud/bus/catalog/InfoEventResolver.java
@@ -56,7 +56,7 @@ public class InfoEventResolver {
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
-    public InfoEvent<?, ?, ?> resolve(InfoEvent event) {
+    public InfoEvent<?, ?> resolve(InfoEvent event) {
         if (event instanceof InfoAddEvent) {
             InfoAddEvent addEvent = (InfoAddEvent) event;
             Info object = addEvent.getObject();

--- a/src/catalog/event-bus/src/main/java/org/geoserver/cloud/bus/catalog/RemoteCatalogEventBridge.java
+++ b/src/catalog/event-bus/src/main/java/org/geoserver/cloud/bus/catalog/RemoteCatalogEventBridge.java
@@ -16,59 +16,108 @@ import org.geoserver.cloud.event.info.InfoPreModifyEvent;
 import org.springframework.context.event.EventListener;
 
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Listens to local catalog and configuration change {@link InfoEvent}s produced by this service
  * instance and broadcasts them to the cluster as {@link RemoteInfoEvent}
  */
-@Slf4j(topic = "org.geoserver.cloud.bus.outgoing")
-@RequiredArgsConstructor
 public class RemoteCatalogEventBridge {
 
-    private final @NonNull Consumer<RemoteInfoEvent> remoteEventPublisher;
-    private final @NonNull Consumer<InfoEvent<?, ?, ?>> localRemoteEventPublisher;
+    private final Outgoing outgoing;
+    private final Incoming incoming;
 
-    private final @NonNull RemoteCatalogEventMapper mapper;
     private boolean enabled = true;
+
+    @SuppressWarnings("rawtypes")
+    public RemoteCatalogEventBridge( //
+            @NonNull Consumer<InfoEvent> localRemoteEventPublisher, //
+            @NonNull Consumer<RemoteInfoEvent> remoteEventPublisher, //
+            @NonNull RemoteCatalogEventMapper mapper, //
+            @NonNull Supplier<String> localBusId) {
+
+        this.outgoing = new Outgoing(remoteEventPublisher, mapper, localBusId);
+        this.incoming = new Incoming(localRemoteEventPublisher, mapper, localBusId);
+    }
 
     public @VisibleForTesting void enabled(boolean enabled) {
         this.enabled = enabled;
     }
 
     @EventListener(InfoEvent.class)
-    public void handleLocalEvent(InfoEvent<? extends InfoEvent<?, ?, ?>, ?, ?> event)
-            throws CatalogException {
+    public void handleLocalEvent(InfoEvent<? extends InfoEvent<?, ?>, ?> event) {
         if (enabled) {
-            event.local()
-                    .filter(e -> !(e instanceof InfoPreModifyEvent))
-                    .map(mapper::toRemote)
-                    .ifPresent(this::publishRemoteEvent);
+            outgoing.broadCastIfLocal(event);
         }
     }
 
     @EventListener(RemoteInfoEvent.class)
-    public void handleRemoteEvent(RemoteInfoEvent incoming) throws CatalogException {
-        mapper.toLocal(incoming).ifPresent(this::publishLocalEvent);
-    }
-
-    private void publishRemoteEvent(RemoteInfoEvent remoteEvent) {
-        log.debug("broadcasting {}", remoteEvent);
-        try {
-            remoteEventPublisher.accept(remoteEvent);
-        } catch (RuntimeException e) {
-            log.error("Error publishing remote event {}", remoteEvent, e);
-            throw e;
+    public void handleRemoteEvent(RemoteInfoEvent busEvent) throws CatalogException {
+        if (enabled) {
+            incoming.handleRemoteEvent(busEvent);
         }
     }
 
-    private void publishLocalEvent(InfoEvent<?, ?, ?> localRemoteEvent) {
-        log.debug("publishing remote event {}", localRemoteEvent);
-        try {
-            localRemoteEventPublisher.accept(localRemoteEvent);
-            ;
-        } catch (RuntimeException e) {
-            log.error("Error accepting remote event {}", localRemoteEvent, e);
-            throw e;
+    @RequiredArgsConstructor
+    @Slf4j(topic = "org.geoserver.cloud.bus.catalog.outgoing")
+    private static class Outgoing {
+        private final @NonNull Consumer<RemoteInfoEvent> remoteEventPublisher;
+        private final @NonNull RemoteCatalogEventMapper mapper;
+        private @NonNull Supplier<String> localBusId;
+
+        public void broadCastIfLocal(InfoEvent<? extends InfoEvent<?, ?>, ?> event)
+                throws CatalogException {
+
+            event.local() //
+                    .filter(e -> !(e instanceof InfoPreModifyEvent)) //
+                    .map(mapper::toRemote) //
+                    .ifPresentOrElse( //
+                            this::publishRemoteEvent, //
+                            () -> log.trace("{}: not re-publishing {}", localBusId.get(), event));
+        }
+
+        private void publishRemoteEvent(RemoteInfoEvent remoteEvent) {
+            log.debug("{}: broadcasting {}", localBusId.get(), remoteEvent);
+            try {
+                remoteEventPublisher.accept(remoteEvent);
+            } catch (RuntimeException e) {
+                log.error("{}: error broadcasting {}", localBusId.get(), remoteEvent, e);
+                throw e;
+            }
+        }
+    }
+
+    @RequiredArgsConstructor
+    @Slf4j(topic = "org.geoserver.cloud.bus.catalog.incoming")
+    private static class Incoming {
+
+        @SuppressWarnings("rawtypes")
+        private final @NonNull Consumer<InfoEvent> localRemoteEventPublisher;
+
+        private final @NonNull RemoteCatalogEventMapper mapper;
+        private @NonNull Supplier<String> localBusId;
+
+        public void handleRemoteEvent(RemoteInfoEvent incoming) throws CatalogException {
+            mapper.ifRemote(incoming) //
+                    .ifPresentOrElse( //
+                            this::publishLocalEvent, //
+                            () ->
+                                    log.trace(
+                                            "{}: not broadcasting local-remote event {}",
+                                            localBusId.get(),
+                                            incoming));
+        }
+
+        private void publishLocalEvent(RemoteInfoEvent incoming) {
+
+            InfoEvent<?, ?> localRemoteEvent = mapper.toLocalRemote(incoming);
+            log.debug("{}: publishing as local-remote {}", localBusId.get(), incoming);
+            try {
+                localRemoteEventPublisher.accept(localRemoteEvent);
+            } catch (RuntimeException e) {
+                log.error("{}: error accepting remote {}", localBusId.get(), localRemoteEvent, e);
+                throw e;
+            }
         }
     }
 }

--- a/src/catalog/event-bus/src/main/java/org/geoserver/cloud/bus/catalog/RemoteInfoEvent.java
+++ b/src/catalog/event-bus/src/main/java/org/geoserver/cloud/bus/catalog/RemoteInfoEvent.java
@@ -17,7 +17,7 @@ public class RemoteInfoEvent extends RemoteApplicationEvent {
 
     private static final long serialVersionUID = 1L;
 
-    private @Getter @NonNull InfoEvent<?, ?, ?> event;
+    private @Getter @NonNull InfoEvent<?, ?> event;
 
     /** Deserialization-time constructor, {@link #getSource()} will be {@code null} */
     protected RemoteInfoEvent() {
@@ -26,10 +26,7 @@ public class RemoteInfoEvent extends RemoteApplicationEvent {
 
     /** Publish-time constructor, {@link #getSource()} won't be {@code null} */
     public RemoteInfoEvent(
-            Object source,
-            InfoEvent<?, ?, ?> event,
-            String originService,
-            Destination destination) {
+            Object source, InfoEvent<?, ?> event, String originService, Destination destination) {
         super(source, originService, destination);
         this.event = event;
     }

--- a/src/catalog/event-bus/src/test/java/org/geoserver/cloud/bus/integration/BusAmqpIntegrationTests.java
+++ b/src/catalog/event-bus/src/test/java/org/geoserver/cloud/bus/integration/BusAmqpIntegrationTests.java
@@ -321,7 +321,7 @@ public abstract class BusAmqpIntegrationTests {
         assertNotNull(busEvent.getOriginService());
         assertEquals("**", busEvent.getDestinationService());
 
-        InfoEvent<?, ?, ?> event = busEvent.getEvent();
+        InfoEvent<?, ?> event = busEvent.getEvent();
         assertNotNull(event);
         assertNotNull(event.getObjectId());
         // assertNotNull(event.getTarget());

--- a/src/catalog/event-bus/src/test/java/org/geoserver/cloud/bus/integration/BusEventCollector.java
+++ b/src/catalog/event-bus/src/test/java/org/geoserver/cloud/bus/integration/BusEventCollector.java
@@ -49,7 +49,7 @@ public class BusEventCollector {
             log.debug("{}: capturing is off, ignoring {}", busId, busEvent);
             return;
         }
-        InfoEvent<?, ?, ?> payloadEvent = busEvent.getEvent();
+        InfoEvent<?, ?> payloadEvent = busEvent.getEvent();
         if (!eventType.isInstance(payloadEvent)) {
             log.debug(
                     "{}: ignoring non {} event {}", busId, eventType.getSimpleName(), payloadEvent);

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/config/catalog/events/CatalogApplicationEventsConfiguration.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/config/catalog/events/CatalogApplicationEventsConfiguration.java
@@ -23,7 +23,7 @@ public class CatalogApplicationEventsConfiguration {
             @Qualifier("geoServer") GeoServer geoServer //
             ) {
 
-        Consumer<? super InfoEvent<?, ?, ?>> publisher = localContextPublisher::publishEvent;
+        Consumer<? super InfoEvent<?, ?>> publisher = localContextPublisher::publishEvent;
         return new CatalogApplicationEventPublisher(publisher, catalog, geoServer);
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/CatalogInfoAddEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/CatalogInfoAddEvent.java
@@ -9,23 +9,21 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import lombok.NonNull;
 
-import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.event.CatalogAddEvent;
 import org.geoserver.cloud.event.info.InfoAddEvent;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonTypeName("CatalogInfoAdded")
-public class CatalogInfoAddEvent extends InfoAddEvent<CatalogInfoAddEvent, Catalog, CatalogInfo> {
+public class CatalogInfoAddEvent extends InfoAddEvent<CatalogInfoAddEvent, CatalogInfo> {
 
     protected CatalogInfoAddEvent() {}
 
-    CatalogInfoAddEvent(Catalog source, Catalog target, @NonNull CatalogInfo object) {
-        super(source, target, object);
+    CatalogInfoAddEvent(@NonNull CatalogInfo object) {
+        super(object);
     }
 
-    public static CatalogInfoAddEvent createLocal(
-            @NonNull Catalog source, @NonNull CatalogAddEvent event) {
-        return new CatalogInfoAddEvent(source, null, event.getSource());
+    public static CatalogInfoAddEvent createLocal(@NonNull CatalogAddEvent event) {
+        return new CatalogInfoAddEvent(event.getSource());
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/CatalogInfoModifyEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/CatalogInfoModifyEvent.java
@@ -31,21 +31,17 @@ import java.util.Optional;
     @JsonSubTypes.Type(value = DefaultDataStoreEvent.class, name = "DefaultDataStoreSet"),
 })
 public class CatalogInfoModifyEvent
-        extends InfoPostModifyEvent<CatalogInfoModifyEvent, Catalog, CatalogInfo> {
+        extends InfoPostModifyEvent<CatalogInfoModifyEvent, CatalogInfo> {
 
     protected CatalogInfoModifyEvent() {}
 
     protected CatalogInfoModifyEvent(
-            Catalog source,
-            Catalog target,
-            @NonNull String objectId,
-            @NonNull ConfigInfoType objectType,
-            @NonNull Patch patch) {
-        super(source, target, objectId, objectType, patch);
+            @NonNull String objectId, @NonNull ConfigInfoType objectType, @NonNull Patch patch) {
+        super(objectId, objectType, patch);
     }
 
     public static CatalogInfoModifyEvent createLocal(
-            @NonNull Catalog source, @NonNull CatalogInfo info, @NonNull Patch patch) {
+            @NonNull CatalogInfo info, @NonNull Patch patch) {
 
         if (info instanceof Catalog) {
             if (patch.get("defaultWorkspace").isPresent()) {
@@ -61,11 +57,10 @@ public class CatalogInfoModifyEvent
                             + patch);
         }
 
-        return new CatalogInfoModifyEvent(source, null, resolveId(info), typeOf(info), patch);
+        return new CatalogInfoModifyEvent(resolveId(info), typeOf(info), patch);
     }
 
-    public static CatalogInfoModifyEvent createLocal(
-            @NonNull Catalog source, @NonNull CatalogPostModifyEvent event) {
+    public static CatalogInfoModifyEvent createLocal(@NonNull CatalogPostModifyEvent event) {
 
         final CatalogInfo info = event.getSource();
         final Patch patch =
@@ -79,21 +74,21 @@ public class CatalogInfoModifyEvent
             Optional<Property> defaultWorkspace = patch.get("defaultWorkspace");
             if (defaultWorkspace.isPresent()) {
                 WorkspaceInfo ws = (WorkspaceInfo) defaultWorkspace.get().getValue();
-                return DefaultWorkspaceEvent.createLocal(source, ws);
+                return DefaultWorkspaceEvent.createLocal(ws);
             }
             Optional<Property> defaultNamespace = patch.get("defaultNamespace");
             if (defaultNamespace.isPresent()) {
                 NamespaceInfo ns = (NamespaceInfo) defaultNamespace.get().getValue();
-                return DefaultNamespaceEvent.createLocal(source, ns);
+                return DefaultNamespaceEvent.createLocal(ns);
             }
             if (patch.get("defaultDataStore").isPresent())
-                return DefaultDataStoreEvent.createLocal(source, event);
+                return DefaultDataStoreEvent.createLocal(event);
 
             throw new IllegalArgumentException(
                     "Catalog change events only support defaultWorkspace, defaultNamespace, and defaultDataStore properties. Diff: "
                             + patch);
         }
 
-        return new CatalogInfoModifyEvent(source, null, resolveId(info), typeOf(info), patch);
+        return new CatalogInfoModifyEvent(resolveId(info), typeOf(info), patch);
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/CatalogInfoPreModifyEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/CatalogInfoPreModifyEvent.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import lombok.NonNull;
 
-import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.event.CatalogModifyEvent;
 import org.geoserver.catalog.plugin.Patch;
@@ -20,26 +19,21 @@ import org.geoserver.cloud.event.info.InfoPreModifyEvent;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonTypeName("CatalogInfoPreModify")
 public class CatalogInfoPreModifyEvent
-        extends InfoPreModifyEvent<CatalogInfoPreModifyEvent, Catalog, CatalogInfo> {
+        extends InfoPreModifyEvent<CatalogInfoPreModifyEvent, CatalogInfo> {
 
     protected CatalogInfoPreModifyEvent() {}
 
     protected CatalogInfoPreModifyEvent(
-            Catalog source,
-            Catalog target,
-            @NonNull String objectId,
-            @NonNull ConfigInfoType objectType,
-            @NonNull Patch patch) {
-        super(source, target, objectId, objectType, patch);
+            @NonNull String objectId, @NonNull ConfigInfoType objectType, @NonNull Patch patch) {
+        super(objectId, objectType, patch);
     }
 
-    public static CatalogInfoPreModifyEvent createLocal(
-            @NonNull Catalog source, @NonNull CatalogModifyEvent event) {
+    public static CatalogInfoPreModifyEvent createLocal(@NonNull CatalogModifyEvent event) {
         PropertyDiff diff =
                 PropertyDiff.valueOf(
                         event.getPropertyNames(), event.getOldValues(), event.getNewValues());
         Patch patch = diff.toPatch();
         return new CatalogInfoPreModifyEvent(
-                source, null, resolveId(event.getSource()), typeOf(event.getSource()), patch);
+                resolveId(event.getSource()), typeOf(event.getSource()), patch);
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/CatalogInfoRemoveEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/CatalogInfoRemoveEvent.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import lombok.NonNull;
 
-import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.event.CatalogRemoveEvent;
 import org.geoserver.cloud.event.info.ConfigInfoType;
@@ -17,27 +16,23 @@ import org.geoserver.cloud.event.info.InfoRemoveEvent;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonTypeName("CatalogInfoRemoved")
-public class CatalogInfoRemoveEvent
-        extends InfoRemoveEvent<CatalogInfoRemoveEvent, Catalog, CatalogInfo> {
+public class CatalogInfoRemoveEvent extends InfoRemoveEvent<CatalogInfoRemoveEvent, CatalogInfo> {
 
     protected CatalogInfoRemoveEvent() {}
 
-    CatalogInfoRemoveEvent(
-            Catalog source, Catalog target, @NonNull String id, @NonNull ConfigInfoType type) {
-        super(source, target, id, type);
+    CatalogInfoRemoveEvent(@NonNull String id, @NonNull ConfigInfoType type) {
+        super(id, type);
     }
 
-    public static CatalogInfoRemoveEvent createLocal(
-            @NonNull Catalog source, @NonNull CatalogRemoveEvent event) {
+    public static CatalogInfoRemoveEvent createLocal(@NonNull CatalogRemoveEvent event) {
 
-        return createLocal(source, event.getSource());
+        return createLocal(event.getSource());
     }
 
-    public static CatalogInfoRemoveEvent createLocal(
-            @NonNull Catalog source, @NonNull CatalogInfo info) {
+    public static CatalogInfoRemoveEvent createLocal(@NonNull CatalogInfo info) {
 
         String id = resolveId(info);
         ConfigInfoType type = ConfigInfoType.valueOf(info);
-        return new CatalogInfoRemoveEvent(source, null, id, type);
+        return new CatalogInfoRemoveEvent(id, type);
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/DefaultDataStoreEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/DefaultDataStoreEvent.java
@@ -11,7 +11,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 
-import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.event.CatalogPostModifyEvent;
@@ -36,27 +35,22 @@ public class DefaultDataStoreEvent extends CatalogInfoModifyEvent {
     protected DefaultDataStoreEvent() {}
 
     DefaultDataStoreEvent(
-            Catalog source,
-            Catalog target,
-            @NonNull String workspaceId,
-            String defaultDataStoreId,
-            @NonNull Patch patch) {
+            @NonNull String workspaceId, String defaultDataStoreId, @NonNull Patch patch) {
 
-        super(source, target, InfoEvent.CATALOG_ID, ConfigInfoType.Catalog, patch);
+        super(InfoEvent.CATALOG_ID, ConfigInfoType.Catalog, patch);
 
         this.workspaceId = workspaceId;
         this.defaultDataStoreId = defaultDataStoreId;
     }
 
-    @Override
-    public String toString() {
-        return String.format(
-                "%s[workspace: %s, store: %s]",
-                getClass().getSimpleName(), getWorkspaceId(), getDefaultDataStoreId());
+    public @Override String toString() {
+        return toStringBuilder()
+                .append("workspace", getWorkspaceId())
+                .append("store", getDefaultDataStoreId())
+                .toString();
     }
 
-    public static DefaultDataStoreEvent createLocal(
-            @NonNull Catalog source, @NonNull CatalogPostModifyEvent event) {
+    public static DefaultDataStoreEvent createLocal(@NonNull CatalogPostModifyEvent event) {
 
         PropertyDiff diff =
                 PropertyDiff.valueOf(
@@ -76,11 +70,11 @@ public class DefaultDataStoreEvent extends CatalogInfoModifyEvent {
 
         Patch patch = diff.toPatch();
 
-        return new DefaultDataStoreEvent(source, null, workspaceId, newDefaultStoreId, patch);
+        return new DefaultDataStoreEvent(workspaceId, newDefaultStoreId, patch);
     }
 
     public static DefaultDataStoreEvent createLocal(
-            @NonNull Catalog source, @NonNull WorkspaceInfo workspace, DataStoreInfo newStore) {
+            @NonNull WorkspaceInfo workspace, DataStoreInfo newStore) {
 
         Patch patch = new Patch();
         patch.add("defaultDataStore", newStore);
@@ -88,7 +82,7 @@ public class DefaultDataStoreEvent extends CatalogInfoModifyEvent {
         final @Nullable String newDefaultStoreId = resolveId(newStore);
         final @NonNull String workspaceId = resolveId(workspace);
 
-        return new DefaultDataStoreEvent(source, null, workspaceId, newDefaultStoreId, patch);
+        return new DefaultDataStoreEvent(workspaceId, newDefaultStoreId, patch);
     }
 
     private static @NonNull WorkspaceInfo resolveWorkspace(Change change) {

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/DefaultNamespaceEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/DefaultNamespaceEvent.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.Getter;
 import lombok.NonNull;
 
-import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.cloud.event.info.ConfigInfoType;
@@ -23,25 +22,21 @@ public class DefaultNamespaceEvent extends CatalogInfoModifyEvent {
     private @Getter String newNamespaceId;
 
     protected DefaultNamespaceEvent() {}
-    ;
 
-    DefaultNamespaceEvent(
-            Catalog source, Catalog target, String newNamespaceId, @NonNull Patch patch) {
-        super(source, target, InfoEvent.CATALOG_ID, ConfigInfoType.Catalog, patch);
+    DefaultNamespaceEvent(String newNamespaceId, @NonNull Patch patch) {
+        super(InfoEvent.CATALOG_ID, ConfigInfoType.Catalog, patch);
         this.newNamespaceId = newNamespaceId;
     }
 
-    @Override
-    public String toString() {
-        return String.format("%s[%s]", getClass().getSimpleName(), getNewNamespaceId());
+    public @Override String toString() {
+        return toStringBuilder().append("namespace", getNewNamespaceId()).toString();
     }
 
-    public static DefaultNamespaceEvent createLocal(
-            @NonNull Catalog source, NamespaceInfo defaultNamespace) {
+    public static DefaultNamespaceEvent createLocal(NamespaceInfo defaultNamespace) {
 
         String namespaceId = resolveId(defaultNamespace);
         Patch patch = new Patch();
         patch.add("defaultNamespace", defaultNamespace);
-        return new DefaultNamespaceEvent(source, null, namespaceId, patch);
+        return new DefaultNamespaceEvent(namespaceId, patch);
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/DefaultWorkspaceEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/DefaultWorkspaceEvent.java
@@ -11,7 +11,6 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 
-import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.cloud.event.info.ConfigInfoType;
@@ -28,23 +27,20 @@ public class DefaultWorkspaceEvent extends CatalogInfoModifyEvent {
         //
     }
 
-    DefaultWorkspaceEvent(
-            Catalog source, Catalog target, String newWorkspaceId, @NonNull Patch patch) {
-        super(source, target, InfoEvent.CATALOG_ID, ConfigInfoType.Catalog, patch);
+    DefaultWorkspaceEvent(String newWorkspaceId, @NonNull Patch patch) {
+        super(InfoEvent.CATALOG_ID, ConfigInfoType.Catalog, patch);
         this.newWorkspaceId = newWorkspaceId;
     }
 
-    @Override
-    public String toString() {
-        return String.format("%s[%s]", getClass().getSimpleName(), getNewWorkspaceId());
+    public @Override String toString() {
+        return toStringBuilder().append("workspace", getNewWorkspaceId()).toString();
     }
 
-    public static DefaultWorkspaceEvent createLocal(
-            @NonNull Catalog source, WorkspaceInfo defaultWorkspace) {
+    public static DefaultWorkspaceEvent createLocal(WorkspaceInfo defaultWorkspace) {
 
         String workspaceId = resolveId(defaultWorkspace);
         Patch patch = new Patch();
         patch.add("defaultWorkspace", defaultWorkspace);
-        return new DefaultWorkspaceEvent(source, null, workspaceId, patch);
+        return new DefaultWorkspaceEvent(workspaceId, patch);
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ConfigInfoAddEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ConfigInfoAddEvent.java
@@ -12,7 +12,6 @@ import lombok.NonNull;
 import org.geoserver.catalog.Info;
 import org.geoserver.cloud.event.info.ConfigInfoType;
 import org.geoserver.cloud.event.info.InfoAddEvent;
-import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.LoggingInfo;
 import org.geoserver.config.ServiceInfo;
@@ -25,35 +24,34 @@ import org.geoserver.config.SettingsInfo;
     @JsonSubTypes.Type(value = ServiceInfoAddEvent.class, name = "ServiceInfoAdded"),
     @JsonSubTypes.Type(value = SettingsInfoAddEvent.class, name = "SettingsInfoAdded"),
 })
-public abstract class ConfigInfoAddEvent<SELF, INFO extends Info>
-        extends InfoAddEvent<SELF, GeoServer, INFO> implements ConfigInfoEvent {
+public abstract class ConfigInfoAddEvent<SELF, INFO extends Info> extends InfoAddEvent<SELF, INFO>
+        implements ConfigInfoEvent {
 
     protected ConfigInfoAddEvent() {
         // default constructor, needed for deserialization
     }
 
-    public ConfigInfoAddEvent(GeoServer source, GeoServer target, INFO object) {
-        super(source, target, object);
+    public ConfigInfoAddEvent(INFO object) {
+        super(object);
     }
 
     @SuppressWarnings("unchecked")
-    public static @NonNull <I extends Info> ConfigInfoAddEvent<?, I> createLocal(
-            @NonNull GeoServer geoServer, @NonNull I info) {
+    public static @NonNull <I extends Info> ConfigInfoAddEvent<?, I> createLocal(@NonNull I info) {
 
         final ConfigInfoType type = ConfigInfoType.valueOf(info);
         switch (type) {
             case GeoServerInfo:
                 return (ConfigInfoAddEvent<?, I>)
-                        GeoServerInfoSetEvent.createLocal(geoServer, (GeoServerInfo) info);
+                        GeoServerInfoSetEvent.createLocal((GeoServerInfo) info);
             case ServiceInfo:
                 return (ConfigInfoAddEvent<?, I>)
-                        ServiceInfoAddEvent.createLocal(geoServer, (ServiceInfo) info);
+                        ServiceInfoAddEvent.createLocal((ServiceInfo) info);
             case SettingsInfo:
                 return (ConfigInfoAddEvent<?, I>)
-                        SettingsInfoAddEvent.createLocal(geoServer, (SettingsInfo) info);
+                        SettingsInfoAddEvent.createLocal((SettingsInfo) info);
             case LoggingInfo:
                 return (ConfigInfoAddEvent<?, I>)
-                        LoggingInfoSetEvent.createLocal(geoServer, (LoggingInfo) info);
+                        LoggingInfoSetEvent.createLocal((LoggingInfo) info);
             default:
                 throw new IllegalArgumentException(
                         "Uknown or unsupported config Info type: " + type + ". " + info);

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ConfigInfoModifyEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ConfigInfoModifyEvent.java
@@ -14,7 +14,6 @@ import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.catalog.plugin.PropertyDiff;
 import org.geoserver.cloud.event.info.ConfigInfoType;
 import org.geoserver.cloud.event.info.InfoPostModifyEvent;
-import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.LoggingInfo;
 import org.geoserver.config.ServiceInfo;
@@ -28,24 +27,20 @@ import org.geoserver.config.SettingsInfo;
     @JsonSubTypes.Type(value = SettingsInfoModifyEvent.class),
 })
 public abstract class ConfigInfoModifyEvent<SELF, INFO extends Info>
-        extends InfoPostModifyEvent<SELF, GeoServer, INFO> implements ConfigInfoEvent {
+        extends InfoPostModifyEvent<SELF, INFO> implements ConfigInfoEvent {
 
     protected ConfigInfoModifyEvent() {
         // default constructor, needed for deserialization
     }
 
     protected ConfigInfoModifyEvent(
-            GeoServer source,
-            GeoServer target,
-            @NonNull String objectId,
-            @NonNull ConfigInfoType objectType,
-            @NonNull Patch patch) {
-        super(source, target, objectId, objectType, patch);
+            @NonNull String objectId, @NonNull ConfigInfoType objectType, @NonNull Patch patch) {
+        super(objectId, objectType, patch);
     }
 
     @SuppressWarnings("unchecked")
     public static @NonNull <I extends Info> ConfigInfoModifyEvent<?, I> createLocal(
-            @NonNull GeoServer geoServer, @NonNull Info info, @NonNull PropertyDiff diff) {
+            @NonNull Info info, @NonNull PropertyDiff diff) {
 
         final ConfigInfoType type = ConfigInfoType.valueOf(info);
         final Patch patch = diff.toPatch();
@@ -53,20 +48,19 @@ public abstract class ConfigInfoModifyEvent<SELF, INFO extends Info>
             case GeoServerInfo:
                 {
                     return (ConfigInfoModifyEvent<?, I>)
-                            GeoServerInfoModifyEvent.createLocal(
-                                    geoServer, (GeoServerInfo) info, patch);
+                            GeoServerInfoModifyEvent.createLocal((GeoServerInfo) info, patch);
                 }
             case ServiceInfo:
                 ServiceInfo service = (ServiceInfo) info;
                 return (ConfigInfoModifyEvent<?, I>)
-                        ServiceInfoModifyEvent.createLocal(geoServer, service, patch);
+                        ServiceInfoModifyEvent.createLocal(service, patch);
             case SettingsInfo:
                 SettingsInfo settings = (SettingsInfo) info;
                 return (ConfigInfoModifyEvent<?, I>)
-                        SettingsInfoModifyEvent.createLocal(geoServer, settings, patch);
+                        SettingsInfoModifyEvent.createLocal(settings, patch);
             case LoggingInfo:
                 return (ConfigInfoModifyEvent<?, I>)
-                        LoggingInfoModifyEvent.createLocal(geoServer, (LoggingInfo) info, patch);
+                        LoggingInfoModifyEvent.createLocal((LoggingInfo) info, patch);
             default:
                 throw new IllegalArgumentException(
                         "Uknown or unsupported config Info type: " + type + ". " + info);

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ConfigInfoPreModifyEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ConfigInfoPreModifyEvent.java
@@ -14,32 +14,27 @@ import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.catalog.plugin.PropertyDiff;
 import org.geoserver.cloud.event.info.ConfigInfoType;
 import org.geoserver.cloud.event.info.InfoPreModifyEvent;
-import org.geoserver.config.GeoServer;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonTypeName("ConfigInfoPreModify")
 public class ConfigInfoPreModifyEvent<SELF, INFO extends Info>
-        extends InfoPreModifyEvent<SELF, GeoServer, INFO> implements ConfigInfoEvent {
+        extends InfoPreModifyEvent<SELF, INFO> implements ConfigInfoEvent {
 
     protected ConfigInfoPreModifyEvent() {
         // default constructor, needed for deserialization
     }
 
     protected ConfigInfoPreModifyEvent(
-            GeoServer source,
-            GeoServer target,
-            @NonNull String objectId,
-            @NonNull ConfigInfoType objectType,
-            @NonNull Patch patch) {
-        super(source, target, objectId, objectType, patch);
+            @NonNull String objectId, @NonNull ConfigInfoType objectType, @NonNull Patch patch) {
+        super(objectId, objectType, patch);
     }
 
     public static @NonNull <I extends Info> ConfigInfoPreModifyEvent<?, I> createLocal(
-            @NonNull GeoServer source, @NonNull Info object, @NonNull PropertyDiff diff) {
+            @NonNull Info object, @NonNull PropertyDiff diff) {
 
         final @NonNull String id = resolveId(object);
         final ConfigInfoType type = ConfigInfoType.valueOf(object);
         final Patch patch = diff.toPatch();
-        return new ConfigInfoPreModifyEvent<>(source, null, id, type, patch);
+        return new ConfigInfoPreModifyEvent<>(id, type, patch);
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ConfigInfoRemoveEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ConfigInfoRemoveEvent.java
@@ -14,7 +14,6 @@ import lombok.Setter;
 import org.geoserver.catalog.Info;
 import org.geoserver.cloud.event.info.ConfigInfoType;
 import org.geoserver.cloud.event.info.InfoRemoveEvent;
-import org.geoserver.config.GeoServer;
 import org.geoserver.config.ServiceInfo;
 import org.geoserver.config.SettingsInfo;
 
@@ -24,7 +23,7 @@ import org.geoserver.config.SettingsInfo;
     @JsonSubTypes.Type(value = SettingsInfoRemoveEvent.class, name = "SettingsInfoRemoved"),
 })
 public abstract class ConfigInfoRemoveEvent<SELF, INFO extends Info>
-        extends InfoRemoveEvent<SELF, GeoServer, INFO> implements ConfigInfoEvent {
+        extends InfoRemoveEvent<SELF, INFO> implements ConfigInfoEvent {
 
     private @Getter @Setter INFO object;
 
@@ -32,26 +31,22 @@ public abstract class ConfigInfoRemoveEvent<SELF, INFO extends Info>
         // default constructor, needed for deserialization
     }
 
-    public ConfigInfoRemoveEvent(
-            GeoServer source,
-            GeoServer target,
-            @NonNull String objectId,
-            @NonNull ConfigInfoType type) {
-        super(source, target, objectId, type);
+    public ConfigInfoRemoveEvent(@NonNull String objectId, @NonNull ConfigInfoType type) {
+        super(objectId, type);
     }
 
     @SuppressWarnings("unchecked")
     public static @NonNull <I extends Info> ConfigInfoRemoveEvent<?, I> createLocal(
-            @NonNull GeoServer geoServer, @NonNull I info) {
+            @NonNull I info) {
 
         final ConfigInfoType type = ConfigInfoType.valueOf(info);
         switch (type) {
             case ServiceInfo:
                 return (ConfigInfoRemoveEvent<?, I>)
-                        ServiceInfoRemoveEvent.createLocal(geoServer, (ServiceInfo) info);
+                        ServiceInfoRemoveEvent.createLocal((ServiceInfo) info);
             case SettingsInfo:
                 return (ConfigInfoRemoveEvent<?, I>)
-                        SettingsInfoRemoveEvent.createLocal(geoServer, (SettingsInfo) info);
+                        SettingsInfoRemoveEvent.createLocal((SettingsInfo) info);
             default:
                 throw new IllegalArgumentException(
                         "Uknown or unsupported config Info type: " + type + ". " + info);

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/GeoServerInfoModifyEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/GeoServerInfoModifyEvent.java
@@ -13,7 +13,6 @@ import lombok.NonNull;
 
 import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.cloud.event.info.ConfigInfoType;
-import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerInfo;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
@@ -30,19 +29,14 @@ public class GeoServerInfoModifyEvent
         // default constructor, needed for deserialization
     }
 
-    protected GeoServerInfoModifyEvent(
-            GeoServer source, GeoServer target, @NonNull String id, @NonNull Patch patch) {
-        super(source, target, id, ConfigInfoType.GeoServerInfo, patch);
+    protected GeoServerInfoModifyEvent(@NonNull String id, @NonNull Patch patch) {
+        super(id, ConfigInfoType.GeoServerInfo, patch);
     }
 
-    public static GeoServerInfoModifyEvent createLocal(
-            GeoServer source, GeoServerInfo info, @NonNull Patch patch) {
+    public static GeoServerInfoModifyEvent createLocal(GeoServerInfo info, @NonNull Patch patch) {
         final String id = resolveId(info);
         return patch.get("updateSequence")
-                .map(
-                        p ->
-                                (GeoServerInfoModifyEvent)
-                                        UpdateSequenceEvent.createLocal(source, id, patch))
-                .orElseGet(() -> new GeoServerInfoModifyEvent(source, null, id, patch));
+                .map(p -> (GeoServerInfoModifyEvent) UpdateSequenceEvent.createLocal(id, patch))
+                .orElseGet(() -> new GeoServerInfoModifyEvent(id, patch));
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/GeoServerInfoSetEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/GeoServerInfoSetEvent.java
@@ -20,11 +20,11 @@ public class GeoServerInfoSetEvent extends ConfigInfoAddEvent<GeoServerInfoSetEv
         // default constructor, needed for deserialization
     }
 
-    protected GeoServerInfoSetEvent(GeoServer source, GeoServer target, GeoServerInfo object) {
-        super(source, target, object);
+    protected GeoServerInfoSetEvent(GeoServerInfo object) {
+        super(object);
     }
 
-    public static GeoServerInfoSetEvent createLocal(GeoServer source, GeoServerInfo value) {
-        return new GeoServerInfoSetEvent(source, null, value);
+    public static GeoServerInfoSetEvent createLocal(GeoServerInfo value) {
+        return new GeoServerInfoSetEvent(value);
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/LoggingInfoModifyEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/LoggingInfoModifyEvent.java
@@ -12,7 +12,6 @@ import lombok.NonNull;
 
 import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.cloud.event.info.ConfigInfoType;
-import org.geoserver.config.GeoServer;
 import org.geoserver.config.LoggingInfo;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
@@ -26,15 +25,13 @@ public class LoggingInfoModifyEvent
         // default constructor, needed for deserialization
     }
 
-    protected LoggingInfoModifyEvent(
-            GeoServer source, GeoServer target, @NonNull String id, @NonNull Patch patch) {
+    protected LoggingInfoModifyEvent(@NonNull String id, @NonNull Patch patch) {
 
-        super(source, target, id, ConfigInfoType.LoggingInfo, patch);
+        super(id, ConfigInfoType.LoggingInfo, patch);
     }
 
-    public static LoggingInfoModifyEvent createLocal(
-            GeoServer source, LoggingInfo info, @NonNull Patch patch) {
+    public static LoggingInfoModifyEvent createLocal(LoggingInfo info, @NonNull Patch patch) {
         String id = resolveId(info);
-        return new LoggingInfoModifyEvent(source, null, id, patch);
+        return new LoggingInfoModifyEvent(id, patch);
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/LoggingInfoSetEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/LoggingInfoSetEvent.java
@@ -20,11 +20,11 @@ public class LoggingInfoSetEvent extends ConfigInfoAddEvent<LoggingInfoSetEvent,
         // default constructor, needed for deserialization
     }
 
-    protected LoggingInfoSetEvent(GeoServer source, GeoServer target, LoggingInfo object) {
-        super(source, target, object);
+    protected LoggingInfoSetEvent(LoggingInfo object) {
+        super(object);
     }
 
-    public static LoggingInfoSetEvent createLocal(GeoServer source, LoggingInfo value) {
-        return new LoggingInfoSetEvent(source, null, value);
+    public static LoggingInfoSetEvent createLocal(LoggingInfo value) {
+        return new LoggingInfoSetEvent(value);
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ServiceInfoAddEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ServiceInfoAddEvent.java
@@ -23,11 +23,11 @@ public class ServiceInfoAddEvent extends ConfigInfoAddEvent<ServiceInfoAddEvent,
         // default constructor, needed for deserialization
     }
 
-    protected ServiceInfoAddEvent(GeoServer source, GeoServer target, ServiceInfo object) {
-        super(source, target, object);
+    protected ServiceInfoAddEvent(ServiceInfo object) {
+        super(object);
     }
 
-    public static ServiceInfoAddEvent createLocal(GeoServer source, ServiceInfo value) {
-        return new ServiceInfoAddEvent(source, null, value);
+    public static ServiceInfoAddEvent createLocal(ServiceInfo value) {
+        return new ServiceInfoAddEvent(value);
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ServiceInfoModifyEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ServiceInfoModifyEvent.java
@@ -14,7 +14,6 @@ import lombok.NonNull;
 import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.cloud.event.info.ConfigInfoType;
 import org.geoserver.cloud.event.info.InfoEvent;
-import org.geoserver.config.GeoServer;
 import org.geoserver.config.LoggingInfo;
 import org.geoserver.config.ServiceInfo;
 
@@ -32,21 +31,21 @@ public class ServiceInfoModifyEvent
     }
 
     protected ServiceInfoModifyEvent(
-            GeoServer source,
-            GeoServer target,
-            @NonNull String objectId,
-            @NonNull Patch patch,
-            String workspaceId) {
+            @NonNull String objectId, @NonNull Patch patch, String workspaceId) {
 
-        super(source, target, objectId, ConfigInfoType.ServiceInfo, patch);
+        super(objectId, ConfigInfoType.ServiceInfo, patch);
         this.workspaceId = workspaceId;
     }
 
+    public @Override String toString() {
+        return toStringBuilder().append("workspace", getWorkspaceId()).toString();
+    }
+
     public static ServiceInfoModifyEvent createLocal(
-            GeoServer source, @NonNull ServiceInfo object, @NonNull Patch patch) {
+            @NonNull ServiceInfo object, @NonNull Patch patch) {
 
         final @NonNull String serviceId = InfoEvent.resolveId(object);
         final String workspaceId = InfoEvent.resolveId(object.getWorkspace());
-        return new ServiceInfoModifyEvent(source, null, serviceId, patch, workspaceId);
+        return new ServiceInfoModifyEvent(serviceId, patch, workspaceId);
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ServiceInfoRemoveEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ServiceInfoRemoveEvent.java
@@ -12,7 +12,6 @@ import lombok.Getter;
 import lombok.NonNull;
 
 import org.geoserver.cloud.event.info.ConfigInfoType;
-import org.geoserver.config.GeoServer;
 import org.geoserver.config.ServiceInfo;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
@@ -27,17 +26,16 @@ public class ServiceInfoRemoveEvent
         // default constructor, needed for deserialization
     }
 
-    protected ServiceInfoRemoveEvent(
-            GeoServer source, GeoServer target, @NonNull String objectId, String workspaceId) {
+    protected ServiceInfoRemoveEvent(@NonNull String objectId, String workspaceId) {
 
-        super(source, target, objectId, ConfigInfoType.ServiceInfo);
+        super(objectId, ConfigInfoType.ServiceInfo);
         this.workspaceId = workspaceId;
     }
 
-    public static ServiceInfoRemoveEvent createLocal(GeoServer source, @NonNull ServiceInfo info) {
+    public static ServiceInfoRemoveEvent createLocal(@NonNull ServiceInfo info) {
 
         final @NonNull String serviceId = info.getId();
         final String workspaceId = resolveId(info.getWorkspace());
-        return new ServiceInfoRemoveEvent(source, null, serviceId, workspaceId);
+        return new ServiceInfoRemoveEvent(serviceId, workspaceId);
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/SettingsInfoAddEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/SettingsInfoAddEvent.java
@@ -26,11 +26,11 @@ public class SettingsInfoAddEvent extends ConfigInfoAddEvent<SettingsInfoAddEven
         // default constructor, needed for deserialization
     }
 
-    protected SettingsInfoAddEvent(GeoServer source, GeoServer target, SettingsInfo object) {
-        super(source, target, object);
+    protected SettingsInfoAddEvent(SettingsInfo object) {
+        super(object);
     }
 
-    public static SettingsInfoAddEvent createLocal(GeoServer source, SettingsInfo value) {
-        return new SettingsInfoAddEvent(source, null, value);
+    public static SettingsInfoAddEvent createLocal(SettingsInfo value) {
+        return new SettingsInfoAddEvent(value);
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/SettingsInfoModifyEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/SettingsInfoModifyEvent.java
@@ -14,7 +14,6 @@ import lombok.NonNull;
 import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.cloud.event.info.ConfigInfoType;
 import org.geoserver.cloud.event.info.InfoEvent;
-import org.geoserver.config.GeoServer;
 import org.geoserver.config.SettingsInfo;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
@@ -31,22 +30,22 @@ public class SettingsInfoModifyEvent
     }
 
     public SettingsInfoModifyEvent(
-            GeoServer source,
-            GeoServer target,
-            @NonNull String objectId,
-            @NonNull Patch patch,
-            @NonNull String workspaceId) {
+            @NonNull String objectId, @NonNull Patch patch, @NonNull String workspaceId) {
 
-        super(source, target, objectId, ConfigInfoType.SettingsInfo, patch);
+        super(objectId, ConfigInfoType.SettingsInfo, patch);
         this.workspaceId = workspaceId;
     }
 
+    public @Override String toString() {
+        return toStringBuilder().append("workspace", getWorkspaceId()).toString();
+    }
+
     public static SettingsInfoModifyEvent createLocal(
-            GeoServer source, @NonNull SettingsInfo object, @NonNull Patch patch) {
+            @NonNull SettingsInfo object, @NonNull Patch patch) {
 
         final String settingsId = object.getId();
         final String workspaceId = InfoEvent.resolveId(object.getWorkspace());
 
-        return new SettingsInfoModifyEvent(source, null, settingsId, patch, workspaceId);
+        return new SettingsInfoModifyEvent(settingsId, patch, workspaceId);
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/SettingsInfoRemoveEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/SettingsInfoRemoveEvent.java
@@ -11,7 +11,6 @@ import lombok.Getter;
 import lombok.NonNull;
 
 import org.geoserver.cloud.event.info.ConfigInfoType;
-import org.geoserver.config.GeoServer;
 import org.geoserver.config.SettingsInfo;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
@@ -25,22 +24,17 @@ public class SettingsInfoRemoveEvent
         // default constructor, needed for deserialization
     }
 
-    protected SettingsInfoRemoveEvent(
-            GeoServer source,
-            GeoServer target,
-            @NonNull String objectId,
-            @NonNull String workspaceId) {
+    protected SettingsInfoRemoveEvent(@NonNull String objectId, @NonNull String workspaceId) {
 
-        super(source, target, objectId, ConfigInfoType.SettingsInfo);
+        super(objectId, ConfigInfoType.SettingsInfo);
         this.workspaceId = workspaceId;
     }
 
-    public static SettingsInfoRemoveEvent createLocal(
-            @NonNull GeoServer source, @NonNull SettingsInfo settings) {
+    public static SettingsInfoRemoveEvent createLocal(@NonNull SettingsInfo settings) {
 
         final @NonNull String settingsId = settings.getId();
         final @NonNull String workspaceId = settings.getWorkspace().getId();
 
-        return new SettingsInfoRemoveEvent(source, null, settingsId, workspaceId);
+        return new SettingsInfoRemoveEvent(settingsId, workspaceId);
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/UpdateSequenceEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/UpdateSequenceEvent.java
@@ -12,7 +12,6 @@ import lombok.Getter;
 import lombok.NonNull;
 
 import org.geoserver.catalog.plugin.Patch;
-import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerInfo;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
@@ -31,29 +30,27 @@ public class UpdateSequenceEvent extends GeoServerInfoModifyEvent {
      */
     private @Getter long updateSequence;
 
-    protected UpdateSequenceEvent(
-            GeoServer source,
-            GeoServer target,
-            @NonNull String id,
-            @NonNull Patch patch,
-            long updateSequence) {
-        super(source, target, id, patch);
+    protected UpdateSequenceEvent(@NonNull String id, @NonNull Patch patch, long updateSequence) {
+        super(id, patch);
         this.updateSequence = updateSequence;
     }
 
-    public static UpdateSequenceEvent createLocal(GeoServer source, GeoServerInfo info) {
+    public @Override String toString() {
+        return toStringBuilder().append("updateSequence", getUpdateSequence()).toString();
+    }
+
+    public static UpdateSequenceEvent createLocal(GeoServerInfo info) {
 
         long updateSequence = info.getUpdateSequence();
         String id = resolveId(info);
         Patch patch = new Patch();
         patch.add("updateSequence", updateSequence);
-        return createLocal(source, id, patch);
+        return createLocal(id, patch);
     }
 
-    public static UpdateSequenceEvent createLocal(
-            GeoServer source, @NonNull String id, @NonNull Patch patch) {
+    public static UpdateSequenceEvent createLocal(@NonNull String id, @NonNull Patch patch) {
 
         long updateSequence = (long) patch.get("updateSequence").orElseThrow().getValue();
-        return new UpdateSequenceEvent(source, null, id, patch, updateSequence);
+        return new UpdateSequenceEvent(id, patch, updateSequence);
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/info/ConfigInfoType.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/info/ConfigInfoType.java
@@ -68,4 +68,8 @@ public enum ConfigInfoType {
         }
         throw new IllegalArgumentException("Unknown info type for object " + object);
     }
+
+    public boolean isA(Class<? extends Info> type) {
+        return type.isAssignableFrom(getType());
+    }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/info/InfoAddEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/info/InfoAddEvent.java
@@ -20,14 +20,14 @@ import org.geoserver.cloud.event.config.ConfigInfoAddEvent;
     @JsonSubTypes.Type(value = CatalogInfoAddEvent.class, name = "CatalogInfoAdded"),
     @JsonSubTypes.Type(value = ConfigInfoAddEvent.class),
 })
-public abstract class InfoAddEvent<SELF, S, I extends Info> extends InfoEvent<SELF, S, I> {
+public abstract class InfoAddEvent<SELF, I extends Info> extends InfoEvent<SELF, I> {
 
     private @Getter @Setter @NonNull I object;
 
     protected InfoAddEvent() {}
 
-    protected InfoAddEvent(S source, S target, @NonNull I object) {
-        super(source, target, resolveId(object), typeOf(object));
+    protected InfoAddEvent(@NonNull I object) {
+        super(resolveId(object), typeOf(object));
         this.object = object;
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/info/InfoEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/info/InfoEvent.java
@@ -15,10 +15,9 @@ import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.Info;
 import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.LoggingInfo;
+import org.springframework.core.style.ToStringCreator;
 
 import java.util.Optional;
-
-import javax.annotation.Nullable;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonSubTypes({
@@ -26,7 +25,7 @@ import javax.annotation.Nullable;
     @JsonSubTypes.Type(value = InfoModifyEvent.class),
     @JsonSubTypes.Type(value = InfoRemoveEvent.class)
 })
-public abstract class InfoEvent<SELF, SOURCE, INFO extends Info> {
+public abstract class InfoEvent<SELF, INFO extends Info> {
 
     private @Setter boolean remote;
 
@@ -39,17 +38,7 @@ public abstract class InfoEvent<SELF, SOURCE, INFO extends Info> {
 
     protected InfoEvent() {}
 
-    protected InfoEvent(
-            @Nullable SOURCE source,
-            @Nullable SOURCE target,
-            @NonNull String objectId,
-            @NonNull ConfigInfoType objectType) {
-        if (source == null && target == null) {
-            throw new IllegalArgumentException("Either source or target shall be non-null");
-        }
-        if (source != null && target != null) {
-            throw new IllegalArgumentException("Either source or target shall be null");
-        }
+    protected InfoEvent(@NonNull String objectId, @NonNull ConfigInfoType objectType) {
         // this.source = source;
         this.objectId = objectId;
         this.objectType = objectType;
@@ -74,11 +63,17 @@ public abstract class InfoEvent<SELF, SOURCE, INFO extends Info> {
         return remote;
     }
 
-    @Override
-    public String toString() {
-        return String.format(
-                "%s[%s(%s)]", getClass().getSimpleName(), getObjectType(), getObjectId());
+    public @Override String toString() {
+        return toStringBuilder().toString();
     }
+
+    protected ToStringCreator toStringBuilder() {
+        return new ToStringCreator(this)
+                .append("remote", isRemote())
+                .append("type", getObjectType())
+                .append("id", getObjectId());
+    }
+
     /**
      * {@link #getObjectId() object identifier} for changes performed to the {@link Catalog} itself
      * (e.g. {@code defaultWorkspace} and the like)

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/info/InfoModifyEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/info/InfoModifyEvent.java
@@ -14,49 +14,30 @@ import lombok.Setter;
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.plugin.Patch;
 
-import javax.annotation.Nullable;
+import java.util.stream.Collectors;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonSubTypes({
     @JsonSubTypes.Type(value = InfoPreModifyEvent.class),
     @JsonSubTypes.Type(value = InfoPostModifyEvent.class),
 })
-public abstract class InfoModifyEvent<SELF, SOURCE, INFO extends Info>
-        extends InfoEvent<SELF, SOURCE, INFO> {
+public abstract class InfoModifyEvent<SELF, INFO extends Info> extends InfoEvent<SELF, INFO> {
 
     private @Getter @Setter @NonNull Patch patch;
 
     protected InfoModifyEvent() {}
 
     protected InfoModifyEvent(
-            @Nullable SOURCE source,
-            @Nullable SOURCE target,
-            @NonNull String objectId,
-            @NonNull ConfigInfoType objectType,
-            @NonNull Patch patch) {
-        super(source, target, objectId, objectType);
+            @NonNull String objectId, @NonNull ConfigInfoType objectType, @NonNull Patch patch) {
+        super(objectId, objectType);
         this.patch = patch;
     }
 
-    @Override
-    public String toString() {
-        return String.format(
-                "%s[%s(%s), changed: %s]",
-                getClass().getSimpleName(),
-                getObjectType(),
-                getObjectId(),
-                getPatch().getPropertyNames());
+    public @Override String toString() {
+        return toStringBuilder()
+                .append(
+                        "changes",
+                        getPatch().getPropertyNames().stream().collect(Collectors.joining(",")))
+                .toString();
     }
-
-    //    public @Override String toString() {
-    //        return String.format(
-    //                "%s(remote: %s, type: %s, id: %s, source: %s, target: %s, patch: %s)",
-    //                getClass().getSimpleName(),
-    //                isRemote(),
-    //                getObjectType(),
-    //                getObjectId(),
-    //                getSource() == null ? null : getSource().getClass().getSimpleName(),
-    //                getTarget() == null ? null : getTarget().getClass().getSimpleName(),
-    //                getPatch());
-    //    }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/info/InfoPostModifyEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/info/InfoPostModifyEvent.java
@@ -14,24 +14,18 @@ import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.cloud.event.catalog.CatalogInfoModifyEvent;
 import org.geoserver.cloud.event.config.ConfigInfoModifyEvent;
 
-import javax.annotation.Nullable;
-
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonSubTypes({
     @JsonSubTypes.Type(value = CatalogInfoModifyEvent.class, name = "CatalogInfoModified"),
     @JsonSubTypes.Type(value = ConfigInfoModifyEvent.class),
 })
-public abstract class InfoPostModifyEvent<SELF, SOURCE, INFO extends Info>
-        extends InfoModifyEvent<SELF, SOURCE, INFO> {
+public abstract class InfoPostModifyEvent<SELF, INFO extends Info>
+        extends InfoModifyEvent<SELF, INFO> {
 
     protected InfoPostModifyEvent() {}
 
     protected InfoPostModifyEvent(
-            @Nullable SOURCE source,
-            @Nullable SOURCE target,
-            @NonNull String objectId,
-            @NonNull ConfigInfoType objectType,
-            @NonNull Patch patch) {
-        super(source, target, objectId, objectType, patch);
+            @NonNull String objectId, @NonNull ConfigInfoType objectType, @NonNull Patch patch) {
+        super(objectId, objectType, patch);
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/info/InfoPreModifyEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/info/InfoPreModifyEvent.java
@@ -14,24 +14,18 @@ import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.cloud.event.catalog.CatalogInfoPreModifyEvent;
 import org.geoserver.cloud.event.config.ConfigInfoPreModifyEvent;
 
-import javax.annotation.Nullable;
-
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonSubTypes({
     @JsonSubTypes.Type(value = CatalogInfoPreModifyEvent.class),
     @JsonSubTypes.Type(value = ConfigInfoPreModifyEvent.class),
 })
-public abstract class InfoPreModifyEvent<SELF, SOURCE, INFO extends Info>
-        extends InfoModifyEvent<SELF, SOURCE, INFO> {
+public abstract class InfoPreModifyEvent<SELF, INFO extends Info>
+        extends InfoModifyEvent<SELF, INFO> {
 
     protected InfoPreModifyEvent() {}
 
     protected InfoPreModifyEvent(
-            @Nullable SOURCE source,
-            @Nullable SOURCE target,
-            @NonNull String objectId,
-            @NonNull ConfigInfoType objectType,
-            @NonNull Patch patch) {
-        super(source, target, objectId, objectType, patch);
+            @NonNull String objectId, @NonNull ConfigInfoType objectType, @NonNull Patch patch) {
+        super(objectId, objectType, patch);
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/info/InfoRemoveEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/info/InfoRemoveEvent.java
@@ -18,13 +18,11 @@ import org.geoserver.cloud.event.config.ConfigInfoRemoveEvent;
     @JsonSubTypes.Type(value = CatalogInfoRemoveEvent.class, name = "CatalogInfoRemoved"),
     @JsonSubTypes.Type(value = ConfigInfoRemoveEvent.class, name = "ConfigInfoRemoved"),
 })
-public abstract class InfoRemoveEvent<SELF, SOURCE, INFO extends Info>
-        extends InfoEvent<SELF, SOURCE, INFO> {
+public abstract class InfoRemoveEvent<SELF, INFO extends Info> extends InfoEvent<SELF, INFO> {
 
     protected InfoRemoveEvent() {}
 
-    protected InfoRemoveEvent(
-            SOURCE source, SOURCE target, @NonNull String objectId, @NonNull ConfigInfoType type) {
-        super(source, target, objectId, type);
+    protected InfoRemoveEvent(@NonNull String objectId, @NonNull ConfigInfoType type) {
+        super(objectId, type);
     }
 }

--- a/src/catalog/events/src/test/java/org/geoserver/cloud/config/catalog/events/CatalogApplicationEventsConfigurationTest.java
+++ b/src/catalog/events/src/test/java/org/geoserver/cloud/config/catalog/events/CatalogApplicationEventsConfigurationTest.java
@@ -351,7 +351,7 @@ public class CatalogApplicationEventsConfigurationTest {
         listener.start();
         remover.accept(info);
         @SuppressWarnings("unchecked")
-        InfoRemoveEvent<?, ?, T> event = listener.expectOne(eventType);
+        InfoRemoveEvent<?, T> event = listener.expectOne(eventType);
         assertEquals(info.getId(), event.getObjectId());
         assertEquals(ConfigInfoType.valueOf(info), event.getObjectType());
     }
@@ -398,12 +398,12 @@ public class CatalogApplicationEventsConfigurationTest {
         modifier.accept(info);
         saver.accept(info);
 
-        InfoPreModifyEvent<?, ?, T> pre = listener.expectOne(preEventType);
+        InfoPreModifyEvent<?, T> pre = listener.expectOne(preEventType);
         assertEquals(info.getId(), pre.getObjectId());
 
         assertEquals(expected, pre.getPatch());
 
-        InfoPostModifyEvent<?, ?, T> post = listener.expectOne(postEventType);
+        InfoPostModifyEvent<?, T> post = listener.expectOne(postEventType);
         assertEquals(proxy.getId(), post.getObjectId());
         assertEquals(expected, post.getPatch());
     }

--- a/src/starters/catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/catalog/RemoteEventsResourcePoolCleaupUpAutoConfiguration.java
+++ b/src/starters/catalog-backend/src/main/java/org/geoserver/cloud/autoconfigure/catalog/RemoteEventsResourcePoolCleaupUpAutoConfiguration.java
@@ -5,7 +5,10 @@
 package org.geoserver.cloud.autoconfigure.catalog;
 
 import org.geoserver.catalog.ResourcePool;
+import org.geoserver.catalog.plugin.CatalogPlugin;
 import org.geoserver.cloud.autoconfigure.catalog.event.ConditionalOnCatalogEvents;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
@@ -15,4 +18,11 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnCatalogEvents
-public class RemoteEventsResourcePoolCleaupUpAutoConfiguration {}
+public class RemoteEventsResourcePoolCleaupUpAutoConfiguration {
+
+    public @Bean RemoteEventResourcePoolProcessor remoteEventResourcePoolProcessor(
+            @Qualifier("rawCatalog") CatalogPlugin rawCatalog) {
+
+        return new RemoteEventResourcePoolProcessor(rawCatalog);
+    }
+}

--- a/src/starters/catalog-backend/src/main/java/org/geoserver/cloud/bus/incoming/caching/RemoteEventCacheEvictor.java
+++ b/src/starters/catalog-backend/src/main/java/org/geoserver/cloud/bus/incoming/caching/RemoteEventCacheEvictor.java
@@ -43,7 +43,7 @@ import java.util.function.BooleanSupplier;
  * {@link CachingCatalogFacade} and {@link CachingGeoServerFacade} as required by the event type and
  * the object it refers to.
  */
-@Slf4j(topic = "org.geoserver.cloud.bus.incoming.caching")
+@Slf4j(topic = "org.geoserver.cloud.events.catalog.caching")
 @RequiredArgsConstructor
 public @Service class RemoteEventCacheEvictor {
 
@@ -162,7 +162,7 @@ public @Service class RemoteEventCacheEvictor {
         }
     }
 
-    private void evictCatalogInfo(InfoEvent<?, ?, ?> event) {
+    private void evictCatalogInfo(InfoEvent<?, ?> event) {
         evictEntry(
                 event,
                 () -> {
@@ -174,7 +174,7 @@ public @Service class RemoteEventCacheEvictor {
                 });
     }
 
-    public void evictConfigEntry(InfoEvent<?, ?, ?> event) {
+    public void evictConfigEntry(InfoEvent<?, ?> event) {
         evictEntry(
                 event,
                 () -> {
@@ -185,15 +185,15 @@ public @Service class RemoteEventCacheEvictor {
                 });
     }
 
-    private void evictEntry(InfoEvent<?, ?, ?> event, BooleanSupplier evictor) {
+    private void evictEntry(InfoEvent<?, ?> event, BooleanSupplier evictor) {
         event.remote()
                 .ifPresent(
                         evt -> {
                             boolean evicted = evictor.getAsBoolean();
                             if (evicted) {
-                                log.debug("Evicted cache entry upon remote event ", evt);
+                                log.debug("Evicted cache entry {}", evt);
                             } else {
-                                log.trace("Remote event resulted in no cache eviction: ", evt);
+                                log.trace("Remote event resulted in no cache eviction: {}", evt);
                             }
                         });
     }

--- a/src/starters/catalog-backend/src/main/java/org/geoserver/cloud/config/datadirectory/DataDirectoryRemoteEventProcessor.java
+++ b/src/starters/catalog-backend/src/main/java/org/geoserver/cloud/config/datadirectory/DataDirectoryRemoteEventProcessor.java
@@ -38,7 +38,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /** Listens to {@link RemoteCatalogEvent}s and updates the local catalog */
-@Slf4j(topic = "org.geoserver.cloud.bus.incoming.datadirectory")
+@Slf4j(topic = "org.geoserver.cloud.events.catalog.datadir")
 @RequiredArgsConstructor
 public class DataDirectoryRemoteEventProcessor {
 
@@ -46,7 +46,7 @@ public class DataDirectoryRemoteEventProcessor {
     private final @NonNull ExtendedCatalogFacade catalogFacade;
 
     @EventListener(InfoRemoveEvent.class)
-    public void onRemoteRemoveEvent(InfoRemoveEvent<?, ?, ? extends Info> event) {
+    public void onRemoteRemoveEvent(InfoRemoveEvent<?, ? extends Info> event) {
         if (event.isLocal()) {
             return;
         }
@@ -102,7 +102,7 @@ public class DataDirectoryRemoteEventProcessor {
     }
 
     @EventListener(InfoAddEvent.class)
-    public void onRemoteAddEvent(InfoAddEvent<?, ?, ? extends Info> event) {
+    public void onRemoteAddEvent(InfoAddEvent<?, ? extends Info> event) {
         if (event.isLocal()) {
             return;
         }
@@ -148,6 +148,9 @@ public class DataDirectoryRemoteEventProcessor {
             case SettingsInfo:
                 configFacade.add((SettingsInfo) object);
                 break;
+            case LoggingInfo:
+                // ignore
+                break;
             default:
                 log.warn("Don't know how to handle remote envent {})", event);
                 break;
@@ -185,7 +188,7 @@ public class DataDirectoryRemoteEventProcessor {
     }
 
     @EventListener(InfoPostModifyEvent.class)
-    public void onRemoteModifyEvent(InfoPostModifyEvent<?, ?, ? extends Info> event) {
+    public void onRemoteModifyEvent(InfoPostModifyEvent<?, ? extends Info> event) {
         if (event.isLocal()) {
             return;
         }
@@ -232,16 +235,18 @@ public class DataDirectoryRemoteEventProcessor {
                 info = catalogFacade.getStyle(objectId);
                 break;
             case GeoServerInfo:
-                info = configFacade.getGlobal();
-                info = ModificationProxy.unwrap(info);
+                info = ModificationProxy.unwrap(configFacade.getGlobal());
                 break;
             case ServiceInfo:
-                info = configFacade.getService(objectId, ServiceInfo.class);
-                info = ModificationProxy.unwrap(info);
+                info =
+                        ModificationProxy.unwrap(
+                                configFacade.getService(objectId, ServiceInfo.class));
                 break;
             case SettingsInfo:
-                info = configFacade.getSettings(objectId);
-                info = ModificationProxy.unwrap(info);
+                info = ModificationProxy.unwrap(configFacade.getSettings(objectId));
+                break;
+            case LoggingInfo:
+                info = ModificationProxy.unwrap(configFacade.getLogging());
                 break;
             default:
                 log.warn("Don't know how to handle remote modify envent {}", event);

--- a/src/starters/catalog-backend/src/main/java/org/geoserver/cloud/config/jdbcconfig/bus/JdbcConfigRemoteEventProcessor.java
+++ b/src/starters/catalog-backend/src/main/java/org/geoserver/cloud/config/jdbcconfig/bus/JdbcConfigRemoteEventProcessor.java
@@ -25,16 +25,16 @@ public class JdbcConfigRemoteEventProcessor {
     private @Autowired ConfigDatabase jdbcConfigDatabase;
 
     @EventListener(InfoRemoveEvent.class)
-    public void onRemoteRemoveEvent(InfoRemoveEvent<?, ?, ?> event) {
+    public void onRemoteRemoveEvent(InfoRemoveEvent<?, ?> event) {
         evictConfigDatabaseEntry(event);
     }
 
     @EventListener(InfoModifyEvent.class)
-    public void onRemoteModifyEvent(InfoModifyEvent<?, ?, ? extends Info> event) {
+    public void onRemoteModifyEvent(InfoModifyEvent<?, ? extends Info> event) {
         evictConfigDatabaseEntry(event);
     }
 
-    private void evictConfigDatabaseEntry(InfoEvent<?, ?, ?> event) {
+    private void evictConfigDatabaseEntry(InfoEvent<?, ?> event) {
         event.remote()
                 .ifPresent(
                         remoteEvent -> {

--- a/src/starters/catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/testconfiguration/AutoConfigurationTestConfiguration.java
+++ b/src/starters/catalog-backend/src/test/java/org/geoserver/cloud/autoconfigure/testconfiguration/AutoConfigurationTestConfiguration.java
@@ -7,6 +7,8 @@ package org.geoserver.cloud.autoconfigure.testconfiguration;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementContextAutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.freemarker.FreeMarkerAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
@@ -17,6 +19,8 @@ import org.springframework.context.annotation.Configuration;
             SecurityAutoConfiguration.class,
             UserDetailsServiceAutoConfiguration.class,
             ManagementContextAutoConfiguration.class,
-            ManagementWebSecurityAutoConfiguration.class
+            ManagementWebSecurityAutoConfiguration.class,
+            FreeMarkerAutoConfiguration.class,
+            DataSourceAutoConfiguration.class
         })
 public class AutoConfigurationTestConfiguration {}


### PR DESCRIPTION
`RemoteEventResourcePoolProcessor` was not being bound to the application context after the last refactoring, resulting in errors processing incoming events.