### PR TITLE
Remote event processing of patches sends CatalogInfo as value instead of references

### DIFF
--- a/src/catalog/catalog-server/client/src/test/java/org/geoserver/cloud/catalog/client/repository/CatalogClientRepositoryTest.java
+++ b/src/catalog/catalog-server/client/src/test/java/org/geoserver/cloud/catalog/client/repository/CatalogClientRepositoryTest.java
@@ -48,8 +48,8 @@ import org.geotools.filter.function.math.FilterFunction_abs;
 import org.geotools.filter.function.math.FilterFunction_acos;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.ecql.ECQL;
+import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opengis.filter.Filter;
@@ -83,8 +83,7 @@ public class CatalogClientRepositoryTest {
     private @Autowired StyleRepository styleRepository;
 
     private static final Catalog fakeCatalog = new CatalogPlugin();
-    public @Rule CatalogTestData testData =
-            CatalogTestData.empty(() -> fakeCatalog, () -> null).initConfig(false);
+    protected CatalogTestData testData;
 
     public @Before void before() {
         List<FunctionName> functions =
@@ -94,6 +93,12 @@ public class CatalogClientRepositoryTest {
                         FilterFunction_acos.NAME,
                         FilterFunction_toWKT.NAME);
         when(mockClient.getSupportedFilterFunctionNames()).thenReturn(Flux.fromIterable(functions));
+        testData =
+                CatalogTestData.empty(() -> fakeCatalog, () -> null).initConfig(false).initialize();
+    }
+
+    public @After void after() {
+        testData.after();
     }
 
     public @Test void workspaceRepository_CRUD() {

--- a/src/catalog/catalog-server/server/src/test/java/org/geoserver/cloud/catalog/server/api/v1/AbstractReactiveCatalogControllerTest.java
+++ b/src/catalog/catalog-server/server/src/test/java/org/geoserver/cloud/catalog/server/api/v1/AbstractReactiveCatalogControllerTest.java
@@ -25,6 +25,7 @@ import org.geoserver.config.GeoServer;
 import org.geoserver.jackson.databind.catalog.ProxyUtils;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.ecql.ECQL;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -64,8 +65,7 @@ public abstract class AbstractReactiveCatalogControllerTest<C extends CatalogInf
     protected @Autowired @Qualifier("catalog") Catalog catalog;
     protected @Autowired @Qualifier("geoServer") GeoServer geoServer;
 
-    public @Rule CatalogTestData testData =
-            CatalogTestData.initialized(() -> catalog, () -> null).initConfig(false);
+    protected CatalogTestData testData;
 
     protected final @NonNull Class<C> infoType;
 
@@ -77,7 +77,14 @@ public abstract class AbstractReactiveCatalogControllerTest<C extends CatalogInf
 
     public @Before void setup() {
         proxyResolver = new ProxyUtils(catalog, geoServer).failOnMissingReference(true);
+        testData =
+                CatalogTestData.initialized(() -> catalog, () -> null).initConfig(false).initialize();
     }
+    
+    public @After void after() {
+        testData.after();
+    }
+
 
     public abstract @Test void testFindAll();
 

--- a/src/catalog/catalog-server/server/src/test/java/org/geoserver/cloud/catalog/server/api/v1/NamespaceControllerTest.java
+++ b/src/catalog/catalog-server/server/src/test/java/org/geoserver/cloud/catalog/server/api/v1/NamespaceControllerTest.java
@@ -7,14 +7,13 @@ package org.geoserver.cloud.catalog.server.api.v1;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.springframework.http.MediaType.*;
-
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.http.MediaType.APPLICATION_STREAM_JSON;
+import java.io.IOException;
+import java.util.List;
 import org.geoserver.catalog.NamespaceInfo;
 import org.junit.Test;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
-
-import java.io.IOException;
-import java.util.List;
 
 @AutoConfigureWebTestClient(timeout = "360000")
 public class NamespaceControllerTest extends AbstractReactiveCatalogControllerTest<NamespaceInfo> {
@@ -34,8 +33,8 @@ public class NamespaceControllerTest extends AbstractReactiveCatalogControllerTe
     }
 
     public @Override @Test void testFindAllByType() {
-        super.testFindAll(
-                NamespaceInfo.class, testData.namespaceA, testData.namespaceB, testData.namespaceC);
+        super.testFindAll(NamespaceInfo.class, testData.namespaceA, testData.namespaceB,
+                testData.namespaceC);
     }
 
     public @Override @Test void testFindById() {
@@ -75,11 +74,8 @@ public class NamespaceControllerTest extends AbstractReactiveCatalogControllerTe
     }
 
     public @Test void testNamespaceInfo_CRUD() throws IOException {
-        NamespaceInfo ns = testData.createNamespace("namedpaceCRUD", "http://namespace.crud.test");
-        crudTest(
-                ns,
-                catalog::getNamespace,
-                n -> n.setPrefix("modified-prefix"),
+        NamespaceInfo ns = testData.faker().namespace();
+        crudTest(ns, catalog::getNamespace, n -> n.setPrefix("modified-prefix"),
                 (old, updated) -> assertEquals("modified-prefix", updated.getPrefix()));
     }
 
@@ -87,14 +83,9 @@ public class NamespaceControllerTest extends AbstractReactiveCatalogControllerTe
         assertEquals(testData.namespaceA, catalog.getDefaultNamespace());
 
         NamespaceInfo returned =
-                client().put("/namespaces/default/{id}", testData.namespaceB.getId())
-                        .expectStatus()
-                        .isOk()
-                        .expectHeader()
-                        .contentType(APPLICATION_JSON)
-                        .expectBody(NamespaceInfo.class)
-                        .returnResult()
-                        .getResponseBody();
+                client().put("/namespaces/default/{id}", testData.namespaceB.getId()).expectStatus()
+                        .isOk().expectHeader().contentType(APPLICATION_JSON)
+                        .expectBody(NamespaceInfo.class).returnResult().getResponseBody();
 
         assertEquals(testData.namespaceB, returned);
     }
@@ -102,53 +93,35 @@ public class NamespaceControllerTest extends AbstractReactiveCatalogControllerTe
     public @Test void testSetDefaultNamespaceNonExistent() {
         assertEquals(testData.namespaceA, catalog.getDefaultNamespace());
 
-        client().put("/namespaces/default/{id}", "non-existent-id")
-                .expectStatus()
-                .isNoContent()
-                .expectHeader()
-                .contentType(APPLICATION_JSON);
+        client().put("/namespaces/default/{id}", "non-existent-id").expectStatus().isNoContent()
+                .expectHeader().contentType(APPLICATION_JSON);
     }
 
     public @Test void testGetDefaultNamespace() {
-        NamespaceInfo returned =
-                client().getRelative("/namespaces/default")
-                        .expectStatus()
-                        .isOk()
-                        .expectHeader()
-                        .contentType(APPLICATION_JSON)
-                        .expectBody(NamespaceInfo.class)
-                        .returnResult()
-                        .getResponseBody();
+        NamespaceInfo returned = client().getRelative("/namespaces/default").expectStatus().isOk()
+                .expectHeader().contentType(APPLICATION_JSON).expectBody(NamespaceInfo.class)
+                .returnResult().getResponseBody();
 
         assertEquals(testData.namespaceA, returned);
         catalog.setDefaultNamespace(testData.namespaceB);
 
-        returned =
-                client().getRelative("/namespaces/default")
-                        .expectStatus()
-                        .isOk()
-                        .expectHeader()
-                        .contentType(APPLICATION_JSON)
-                        .expectBody(NamespaceInfo.class)
-                        .returnResult()
-                        .getResponseBody();
+        returned = client().getRelative("/namespaces/default").expectStatus().isOk().expectHeader()
+                .contentType(APPLICATION_JSON).expectBody(NamespaceInfo.class).returnResult()
+                .getResponseBody();
 
         assertEquals(testData.namespaceB, returned);
     }
 
     public @Test void testGetDefaultNamespaceNoDefaultExists() {
         testData.deleteAll();
-        client().getRelative("/namespaces/default")
-                .expectStatus()
-                .isNoContent()
-                .expectHeader()
+        client().getRelative("/namespaces/default").expectStatus().isNoContent().expectHeader()
                 .contentType(APPLICATION_JSON);
     }
 
     public @Test void testFindOneNamespaceByURI() {
         NamespaceInfo ns1 = testData.namespaceA;
         NamespaceInfo ns2 =
-                testData.createNamespace("second-ns-with-duplicate-uri", "prefix2", ns1.getURI());
+                testData.faker().namespace("second-ns-with-duplicate-uri", "prefix2", ns1.getURI());
         ns2.setIsolated(true);
         catalog.add(ns2);
 
@@ -158,34 +131,23 @@ public class NamespaceControllerTest extends AbstractReactiveCatalogControllerTe
     }
 
     protected NamespaceInfo findByURI(String uri) {
-        NamespaceInfo found =
-                client().getRelative("/namespaces/uri?uri={uri}", uri)
-                        .expectStatus()
-                        .isOk()
-                        .expectHeader()
-                        .contentType(APPLICATION_JSON)
-                        .expectBody(NamespaceInfo.class)
-                        .returnResult()
-                        .getResponseBody();
+        NamespaceInfo found = client().getRelative("/namespaces/uri?uri={uri}", uri).expectStatus()
+                .isOk().expectHeader().contentType(APPLICATION_JSON).expectBody(NamespaceInfo.class)
+                .returnResult().getResponseBody();
         return found;
     }
 
     public @Test void testFindAllNamespacesByURI() {
         NamespaceInfo ns1 = testData.namespaceA;
         NamespaceInfo ns2 =
-                testData.createNamespace("second-ns-with-duplicate-uri", "prefix2", ns1.getURI());
+                testData.faker().namespace("second-ns-with-duplicate-uri", "prefix2", ns1.getURI());
         ns2.setIsolated(true);
         catalog.add(ns2);
 
         List<NamespaceInfo> found =
-                client().getRelative("/namespaces/uri/all?uri={uri}", ns1.getURI())
-                        .expectStatus()
-                        .isOk()
-                        .expectHeader()
-                        .contentType(APPLICATION_STREAM_JSON)
-                        .expectBodyList(NamespaceInfo.class)
-                        .returnResult()
-                        .getResponseBody();
+                client().getRelative("/namespaces/uri/all?uri={uri}", ns1.getURI()).expectStatus()
+                        .isOk().expectHeader().contentType(APPLICATION_STREAM_JSON)
+                        .expectBodyList(NamespaceInfo.class).returnResult().getResponseBody();
 
         assertTrue(found.contains(ns1));
         assertTrue(found.contains(ns2));
@@ -195,19 +157,13 @@ public class NamespaceControllerTest extends AbstractReactiveCatalogControllerTe
     public @Test void testCreateNamespaceDuplicateURI() {
         NamespaceInfo ns1 = testData.namespaceA;
         NamespaceInfo ns2 =
-                testData.createNamespace("second-ns-with-duplicate-uri", "prefix2", ns1.getURI());
+                testData.faker().namespace("second-ns-with-duplicate-uri", "prefix2", ns1.getURI());
         client().create(ns2).expectStatus().isBadRequest();
 
         ns2.setIsolated(true);
-        NamespaceInfo created =
-                client().create(ns2)
-                        .expectStatus()
-                        .isCreated()
-                        .expectHeader()
-                        .contentType(APPLICATION_JSON)
-                        .expectBody(NamespaceInfo.class)
-                        .returnResult()
-                        .getResponseBody();
+        NamespaceInfo created = client().create(ns2).expectStatus().isCreated().expectHeader()
+                .contentType(APPLICATION_JSON).expectBody(NamespaceInfo.class).returnResult()
+                .getResponseBody();
         assertNotNull(created.getId());
         assertEquals(ns2.getPrefix(), created.getPrefix());
         assertEquals(ns1.getURI(), created.getURI());

--- a/src/catalog/catalog-server/server/src/test/java/org/geoserver/cloud/catalog/server/api/v1/StoreControllerTest.java
+++ b/src/catalog/catalog-server/server/src/test/java/org/geoserver/cloud/catalog/server/api/v1/StoreControllerTest.java
@@ -6,7 +6,14 @@ package org.geoserver.cloud.catalog.server.api.v1;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.geoserver.catalog.CoverageStoreInfo;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.HTTPStoreInfo;
@@ -23,15 +30,6 @@ import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWeb
 import org.springframework.http.MediaType;
 import org.springframework.lang.Nullable;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 @AutoConfigureWebTestClient(timeout = "360000")
 public class StoreControllerTest extends AbstractReactiveCatalogControllerTest<StoreInfo> {
 
@@ -44,12 +42,10 @@ public class StoreControllerTest extends AbstractReactiveCatalogControllerTest<S
         assertEquals(expected.getDescription(), actual.getDescription());
         // connection params may have been serialized as string
         final Map<String, Serializable> cm1 =
-                expected.getConnectionParameters() == null
-                        ? new HashMap<>()
+                expected.getConnectionParameters() == null ? new HashMap<>()
                         : expected.getConnectionParameters();
         final Map<String, Serializable> cm2 =
-                actual.getConnectionParameters() == null
-                        ? new HashMap<>()
+                actual.getConnectionParameters() == null ? new HashMap<>()
                         : actual.getConnectionParameters();
         assertEquals(cm1.size(), cm2.size());
         cm1.forEach((k, v) -> assertEquals(String.valueOf(v), String.valueOf(cm2.get(k))));
@@ -57,22 +53,16 @@ public class StoreControllerTest extends AbstractReactiveCatalogControllerTest<S
         assertEquals(expected.getWorkspace(), actual.getWorkspace());
         assertEquals(expected.isEnabled(), actual.isEnabled());
         if (expected instanceof CoverageStoreInfo)
-            assertEquals(
-                    ((CoverageStoreInfo) expected).getURL(), ((CoverageStoreInfo) actual).getURL());
+            assertEquals(((CoverageStoreInfo) expected).getURL(),
+                    ((CoverageStoreInfo) actual).getURL());
         if (expected instanceof HTTPStoreInfo)
-            assertEquals(
-                    ((HTTPStoreInfo) expected).getCapabilitiesURL(),
+            assertEquals(((HTTPStoreInfo) expected).getCapabilitiesURL(),
                     ((HTTPStoreInfo) actual).getCapabilitiesURL());
     }
 
     public @Override @Test void testFindAll() {
-        super.testFindAll(
-                testData.dataStoreA,
-                testData.dataStoreB,
-                testData.dataStoreC,
-                testData.coverageStoreA,
-                testData.wmsStoreA,
-                testData.wmtsStoreA);
+        super.testFindAll(testData.dataStoreA, testData.dataStoreB, testData.dataStoreC,
+                testData.coverageStoreA, testData.wmsStoreA, testData.wmtsStoreA);
     }
 
     public @Override @Test void testFindById() {
@@ -83,17 +73,12 @@ public class StoreControllerTest extends AbstractReactiveCatalogControllerTest<S
     }
 
     public @Override @Test void testFindAllByType() {
-        super.testFindAll(
-                StoreInfo.class,
-                testData.dataStoreA,
-                testData.dataStoreB,
-                testData.dataStoreC,
-                testData.coverageStoreA,
-                testData.wmsStoreA,
+        super.testFindAll(StoreInfo.class, testData.dataStoreA, testData.dataStoreB,
+                testData.dataStoreC, testData.coverageStoreA, testData.wmsStoreA,
                 testData.wmtsStoreA);
 
-        super.testFindAll(
-                DataStoreInfo.class, testData.dataStoreA, testData.dataStoreB, testData.dataStoreC);
+        super.testFindAll(DataStoreInfo.class, testData.dataStoreA, testData.dataStoreB,
+                testData.dataStoreC);
         super.testFindAll(CoverageStoreInfo.class, testData.coverageStoreA);
         super.testFindAll(WMSStoreInfo.class, testData.wmsStoreA);
         super.testFindAll(WMTSStoreInfo.class, testData.wmtsStoreA);
@@ -124,112 +109,73 @@ public class StoreControllerTest extends AbstractReactiveCatalogControllerTest<S
     }
 
     public @Test void testDataStoreInfo_CRUD() throws IOException {
-        DataStoreInfo store =
-                testData.createDataStore(
-                        "dataStoreCRUD-id",
-                        testData.workspaceB,
-                        "dataStoreCRUD",
-                        "dataStoreCRUD description",
-                        true);
-        crudTest(
-                store,
-                catalog::getDataStore,
-                created -> {
-                    created.setEnabled(false);
-                    created.setName("modified name");
-                    created.setDescription("modified description");
-                    created.getConnectionParameters().put("newkey", "new param");
-                    return;
-                },
-                (orig, updated) -> {
-                    assertFalse(updated.isEnabled());
-                    assertEquals("modified name", updated.getName());
-                    assertEquals("modified description", updated.getDescription());
-                    assertEquals("new param", updated.getConnectionParameters().get("newkey"));
-                });
+        DataStoreInfo store = testData.faker().dataStoreInfo("dataStoreCRUD-id",
+                testData.workspaceB, "dataStoreCRUD", "dataStoreCRUD description", true);
+        crudTest(store, catalog::getDataStore, created -> {
+            created.setEnabled(false);
+            created.setName("modified name");
+            created.setDescription("modified description");
+            created.getConnectionParameters().put("newkey", "new param");
+            return;
+        }, (orig, updated) -> {
+            assertFalse(updated.isEnabled());
+            assertEquals("modified name", updated.getName());
+            assertEquals("modified description", updated.getDescription());
+            assertEquals("new param", updated.getConnectionParameters().get("newkey"));
+        });
     }
 
     public @Test void testCoverageStoreInfo_CRUD() {
         CoverageStoreInfo store =
-                testData.createCoverageStore(
-                        "coverageStoreCRUD",
-                        testData.workspaceC,
-                        "coverageStoreCRUD name",
-                        "GeoTIFF",
-                        "file:/test/coverageStoreCRUD.tiff");
-        crudTest(
-                store,
-                catalog::getCoverageStore,
-                created -> {
-                    created.setEnabled(false);
-                    created.setName("modified name");
-                    created.setDescription("modified description");
-                    ((CoverageStoreInfo) created)
-                            .setURL("file:/test/coverageStoreCRUD_modified.tiff");
-                    return;
-                },
-                (orig, updated) -> {
-                    assertFalse(updated.isEnabled());
-                    assertEquals("modified name", updated.getName());
-                    assertEquals("modified description", updated.getDescription());
-                    assertEquals(
-                            "file:/test/coverageStoreCRUD_modified.tiff",
-                            ((CoverageStoreInfo) updated).getURL());
-                });
+                testData.createCoverageStore("coverageStoreCRUD", testData.workspaceC,
+                        "coverageStoreCRUD name", "GeoTIFF", "file:/test/coverageStoreCRUD.tiff");
+        crudTest(store, catalog::getCoverageStore, created -> {
+            created.setEnabled(false);
+            created.setName("modified name");
+            created.setDescription("modified description");
+            ((CoverageStoreInfo) created).setURL("file:/test/coverageStoreCRUD_modified.tiff");
+            return;
+        }, (orig, updated) -> {
+            assertFalse(updated.isEnabled());
+            assertEquals("modified name", updated.getName());
+            assertEquals("modified description", updated.getDescription());
+            assertEquals("file:/test/coverageStoreCRUD_modified.tiff",
+                    ((CoverageStoreInfo) updated).getURL());
+        });
     }
 
     public @Test void testWMSStoreInfo_CRUD() {
-        WMSStoreInfo store =
-                testData.createWebMapServer(
-                        "wmsStoreCRUD",
-                        testData.workspaceA,
-                        "wmsStoreCRUD_name",
-                        "http://test.com",
-                        true);
-        crudTest(
-                store,
-                id -> catalog.getStore(id, WMSStoreInfo.class),
-                created -> {
-                    created.setEnabled(false);
-                    created.setName("modified name");
-                    created.setDescription("modified description");
-                    ((WMSStoreInfo) created).setCapabilitiesURL("http://new.caps.url");
-                    return;
-                },
-                (orig, updated) -> {
-                    assertFalse(updated.isEnabled());
-                    assertEquals("modified name", updated.getName());
-                    assertEquals("modified description", updated.getDescription());
-                    assertEquals(
-                            "http://new.caps.url", ((WMSStoreInfo) updated).getCapabilitiesURL());
-                });
+        WMSStoreInfo store = testData.createWebMapServer("wmsStoreCRUD", testData.workspaceA,
+                "wmsStoreCRUD_name", "http://test.com", true);
+        crudTest(store, id -> catalog.getStore(id, WMSStoreInfo.class), created -> {
+            created.setEnabled(false);
+            created.setName("modified name");
+            created.setDescription("modified description");
+            ((WMSStoreInfo) created).setCapabilitiesURL("http://new.caps.url");
+            return;
+        }, (orig, updated) -> {
+            assertFalse(updated.isEnabled());
+            assertEquals("modified name", updated.getName());
+            assertEquals("modified description", updated.getDescription());
+            assertEquals("http://new.caps.url", ((WMSStoreInfo) updated).getCapabilitiesURL());
+        });
     }
 
     public @Test void testWMTSStoreInfo_CRUD() {
-        WMTSStoreInfo store =
-                testData.createWebMapTileServer(
-                        "wmsStoreCRUD",
-                        testData.workspaceA,
-                        "wmtsStoreCRUD_name",
-                        "http://test.com",
-                        true);
-        crudTest(
-                store,
-                id -> catalog.getStore(id, WMTSStoreInfo.class),
-                created -> {
-                    created.setEnabled(false);
-                    created.setName("modified name");
-                    created.setDescription("modified description");
-                    ((WMTSStoreInfo) created).setCapabilitiesURL("http://new.caps.url");
-                    return;
-                },
-                (orig, updated) -> {
-                    assertFalse(updated.isEnabled());
-                    assertEquals("modified name", updated.getName());
-                    assertEquals("modified description", updated.getDescription());
-                    assertEquals(
-                            "http://new.caps.url", ((WMTSStoreInfo) updated).getCapabilitiesURL());
-                });
+        WMTSStoreInfo store = testData.createWebMapTileServer("wmsStoreCRUD", testData.workspaceA,
+                "wmtsStoreCRUD_name", "http://test.com", true);
+        crudTest(store, id -> catalog.getStore(id, WMTSStoreInfo.class), created -> {
+            created.setEnabled(false);
+            created.setName("modified name");
+            created.setDescription("modified description");
+            ((WMTSStoreInfo) created).setCapabilitiesURL("http://new.caps.url");
+            return;
+        }, (orig, updated) -> {
+            assertFalse(updated.isEnabled());
+            assertEquals("modified name", updated.getName());
+            assertEquals("modified description", updated.getDescription());
+            assertEquals("http://new.caps.url", ((WMTSStoreInfo) updated).getCapabilitiesURL());
+        });
     }
 
     public @Test void testFindStoreById() throws IOException {
@@ -242,14 +188,11 @@ public class StoreControllerTest extends AbstractReactiveCatalogControllerTest<S
 
     public @Test void testFindStoreById_SubtypeMismatch() throws IOException {
         CatalogTestClient<StoreInfo> client = client();
-        client.findById(testData.coverageStoreA.getId(), DataStoreInfo.class)
-                .expectStatus()
+        client.findById(testData.coverageStoreA.getId(), DataStoreInfo.class).expectStatus()
                 .isNoContent();
-        client.findById(testData.dataStoreA.getId(), CoverageStoreInfo.class)
-                .expectStatus()
+        client.findById(testData.dataStoreA.getId(), CoverageStoreInfo.class).expectStatus()
                 .isNoContent();
-        client.findById(testData.dataStoreB.getId(), CoverageStoreInfo.class)
-                .expectStatus()
+        client.findById(testData.dataStoreB.getId(), CoverageStoreInfo.class).expectStatus()
                 .isNoContent();
     }
 
@@ -288,17 +231,10 @@ public class StoreControllerTest extends AbstractReactiveCatalogControllerTest<S
         String workspaceId = store.getWorkspace().getId();
         String name = store.getName();
 
-        StoreInfo found =
-                client().getRelative(
-                                "/workspaces/{workspaceId}/stores/name/{name}?type={subType}",
-                                workspaceId,
-                                name,
-                                subType)
-                        .expectStatus()
-                        .isOk()
-                        .expectBody(StoreInfo.class)
-                        .returnResult()
-                        .getResponseBody();
+        StoreInfo found = client()
+                .getRelative("/workspaces/{workspaceId}/stores/name/{name}?type={subType}",
+                        workspaceId, name, subType)
+                .expectStatus().isOk().expectBody(StoreInfo.class).returnResult().getResponseBody();
         assertEquals(store.getId(), found.getId());
         assertEquals(store.getName(), found.getName());
     }
@@ -314,25 +250,16 @@ public class StoreControllerTest extends AbstractReactiveCatalogControllerTest<S
     private void testFindStoreByName_WrongWorkspace(StoreInfo store, WorkspaceInfo workspace) {
         String name = store.getName();
         ClassMappings subType = null;
-        client().getRelative(
-                        "/workspaces/{workspaceId}/stores/name/{name}?type={subType}",
-                        workspace.getId(),
-                        name,
-                        subType)
-                .expectStatus()
-                .isNoContent();
+        client().getRelative("/workspaces/{workspaceId}/stores/name/{name}?type={subType}",
+                workspace.getId(), name, subType).expectStatus().isNoContent();
     }
 
     public @Test void testFindStoresByWorkspace() {
-        testFindStoresByWorkspace(
-                testData.workspaceA,
-                testData.dataStoreA,
-                testData.coverageStoreA,
-                testData.wmsStoreA,
-                testData.wmtsStoreA);
+        testFindStoresByWorkspace(testData.workspaceA, testData.dataStoreA, testData.coverageStoreA,
+                testData.wmsStoreA, testData.wmtsStoreA);
         testFindStoresByWorkspace(testData.workspaceB, testData.dataStoreB);
-        WorkspaceInfo emptyWs = testData.createWorkspace("emptyws");
-        NamespaceInfo emptyNs = testData.createNamespace("emptyns", "http://test.com/emptyns");
+        WorkspaceInfo emptyWs = testData.faker().workspaceInfo("emptyws");
+        NamespaceInfo emptyNs = testData.faker().namespace();
         catalog.add(emptyWs);
         catalog.add(emptyNs);
         testFindStoresByWorkspace(emptyWs);
@@ -340,14 +267,9 @@ public class StoreControllerTest extends AbstractReactiveCatalogControllerTest<S
 
     public void testFindStoresByWorkspace(WorkspaceInfo ws, StoreInfo... expected) {
         List<StoreInfo> stores =
-                client().getRelative("/workspaces/{workspaceId}/stores", ws.getId())
-                        .expectStatus()
-                        .isOk()
-                        .expectHeader()
-                        .contentType(MediaType.APPLICATION_STREAM_JSON)
-                        .expectBodyList(StoreInfo.class)
-                        .returnResult()
-                        .getResponseBody();
+                client().getRelative("/workspaces/{workspaceId}/stores", ws.getId()).expectStatus()
+                        .isOk().expectHeader().contentType(MediaType.APPLICATION_STREAM_JSON)
+                        .expectBodyList(StoreInfo.class).returnResult().getResponseBody();
 
         Set<String> expectedIds =
                 Arrays.stream(expected).map(StoreInfo::getId).collect(Collectors.toSet());

--- a/src/catalog/catalog-server/server/src/test/java/org/geoserver/cloud/catalog/server/api/v1/WorkspaceControllerTest.java
+++ b/src/catalog/catalog-server/server/src/test/java/org/geoserver/cloud/catalog/server/api/v1/WorkspaceControllerTest.java
@@ -64,7 +64,7 @@ public class WorkspaceControllerTest extends AbstractReactiveCatalogControllerTe
     }
 
     public @Test void testWorkspaceCRUD() {
-        WorkspaceInfo ws = testData.createWorkspace("workspaceCRUD");
+        WorkspaceInfo ws = testData.faker().workspaceInfo("workspaceCRUD");
         crudTest(
                 ws,
                 catalog::getWorkspace,

--- a/src/catalog/event-bus/src/test/java/org/geoserver/cloud/bus/integration/BusAmqpIntegrationTests.java
+++ b/src/catalog/event-bus/src/test/java/org/geoserver/cloud/bus/integration/BusAmqpIntegrationTests.java
@@ -127,10 +127,7 @@ public abstract class BusAmqpIntegrationTests {
         Catalog remoteCatalog = remoteAppContext.getBean("rawCatalog", Catalog.class);
         GeoServer remoteGeoserver = remoteAppContext.getBean(GeoServer.class);
         CatalogTestData remoteTestData =
-                CatalogTestData.empty(() -> remoteCatalog, () -> remoteGeoserver)
-                        .createCatalogObjects()
-                        .createConfigObjects();
-
+                CatalogTestData.empty(() -> remoteCatalog, () -> remoteGeoserver).initialize();
         remoteTestData.initCatalog(true).initConfig(true).initialize();
         try {
             Thread.sleep(100);
@@ -149,10 +146,7 @@ public abstract class BusAmqpIntegrationTests {
 
         eventsCaptor.stop().clear().capureEventsOf(InfoEvent.class);
 
-        testData =
-                CatalogTestData.empty(() -> catalog, () -> geoserver)
-                        .createCatalogObjects()
-                        .createConfigObjects();
+        testData = CatalogTestData.empty(() -> catalog, () -> geoserver).initialize();
     }
 
     @AfterEach

--- a/src/catalog/event-bus/src/test/java/org/geoserver/cloud/bus/integration/CatalogRemoteApplicationEventsTest.java
+++ b/src/catalog/event-bus/src/test/java/org/geoserver/cloud/bus/integration/CatalogRemoteApplicationEventsTest.java
@@ -390,8 +390,9 @@ public class CatalogRemoteApplicationEventsTest extends BusAmqpIntegrationTests 
 
                     l.setDefaultWMSInterpolationMethod(WMSInterpolation.Bicubic);
                     l.setInternationalTitle(
-                            testData.createInternationalString(
-                                    Locale.ENGLISH, "test", Locale.ITALIAN, "proba"));
+                            testData.faker()
+                                    .internationalString(
+                                            Locale.ENGLISH, "test", Locale.ITALIAN, "proba"));
 
                     l.setType(PublishedType.REMOTE);
                 },

--- a/src/catalog/event-bus/src/test/java/org/geoserver/cloud/bus/integration/ConfigRemoteApplicationEventsTest.java
+++ b/src/catalog/event-bus/src/test/java/org/geoserver/cloud/bus/integration/ConfigRemoteApplicationEventsTest.java
@@ -55,7 +55,7 @@ public class ConfigRemoteApplicationEventsTest extends BusAmqpIntegrationTests {
     }
 
     public @Test void testConfigRemoteModifyEvent_ServiceInfo_Workspace() {
-        WMSInfo service = testData.createService("WMS_WS_TEST", WMSInfoImpl::new);
+        WMSInfo service = testData.faker().serviceInfo("WMS_WS_TEST", WMSInfoImpl::new);
         service.setWorkspace(testData.workspaceB);
         geoserver.add(service);
 
@@ -65,7 +65,7 @@ public class ConfigRemoteApplicationEventsTest extends BusAmqpIntegrationTests {
                 service,
                 s -> {
                     s.setCacheConfiguration(cacheCfg);
-                    s.getAuthorityURLs().addAll(testData.authUrls(2));
+                    s.getAuthorityURLs().addAll(testData.faker().authUrls(2));
                 },
                 geoserver::save,
                 ServiceInfoModifyEvent.class);
@@ -119,7 +119,7 @@ public class ConfigRemoteApplicationEventsTest extends BusAmqpIntegrationTests {
         GeoServerInfo global = new GeoServerInfoImpl();
         SettingsInfo settings = new SettingsInfoImpl();
         settings.setCharset("ISO-8859-1");
-        settings.setContact(testData.createContact());
+        settings.setContact(testData.faker().contactInfo());
 
         global.setSettings(settings);
         geoserver.setGlobal(global);

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/CatalogInfoModifyEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/CatalogInfoModifyEvent.java
@@ -68,6 +68,7 @@ public class CatalogInfoModifyEvent
                                 event.getPropertyNames(),
                                 event.getOldValues(),
                                 event.getNewValues())
+                        .clean()
                         .toPatch();
 
         if (info instanceof Catalog) {

--- a/src/catalog/events/src/test/java/org/geoserver/cloud/config/catalog/events/CatalogApplicationEventsConfigurationTest.java
+++ b/src/catalog/events/src/test/java/org/geoserver/cloud/config/catalog/events/CatalogApplicationEventsConfigurationTest.java
@@ -45,8 +45,8 @@ import org.geoserver.config.SettingsInfo;
 import org.geoserver.config.impl.CoverageAccessInfoImpl;
 import org.geoserver.config.impl.SettingsInfoImpl;
 import org.geoserver.wms.WMSInfoImpl;
+import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -72,12 +72,17 @@ public class CatalogApplicationEventsConfigurationTest {
 
     private @Autowired ApplicationEventCapturingListener listener;
 
-    public @Rule CatalogTestData testData = CatalogTestData.empty(() -> catalog, () -> geoserver);
+    private CatalogTestData testData;
 
     public @Before void before() {
         listener.setCapureEventsOf(InfoEvent.class);
         catalog.dispose();
         listener.clear();
+        testData = CatalogTestData.empty(() -> catalog, () -> geoserver).initialize();
+    }
+
+    public @After void after() {
+        testData.after();
     }
 
     public @Test void testCatalogEventBroadcasterHasSetUpItself() {

--- a/src/catalog/jackson-bindings/geoserver/pom.xml
+++ b/src/catalog/jackson-bindings/geoserver/pom.xml
@@ -30,11 +30,11 @@
       <groupId>org.mapstruct</groupId>
       <artifactId>mapstruct</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
+    <!--    <dependency>-->
+    <!--      <groupId>org.junit.vintage</groupId>-->
+    <!--      <artifactId>junit-vintage-engine</artifactId>-->
+    <!--      <scope>test</scope>-->
+    <!--    </dependency>-->
     <dependency>
       <!-- contains CatalogTestData support class -->
       <groupId>org.geoserver.cloud.catalog</groupId>

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModule.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModule.java
@@ -41,6 +41,8 @@ import org.geoserver.jackson.databind.catalog.dto.QueryDto;
 import org.geoserver.jackson.databind.catalog.dto.VersionDto;
 import org.geoserver.jackson.databind.catalog.dto.VirtualTableDto;
 import org.geoserver.jackson.databind.catalog.mapper.ValueMappers;
+import org.geoserver.jackson.databind.config.dto.NameDto;
+import org.geoserver.jackson.databind.mapper.PatchMapper;
 import org.geoserver.jackson.databind.mapper.SharedMappers;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.jackson.databind.filter.GeoToolsFilterModule;
@@ -91,6 +93,7 @@ public class GeoServerCatalogModule extends SimpleModule {
     private static final long serialVersionUID = -8756800180255446679L;
 
     static final SharedMappers SHARED_MAPPER = Mappers.getMapper(SharedMappers.class);
+    static final PatchMapper PATCH_MAPPER = Mappers.getMapper(PatchMapper.class);
     static final ValueMappers VALUE_MAPPER = Mappers.getMapper(ValueMappers.class);
 
     private final CatalogInfoDeserializer<CatalogInfo> deserializer =
@@ -229,18 +232,18 @@ public class GeoServerCatalogModule extends SimpleModule {
     }
 
     private void registerSharedMappers() {
+
+        addMapperSerializer(
+                Patch.class, PATCH_MAPPER::patchToDto, PatchDto.class, PATCH_MAPPER::dtoToPatch);
+
         addMapperSerializer(
                 CoordinateReferenceSystem.class, SHARED_MAPPER::crs, CRS.class, SHARED_MAPPER::crs);
 
         addMapperSerializer(
                 ReferencedEnvelope.class,
-                SHARED_MAPPER::referencedEnvelopeToDto,
+                SHARED_MAPPER::referencedEnvelope,
                 Envelope.class,
-                SHARED_MAPPER::dtoToReferencedEnvelope);
-
-        addMapperSerializer(
-                Patch.class, SHARED_MAPPER::patchToDto, PatchDto.class, SHARED_MAPPER::dtoToPatch);
-
+                SHARED_MAPPER::referencedEnvelope);
         addMapperSerializer(
                 org.geotools.util.Version.class,
                 SHARED_MAPPER::versionToDto,
@@ -248,9 +251,18 @@ public class GeoServerCatalogModule extends SimpleModule {
                 SHARED_MAPPER::dtoToVersion);
 
         addMapperSerializer(
-                KeywordInfo.class,
-                SHARED_MAPPER::keywordToDto,
-                Keyword.class,
-                SHARED_MAPPER::dtoToKeyword);
+                KeywordInfo.class, SHARED_MAPPER::keyword, Keyword.class, SHARED_MAPPER::keyword);
+
+        addMapperSerializer(
+                org.opengis.feature.type.Name.class,
+                SHARED_MAPPER::map,
+                NameDto.class,
+                SHARED_MAPPER::map);
+
+        addMapperSerializer(
+                org.geotools.util.Version.class,
+                SHARED_MAPPER::versionToDto,
+                VersionDto.class,
+                SHARED_MAPPER::dtoToVersion);
     }
 }

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/AttributeType.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/AttributeType.java
@@ -5,11 +5,13 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
+import lombok.Generated;
 
 import java.io.Serializable;
 import java.util.Map;
 
 @Data
+@Generated
 public class AttributeType {
     private String name;
     private InfoReference featureType;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Attribution.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Attribution.java
@@ -5,8 +5,9 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
+import lombok.Generated;
 
-public @Data class Attribution {
+public @Data @Generated class Attribution {
     private String id;
     private String title;
     private String href;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/AuthorityURL.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/AuthorityURL.java
@@ -5,8 +5,9 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
+import lombok.Generated;
 
-public @Data class AuthorityURL {
+public @Data @Generated class AuthorityURL {
     private String name;
     private String href;
 }

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/CRS.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/CRS.java
@@ -5,8 +5,9 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
+import lombok.Generated;
 
-public @Data class CRS {
+public @Data @Generated class CRS {
     private String srs;
     private String WKT;
 }

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/CatalogInfoDto.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/CatalogInfoDto.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 import java.util.Date;
 
@@ -23,6 +24,7 @@ import java.util.Date;
     @JsonSubTypes.Type(value = Published.class)
 })
 @Data
+@Generated
 @EqualsAndHashCode(callSuper = true)
 public abstract class CatalogInfoDto extends InfoDto {
     private Date dateCreated;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Coverage.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Coverage.java
@@ -6,12 +6,14 @@ package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
 @Data
+@Generated
 @EqualsAndHashCode(callSuper = true)
 public class Coverage extends Resource {
     private String nativeFormat;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/CoverageDimension.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/CoverageDimension.java
@@ -5,6 +5,7 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
+import lombok.Generated;
 
 import org.geoserver.catalog.impl.CoverageDimensionImpl;
 
@@ -13,7 +14,7 @@ import java.util.List;
 /**
  * @see CoverageDimensionImpl
  */
-public @Data class CoverageDimension {
+public @Data @Generated class CoverageDimension {
     private String id;
     private String name;
     private String description;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/CoverageStore.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/CoverageStore.java
@@ -6,8 +6,10 @@ package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 @Data
+@Generated
 @EqualsAndHashCode(callSuper = true)
 public class CoverageStore extends Store {
 

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/DataLink.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/DataLink.java
@@ -5,8 +5,9 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
+import lombok.Generated;
 
-public @Data class DataLink {
+public @Data @Generated class DataLink {
     private String id;
     private String about;
     private String type;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/DataStore.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/DataStore.java
@@ -6,7 +6,9 @@ package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 @Data
+@Generated
 @EqualsAndHashCode(callSuper = true)
 public class DataStore extends Store {}

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Dimension.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Dimension.java
@@ -5,6 +5,7 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
+import lombok.Generated;
 
 import org.geoserver.catalog.DimensionDefaultValueSetting;
 import org.geoserver.catalog.DimensionInfo;
@@ -13,7 +14,7 @@ import org.geoserver.catalog.DimensionPresentation;
 import java.math.BigDecimal;
 
 /** DTO for {@link DimensionInfo} */
-public @Data class Dimension {
+public @Data @Generated class Dimension {
     private boolean enabled;
     private String attribute;
     private String endAttribute;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Envelope.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Envelope.java
@@ -5,8 +5,9 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
+import lombok.Generated;
 
-public @Data class Envelope {
+public @Data @Generated class Envelope {
     private CRS crs;
     private double[] coordinates;
 }

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/FeatureType.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/FeatureType.java
@@ -6,10 +6,12 @@ package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 import java.util.List;
 
 @Data
+@Generated
 @EqualsAndHashCode(callSuper = true)
 public class FeatureType extends Resource {
     private String cqlFilter;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/GridGeometryDto.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/GridGeometryDto.java
@@ -5,6 +5,7 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
+import lombok.Generated;
 
 import org.geoserver.config.util.XStreamPersister;
 import org.geotools.coverage.grid.GridGeometry2D;
@@ -14,7 +15,7 @@ import org.geotools.coverage.grid.GridGeometry2D;
  *
  * @see XStreamPersister#GridGeometry2DConverter
  */
-public @Data class GridGeometryDto {
+public @Data @Generated class GridGeometryDto {
     private int[] low;
     private int[] high;
     private double[] transform;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/HTTPStore.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/HTTPStore.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonSubTypes({
@@ -16,6 +17,7 @@ import lombok.EqualsAndHashCode;
     @JsonSubTypes.Type(value = WMTSStore.class, name = "WMTSStoreInfo")
 })
 @Data
+@Generated
 @EqualsAndHashCode(callSuper = true)
 public abstract class HTTPStore extends Store {
     private String capabilitiesURL;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/InfoDto.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/InfoDto.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import lombok.Data;
+import lombok.Generated;
 
 import org.geoserver.jackson.databind.config.dto.ConfigInfoDto;
 
@@ -17,6 +18,7 @@ import org.geoserver.jackson.databind.config.dto.ConfigInfoDto;
     @JsonSubTypes.Type(value = ConfigInfoDto.class)
 })
 @Data
+@Generated
 public abstract class InfoDto {
     private String id;
 }

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/InfoReference.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/InfoReference.java
@@ -6,12 +6,14 @@ package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Generated;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
 import org.geoserver.catalog.impl.ClassMappings;
 
 @Data
+@Generated
 @NoArgsConstructor
 @AllArgsConstructor
 public class InfoReference {

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Keyword.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Keyword.java
@@ -5,8 +5,9 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
+import lombok.Generated;
 
-public @Data class Keyword {
+public @Data @Generated class Keyword {
     private String value;
     private String language;
     private String vocabulary;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Layer.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Layer.java
@@ -6,10 +6,12 @@ package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 import java.util.Set;
 
 @Data
+@Generated
 @EqualsAndHashCode(callSuper = true)
 public class Layer extends Published {
     public enum WMSInterpolation {

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/LayerGroup.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/LayerGroup.java
@@ -6,11 +6,13 @@ package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 import java.util.List;
 import java.util.Map;
 
 @Data
+@Generated
 @EqualsAndHashCode(callSuper = true)
 public class LayerGroup extends Published {
 

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/LayerGroupStyle.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/LayerGroupStyle.java
@@ -5,6 +5,7 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
+import lombok.Generated;
 
 import java.util.List;
 import java.util.Map;
@@ -16,6 +17,7 @@ import java.util.Map;
  * @since 1.0-RC2 (geoserver 2.21.0)
  */
 @Data
+@Generated
 public class LayerGroupStyle {
 
     private String id;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/LayerIdentifier.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/LayerIdentifier.java
@@ -5,8 +5,9 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
+import lombok.Generated;
 
-public @Data class LayerIdentifier {
+public @Data @Generated class LayerIdentifier {
     private String authority;
     private String identifier;
 }

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Legend.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Legend.java
@@ -5,8 +5,9 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
+import lombok.Generated;
 
-public @Data class Legend {
+public @Data @Generated class Legend {
     private String id;
     private int width;
     private int height;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Map.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Map.java
@@ -6,10 +6,12 @@ package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 import java.util.List;
 
 @Data
+@Generated
 @EqualsAndHashCode(callSuper = true)
 public class Map extends CatalogInfoDto {
 

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/MetadataLink.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/MetadataLink.java
@@ -5,8 +5,9 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
+import lombok.Generated;
 
-public @Data class MetadataLink {
+public @Data @Generated class MetadataLink {
     private String id;
     private String type;
     private String about;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Namespace.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Namespace.java
@@ -6,11 +6,13 @@ package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 import java.io.Serializable;
 import java.util.Map;
 
 @Data
+@Generated
 @EqualsAndHashCode(callSuper = true)
 public class Namespace extends CatalogInfoDto {
     private String prefix;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/NumberRangeDto.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/NumberRangeDto.java
@@ -5,6 +5,7 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
+import lombok.Generated;
 
 import org.geoserver.config.util.XStreamPersister;
 import org.geotools.util.NumberRange;
@@ -13,7 +14,7 @@ import org.geotools.util.NumberRange;
  * @see NumberRange
  * @see XStreamPersister#NumberRangeConverter
  */
-public @Data class NumberRangeDto {
+public @Data @Generated class NumberRangeDto {
 
     private Number min;
     private Number max;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/PatchDto.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/PatchDto.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import lombok.Data;
+import lombok.Generated;
 
 import org.geotools.jackson.databind.filter.dto.Expression.Literal;
 
@@ -17,6 +18,6 @@ import java.util.TreeMap;
 /** DTO for {@link org.geoserver.catalog.plugin.Patch} */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonTypeName("Patch")
-public @Data class PatchDto {
+public @Data @Generated class PatchDto {
     private Map<String, Literal> patches = new TreeMap<>();
 }

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Published.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Published.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 import java.io.Serializable;
 import java.util.List;
@@ -20,6 +21,7 @@ import java.util.Map;
     @JsonSubTypes.Type(value = LayerGroup.class, name = "LayerGroupInfo")
 })
 @Data
+@Generated
 @EqualsAndHashCode(callSuper = true)
 public abstract class Published extends CatalogInfoDto {
 

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/QueryDto.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/QueryDto.java
@@ -5,6 +5,7 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
+import lombok.Generated;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +20,7 @@ import java.util.List;
 /** DTO for {@link Query} */
 @NoArgsConstructor
 @RequiredArgsConstructor
-public @Data class QueryDto {
+public @Data @Generated class QueryDto {
     private @NonNull Class<?> type;
     private @NonNull Filter filter = Filter.INCLUDE;
     private @NonNull List<SortBy> sortBy = new ArrayList<>();

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Resource.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Resource.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 import java.io.Serializable;
 import java.util.List;
@@ -22,6 +23,7 @@ import java.util.Map;
     @JsonSubTypes.Type(value = WMTSLayer.class, name = "WMTSLayerInfo")
 })
 @Data
+@Generated
 @EqualsAndHashCode(callSuper = true)
 public abstract class Resource extends CatalogInfoDto {
     public enum ProjectionPolicy {

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Store.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Store.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 import java.io.Serializable;
 import java.util.Map;
@@ -20,6 +21,7 @@ import java.util.Map;
     @JsonSubTypes.Type(value = HTTPStore.class)
 })
 @Data
+@Generated
 @EqualsAndHashCode(callSuper = true)
 public abstract class Store extends CatalogInfoDto {
     private String name;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Style.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Style.java
@@ -6,11 +6,13 @@ package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 import java.io.Serializable;
 import java.util.Map;
 
 @Data
+@Generated
 @EqualsAndHashCode(callSuper = true)
 public class Style extends CatalogInfoDto {
 

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/VersionDto.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/VersionDto.java
@@ -5,10 +5,11 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
+import lombok.Generated;
 import lombok.experimental.Accessors;
 
 /** DTO for {@link org.geotools.util.Version} */
 @Accessors(chain = true)
-public @Data class VersionDto {
+public @Data @Generated class VersionDto {
     private String value;
 }

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/VirtualTableDto.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/VirtualTableDto.java
@@ -5,11 +5,12 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
+import lombok.Generated;
 
 import org.geotools.jdbc.VirtualTable;
 
 /** DTO type for {@link VirtualTable} */
-public @Data class VirtualTableDto {
+public @Data @Generated class VirtualTableDto {
 
     private String name;
     private String sql;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/WMSLayer.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/WMSLayer.java
@@ -6,10 +6,12 @@ package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 import java.util.List;
 
 @Data
+@Generated
 @EqualsAndHashCode(callSuper = true)
 public class WMSLayer extends Resource {
     private String forcedRemoteStyle = "";

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/WMSStore.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/WMSStore.java
@@ -6,7 +6,9 @@ package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 @Data
+@Generated
 @EqualsAndHashCode(callSuper = true)
 public class WMSStore extends HTTPStore {}

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/WMTSLayer.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/WMTSLayer.java
@@ -6,7 +6,9 @@ package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 @Data
+@Generated
 @EqualsAndHashCode(callSuper = true)
 public class WMTSLayer extends Resource {}

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/WMTSStore.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/WMTSStore.java
@@ -6,8 +6,10 @@ package org.geoserver.jackson.databind.catalog.dto;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 @Data
+@Generated
 @EqualsAndHashCode(callSuper = true)
 public class WMTSStore extends HTTPStore {
     private String headerName; // todo: replace with Map<String, String>

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Workspace.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Workspace.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 import java.io.Serializable;
 import java.util.Map;
@@ -16,6 +17,7 @@ import java.util.Map;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonTypeName("WorkspaceInfo")
 @Data
+@Generated
 @EqualsAndHashCode(callSuper = true)
 public class Workspace extends CatalogInfoDto {
     private String name;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/mapper/CatalogInfoMapperConfig.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/mapper/CatalogInfoMapperConfig.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.jackson.databind.catalog.mapper;
 
+import org.geoserver.jackson.databind.mapper.PatchMapper;
 import org.geoserver.jackson.databind.mapper.SharedMappers;
 import org.mapstruct.MapperConfig;
 import org.mapstruct.ReportingPolicy;
@@ -11,5 +12,5 @@ import org.mapstruct.ReportingPolicy;
 @MapperConfig(
         componentModel = "default",
         unmappedTargetPolicy = ReportingPolicy.ERROR,
-        uses = {SharedMappers.class, ObjectFacotries.class, ValueMappers.class})
+        uses = {ObjectFacotries.class, ValueMappers.class, SharedMappers.class, PatchMapper.class})
 public class CatalogInfoMapperConfig {}

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/ConfigInfoDeserializer.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/ConfigInfoDeserializer.java
@@ -19,6 +19,6 @@ public class ConfigInfoDeserializer<T extends Info, D extends InfoDto>
             Mappers.getMapper(GeoServerConfigMapper.class);
 
     public ConfigInfoDeserializer(@NonNull Class<D> from) {
-        super(from, dto -> (T) mapper.toInfo(dto));
+        super(from, dto -> mapper.toInfo(dto));
     }
 }

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/ConfigInfoDto.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/ConfigInfoDto.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 import org.geoserver.jackson.databind.catalog.dto.InfoDto;
 
@@ -20,4 +21,4 @@ import org.geoserver.jackson.databind.catalog.dto.InfoDto;
     @JsonSubTypes.Type(value = Service.class)
 })
 @EqualsAndHashCode(callSuper = true)
-public @Data class ConfigInfoDto extends InfoDto {}
+public @Data @Generated class ConfigInfoDto extends InfoDto {}

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/Contact.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/Contact.java
@@ -5,13 +5,14 @@
 package org.geoserver.jackson.databind.config.dto;
 
 import lombok.Data;
+import lombok.Generated;
 
 import org.geoserver.config.ContactInfo;
 
 import java.util.Map;
 
 /** DTO for {@link ContactInfo} */
-public @Data class Contact {
+public @Data @Generated class Contact {
     private String id;
     private String address;
     private String addressCity;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/CoverageAccess.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/CoverageAccess.java
@@ -5,11 +5,12 @@
 package org.geoserver.jackson.databind.config.dto;
 
 import lombok.Data;
+import lombok.Generated;
 
 import org.geoserver.config.CoverageAccessInfo;
 
 /** DTO for {@link CoverageAccessInfo} */
-public @Data class CoverageAccess {
+public @Data @Generated class CoverageAccess {
     public enum QueueType {
         UNBOUNDED,
         DIRECT

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/GeoServer.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/GeoServer.java
@@ -6,6 +6,7 @@ package org.geoserver.jackson.databind.config.dto;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 import org.geoserver.config.GeoServerInfo;
 
@@ -14,7 +15,7 @@ import java.util.Map;
 
 /** DTO for {@link GeoServerInfo} */
 @EqualsAndHashCode(callSuper = true)
-public @Data class GeoServer extends ConfigInfoDto {
+public @Data @Generated class GeoServer extends ConfigInfoDto {
     public static enum ResourceErrorHandling {
         OGC_EXCEPTION_REPORT,
         SKIP_MISCONFIGURED_LAYERS

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/JaiDto.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/JaiDto.java
@@ -5,20 +5,21 @@
 package org.geoserver.jackson.databind.config.dto;
 
 import lombok.Data;
+import lombok.Generated;
 
 import org.geoserver.config.JAIInfo;
 
 import java.util.Set;
 
 /** DTO for {@link JAIInfo} */
-public @Data class JaiDto {
+public @Data @Generated class JaiDto {
     public static enum PngEncoderType {
         JDK,
         NATIVE,
         PNGJ
     };
 
-    public static @Data class JAIEXTInfo {
+    public static @Data @Generated class JAIEXTInfo {
         private Set<String> JAIOperations;
         private Set<String> JAIEXTOperations;
     }

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/Logging.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/Logging.java
@@ -6,12 +6,13 @@ package org.geoserver.jackson.databind.config.dto;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 import org.geoserver.config.LoggingInfo;
 
 /** DTO for {@link LoggingInfo} */
 @EqualsAndHashCode(callSuper = true)
-public @Data class Logging extends ConfigInfoDto {
+public @Data @Generated class Logging extends ConfigInfoDto {
     private String level;
     private String location;
     private boolean stdOutLogging;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/NameDto.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/NameDto.java
@@ -5,9 +5,10 @@
 package org.geoserver.jackson.databind.config.dto;
 
 import lombok.Data;
+import lombok.Generated;
 
 /** DTO for {@link org.opengis.feature.type.Name} */
-public @Data class NameDto {
+public @Data @Generated class NameDto {
     private String namespaceURI;
     private String localPart;
 }

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/Service.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/Service.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 import org.geoserver.catalog.LayerInfo.WMSInterpolation;
 import org.geoserver.catalog.impl.AuthorityURL;
@@ -44,7 +45,7 @@ import java.util.Set;
     @JsonSubTypes.Type(value = Service.WmtsService.class, name = "WMTSInfo")
 })
 @EqualsAndHashCode(callSuper = true)
-public abstract @Data class Service extends ConfigInfoDto {
+public abstract @Data @Generated class Service extends ConfigInfoDto {
     private String name;
     private InfoReference workspace;
     private boolean citeCompliant;
@@ -80,7 +81,7 @@ public abstract @Data class Service extends ConfigInfoDto {
     private Map<String, String> internationalAbstract;
 
     @EqualsAndHashCode(callSuper = true)
-    public static @Data class WmsService extends Service {
+    public static @Data @Generated class WmsService extends Service {
         // Works well as POJO, no need to create a separate DTO
         private WatermarkInfoImpl watermark;
         // enum, direct use
@@ -123,7 +124,7 @@ public abstract @Data class Service extends ConfigInfoDto {
     }
 
     @EqualsAndHashCode(callSuper = true)
-    public static @Data class WfsService extends Service {
+    public static @Data @Generated class WfsService extends Service {
         private Map<Version, GMLInfoImpl> GML;
         private int maxFeatures;
         private ServiceLevel serviceLevel;
@@ -139,7 +140,7 @@ public abstract @Data class Service extends ConfigInfoDto {
     }
 
     @EqualsAndHashCode(callSuper = true)
-    public static @Data class WcsService extends Service {
+    public static @Data @Generated class WcsService extends Service {
         private boolean GMLPrefixing;
         private long maxInputMemory;
         private long maxOutputMemory;
@@ -152,7 +153,7 @@ public abstract @Data class Service extends ConfigInfoDto {
     }
 
     @EqualsAndHashCode(callSuper = true)
-    public static @Data class WpsService extends Service {
+    public static @Data @Generated class WpsService extends Service {
         private double connectionTimeout;
         private int resourceExpirationTimeout;
         private int maxSynchronousProcesses;
@@ -170,7 +171,7 @@ public abstract @Data class Service extends ConfigInfoDto {
         private boolean remoteInputDisabled;
 
         /** DTO for {@link ProcessGroupInfo} */
-        public static @Data class ProcessGroup {
+        public static @Data @Generated class ProcessGroup {
             private String factoryClass;
             private boolean isEnabled;
             private List<WpsService.Process> filteredProcesses;
@@ -178,7 +179,7 @@ public abstract @Data class Service extends ConfigInfoDto {
             private List<String> roles;
         }
         /** DTO for {@link ProcessInfo} */
-        public static @Data class Process {
+        public static @Data @Generated class Process {
             private NameDto name;
             private boolean enabled;
             private List<String> roles;
@@ -187,5 +188,5 @@ public abstract @Data class Service extends ConfigInfoDto {
 
     /** DTO for {@link WMTSInfo} */
     @EqualsAndHashCode(callSuper = true)
-    public static @Data class WmtsService extends Service {}
+    public static @Data @Generated class WmtsService extends Service {}
 }

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/Settings.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/Settings.java
@@ -6,6 +6,7 @@ package org.geoserver.jackson.databind.config.dto;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 
 import org.geoserver.config.SettingsInfo;
 import org.geoserver.jackson.databind.catalog.dto.InfoReference;
@@ -16,7 +17,7 @@ import java.util.Map;
 
 /** DTO for {@link SettingsInfo} */
 @EqualsAndHashCode(callSuper = true)
-public @Data class Settings extends ConfigInfoDto {
+public @Data @Generated class Settings extends ConfigInfoDto {
     private InfoReference workspace;
     private String title;
     private Contact contact;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/ConfigInfoMapperConfig.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/ConfigInfoMapperConfig.java
@@ -5,6 +5,7 @@
 package org.geoserver.jackson.databind.config.dto.mapper;
 
 import org.geoserver.jackson.databind.catalog.mapper.ValueMappers;
+import org.geoserver.jackson.databind.mapper.PatchMapper;
 import org.geoserver.jackson.databind.mapper.SharedMappers;
 import org.mapstruct.MapperConfig;
 import org.mapstruct.ReportingPolicy;
@@ -12,5 +13,11 @@ import org.mapstruct.ReportingPolicy;
 @MapperConfig(
         componentModel = "default",
         unmappedTargetPolicy = ReportingPolicy.ERROR,
-        uses = {SharedMappers.class, ObjectFacotries.class, WPSMapper.class, ValueMappers.class})
+        uses = {
+            ObjectFacotries.class,
+            WPSMapper.class,
+            ValueMappers.class,
+            SharedMappers.class,
+            PatchMapper.class
+        })
 public class ConfigInfoMapperConfig {}

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/GeoServerConfigMapper.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/GeoServerConfigMapper.java
@@ -49,7 +49,7 @@ public interface GeoServerConfigMapper {
 
     CatalogInfoMapper catalogInfoMapper = Mappers.getMapper(CatalogInfoMapper.class);
 
-    default <T extends Info> Info toInfo(InfoDto dto) {
+    default <T extends Info> T toInfo(InfoDto dto) {
         if (dto == null) return null;
         if (dto instanceof ConfigInfoDto) return toInfo((ConfigInfoDto) dto);
         if (dto instanceof CatalogInfoDto) return catalogInfoMapper.map((CatalogInfoDto) dto);

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/mapper/PatchMapper.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/mapper/PatchMapper.java
@@ -1,0 +1,115 @@
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.jackson.databind.mapper;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.geoserver.catalog.Info;
+import org.geoserver.catalog.plugin.Patch;
+import org.geoserver.catalog.plugin.PropertyDiff;
+import org.geoserver.jackson.databind.catalog.ProxyUtils;
+import org.geoserver.jackson.databind.catalog.dto.InfoReference;
+import org.geoserver.jackson.databind.catalog.dto.PatchDto;
+import org.geotools.jackson.databind.filter.dto.Expression;
+import org.geotools.jackson.databind.filter.dto.Expression.Literal;
+import org.geotools.jackson.databind.filter.mapper.ExpressionMapper;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Function;
+
+@Mapper
+@Slf4j(topic = "org.geoserver.jackson.databind.mapper")
+public abstract class PatchMapper {
+
+    private static SharedMappers SHARED = Mappers.getMapper(SharedMappers.class);
+
+    private static ExpressionMapper expressionMapper = Mappers.getMapper(ExpressionMapper.class);
+
+    public Patch dtoToPatch(PatchDto dto) {
+        if (dto != null) {
+            Patch patch = new Patch();
+            dto.getPatches().entrySet().stream().map(this::dtoToProperty).forEach(patch::add);
+            return patch;
+        }
+        return null;
+    }
+
+    public PatchDto patchToDto(Patch patch) {
+        if (patch == null) return null;
+
+        PatchDto dto = new PatchDto();
+        for (Patch.Property propChange : patch.getPatches()) {
+            String name = propChange.getName();
+            Object value = valueToDto(propChange.getValue());
+            if (value instanceof InfoReference && log.isTraceEnabled()) {
+                log.trace(
+                        "Replaced patch property {} of type {} by {}",
+                        name,
+                        ProxyUtils.referenceTypeOf(propChange.getValue()).orElse(null),
+                        value);
+            }
+            Literal literal = new org.geotools.jackson.databind.filter.dto.Expression.Literal();
+            literal.setValue(value);
+            dto.getPatches().put(name, literal);
+        }
+        return dto;
+    }
+
+    private Patch.Property dtoToProperty(Map.Entry<String, Expression.Literal> entry) {
+        final String name = entry.getKey();
+        final Expression.Literal dto = entry.getValue();
+        org.opengis.filter.expression.Literal literal = expressionMapper.map(dto);
+        Object valueDto = literal.getValue();
+        Object propertyValye = dtoToValue(valueDto);
+        return new Patch.Property(name, propertyValye);
+    }
+
+    private Object dtoToValue(final Object valueDto) {
+        Object value = valueDto;
+        if (valueDto instanceof InfoReference) {
+            value = SHARED.referenceToInfo((InfoReference) valueDto);
+        } else if (valueDto instanceof Collection) {
+            Collection<?> c = (Collection<?>) valueDto;
+            value = copyOf(c, this::dtoToValue);
+        } else if (value instanceof Map) {
+            @SuppressWarnings("unchecked")
+            Map<Object, Object> fromMap = (Map<Object, Object>) valueDto;
+            value = copyOf(fromMap, this::dtoToValue);
+        }
+        return value;
+    }
+
+    /**
+     * If value is an identified {@link Info} (catalog or config object), returns an {@link
+     * InfoReference} instead, to be resolved at the receiving end
+     */
+    private Object valueToDto(final Object value) {
+        Object dto = value;
+        if (ProxyUtils.encodeByReference(value)) {
+            dto = SHARED.infoToReference((Info) value);
+        } else if (value instanceof Collection) {
+            Collection<?> c = (Collection<?>) value;
+            dto = copyOf(c, this::valueToDto);
+        } else if (value instanceof Map) {
+            @SuppressWarnings("unchecked")
+            Map<Object, Object> fromMap = (Map<Object, Object>) value;
+            dto = copyOf(fromMap, this::valueToDto);
+        }
+        return dto;
+    }
+
+    private Object copyOf(Map<Object, Object> fromMap, Function<Object, Object> valueMapper) {
+        // create a Map of a type compatible with the original collection
+        return PropertyDiff.PropertyDiffBuilder.copyOf(fromMap, valueMapper);
+    }
+
+    private <V, R> Collection<R> copyOf(Collection<? extends V> c, Function<V, R> valueMapper) {
+        // create a collection of a type compatible with the original collection
+        return PropertyDiff.PropertyDiffBuilder.copyOf(c, valueMapper);
+    }
+}

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/mapper/SharedMappers.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/mapper/SharedMappers.java
@@ -246,7 +246,6 @@ public abstract class SharedMappers {
         }
         return value;
     }
-    ;
 
     private ClassMappings resolveType(@NonNull Info value) {
         value = ModificationProxy.unwrap(value);

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/mapper/SharedMappers.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/mapper/SharedMappers.java
@@ -20,38 +20,26 @@ import org.geoserver.catalog.impl.MetadataLinkInfoImpl;
 import org.geoserver.catalog.impl.ModificationProxy;
 import org.geoserver.catalog.impl.ResolvingProxy;
 import org.geoserver.catalog.impl.StyleInfoImpl;
-import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.jackson.databind.catalog.dto.CRS;
 import org.geoserver.jackson.databind.catalog.dto.Envelope;
 import org.geoserver.jackson.databind.catalog.dto.InfoReference;
 import org.geoserver.jackson.databind.catalog.dto.Keyword;
-import org.geoserver.jackson.databind.catalog.dto.PatchDto;
 import org.geoserver.jackson.databind.catalog.dto.VersionDto;
 import org.geoserver.jackson.databind.config.dto.NameDto;
 import org.geoserver.wfs.GMLInfo;
 import org.geotools.feature.NameImpl;
 import org.geotools.geometry.jts.ReferencedEnvelope;
-import org.geotools.jackson.databind.filter.dto.Expression.Literal;
-import org.geotools.jackson.databind.filter.mapper.ExpressionMapper;
 import org.geotools.referencing.CRS.AxisOrder;
 import org.geotools.referencing.wkt.Formattable;
 import org.geotools.util.Version;
 import org.mapstruct.Mapper;
 import org.mapstruct.ObjectFactory;
-import org.mapstruct.factory.Mappers;
 import org.opengis.feature.type.Name;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 
 @Mapper
 @Slf4j
@@ -82,12 +70,12 @@ public abstract class SharedMappers {
         if (ClassMappings.STYLE.equals(type)) {
             StyleInfo s = (StyleInfo) info;
             MetadataMap metadata = s.getMetadata();
-            boolean isRemote =
+            boolean isRemoteStyle =
                     metadata != null
                             && Boolean.valueOf(
                                     metadata.getOrDefault(StyleInfoImpl.IS_REMOTE, "false")
                                             .toString());
-            if (isRemote) {
+            if (isRemoteStyle) {
                 return null;
             }
         }
@@ -123,9 +111,9 @@ public abstract class SharedMappers {
         return new org.geoserver.catalog.Keyword(source.getValue());
     }
 
-    public abstract KeywordInfo dtoToKeyword(Keyword dto);
+    public abstract KeywordInfo keyword(Keyword dto);
 
-    public abstract Keyword keywordToDto(KeywordInfo keyword);
+    public abstract Keyword keyword(KeywordInfo keyword);
 
     public @ObjectFactory MetadataLinkInfoImpl metadataLinkInfo() {
         return new MetadataLinkInfoImpl();
@@ -139,7 +127,7 @@ public abstract class SharedMappers {
         return new LayerIdentifier();
     }
 
-    /** Added sue to {@link GMLInfo#getMimeTypeToForce()} */
+    /** Added due to {@link GMLInfo#getMimeTypeToForce()} */
     public String optToString(Optional<String> value) {
         return value == null ? null : value.orElse(null);
     }
@@ -152,99 +140,6 @@ public abstract class SharedMappers {
 
     public Name map(NameDto dto) {
         return new NameImpl(dto.getNamespaceURI(), dto.getLocalPart());
-    }
-
-    public Patch dtoToPatch(PatchDto dto) {
-        if (dto == null) return null;
-        ExpressionMapper expressionMapper = Mappers.getMapper(ExpressionMapper.class);
-        Patch patch = new Patch();
-        dto.getPatches()
-                .forEach(
-                        (k, literalDto) -> {
-                            org.opengis.filter.expression.Literal literal =
-                                    expressionMapper.map(literalDto);
-                            Object v = literal.getValue();
-                            if (v instanceof InfoReference) {
-                                v = referenceToInfo((InfoReference) v);
-                            } else if (v instanceof Collection) {
-                                v = resolveCollection((Collection<?>) v);
-                            }
-                            patch.add(new Patch.Property(k, v));
-                        });
-        return patch;
-    }
-
-    private Collection<?> resolveCollection(Collection<?> v) {
-        @SuppressWarnings("unchecked")
-        Collection<Object> resolved = (Collection<Object>) newCollectionInstance(v.getClass());
-        for (Object o : v) {
-            Object resolvedMember = o;
-            if (o instanceof InfoReference) {
-                resolvedMember = referenceToInfo((InfoReference) o);
-            }
-            resolved.add(resolvedMember);
-        }
-        return resolved;
-    }
-
-    private Object newCollectionInstance(Class<?> class1) {
-        try {
-            return class1.getConstructor().newInstance();
-        } catch (Exception e) {
-            if (List.class.isAssignableFrom(class1)) return new ArrayList<>();
-            if (Set.class.isAssignableFrom(class1)) return new HashSet<>();
-            if (Map.class.isAssignableFrom(class1)) return new HashMap<>();
-        }
-        return null;
-    }
-
-    public PatchDto patchToDto(Patch patch) {
-        if (patch == null) return null;
-
-        PatchDto dto = new PatchDto();
-        for (Patch.Property propChange : patch.getPatches()) {
-            String name = propChange.getName();
-            Object value = resolvePatchValue(propChange);
-            Literal literal = new org.geotools.jackson.databind.filter.dto.Expression.Literal();
-            literal.setValue(value);
-            dto.getPatches().put(name, literal);
-        }
-        return dto;
-    }
-
-    /**
-     * If value is an identified {@link Info} (catalog or config object), returns an {@link
-     * InfoReference} instead, to be resolved at the receiving end
-     */
-    private Object resolvePatchValue(Patch.Property prop) {
-        if (prop == null) return null;
-        return patchPropertyValueToDto(prop.getValue());
-    }
-
-    private Object patchPropertyValueToDto(Object value) {
-        if (value instanceof Info) {
-            return value; // resolveReferenceOrValueObject((Info) value);
-        } else if (value instanceof Collection) {
-            @SuppressWarnings("unchecked")
-            Collection<Object> col = (Collection<Object>) newCollectionInstance(value.getClass());
-            for (Object v : ((Collection<?>) value)) {
-                col.add(patchPropertyValueToDto(v));
-            }
-            return col;
-        }
-
-        return value;
-    }
-
-    private Object resolveReferenceOrValueObject(Info value) {
-        value = ModificationProxy.unwrap(value);
-        ClassMappings cm = ClassMappings.fromImpl(value.getClass());
-        boolean useReference = cm != null; // && !(ClassMappings.GLOBAL == cm ||
-        // ClassMappings.LOGGING == cm);
-        if (useReference) {
-            return this.infoToReference((Info) value);
-        }
-        return value;
     }
 
     private ClassMappings resolveType(@NonNull Info value) {
@@ -309,7 +204,7 @@ public abstract class SharedMappers {
         return crs;
     }
 
-    public Envelope referencedEnvelopeToDto(ReferencedEnvelope env) {
+    public Envelope referencedEnvelope(ReferencedEnvelope env) {
         if (env == null) return null;
         Envelope dto = new Envelope();
         int dimension = env.getDimension();
@@ -323,7 +218,7 @@ public abstract class SharedMappers {
         return dto;
     }
 
-    public ReferencedEnvelope dtoToReferencedEnvelope(Envelope source) {
+    public ReferencedEnvelope referencedEnvelope(Envelope source) {
         if (source == null) return null;
         CoordinateReferenceSystem crs = crs(source.getCrs());
         ReferencedEnvelope env = new ReferencedEnvelope(crs);

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModuleTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModuleTest.java
@@ -4,16 +4,11 @@
  */
 package org.geoserver.jackson.databind.catalog;
 
-import static com.google.common.collect.Lists.newArrayList;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -28,10 +23,7 @@ import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.CatalogTestData;
 import org.geoserver.catalog.CoverageDimensionInfo;
 import org.geoserver.catalog.DataLinkInfo;
-import org.geoserver.catalog.DimensionDefaultValueSetting;
-import org.geoserver.catalog.DimensionDefaultValueSetting.Strategy;
 import org.geoserver.catalog.DimensionInfo;
-import org.geoserver.catalog.DimensionPresentation;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.Keyword;
@@ -41,57 +33,38 @@ import org.geoserver.catalog.LayerIdentifierInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.LegendInfo;
 import org.geoserver.catalog.MetadataLinkInfo;
-import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.SLDHandler;
 import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.StyleInfo;
-import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.AttributionInfoImpl;
 import org.geoserver.catalog.impl.AuthorityURL;
 import org.geoserver.catalog.impl.ClassMappings;
-import org.geoserver.catalog.impl.CoverageDimensionImpl;
-import org.geoserver.catalog.impl.DataLinkInfoImpl;
-import org.geoserver.catalog.impl.DimensionInfoImpl;
 import org.geoserver.catalog.impl.LayerGroupStyle;
 import org.geoserver.catalog.impl.LayerGroupStyleImpl;
-import org.geoserver.catalog.impl.LayerIdentifier;
 import org.geoserver.catalog.impl.LegendInfoImpl;
-import org.geoserver.catalog.impl.MetadataLinkInfoImpl;
 import org.geoserver.catalog.impl.ModificationProxy;
 import org.geoserver.catalog.plugin.CatalogPlugin;
-import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.catalog.plugin.Query;
-import org.geoserver.config.CoverageAccessInfo;
-import org.geoserver.config.CoverageAccessInfo.QueueType;
 import org.geoserver.config.GeoServer;
-import org.geoserver.config.JAIInfo;
-import org.geoserver.config.ServiceInfo;
 import org.geoserver.config.impl.ContactInfoImpl;
-import org.geoserver.config.impl.CoverageAccessInfoImpl;
-import org.geoserver.config.impl.JAIEXTInfoImpl;
-import org.geoserver.config.impl.JAIInfoImpl;
 import org.geoserver.config.plugin.GeoServerImpl;
 import org.geoserver.platform.GeoServerExtensionsHelper;
-import org.geoserver.wfs.WFSInfo;
-import org.geoserver.wms.WMSInfo;
 import org.geotools.coverage.grid.GeneralGridEnvelope;
 import org.geotools.coverage.grid.GridGeometry2D;
 import org.geotools.data.DataUtilities;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.SchemaException;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.jackson.databind.util.ObjectMapperUtil;
 import org.geotools.jdbc.VirtualTable;
 import org.geotools.measure.Measure;
 import org.geotools.referencing.CRS;
-import org.geotools.util.GrowableInternationalString;
 import org.geotools.util.NumberRange;
-import org.geotools.util.SimpleInternationalString;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.opengis.coverage.SampleDimensionType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.opengis.coverage.grid.GridEnvelope;
 import org.opengis.coverage.grid.GridGeometry;
 import org.opengis.feature.simple.SimpleFeatureType;
@@ -102,17 +75,14 @@ import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.Literal;
 import org.opengis.filter.sort.SortOrder;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
-import org.opengis.util.InternationalString;
 
 import si.uom.SI;
 
 import java.lang.reflect.Proxy;
-import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 
 /**
  * Verifies that all {@link CatalogInfo} can be sent over the wire and parsed back using jackson,
@@ -123,27 +93,31 @@ public class GeoServerCatalogModuleTest {
 
     private FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
 
+    private boolean debug = Boolean.valueOf(System.getProperty("debug", "false"));
+
+    protected void print(String logmsg, Object... args) {
+        if (debug) log.debug(logmsg, args);
+    }
+
+    private static ObjectMapper objectMapper;
+
     private Catalog catalog;
     private CatalogTestData data;
-    private ObjectMapper objectMapper;
     private GeoServer geoserver;
     private ProxyUtils proxyResolver;
 
-    public static @BeforeClass void oneTimeSetup() {
+    public static @BeforeAll void oneTimeSetup() {
         // avoid the chatty warning logs due to catalog looking up a bean of type
         // GeoServerConfigurationLock
         GeoServerExtensionsHelper.setIsSpringContext(false);
+        objectMapper = ObjectMapperUtil.newObjectMapper();
     }
 
-    public @Before void before() {
+    public @BeforeEach void before() {
         catalog = new CatalogPlugin();
         geoserver = new GeoServerImpl();
         data = CatalogTestData.initialized(() -> catalog, () -> geoserver).initialize();
         proxyResolver = new ProxyUtils(catalog, geoserver);
-
-        objectMapper = new ObjectMapper();
-        objectMapper.setDefaultPropertyInclusion(Include.NON_EMPTY);
-        objectMapper.findAndRegisterModules();
     }
 
     private <T extends CatalogInfo> void catalogInfoRoundtripTest(final T orig)
@@ -158,7 +132,7 @@ public class GeoServerCatalogModuleTest {
         Class<T> abstractType = (Class<T>) classMappings.getInterface();
 
         String encoded = writer.writeValueAsString(orig);
-        log.info(encoded);
+        print(encoded);
         T decoded = objectMapper.readValue(encoded, abstractType);
         // assert it can also be parsed using the generic CatalogInfo class
         CatalogInfo asCatalogInfo = objectMapper.readValue(encoded, CatalogInfo.class);
@@ -232,14 +206,19 @@ public class GeoServerCatalogModuleTest {
         ft.setTitle("Title");
         ft.setAbstract("abstract");
         ft.setInternationalTitle(
-                data.createInternationalString(
-                        Locale.ENGLISH, "english title", Locale.CANADA_FRENCH, "titre anglais"));
+                data.faker()
+                        .internationalString(
+                                Locale.ENGLISH,
+                                "english title",
+                                Locale.CANADA_FRENCH,
+                                "titre anglais"));
         ft.setInternationalAbstract(
-                data.createInternationalString(
-                        Locale.ENGLISH,
-                        "english abstract",
-                        Locale.CANADA_FRENCH,
-                        "résumé anglais"));
+                data.faker()
+                        .internationalString(
+                                Locale.ENGLISH,
+                                "english abstract",
+                                Locale.CANADA_FRENCH,
+                                "résumé anglais"));
 
         catalogInfoRoundtripTest(ft);
     }
@@ -276,25 +255,35 @@ public class GeoServerCatalogModuleTest {
         lg.setTitle("LG Title");
         lg.setAbstract("LG abstract");
         lg.setInternationalTitle(
-                data.createInternationalString(
-                        Locale.ENGLISH, "english title", Locale.CANADA_FRENCH, "titre anglais"));
+                data.faker()
+                        .internationalString(
+                                Locale.ENGLISH,
+                                "english title",
+                                Locale.CANADA_FRENCH,
+                                "titre anglais"));
         lg.setInternationalAbstract(
-                data.createInternationalString(
-                        Locale.ENGLISH,
-                        "english abstract",
-                        Locale.CANADA_FRENCH,
-                        "résumé anglais"));
+                data.faker()
+                        .internationalString(
+                                Locale.ENGLISH,
+                                "english abstract",
+                                Locale.CANADA_FRENCH,
+                                "résumé anglais"));
 
         LayerGroupStyle lgs = new LayerGroupStyleImpl();
         lgs.setId("lgsid");
         lgs.setTitle("Lgs Title");
         lgs.setAbstract("Lgs Abstract");
         lgs.setInternationalTitle(
-                data.createInternationalString(
-                        Locale.ITALIAN, "Italian title", Locale.FRENCH, "French title"));
+                data.faker()
+                        .internationalString(
+                                Locale.ITALIAN, "Italian title", Locale.FRENCH, "French title"));
         lgs.setInternationalAbstract(
-                data.createInternationalString(
-                        Locale.ITALIAN, "Italian abstract", Locale.FRENCH, "French abstract"));
+                data.faker()
+                        .internationalString(
+                                Locale.ITALIAN,
+                                "Italian abstract",
+                                Locale.FRENCH,
+                                "French abstract"));
 
         lgs.setLayers(Arrays.asList(data.createLayer(data.coverageA, data.style1)));
         lgs.setStyles(Arrays.asList(data.createStyle("test-style")));
@@ -342,161 +331,6 @@ public class GeoServerCatalogModuleTest {
         attinfo.setHref("http://nevermind");
         attinfo.setLogoWidth(10);
         return attinfo;
-    }
-
-    public @Test void testPatch() throws Exception {
-        testPatch("nullvalue", null);
-        testPatch("int", Integer.MAX_VALUE);
-        testPatch("long", Long.MAX_VALUE);
-        testPatch("date", new Date(10_000_000));
-        testPatch("string", "string value");
-        // some CatalogInfo properties, , shall be converted to references
-        testPatch("workspace", data.workspaceA);
-        testPatch("namespace", data.namespaceA);
-        testPatch("dataStore", data.dataStoreA);
-        testPatch("coverageStore", data.coverageStoreA);
-        testPatch("layer", data.layerFeatureTypeA);
-        testPatch("style", data.style1);
-        // some Config Info properties, shall be converted to references
-        testPatch("global", data.global);
-        testPatch("logging", data.logging);
-        // testPatch("settings", testData.workspaceASettings);
-        testPatch("wmsService", data.wmsService);
-
-        // some Info properties that are actually value-objects and shall be serialized
-        testPatch("attribution", attInfo("attributionInfo1"));
-        testPatch("contact", contact("acme"));
-    }
-
-    public @Test void testPatchWithModificationProxy() throws Exception {
-        testPatch("workspace", forceProxy(data.workspaceA));
-        testPatch("namespace", forceProxy(data.namespaceA));
-        testPatch("dataStore", forceProxy(data.dataStoreA));
-        testPatch("coverageStore", forceProxy(data.coverageStoreA));
-        testPatch("layer", forceProxy(data.layerFeatureTypeA));
-        testPatch("style", forceProxy(data.style1));
-        testPatch("global", forceProxy(data.global));
-        testPatch("logging", forceProxy(data.logging));
-        testPatch("settings", forceProxy(data.workspaceASettings));
-        testPatch("wmsService", forceProxy(data.wmsService));
-    }
-
-    public @Test void testPatchWithListProperty() throws Exception {
-        testPatch("nullvalue", newArrayList(null, null));
-        testPatch("int", List.of(Integer.MAX_VALUE, Integer.MIN_VALUE));
-        testPatch("long", List.of(Long.MAX_VALUE, Long.MIN_VALUE));
-        testPatch("date", List.of(new Date(10_000_000), new Date(11_000_000)));
-        testPatch("string", List.of("string1", "string2"));
-        // some CatalogInfo properties, , shall be converted to references
-        testPatch("workspaces", List.of(data.workspaceA, data.workspaceB));
-        testPatch("namespaces", List.of(data.namespaceA, data.namespaceB));
-        testPatch("stores", List.of(data.dataStoreA, data.coverageStoreA));
-        testPatch("layers", List.of(data.layerFeatureTypeA));
-        testPatch("styles", List.of(data.style1, data.style2));
-        testPatch("attribution", List.of(attInfo("attributionInfo1"), attInfo("attribution2")));
-        testPatch("contact", List.of(contact("org1"), contact("org2")));
-
-        testPatch("serviceInfos", List.of(data.wmsService));
-        // REVISIT: WFSInfoImpl.equals is broken
-        // testPatch("serviceInfos", List.of(data.wmsService, data.wfsService));
-        // REVISIT: WCSInfoImpl.equals is broken
-        // testPatch("serviceInfos", List.of(data.wcsService));
-    }
-
-    public @Test void testPatchWithListProperty_AttributeTypeInfos() throws Exception {
-        FeatureTypeInfo ft = data.featureTypeA;
-        List<AttributeTypeInfo> attributes = createTestAttributes(ft);
-
-        testPatch("attributes", attributes);
-    }
-
-    public @Test void testPatchWithSetProperty() throws Exception {
-        WorkspaceInfo wsa = catalog.getWorkspace(data.workspaceA.getId());
-        WorkspaceInfo wsb = catalog.getWorkspace(data.workspaceB.getId());
-        Set<WorkspaceInfo> workspaces = Set.of(wsa, wsb);
-
-        Set<NamespaceInfo> namespaces = Set.of(data.namespaceA, data.namespaceB);
-        Set<StoreInfo> stores = Set.of(data.dataStoreA, data.coverageStoreA);
-        Set<LayerInfo> layers = Set.of(data.layerFeatureTypeA);
-        Set<StyleInfo> styles = Set.of(data.style1, data.style2);
-
-        WMSInfo s1 = geoserver.getService(data.wmsService.getId(), WMSInfo.class);
-        WFSInfo s2 = geoserver.getService(data.wfsService.getId(), WFSInfo.class);
-        Set<ServiceInfo> services = Set.of(s1, s2);
-        Set<AttributionInfoImpl> attributionInfos =
-                Set.of(attInfo("attributionInfo1"), attInfo("attribution2"));
-        Set<ContactInfoImpl> contactInfos = Set.of(contact("org1"), contact("org2"));
-
-        testPatch("workspaces", workspaces);
-        testPatch("namespaces", namespaces);
-        testPatch("stores", stores);
-        testPatch("layers", layers);
-        testPatch("styles", styles);
-        testPatch("attribution", attributionInfos);
-        testPatch("contact", contactInfos);
-
-        testPatch("serviceInfos", Set.of(data.wmsService));
-        // REVISIT: WFSInfoImpl.equals is broken
-        // testPatch("serviceInfos", services);
-    }
-
-    public @Test void testPatchWithSimpleInternationalStringProperty() throws Exception {
-        InternationalString simpleI18n = new SimpleInternationalString("simpleI18n");
-        Patch patch = new Patch();
-        patch.add("simpleI18n", simpleI18n);
-
-        ObjectWriter writer = objectMapper.writer();
-        writer = writer.withDefaultPrettyPrinter();
-        String encoded = writer.writeValueAsString(patch);
-        log.debug(encoded);
-        Patch decoded = objectMapper.readValue(encoded, Patch.class);
-        Patch expected = new Patch();
-        expected.add("simpleI18n", new GrowableInternationalString(simpleI18n.toString()));
-        assertEquals(expected, decoded);
-    }
-
-    public @Test void testPatchWithGrowableInternationalStringProperty() throws Exception {
-        GrowableInternationalString growableI18n = new GrowableInternationalString("default lang");
-        growableI18n.add(Locale.forLanguageTag("es-AR"), "en argentino");
-        growableI18n.add(Locale.forLanguageTag("es"), "en español");
-        testPatch("growableI18n", growableI18n);
-    }
-
-    public @Test void testPatch_CoverageAccessInfo() throws Exception {
-        CoverageAccessInfo coverageInfo = new CoverageAccessInfoImpl();
-        coverageInfo.setCorePoolSize(10);
-        coverageInfo.setQueueType(QueueType.UNBOUNDED);
-
-        testPatch("coverageInfo", coverageInfo);
-    }
-
-    public @Test void testPatch_ContactInfo() throws Exception {
-        ContactInfoImpl contact = this.contact("TestOrg");
-        testPatch("contact", contact);
-    }
-
-    public @Test void testPatch_JAIInfo() throws Exception {
-        JAIInfo jaiInfo = new JAIInfoImpl();
-        jaiInfo.setAllowInterpolation(true);
-        jaiInfo.setAllowNativeMosaic(true);
-        jaiInfo.setJAIEXTInfo(new JAIEXTInfoImpl());
-        jaiInfo.setTileCache(null);
-        testPatch("jaiInfo", jaiInfo);
-    }
-
-    private void testPatch(String name, Object value) throws Exception {
-        Patch patch = new Patch();
-        patch.add(name, value);
-
-        ObjectWriter writer = objectMapper.writer();
-        writer = writer.withDefaultPrettyPrinter();
-        String encoded = writer.writeValueAsString(patch);
-        log.debug(encoded);
-        Patch decoded = objectMapper.readValue(encoded, Patch.class);
-
-        Patch resolved = proxyResolver.resolve(decoded);
-        log.debug(writer.writeValueAsString(resolved));
-        assertEquals(patch, resolved);
     }
 
     public @Test void testFilterWithInfoLiterals() throws JsonProcessingException {
@@ -595,9 +429,10 @@ public class GeoServerCatalogModuleTest {
         ObjectWriter writer = objectMapper.writer();
         writer = writer.withDefaultPrettyPrinter();
         String encoded = writer.writeValueAsString(orig);
-        log.debug(encoded);
+        print("encoded: {}", encoded);
         @SuppressWarnings("unchecked")
         T decoded = (T) objectMapper.readValue(encoded, clazz);
+        print("decoded: {}", decoded);
         return decoded;
     }
 
@@ -713,32 +548,12 @@ public class GeoServerCatalogModuleTest {
     }
 
     public @Test void testValueCoverageDimensionInfo() throws Exception {
-        CoverageDimensionImpl c = new CoverageDimensionImpl();
-        c.setDescription("description");
-        c.setDimensionType(SampleDimensionType.UNSIGNED_1BIT);
-        c.setId("id");
-        c.setName("name");
-        c.setNullValues(Arrays.asList(0.0)); // , Double.NEGATIVE_INFINITY,
-        // Double.POSITIVE_INFINITY));
-        c.setRange(NumberRange.create(0.0, 255.0));
-        c.setUnit("unit");
-        testValueWithEquals(c, CoverageDimensionInfo.class);
+        CoverageDimensionInfo cdi = data.faker().coverageDimensionInfo();
+        testValueWithEquals(cdi, CoverageDimensionInfo.class);
     }
 
     public @Test void testValueDimensionInfo() throws Exception {
-        DimensionInfoImpl di = new DimensionInfoImpl();
-        di.setAcceptableInterval("searchRange");
-        di.setAttribute("attribute");
-        DimensionDefaultValueSetting defaultValue = new DimensionDefaultValueSetting();
-        defaultValue.setReferenceValue("referenceValue");
-        defaultValue.setStrategyType(Strategy.MAXIMUM);
-        di.setDefaultValue(defaultValue);
-        di.setEnabled(true);
-        di.setNearestMatchEnabled(true);
-        di.setResolution(BigDecimal.TEN);
-        di.setUnits("units");
-        di.setUnitSymbol("unitSymbol");
-        di.setPresentation(DimensionPresentation.DISCRETE_INTERVAL);
+        DimensionInfo di = data.faker().dimensionInfo();
 
         // bad equals implementation on DimensionInfoImpl
         DimensionInfo actual = testValue(di, DimensionInfo.class);
@@ -759,18 +574,12 @@ public class GeoServerCatalogModuleTest {
     }
 
     public @Test void testValueDataLinkInfo() throws Exception {
-        DataLinkInfoImpl dl = new DataLinkInfoImpl();
-        dl.setAbout("about");
-        dl.setContent("content");
-        dl.setId("id");
-        dl.setType("type");
+        DataLinkInfo dl = data.faker().dataLinkInfo();
         testValueWithEquals(dl, DataLinkInfo.class);
     }
 
     public @Test void testValueLayerIdentifierInfo() throws Exception {
-        org.geoserver.catalog.impl.LayerIdentifier li = new LayerIdentifier();
-        li.setAuthority("authorityName");
-        li.setIdentifier("identifier");
+        org.geoserver.catalog.impl.LayerIdentifier li = data.faker().layerIdentifierInfo();
         testValueWithEquals(li, LayerIdentifierInfo.class);
     }
 
@@ -791,13 +600,7 @@ public class GeoServerCatalogModuleTest {
     }
 
     public @Test void testValueMetadataLinkInfo() throws Exception {
-        MetadataLinkInfoImpl link = new MetadataLinkInfoImpl();
-        link.setAbout("about");
-        link.setContent("content");
-        link.setId("id");
-        link.setMetadataType("metadataType");
-        link.setType("type");
-        testValueWithEquals(link, MetadataLinkInfo.class);
+        testValueWithEquals(data.faker().metadataLink(), MetadataLinkInfo.class);
     }
 
     public @Test void testValueVirtualTable() throws Exception {

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModuleTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModuleTest.java
@@ -27,9 +27,7 @@ import org.geoserver.catalog.CatalogBuilder;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.CatalogTestData;
 import org.geoserver.catalog.CoverageDimensionInfo;
-import org.geoserver.catalog.CoverageStoreInfo;
 import org.geoserver.catalog.DataLinkInfo;
-import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.DimensionDefaultValueSetting;
 import org.geoserver.catalog.DimensionDefaultValueSetting.Strategy;
 import org.geoserver.catalog.DimensionInfo;
@@ -68,9 +66,7 @@ import org.geoserver.catalog.plugin.Query;
 import org.geoserver.config.CoverageAccessInfo;
 import org.geoserver.config.CoverageAccessInfo.QueueType;
 import org.geoserver.config.GeoServer;
-import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.JAIInfo;
-import org.geoserver.config.LoggingInfo;
 import org.geoserver.config.ServiceInfo;
 import org.geoserver.config.impl.ContactInfoImpl;
 import org.geoserver.config.impl.CoverageAccessInfoImpl;
@@ -373,19 +369,16 @@ public class GeoServerCatalogModuleTest {
     }
 
     public @Test void testPatchWithModificationProxy() throws Exception {
-        testPatch("workspace", ModificationProxy.create(data.workspaceA, WorkspaceInfo.class));
-        testPatch("namespace", ModificationProxy.create(data.namespaceA, NamespaceInfo.class));
-        testPatch("dataStore", ModificationProxy.create(data.dataStoreA, DataStoreInfo.class));
-        testPatch(
-                "coverageStore",
-                ModificationProxy.create(data.coverageStoreA, CoverageStoreInfo.class));
-        testPatch("layer", ModificationProxy.create(data.layerFeatureTypeA, LayerInfo.class));
-        testPatch("style", ModificationProxy.create(data.style1, StyleInfo.class));
-        // some Config Info properties, shall be converted to references
-        testPatch("global", ModificationProxy.create(data.global, GeoServerInfo.class));
-        testPatch("logging", ModificationProxy.create(data.logging, LoggingInfo.class));
-        // testPatch("settings", testData.workspaceASettings);
-        testPatch("wmsService", ModificationProxy.create(data.wmsService, WMSInfo.class));
+        testPatch("workspace", forceProxy(data.workspaceA));
+        testPatch("namespace", forceProxy(data.namespaceA));
+        testPatch("dataStore", forceProxy(data.dataStoreA));
+        testPatch("coverageStore", forceProxy(data.coverageStoreA));
+        testPatch("layer", forceProxy(data.layerFeatureTypeA));
+        testPatch("style", forceProxy(data.style1));
+        testPatch("global", forceProxy(data.global));
+        testPatch("logging", forceProxy(data.logging));
+        testPatch("settings", forceProxy(data.workspaceASettings));
+        testPatch("wmsService", forceProxy(data.wmsService));
     }
 
     public @Test void testPatchWithListProperty() throws Exception {
@@ -548,7 +541,7 @@ public class GeoServerCatalogModuleTest {
     }
 
     @SuppressWarnings("unchecked")
-    private <T extends CatalogInfo> T forceProxy(T info) {
+    private <T extends Info> T forceProxy(T info) {
         if (!Proxy.isProxyClass(info.getClass())) {
             Class<? extends Info> iface = ClassMappings.fromImpl(info.getClass()).getInterface();
             return (T) ModificationProxy.create(info, iface);

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/PatchSerializationTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/PatchSerializationTest.java
@@ -1,0 +1,689 @@
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.jackson.databind.catalog;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.geoserver.catalog.AttributeTypeInfo;
+import org.geoserver.catalog.AttributionInfo;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogBuilder;
+import org.geoserver.catalog.CatalogTestData;
+import org.geoserver.catalog.DimensionInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.Info;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.LegendInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.StoreInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.faker.CatalogFaker;
+import org.geoserver.catalog.impl.ClassMappings;
+import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.catalog.plugin.CatalogPlugin;
+import org.geoserver.catalog.plugin.Patch;
+import org.geoserver.config.ContactInfo;
+import org.geoserver.config.CoverageAccessInfo;
+import org.geoserver.config.CoverageAccessInfo.QueueType;
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.JAIInfo;
+import org.geoserver.config.ServiceInfo;
+import org.geoserver.config.SettingsInfo;
+import org.geoserver.config.impl.CoverageAccessInfoImpl;
+import org.geoserver.config.plugin.GeoServerImpl;
+import org.geoserver.jackson.databind.catalog.mapper.CatalogInfoMapper;
+import org.geoserver.jackson.databind.catalog.mapper.ValueMappers;
+import org.geoserver.jackson.databind.config.dto.mapper.GeoServerConfigMapper;
+import org.geoserver.jackson.databind.mapper.SharedMappers;
+import org.geoserver.ows.util.OwsUtils;
+import org.geoserver.platform.GeoServerExtensionsHelper;
+import org.geoserver.wfs.WFSInfo;
+import org.geoserver.wms.WMSInfo;
+import org.geotools.coverage.grid.GeneralGridEnvelope;
+import org.geotools.coverage.grid.GridGeometry2D;
+import org.geotools.data.DataUtilities;
+import org.geotools.feature.NameImpl;
+import org.geotools.feature.SchemaException;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.jackson.databind.util.ObjectMapperUtil;
+import org.geotools.measure.Measure;
+import org.geotools.referencing.CRS;
+import org.geotools.util.GrowableInternationalString;
+import org.geotools.util.NumberRange;
+import org.geotools.util.SimpleInternationalString;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opengis.coverage.grid.GridEnvelope;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.util.InternationalString;
+
+import si.uom.SI;
+
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * Verifies that {@link Patch patches} can be JSON round-tripped. As a reference, it should cover as
+ * much of {@link SharedMappers}, {@link ValueMappers}, {@link GeoServerConfigMapper}, and {@link
+ * CatalogInfoMapper} as possible.
+ */
+@Slf4j
+public class PatchSerializationTest {
+
+    private boolean debug = Boolean.valueOf(System.getProperty("debug", "false"));
+
+    protected void print(String logmsg, Object... args) {
+        if (debug) log.debug(logmsg, args);
+    }
+
+    public static ObjectMapper objectMapper;
+
+    private Catalog catalog;
+    private CatalogTestData data;
+    private GeoServer geoserver;
+    private ProxyUtils proxyResolver;
+
+    public static @BeforeAll void oneTimeSetup() {
+        // avoid the chatty warning logs due to catalog looking up a bean of type
+        // GeoServerConfigurationLock
+        GeoServerExtensionsHelper.setIsSpringContext(false);
+        objectMapper = ObjectMapperUtil.newObjectMapper();
+    }
+
+    public @BeforeEach void before() {
+        catalog = new CatalogPlugin();
+        geoserver = new GeoServerImpl();
+        data = CatalogTestData.initialized(() -> catalog, () -> geoserver).initialize();
+        proxyResolver = new ProxyUtils(catalog, geoserver);
+    }
+
+    private List<AttributeTypeInfo> createTestAttributes(FeatureTypeInfo info)
+            throws SchemaException {
+        String typeSpec =
+                "name:string,id:String,polygonProperty:Polygon:srid=32615,centroid:Point,url:java.net.URL,uuid:UUID";
+        SimpleFeatureType ft = DataUtilities.createType("TestType", typeSpec);
+        return new CatalogBuilder(new CatalogPlugin()).getAttributes(ft, info);
+    }
+
+    public @Test void simpleTypes() throws Exception {
+        testPatch("nullvalue", null);
+        testPatch("int", Integer.MAX_VALUE);
+        testPatch("long", Long.MAX_VALUE);
+        testPatch("date", new Date(10_000_000));
+        testPatch("string", "string value");
+    }
+
+    public @Test void workspace() throws Exception {
+        testPatch("workspace", data.workspaceA);
+    }
+
+    public @Test void namespaceInfo() throws Exception {
+        testPatch("namespace", data.namespaceA);
+    }
+
+    public @Test void dataStoreInfo() throws Exception {
+        testPatch("dataStore", data.dataStoreA);
+    }
+
+    public @Test void coverageStoreInfo() throws Exception {
+        testPatch("coverageStore", data.coverageStoreA);
+    }
+
+    public @Test void wmsStoreInfo() throws Exception {
+        testPatch("wms", data.wmsStoreA);
+    }
+
+    public @Test void wmtsStoreInfo() throws Exception {
+        testPatch("wmts", data.wmtsStoreA);
+    }
+
+    public @Test void featureTypeInfo() throws Exception {
+        testPatch("ft", data.featureTypeA);
+    }
+
+    public @Test void coverageInfo() throws Exception {
+        testPatch("coverage", data.coverageA);
+    }
+
+    public @Test void wmsLayerInfo() throws Exception {
+        testPatch("wmsl", data.wmsLayerA);
+    }
+
+    public @Test void wmtsLayerInfo() throws Exception {
+        testPatch("wmtsl", data.wmtsLayerA);
+    }
+
+    public @Test void layerInfo() throws Exception {
+        testPatch("layer", data.layerFeatureTypeA);
+    }
+
+    public @Test void layerGroupInfo() throws Exception {
+        testPatch("layer", data.layerGroup1);
+    }
+
+    public @Test void layerInfo_references() throws Exception {
+        LayerInfo layer = data.layerFeatureTypeA;
+        StyleInfo s1 = data.faker().styleInfo("s1");
+        StyleInfo s2 = data.faker().styleInfo("s2");
+        catalog.add(s1);
+        catalog.add(s2);
+
+        layer.setDefaultStyle(data.style2);
+        layer.getStyles().add(s1);
+        layer.getStyles().add(s2);
+        catalog.save(layer);
+
+        final Patch patch =
+                new Patch()
+                        .with("styles", layer.getStyles())
+                        .with("defaultStyle", layer.getDefaultStyle());
+
+        final Patch resolved = testPatch(patch);
+        Set<StyleInfo> styles = resolved.get("styles").orElseThrow().value();
+        StyleInfo defaultStyle = resolved.get("defaultStyle").orElseThrow().value();
+        assertModificationProxy(defaultStyle);
+        assertCatalogSet(defaultStyle);
+        styles.forEach(this::assertModificationProxy);
+        styles.forEach(this::assertCatalogSet);
+
+        final Patch unresolved = roundtrip(patch);
+        styles = unresolved.get("styles").orElseThrow().value();
+        defaultStyle = unresolved.get("defaultStyle").orElseThrow().value();
+        assertResolvingProxy(defaultStyle);
+        styles.forEach(this::assertResolvingProxy);
+    }
+
+    public @Test void layerInfo_value_object_properties() throws Exception {
+        LayerInfo layer = data.layerFeatureTypeA;
+
+        layer.setLegend(data.faker().legendInfo());
+        layer.setAttribution(data.faker().attributionInfo());
+
+        layer.getAuthorityURLs().add(data.faker().authorityURLInfo());
+        layer.getAuthorityURLs().add(data.faker().authorityURLInfo());
+
+        layer.getIdentifiers().add(data.faker().layerIdentifierInfo());
+        layer.getIdentifiers().add(data.faker().layerIdentifierInfo());
+
+        Patch patch =
+                new Patch()
+                        .with("legend", layer.getLegend())
+                        .with("attribution", layer.getAttribution())
+                        .with("authorityURLs", layer.getAuthorityURLs())
+                        .with("identifiers", layer.getIdentifiers());
+        final Patch roundtripped = roundtrip(patch);
+
+        LegendInfo legend = roundtripped.get("legend").orElseThrow().value();
+        assertValueObject(legend, LegendInfo.class);
+    }
+
+    public @Test void styleInfo() throws Exception {
+        testPatch("style", data.style1);
+    }
+
+    public @Test void geoserverInfo() throws Exception {
+        testPatch("global", data.global);
+    }
+
+    public @Test void loggingInfo() throws Exception {
+        testPatch("logging", data.logging);
+    }
+
+    public @Test void settingsInfo() throws Exception {
+        testPatch("settings", data.faker().settingsInfo(null));
+    }
+
+    public @Test void settingsInfo_workspace() throws Exception {
+        Patch resolved = testPatch("settings", data.faker().settingsInfo(data.workspaceA));
+        SettingsInfo setting = resolved.get("settings").orElseThrow().value();
+        assertModificationProxy(setting.getWorkspace());
+    }
+
+    public @Test void wmsInfo() throws Exception {
+        testPatch("wmsService", data.wmsService);
+    }
+
+    public @Test void wcsInfo() throws Exception {
+        // WCSInfoImpl.equals is broken, we're still checking it's sent as a reference
+        testPatchNoEquals(patch("wcsService", data.wcsService));
+    }
+
+    public @Test void wfsInfo() throws Exception {
+        testPatch("wfsService", data.wfsService);
+    }
+
+    public @Test void wpsInfo() throws Exception {
+        Patch patch = patch("wpsService", data.wpsService);
+        // WPSInfoImpl.equals is broken, we're still checking it's sent as a reference
+        testPatchNoEquals(patch);
+    }
+
+    public @Test void attributionInfo() throws Exception {
+        testPatch("attribution", data.faker().attributionInfo());
+    }
+
+    public @Test void contactInfo() throws Exception {
+        testPatch("contact", data.faker().contactInfo());
+    }
+
+    public @Test void keywordInfo() throws Exception {
+        CatalogFaker faker = data.faker();
+        testPatch("kw", faker.keywordInfo());
+    }
+
+    public @Test void keywordInfo_list() throws Exception {
+        CatalogFaker faker = data.faker();
+        testPatch("keywords", Arrays.asList(faker.keywordInfo(), null, faker.keywordInfo()));
+    }
+
+    public @Test void name() throws Exception {
+        org.opengis.feature.type.Name name = new NameImpl("localname");
+        testPatch("name", name);
+    }
+
+    public @Test void name_with_ns() throws Exception {
+        org.opengis.feature.type.Name name = new NameImpl("http://name.space", "localname");
+        testPatch("name", name);
+    }
+
+    public @Test void version() throws Exception {
+        testPatch("version", new org.geotools.util.Version("1.0.1"));
+    }
+
+    public @Test void version_list() throws Exception {
+        testPatch(
+                "version",
+                List.of(
+                        new org.geotools.util.Version("1.0.1"),
+                        new org.geotools.util.Version("1.0.2")));
+    }
+
+    public @Test void class_property() throws Exception {
+        testPatch("binding", org.geotools.util.Version.class);
+    }
+
+    public @Test void metadataLinkInfo() throws Exception {
+        testPatch("metadataLink", data.faker().metadataLink());
+    }
+
+    public @Test void coordinateReferenceSystem() throws Exception {
+        final boolean longitudeFirst = true;
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:3857", longitudeFirst);
+        Patch resolved = testPatchNoEquals(patch("crs", crs));
+        assertEquals(List.of("crs"), resolved.getPropertyNames());
+        CoordinateReferenceSystem roundtripped =
+                resolved.getValue("crs").map(CoordinateReferenceSystem.class::cast).orElseThrow();
+        assertTrue(CRS.equalsIgnoreMetadata(crs, roundtripped));
+    }
+
+    public @Test void referencedEnvelope() throws Exception {
+        final boolean longitudeFirst = true;
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:3857", longitudeFirst);
+        ReferencedEnvelope env = new ReferencedEnvelope(0, 1000, -1, -1000, crs);
+        testPatch("bounds", env);
+    }
+
+    public @Test void numberRange() throws Exception {
+        testPatch("range", NumberRange.create(-1, 1));
+        // testPatch("range", NumberRange.create(-1.1f, 1.1f));
+        // testPatch("range", NumberRange.create((short) 10, (short) 15));
+        testPatch("range", NumberRange.create(Double.MIN_VALUE, 1.01));
+    }
+
+    public @Test void measure() throws Exception {
+        testPatch("meters", new Measure(1000, SI.METRE));
+        testPatch("radians", new Measure(.75, SI.RADIAN_PER_SECOND));
+    }
+
+    public @Test void gridGeometry() throws Exception {
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:4326", true);
+        ReferencedEnvelope env = new ReferencedEnvelope(-180, 180, -90, 90, crs);
+        GridEnvelope range = new GeneralGridEnvelope(new int[] {0, 0}, new int[] {1024, 768});
+        GridGeometry2D gridGeometry = new GridGeometry2D(range, env);
+        testPatch("gridGeometry", gridGeometry);
+    }
+
+    public @Test void testPatchWithModificationProxy() throws Exception {
+        testPatch("workspace", forceProxy(data.workspaceA));
+        testPatch("namespace", forceProxy(data.namespaceA));
+        testPatch("dataStore", forceProxy(data.dataStoreA));
+        testPatch("coverageStore", forceProxy(data.coverageStoreA));
+        testPatch("layer", forceProxy(data.layerFeatureTypeA));
+        testPatch("style", forceProxy(data.style1));
+        testPatch("global", forceProxy(data.global));
+        testPatch("logging", forceProxy(data.logging));
+        testPatch("settings", forceProxy(data.workspaceASettings));
+        testPatch("wmsService", forceProxy(data.wmsService));
+    }
+
+    public @Test void testPatchWithListProperty() throws Exception {
+        testPatch("nullvalue", newArrayList(null, null));
+        testPatch("int", List.of(Integer.MAX_VALUE, Integer.MIN_VALUE));
+        testPatch("long", List.of(Long.MAX_VALUE, Long.MIN_VALUE));
+        testPatch("date", List.of(new Date(10_000_000), new Date(11_000_000)));
+        testPatch("string", List.of("string1", "string2"));
+        // some CatalogInfo properties, , shall be converted to references
+        testPatch("workspaces", List.of(data.workspaceA, data.workspaceB));
+        testPatch("namespaces", List.of(data.namespaceA, data.namespaceB));
+        testPatch("stores", List.of(data.dataStoreA, data.coverageStoreA));
+        testPatch("layers", List.of(data.layerFeatureTypeA));
+        testPatch("styles", List.of(data.style1, data.style2));
+        testPatch(
+                "attribution",
+                List.of(data.faker().attributionInfo(), data.faker().attributionInfo()));
+        testPatch("contact", List.of(data.faker().contactInfo(), data.faker().contactInfo()));
+
+        testPatch("serviceInfos", List.of(data.wmsService));
+        // REVISIT: WFSInfoImpl.equals is broken
+        // testPatch("serviceInfos", List.of(data.wmsService, data.wfsService));
+        // REVISIT: WCSInfoImpl.equals is broken
+        // testPatch("serviceInfos", List.of(data.wcsService));
+    }
+
+    public @Test void attributeTypeInfo_list() throws Exception {
+        FeatureTypeInfo ft = data.featureTypeA;
+        List<AttributeTypeInfo> attributes = createTestAttributes(ft);
+
+        Patch roundTrippedAndResolved = testPatch("attributes", attributes);
+        List<AttributeTypeInfo> rtripAtts =
+                roundTrippedAndResolved.get("attributes").orElseThrow().value();
+
+        for (AttributeTypeInfo att : rtripAtts) {
+            assertModificationProxy(ft, att.getFeatureType());
+        }
+    }
+
+    public @Test void testPatchWithSetProperty() throws Exception {
+        WorkspaceInfo wsa = catalog.getWorkspace(data.workspaceA.getId());
+        WorkspaceInfo wsb = catalog.getWorkspace(data.workspaceB.getId());
+        Set<WorkspaceInfo> workspaces = Set.of(wsa, wsb);
+
+        Set<NamespaceInfo> namespaces = Set.of(data.namespaceA, data.namespaceB);
+        Set<StoreInfo> stores = Set.of(data.dataStoreA, data.coverageStoreA);
+        Set<LayerInfo> layers = Set.of(data.layerFeatureTypeA);
+        Set<StyleInfo> styles = Set.of(data.style1, data.style2);
+
+        WMSInfo s1 = geoserver.getService(data.wmsService.getId(), WMSInfo.class);
+        WFSInfo s2 = geoserver.getService(data.wfsService.getId(), WFSInfo.class);
+        Set<ServiceInfo> services = Set.of(s1, s2);
+
+        Set<AttributionInfo> attributionInfos =
+                Set.of(data.faker().attributionInfo(), data.faker().attributionInfo());
+        Set<ContactInfo> contactInfos =
+                Set.of(data.faker().contactInfo(), data.faker().contactInfo());
+
+        testPatch("workspaces", workspaces);
+        testPatch("namespaces", namespaces);
+        testPatch("stores", stores);
+        testPatch("layers", layers);
+        testPatch("styles", styles);
+        testPatch("attribution", attributionInfos);
+        testPatch("contact", contactInfos);
+
+        testPatch("serviceInfos", Set.of(data.wmsService));
+        testPatch("serviceInfos", services);
+    }
+
+    public @Test void simpleInternationalString() throws Exception {
+        InternationalString simpleI18n = new SimpleInternationalString("simpleI18n");
+        Patch patch = new Patch();
+        patch.add("simpleI18n", simpleI18n);
+
+        ObjectWriter writer = objectMapper.writer();
+        writer = writer.withDefaultPrettyPrinter();
+        String encoded = writer.writeValueAsString(patch);
+        print("encoded: {}", encoded);
+        Patch decoded = objectMapper.readValue(encoded, Patch.class);
+        Patch expected = new Patch();
+        expected.add("simpleI18n", new GrowableInternationalString(simpleI18n.toString()));
+        assertEquals(expected, decoded);
+    }
+
+    public @Test void authorityURLInfo() throws Exception {
+        testPatch("authorityURL", data.faker().authorityURLInfo());
+    }
+
+    public @Test void coverageAccessInfo() throws Exception {
+        CoverageAccessInfo coverageInfo = new CoverageAccessInfoImpl();
+        coverageInfo.setCorePoolSize(10);
+        coverageInfo.setQueueType(QueueType.UNBOUNDED);
+
+        testPatch("coverageInfo", coverageInfo);
+    }
+
+    public @Test void jaiInfo() throws Exception {
+        JAIInfo jaiInfo = data.faker().jaiInfo();
+        testPatch("jaiInfo", jaiInfo);
+    }
+
+    public @Test void growableInternationalString() throws Exception {
+        GrowableInternationalString growableI18n = new GrowableInternationalString("default lang");
+        growableI18n.add(Locale.forLanguageTag("es-AR"), "en argentino");
+        growableI18n.add(Locale.forLanguageTag("es"), "en español");
+        testPatch("growableI18n", growableI18n);
+    }
+
+    public @Test void coverageDimensionInfo() throws Exception {
+        testPatch("coverageDimensionInfo", data.faker().coverageDimensionInfo());
+    }
+
+    public @Test void dimensionInfo() throws Exception {
+        // equals is broken
+        DimensionInfo expected = data.faker().dimensionInfo();
+        Patch patch = testPatchNoEquals(patch("dimensionInfo", expected));
+        DimensionInfo actual =
+                patch.getValue("dimensionInfo").map(DimensionInfo.class::cast).orElseThrow();
+
+        assertEquals(expected.getAcceptableInterval(), actual.getAcceptableInterval());
+        assertEquals(expected.getAttribute(), actual.getAttribute());
+        assertEquals(
+                expected.getDefaultValue().getReferenceValue(),
+                actual.getDefaultValue().getReferenceValue());
+        assertEquals(
+                expected.getDefaultValue().getStrategyType(),
+                actual.getDefaultValue().getStrategyType());
+        assertEquals(expected.isEnabled(), actual.isEnabled());
+        assertEquals(expected.isNearestMatchEnabled(), actual.isNearestMatchEnabled());
+        assertEquals(expected.isRawNearestMatchEnabled(), actual.isRawNearestMatchEnabled());
+        assertEquals(expected.getResolution(), actual.getResolution());
+        assertEquals(expected.getUnits(), actual.getUnits());
+        assertEquals(expected.getUnitSymbol(), actual.getUnitSymbol());
+        assertEquals(expected.getPresentation(), actual.getPresentation());
+    }
+
+    public @Test void dataLinkInfo() throws Exception {
+        testPatch("dl", data.faker().dataLinkInfo());
+    }
+
+    public @Test void layerIdentifierInfo() throws Exception {
+        testPatch("layerIdentifier", data.faker().layerIdentifierInfo());
+    }
+
+    private Patch testPatch(String name, Object value) throws Exception {
+        Patch patch = patch(name, value);
+        return testPatch(patch);
+    }
+
+    private Patch testPatch(Patch patch) throws JsonProcessingException, JsonMappingException {
+        Patch resolved = testPatchNoEquals(patch);
+        assertEquals(patch, resolved);
+        return resolved;
+    }
+
+    private Patch testPatchNoEquals(Patch patch)
+            throws JsonProcessingException, JsonMappingException {
+
+        Patch decoded = roundtrip(patch);
+        Patch resolved = resolve(decoded);
+        print("resolved: {}", resolved);
+
+        Object patchValue = patch.getPatches().get(0).getValue();
+        boolean encodeByReference = ProxyUtils.encodeByReference(patchValue);
+        if (encodeByReference) {
+            Info decodedValue = resolved.getPatches().get(0).value();
+            Info decodedUnwrapped = assertModificationProxy(decodedValue);
+            Info orig = ModificationProxy.unwrap(patch.getPatches().get(0).value());
+            assertThat(decodedUnwrapped).isSameAs(orig);
+        }
+
+        return resolved;
+    }
+
+    private Patch patch(String name, Object value) {
+        Patch patch = new Patch();
+        patch.add(name, value);
+        return patch;
+    }
+
+    protected Patch resolve(Patch decoded) {
+        Patch resolved = proxyResolver.resolve(decoded);
+        return resolved;
+    }
+
+    private Patch roundtrip(Patch patch) throws JsonProcessingException, JsonMappingException {
+        Object patchValue = patch.getPatches().get(0).getValue();
+        boolean encodeByReference = ProxyUtils.encodeByReference(patchValue);
+
+        String encoded = asJson(patch);
+        print("encoded: {}", encoded);
+
+        Patch decoded = objectMapper.readValue(encoded, Patch.class);
+        print("decoded: {}", asJson(decoded));
+
+        Object roundtrippedValue = decoded.getPatches().get(0).getValue();
+        if (encodeByReference) {
+            String typeName = typeName(roundtrippedValue);
+            Class<? extends Info> type = ProxyUtils.referenceTypeOf(patchValue).orElseThrow();
+            Supplier<String> desc =
+                    () -> {
+                        return String.format(
+                                "Patch value of type %s shall be encoded as reference, got value %s",
+                                type.getCanonicalName(), typeName);
+                    };
+            assertThat(typeName).as(desc).isEqualTo("ResolvingProxy");
+        } else {
+            assertNotAProxy(roundtrippedValue);
+        }
+
+        return decoded;
+    }
+
+    protected String asJson(Patch patch) throws JsonProcessingException {
+        ObjectWriter writer = objectMapper.writer();
+        writer = writer.withDefaultPrettyPrinter();
+        String encoded = writer.writeValueAsString(patch);
+        return encoded;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends Info> T forceProxy(T info) {
+        if (!Proxy.isProxyClass(info.getClass())) {
+            Class<? extends Info> iface = ClassMappings.fromImpl(info.getClass()).getInterface();
+            return (T) ModificationProxy.create(info, iface);
+        }
+        return info;
+    }
+
+    protected String typeName(Object mp) {
+        if (mp == null) return null;
+        if (mp instanceof Info) {
+            Info info = (Info) mp;
+            if (proxyResolver.isResolvingProxy(info)) return "ResolvingProxy";
+            if (proxyResolver.isModificationProxy(info)) return "ModificationProxy";
+        }
+        return mp.getClass().getCanonicalName();
+    }
+
+    private void assertCatalogSet(Info value) {
+        Info real = ModificationProxy.unwrap(value);
+        Catalog assignedCatalog = (Catalog) OwsUtils.get(real, "catalog");
+        assertSame(this.catalog, assignedCatalog);
+    }
+
+    protected void assertNotAProxy(Object value) {
+        if (value instanceof Info) {
+            Info info = (Info) value;
+            assertThat(proxyResolver.isResolvingProxy(info))
+                    .as(
+                            () ->
+                                    String.format(
+                                            "%s should not be a ResolvingProxy",
+                                            info.getId(), typeName(info)))
+                    .isFalse();
+            assertThat(proxyResolver.isModificationProxy(info))
+                    .as(
+                            () ->
+                                    String.format(
+                                            "%s should not be a ModificationProxy",
+                                            info.getId(), typeName(info)))
+                    .isFalse();
+        }
+    }
+
+    protected <I extends Info> I assertModificationProxy(I info) {
+        assertThat(proxyResolver.isModificationProxy(info))
+                .as(
+                        () ->
+                                String.format(
+                                        "%s should be a ModificationProxy, got %s",
+                                        info.getId(), typeName(info)))
+                .isTrue();
+
+        I real = ModificationProxy.unwrap(info);
+        assertNotNull(real);
+        return real;
+    }
+
+    protected <I extends Info> I assertModificationProxy(I expected, I actual) {
+        I actualUnwrapped = assertModificationProxy(actual);
+        I expectedUnwrapped = ModificationProxy.unwrap(expected);
+        assertSame(expectedUnwrapped, actualUnwrapped);
+        return actualUnwrapped;
+    }
+
+    protected void assertResolvingProxy(Info info) {
+        assertThat(proxyResolver.isResolvingProxy(info))
+                .as(
+                        () ->
+                                String.format(
+                                        "%s should be a ResolvingProxy, got %s",
+                                        info.getId(), typeName(info)))
+                .isTrue();
+    }
+
+    private void assertValueObject(Object valueObject, Class<?> valueType) {
+        if (valueObject instanceof Info) {
+            Supplier<String> msg =
+                    () ->
+                            String.format(
+                                    "expected pure value object of type %s, got %s",
+                                    valueType.getCanonicalName(), typeName(valueObject));
+            assertThat(proxyResolver.isResolvingProxy((Info) valueObject)).as(msg).isFalse();
+            assertThat(proxyResolver.isModificationProxy((Info) valueObject)).as(msg).isFalse();
+        }
+        assertThat(valueObject).isInstanceOf(valueType);
+    }
+}

--- a/src/catalog/jackson-bindings/geotools/src/main/java/org/geotools/jackson/databind/filter/dto/Expression.java
+++ b/src/catalog/jackson-bindings/geotools/src/main/java/org/geotools/jackson/databind/filter/dto/Expression.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 import lombok.ToString;
 import lombok.experimental.Accessors;
 
@@ -28,10 +29,10 @@ import java.util.stream.Collectors;
     @JsonSubTypes.Type(value = Expression.BinaryExpression.class, name = "BinaryExpression")
 })
 @Accessors(chain = true)
-public @Data abstract class Expression {
+public @Data @Generated abstract class Expression {
 
     @EqualsAndHashCode(callSuper = true)
-    public static @Data class Literal extends Expression {
+    public static @Data @Generated class Literal extends Expression {
         /**
          * JsonTypeInfo necessary for jackson to resolve which deserializer to use, adds an "@type"
          * property to the {@code Literal} object, without messing with the value representation.
@@ -77,7 +78,7 @@ public @Data abstract class Expression {
     }
 
     @EqualsAndHashCode(callSuper = true)
-    public static @Data class PropertyName extends Expression {
+    public static @Data @Generated class PropertyName extends Expression {
         private String propertyName;
         private Map<String, String> namespaceContext;
     }
@@ -89,36 +90,36 @@ public @Data abstract class Expression {
         @JsonSubTypes.Type(value = Divide.class, name = "Divide")
     })
     @EqualsAndHashCode(callSuper = true)
-    public abstract static @Data class BinaryExpression extends Expression {
+    public abstract static @Data @Generated class BinaryExpression extends Expression {
         private Expression expression1;
         private Expression expression2;
     }
 
     @EqualsAndHashCode(callSuper = true)
     @ToString(callSuper = true)
-    public static @Data class Add extends BinaryExpression {}
+    public static @Data @Generated class Add extends BinaryExpression {}
 
     @EqualsAndHashCode(callSuper = true)
     @ToString(callSuper = true)
-    public static @Data class Divide extends BinaryExpression {}
+    public static @Data @Generated class Divide extends BinaryExpression {}
 
     @EqualsAndHashCode(callSuper = true)
     @ToString(callSuper = true)
-    public static @Data class Multiply extends BinaryExpression {}
+    public static @Data @Generated class Multiply extends BinaryExpression {}
 
     @EqualsAndHashCode(callSuper = true)
     @ToString(callSuper = true)
-    public static @Data class Subtract extends BinaryExpression {}
+    public static @Data @Generated class Subtract extends BinaryExpression {}
 
     @EqualsAndHashCode(callSuper = true)
     @ToString(callSuper = true)
-    public static @Data class Function extends Expression {
+    public static @Data @Generated class Function extends Expression {
         private String name;
         private List<Expression> parameters = new ArrayList<>();
     }
 
     @JsonTypeName("FunctionName")
-    public static @Data class FunctionName {
+    public static @Data @Generated class FunctionName {
         private String name;
         private int argumentCount;
         private List<String> argumentNames = new ArrayList<>();

--- a/src/catalog/jackson-bindings/geotools/src/main/java/org/geotools/jackson/databind/filter/dto/Filter.java
+++ b/src/catalog/jackson-bindings/geotools/src/main/java/org/geotools/jackson/databind/filter/dto/Filter.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Generated;
 import lombok.ToString;
 import lombok.experimental.Accessors;
 
@@ -29,19 +30,19 @@ import java.util.Set;
     @JsonSubTypes.Type(value = Filter.BinaryLogicOperator.class)
 })
 @Accessors(chain = true)
-public @Data class Filter {
+public @Data @Generated class Filter {
     public static final IncludeFilter INCLUDE = new IncludeFilter();
     public static final ExcludeFilter EXCLUDE = new ExcludeFilter();
 
     @EqualsAndHashCode(callSuper = true)
-    public static @Data class IncludeFilter extends Filter {}
+    public static @Data @Generated class IncludeFilter extends Filter {}
 
     @EqualsAndHashCode(callSuper = true)
-    public static @Data class ExcludeFilter extends Filter {}
+    public static @Data @Generated class ExcludeFilter extends Filter {}
 
     @Accessors(chain = true)
     @EqualsAndHashCode(callSuper = true)
-    public static @Data class Id extends Filter {
+    public static @Data @Generated class Id extends Filter {
         private Set<FeatureId> identifiers;
 
         @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY)
@@ -50,7 +51,7 @@ public @Data class Filter {
             @JsonSubTypes.Type(value = ResourceId.class, name = "ResourceId")
         })
         @Accessors(chain = true)
-        public static @Data class FeatureId {
+        public static @Data @Generated class FeatureId {
             private String id;
             private String previousRid;
             private String featureVersion;
@@ -58,7 +59,7 @@ public @Data class Filter {
 
         @Accessors(chain = true)
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class ResourceId extends FeatureId {
+        public static @Data @Generated class ResourceId extends FeatureId {
             String version;
             Date startTime;
             Date endTime;
@@ -67,13 +68,13 @@ public @Data class Filter {
 
     @Accessors(chain = true)
     @EqualsAndHashCode(callSuper = true)
-    public static @Data class NativeFilter extends Filter {
+    public static @Data @Generated class NativeFilter extends Filter {
         private String Native;
     }
 
     @Accessors(chain = true)
     @EqualsAndHashCode(callSuper = true)
-    public static @Data class Not extends Filter {
+    public static @Data @Generated class Not extends Filter {
         private Filter filter;
     }
 
@@ -84,26 +85,26 @@ public @Data class Filter {
     })
     @Accessors(chain = true)
     @EqualsAndHashCode(callSuper = true)
-    public abstract static @Data class BinaryLogicOperator extends Filter {
+    public abstract static @Data @Generated class BinaryLogicOperator extends Filter {
         private List<Filter> children;
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class And extends BinaryLogicOperator {}
+        public static @Data @Generated class And extends BinaryLogicOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class Or extends BinaryLogicOperator {}
+        public static @Data @Generated class Or extends BinaryLogicOperator {}
     }
 
     @Accessors(chain = true)
     @EqualsAndHashCode(callSuper = true)
-    public static @Data class PropertyIsNil extends Filter {
+    public static @Data @Generated class PropertyIsNil extends Filter {
         private Expression expression;
         private Object nilReason;
     }
 
     @Accessors(chain = true)
     @EqualsAndHashCode(callSuper = true)
-    public static @Data class PropertyIsNull extends Filter {
+    public static @Data @Generated class PropertyIsNull extends Filter {
         private Expression expression;
     }
 
@@ -115,7 +116,7 @@ public @Data class Filter {
     })
     @Accessors(chain = true)
     @EqualsAndHashCode(callSuper = true)
-    public abstract static @Data class MultiValuedFilter extends Filter {
+    public abstract static @Data @Generated class MultiValuedFilter extends Filter {
         public enum MatchAction {
             ANY,
             ALL,
@@ -133,14 +134,14 @@ public @Data class Filter {
     })
     @Accessors(chain = true)
     @EqualsAndHashCode(callSuper = true)
-    public abstract static @Data class BinaryOperator extends MultiValuedFilter {
+    public abstract static @Data @Generated class BinaryOperator extends MultiValuedFilter {
         private Expression expression1;
         private Expression expression2;
     }
 
     @Accessors(chain = true)
     @EqualsAndHashCode(callSuper = true)
-    public static @Data class PropertyIsBetween extends MultiValuedFilter {
+    public static @Data @Generated class PropertyIsBetween extends MultiValuedFilter {
         private Expression expression;
         private Expression lowerBoundary;
         private Expression upperBoundary;
@@ -148,7 +149,7 @@ public @Data class Filter {
 
     @Accessors(chain = true)
     @EqualsAndHashCode(callSuper = true)
-    public static @Data class PropertyIsLike extends MultiValuedFilter {
+    public static @Data @Generated class PropertyIsLike extends MultiValuedFilter {
         private Expression expression;
         private String literal;
         private String wildCard;
@@ -180,26 +181,30 @@ public @Data class Filter {
     })
     @Accessors(chain = true)
     @EqualsAndHashCode(callSuper = true)
-    public abstract static @Data class BinaryComparisonOperator extends BinaryOperator {
+    public abstract static @Data @Generated class BinaryComparisonOperator extends BinaryOperator {
         private boolean matchingCase;
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class PropertyIsEqualTo extends BinaryComparisonOperator {}
+        public static @Data @Generated class PropertyIsEqualTo extends BinaryComparisonOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class PropertyIsGreaterThan extends BinaryComparisonOperator {}
+        public static @Data @Generated class PropertyIsGreaterThan
+                extends BinaryComparisonOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class PropertyIsGreaterThanOrEqualTo extends BinaryComparisonOperator {}
+        public static @Data @Generated class PropertyIsGreaterThanOrEqualTo
+                extends BinaryComparisonOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class PropertyIsLessThan extends BinaryComparisonOperator {}
+        public static @Data @Generated class PropertyIsLessThan extends BinaryComparisonOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class PropertyIsLessThanOrEqualTo extends BinaryComparisonOperator {}
+        public static @Data @Generated class PropertyIsLessThanOrEqualTo
+                extends BinaryComparisonOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class PropertyIsNotEqualTo extends BinaryComparisonOperator {}
+        public static @Data @Generated class PropertyIsNotEqualTo
+                extends BinaryComparisonOperator {}
     }
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
@@ -219,34 +224,34 @@ public @Data class Filter {
     })
     @Accessors(chain = true)
     @EqualsAndHashCode(callSuper = true)
-    public abstract static @Data class BinarySpatialOperator extends BinaryOperator {
+    public abstract static @Data @Generated class BinarySpatialOperator extends BinaryOperator {
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class BBOX extends BinarySpatialOperator {}
+        public static @Data @Generated class BBOX extends BinarySpatialOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class Contains extends BinarySpatialOperator {}
+        public static @Data @Generated class Contains extends BinarySpatialOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class Crosses extends BinarySpatialOperator {}
+        public static @Data @Generated class Crosses extends BinarySpatialOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class Disjoint extends BinarySpatialOperator {}
+        public static @Data @Generated class Disjoint extends BinarySpatialOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class Equals extends BinarySpatialOperator {}
+        public static @Data @Generated class Equals extends BinarySpatialOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class Intersects extends BinarySpatialOperator {}
+        public static @Data @Generated class Intersects extends BinarySpatialOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class Overlaps extends BinarySpatialOperator {}
+        public static @Data @Generated class Overlaps extends BinarySpatialOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class Touches extends BinarySpatialOperator {}
+        public static @Data @Generated class Touches extends BinarySpatialOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class Within extends BinarySpatialOperator {}
+        public static @Data @Generated class Within extends BinarySpatialOperator {}
 
         @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
         @JsonSubTypes({
@@ -256,16 +261,17 @@ public @Data class Filter {
             @JsonSubTypes.Type(value = Filter.BinarySpatialOperator.Beyond.class, name = "Beyond")
         })
         @EqualsAndHashCode(callSuper = true)
-        public static @Data abstract class DistanceBufferOperator extends BinarySpatialOperator {
+        public static @Data @Generated abstract class DistanceBufferOperator
+                extends BinarySpatialOperator {
             private double distance;
             private String distanceUnits;
         }
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class Beyond extends DistanceBufferOperator {}
+        public static @Data @Generated class Beyond extends DistanceBufferOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class DWithin extends DistanceBufferOperator {}
+        public static @Data @Generated class DWithin extends DistanceBufferOperator {}
     }
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
@@ -291,49 +297,49 @@ public @Data class Filter {
     })
     @Accessors(chain = true)
     @EqualsAndHashCode(callSuper = true)
-    public abstract static @Data class BinaryTemporalOperator extends BinaryOperator {
+    public abstract static @Data @Generated class BinaryTemporalOperator extends BinaryOperator {
 
         @EqualsAndHashCode(callSuper = true)
         @ToString(doNotUseGetters = true, callSuper = true)
-        public static @Data class After extends BinaryTemporalOperator {}
+        public static @Data @Generated class After extends BinaryTemporalOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class AnyInteracts extends BinaryTemporalOperator {}
+        public static @Data @Generated class AnyInteracts extends BinaryTemporalOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class Before extends BinaryTemporalOperator {}
+        public static @Data @Generated class Before extends BinaryTemporalOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class Begins extends BinaryTemporalOperator {}
+        public static @Data @Generated class Begins extends BinaryTemporalOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class BegunBy extends BinaryTemporalOperator {}
+        public static @Data @Generated class BegunBy extends BinaryTemporalOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class During extends BinaryTemporalOperator {}
+        public static @Data @Generated class During extends BinaryTemporalOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class EndedBy extends BinaryTemporalOperator {}
+        public static @Data @Generated class EndedBy extends BinaryTemporalOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class Ends extends BinaryTemporalOperator {}
+        public static @Data @Generated class Ends extends BinaryTemporalOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class Meets extends BinaryTemporalOperator {}
+        public static @Data @Generated class Meets extends BinaryTemporalOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class MetBy extends BinaryTemporalOperator {}
+        public static @Data @Generated class MetBy extends BinaryTemporalOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class OverlappedBy extends BinaryTemporalOperator {}
+        public static @Data @Generated class OverlappedBy extends BinaryTemporalOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class TContains extends BinaryTemporalOperator {}
+        public static @Data @Generated class TContains extends BinaryTemporalOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class TEquals extends BinaryTemporalOperator {}
+        public static @Data @Generated class TEquals extends BinaryTemporalOperator {}
 
         @EqualsAndHashCode(callSuper = true)
-        public static @Data class TOverlaps extends BinaryTemporalOperator {}
+        public static @Data @Generated class TOverlaps extends BinaryTemporalOperator {}
     }
 }

--- a/src/catalog/jackson-bindings/geotools/src/main/java/org/geotools/jackson/databind/filter/dto/SortBy.java
+++ b/src/catalog/jackson-bindings/geotools/src/main/java/org/geotools/jackson/databind/filter/dto/SortBy.java
@@ -6,12 +6,13 @@ package org.geotools.jackson.databind.filter.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Generated;
 import lombok.NoArgsConstructor;
 
 /** DTO for {@link org.opengis.filter.sort.SortBy} */
 @NoArgsConstructor
 @AllArgsConstructor
-public @Data class SortBy {
+public @Data @Generated class SortBy {
 
     public static enum SortOrder {
         ASCENDING,

--- a/src/catalog/jackson-bindings/geotools/src/main/java/org/geotools/jackson/databind/util/ObjectMapperUtil.java
+++ b/src/catalog/jackson-bindings/geotools/src/main/java/org/geotools/jackson/databind/util/ObjectMapperUtil.java
@@ -1,0 +1,23 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geotools.jackson.databind.util;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @since 1.0
+ */
+public class ObjectMapperUtil {
+
+    public static ObjectMapper newObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setDefaultPropertyInclusion(Include.NON_EMPTY);
+        objectMapper.enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN);
+        objectMapper.findAndRegisterModules();
+        return objectMapper;
+    }
+}

--- a/src/catalog/jackson-bindings/geotools/src/test/java/org/geotools/jackson/databind/filter/ExpressionRoundtripTest.java
+++ b/src/catalog/jackson-bindings/geotools/src/test/java/org/geotools/jackson/databind/filter/ExpressionRoundtripTest.java
@@ -56,6 +56,11 @@ import java.util.stream.IntStream;
  */
 @Slf4j
 public abstract class ExpressionRoundtripTest {
+    private boolean debug = Boolean.valueOf(System.getProperty("debug", "false"));
+
+    protected void print(String logmsg, Object... args) {
+        if (debug) log.debug(logmsg, args);
+    }
 
     protected abstract <E extends Expression> E roundtripTest(E dto) throws Exception;
 
@@ -235,7 +240,7 @@ public abstract class ExpressionRoundtripTest {
         List<FunctionName> allFunctionDescriptions = finder.getAllFunctionDescriptions();
         for (FunctionName functionName : allFunctionDescriptions) {
             if (ignore.contains(functionName.getName())) {
-                log.info(
+                print(
                         "Ignoring function {}, can't represent its arguments in JSON",
                         functionName.getName());
                 continue;
@@ -256,7 +261,7 @@ public abstract class ExpressionRoundtripTest {
     }
 
     private void testFunctionRoundtrip(FunctionName functionDescriptor) throws Exception {
-        log.debug("Testing function {}", functionDescriptor);
+        print("Testing function {}", functionDescriptor);
 
         String name = functionDescriptor.getName();
         Name functionName = functionDescriptor.getFunctionName();
@@ -264,7 +269,7 @@ public abstract class ExpressionRoundtripTest {
         List<String> argumentNames = functionDescriptor.getArgumentNames();
         List<Parameter<?>> arguments = functionDescriptor.getArguments();
         Parameter<?> returnValueDescriptor = functionDescriptor.getReturn();
-        log.debug(
+        print(
                 "functionName: {}, argumentCount: {}, argumentNames: {}, ret: {}",
                 functionName,
                 argumentCount,
@@ -300,7 +305,7 @@ public abstract class ExpressionRoundtripTest {
         dto.setArgumentCount(argumentCount);
         dto.getArgumentNames().addAll(argumentNames);
 
-        log.debug("Testing FunctionName {}", dto);
+        print("Testing FunctionName {}", dto);
         roundtripTest(dto);
     }
 

--- a/src/catalog/jackson-bindings/geotools/src/test/java/org/geotools/jackson/databind/filter/GeoToolsFilterModuleExpressionsTest.java
+++ b/src/catalog/jackson-bindings/geotools/src/test/java/org/geotools/jackson/databind/filter/GeoToolsFilterModuleExpressionsTest.java
@@ -7,13 +7,15 @@ package org.geotools.jackson.databind.filter;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
 
 import org.geotools.jackson.databind.filter.dto.Expression;
 import org.geotools.jackson.databind.filter.dto.Expression.FunctionName;
 import org.geotools.jackson.databind.filter.mapper.ExpressionMapper;
-import org.junit.Before;
+import org.geotools.jackson.databind.util.ObjectMapperUtil;
+import org.junit.BeforeClass;
 import org.mapstruct.factory.Mappers;
 import org.opengis.filter.expression.Function;
 
@@ -21,22 +23,26 @@ import org.opengis.filter.expression.Function;
  * Test suite for {@link GeoToolsFilterModule} serialization and deserialization of {@link
  * org.opengis.filter.expression.Expression}s
  */
+@Slf4j
 public class GeoToolsFilterModuleExpressionsTest extends ExpressionRoundtripTest {
+    private boolean debug = Boolean.valueOf(System.getProperty("debug", "false"));
 
-    private ObjectMapper objectMapper;
-    private ExpressionMapper expressionMapper;
+    protected void print(String logmsg, Object... args) {
+        if (debug) log.debug(logmsg, args);
+    }
 
-    public @Before void before() {
-        objectMapper = new ObjectMapper();
-        objectMapper.setDefaultPropertyInclusion(Include.NON_EMPTY);
-        objectMapper.findAndRegisterModules();
+    private static ObjectMapper objectMapper;
+    private static ExpressionMapper expressionMapper;
+
+    public static @BeforeClass void beforeAll() {
+        objectMapper = ObjectMapperUtil.newObjectMapper();
         expressionMapper = Mappers.getMapper(ExpressionMapper.class);
     }
 
     protected @Override <E extends Expression> E roundtripTest(E dto) throws Exception {
         final org.opengis.filter.expression.Expression expected = expressionMapper.map(dto);
         String serialized = objectMapper.writeValueAsString(expected);
-        System.err.println(serialized);
+        print("serialized: {}", serialized);
         org.opengis.filter.expression.Expression deserialized;
         deserialized =
                 objectMapper.readValue(serialized, org.opengis.filter.expression.Expression.class);
@@ -56,7 +62,7 @@ public class GeoToolsFilterModuleExpressionsTest extends ExpressionRoundtripTest
     protected @Override FunctionName roundtripTest(FunctionName dto) throws Exception {
         org.opengis.filter.capability.FunctionName expected = expressionMapper.map(dto);
         String serialized = objectMapper.writeValueAsString(expected);
-        System.err.println(serialized);
+        print("serialized: {}", serialized);
         org.opengis.filter.capability.FunctionName deserialized =
                 objectMapper.readValue(
                         serialized, org.opengis.filter.capability.FunctionName.class);

--- a/src/catalog/jackson-bindings/geotools/src/test/java/org/geotools/jackson/databind/filter/GeoToolsFilterModuleFiltersTest.java
+++ b/src/catalog/jackson-bindings/geotools/src/test/java/org/geotools/jackson/databind/filter/GeoToolsFilterModuleFiltersTest.java
@@ -6,13 +6,15 @@ package org.geotools.jackson.databind.filter;
 
 import static org.junit.Assert.assertEquals;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
 
 import org.geotools.jackson.databind.filter.dto.Filter;
 import org.geotools.jackson.databind.filter.dto.SortBy;
 import org.geotools.jackson.databind.filter.mapper.FilterMapper;
-import org.junit.Before;
+import org.geotools.jackson.databind.util.ObjectMapperUtil;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mapstruct.factory.Mappers;
@@ -21,23 +23,26 @@ import org.mapstruct.factory.Mappers;
  * Test suite for {@link GeoToolsFilterModule} serialization and deserialization of {@link
  * org.opengis.filter.Filter}s
  */
+@Slf4j
 public class GeoToolsFilterModuleFiltersTest extends FilterRoundtripTest {
+    private boolean debug = Boolean.valueOf(System.getProperty("debug", "false"));
 
-    private ObjectMapper objectMapper;
-    private FilterMapper filterMapper;
+    protected void print(String logmsg, Object... args) {
+        if (debug) log.debug(logmsg, args);
+    }
 
-    public @Before void before() {
-        objectMapper = new ObjectMapper();
-        objectMapper.setDefaultPropertyInclusion(Include.NON_EMPTY);
-        objectMapper.findAndRegisterModules();
+    private static ObjectMapper objectMapper;
+    private static FilterMapper filterMapper;
 
+    public static @BeforeClass void beforeAll() {
+        objectMapper = ObjectMapperUtil.newObjectMapper();
         filterMapper = Mappers.getMapper(FilterMapper.class);
     }
 
     protected @Override <F extends Filter> F roundtripTest(F dto) throws Exception {
         final org.opengis.filter.Filter expected = filterMapper.map(dto);
         String serialized = objectMapper.writeValueAsString(expected);
-        System.err.println(serialized);
+        print("serialized: {}", serialized);
         org.opengis.filter.Filter deserialized;
         deserialized = objectMapper.readValue(serialized, org.opengis.filter.Filter.class);
         assertEquals(expected, deserialized);
@@ -47,7 +52,7 @@ public class GeoToolsFilterModuleFiltersTest extends FilterRoundtripTest {
     protected @Override void roundtripTest(SortBy dto) throws Exception {
         final org.opengis.filter.sort.SortBy expected = filterMapper.map(dto);
         String serialized = objectMapper.writeValueAsString(expected);
-        System.err.println(serialized);
+        print("serialized: {}", serialized);
         org.opengis.filter.sort.SortBy deserialized;
         deserialized = objectMapper.readValue(serialized, org.opengis.filter.sort.SortBy.class);
         assertEquals(expected, deserialized);

--- a/src/catalog/jackson-bindings/geotools/src/test/java/org/geotools/jackson/databind/filter/dto/ExpressionSerializationTest.java
+++ b/src/catalog/jackson-bindings/geotools/src/test/java/org/geotools/jackson/databind/filter/dto/ExpressionSerializationTest.java
@@ -6,30 +6,33 @@ package org.geotools.jackson.databind.filter.dto;
 
 import static org.junit.Assert.assertEquals;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
 
 import org.geotools.jackson.databind.filter.ExpressionRoundtripTest;
 import org.geotools.jackson.databind.filter.dto.Expression.FunctionName;
-import org.junit.Before;
+import org.geotools.jackson.databind.util.ObjectMapperUtil;
+import org.junit.BeforeClass;
 
+@Slf4j
 public class ExpressionSerializationTest extends ExpressionRoundtripTest {
+    private boolean debug = Boolean.valueOf(System.getProperty("debug", "false"));
 
-    private ObjectMapper objectMapper;
+    protected void print(String logmsg, Object... args) {
+        if (debug) log.debug(logmsg, args);
+    }
 
-    public @Before void before() {
-        objectMapper = new ObjectMapper();
-        objectMapper.setDefaultPropertyInclusion(Include.NON_EMPTY);
-        objectMapper.enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN);
-        // should register our modules, but also all the other ones like JavaTimeModule
-        objectMapper.findAndRegisterModules();
+    private static ObjectMapper objectMapper;
+
+    public static @BeforeClass void beforeAll() {
+        objectMapper = ObjectMapperUtil.newObjectMapper();
     }
 
     @SuppressWarnings("unchecked")
     protected @Override <E extends Expression> E roundtripTest(E dto) throws Exception {
         String serialized = objectMapper.writeValueAsString(dto);
-        System.err.println(serialized);
+        print("serialized: {}", serialized);
         Expression deserialized = objectMapper.readValue(serialized, Expression.class);
         assertEquals(dto, deserialized);
         return (E) deserialized;
@@ -37,7 +40,7 @@ public class ExpressionSerializationTest extends ExpressionRoundtripTest {
 
     protected @Override FunctionName roundtripTest(FunctionName dto) throws Exception {
         String serialized = objectMapper.writeValueAsString(dto);
-        System.err.println(serialized);
+        print("serialized: {}", serialized);
         FunctionName deserialized =
                 objectMapper.readValue(serialized, Expression.FunctionName.class);
         assertEquals(dto, deserialized);

--- a/src/catalog/jackson-bindings/geotools/src/test/java/org/geotools/jackson/databind/filter/dto/FilterSerializationTest.java
+++ b/src/catalog/jackson-bindings/geotools/src/test/java/org/geotools/jackson/databind/filter/dto/FilterSerializationTest.java
@@ -6,26 +6,32 @@ package org.geotools.jackson.databind.filter.dto;
 
 import static org.junit.Assert.assertEquals;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.geotools.jackson.databind.filter.FilterRoundtripTest;
-import org.junit.Before;
+import org.geotools.jackson.databind.util.ObjectMapperUtil;
+import org.junit.BeforeClass;
 
+@Slf4j
 public class FilterSerializationTest extends FilterRoundtripTest {
+    private boolean debug = Boolean.valueOf(System.getProperty("debug", "false"));
 
-    private ObjectMapper objectMapper;
+    protected void print(String logmsg, Object... args) {
+        if (debug) log.debug(logmsg, args);
+    }
 
-    public @Before void before() {
-        objectMapper = new ObjectMapper();
-        objectMapper.setDefaultPropertyInclusion(Include.NON_EMPTY);
-        objectMapper.findAndRegisterModules();
+    private static ObjectMapper objectMapper;
+
+    public static @BeforeClass void beforeAll() {
+        objectMapper = ObjectMapperUtil.newObjectMapper();
     }
 
     @SuppressWarnings("unchecked")
     protected @Override <F extends Filter> F roundtripTest(F dto) throws Exception {
         String serialized = objectMapper.writeValueAsString(dto);
-        System.err.println(serialized);
+        print("serialized: {}", serialized);
         Filter deserialized = objectMapper.readValue(serialized, Filter.class);
         assertEquals(dto, deserialized);
         return (F) deserialized;
@@ -33,7 +39,7 @@ public class FilterSerializationTest extends FilterRoundtripTest {
 
     protected @Override void roundtripTest(SortBy dto) throws Exception {
         String serialized = objectMapper.writeValueAsString(dto);
-        System.err.println(serialized);
+        print("serialized: {}", serialized);
         SortBy deserialized = objectMapper.readValue(serialized, SortBy.class);
         assertEquals(dto, deserialized);
     }

--- a/src/catalog/jackson-bindings/geotools/src/test/java/org/geotools/jackson/databind/geojson/GeoToolsGeoJsonModuleTest.java
+++ b/src/catalog/jackson-bindings/geotools/src/test/java/org/geotools/jackson/databind/geojson/GeoToolsGeoJsonModuleTest.java
@@ -7,11 +7,13 @@ package org.geotools.jackson.databind.geojson;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.junit.Before;
+import lombok.extern.slf4j.Slf4j;
+
+import org.geotools.jackson.databind.util.ObjectMapperUtil;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
@@ -33,14 +35,18 @@ import java.util.EnumSet;
 /**
  * Test suite for {@link GeoToolsGeoJsonModule}, assuming it's registered to an {@link ObjectMapper}
  */
+@Slf4j
 public class GeoToolsGeoJsonModuleTest {
+    private boolean debug = Boolean.valueOf(System.getProperty("debug", "false"));
 
-    private ObjectMapper objectMapper;
+    protected void print(String logmsg, Object... args) {
+        if (debug) log.debug(logmsg, args);
+    }
 
-    public @Before void before() {
-        objectMapper = new ObjectMapper();
-        objectMapper.setDefaultPropertyInclusion(Include.NON_EMPTY);
-        objectMapper.findAndRegisterModules();
+    private static ObjectMapper objectMapper;
+
+    public static @BeforeClass void beforeAll() {
+        objectMapper = ObjectMapperUtil.newObjectMapper();
     }
 
     public @Test void testEmptyGeometries() throws JsonProcessingException {
@@ -125,10 +131,10 @@ public class GeoToolsGeoJsonModuleTest {
     private Geometry roundtripTest(Geometry orig) throws JsonProcessingException {
         String preWkt = toWKT(orig);
         String serialized = objectMapper.writeValueAsString(orig);
-        System.err.println(serialized);
+        print("serialized: {}", serialized);
         Geometry deserialized = objectMapper.readValue(serialized, Geometry.class);
         String postWkt = toWKT(deserialized);
-        System.err.printf(" orig: %s%n read: %s%n%n", preWkt, postWkt);
+        print("orig: {}\n read: {}", preWkt, postWkt);
         assertActuallyEqualsExact(orig, deserialized);
         return deserialized;
     }

--- a/src/catalog/jackson-bindings/starter/src/test/resources/logback-test.xml
+++ b/src/catalog/jackson-bindings/starter/src/test/resources/logback-test.xml
@@ -1,0 +1,13 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.springframework" level="WARN"/>
+</configuration>

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogPlugin.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogPlugin.java
@@ -1360,6 +1360,8 @@ public class CatalogPlugin extends CatalogImpl implements Catalog {
     }
 
     protected <T extends CatalogInfo> void doAdd(T object, Function<T, T> inserter) {
+        Objects.requireNonNull(object, "object");
+        Objects.requireNonNull(inserter, "insert function");
         setId(object);
         validationSupport.validate(object, true);
         T added;

--- a/src/catalog/plugin/src/test/java/org/geoserver/catalog/CatalogConformanceTest.java
+++ b/src/catalog/plugin/src/test/java/org/geoserver/catalog/CatalogConformanceTest.java
@@ -127,7 +127,7 @@ public abstract class CatalogConformanceTest {
         dataAccessRuleDAO = new DataAccessRuleDAO(dd, rawCatalog);
         dataAccessRuleDAO.reload();
 
-        data = CatalogTestData.empty(() -> rawCatalog, () -> null).createCatalogObjects();
+        data = CatalogTestData.empty(() -> rawCatalog, () -> null).initialize();
     }
 
     protected <T extends CatalogInfo> T add(T info, Consumer<T> adder, Function<String, T> query) {

--- a/src/catalog/plugin/src/test/java/org/geoserver/catalog/faker/CatalogFaker.java
+++ b/src/catalog/plugin/src/test/java/org/geoserver/catalog/faker/CatalogFaker.java
@@ -1,0 +1,645 @@
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.catalog.faker;
+
+import com.github.javafaker.Address;
+import com.github.javafaker.Faker;
+import com.google.common.collect.Lists;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import org.geoserver.catalog.AttributionInfo;
+import org.geoserver.catalog.AuthorityURLInfo;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogFactory;
+import org.geoserver.catalog.CoverageDimensionInfo;
+import org.geoserver.catalog.CoverageInfo;
+import org.geoserver.catalog.CoverageStoreInfo;
+import org.geoserver.catalog.DataLinkInfo;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.DimensionDefaultValueSetting;
+import org.geoserver.catalog.DimensionDefaultValueSetting.Strategy;
+import org.geoserver.catalog.DimensionInfo;
+import org.geoserver.catalog.DimensionPresentation;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.Keyword;
+import org.geoserver.catalog.KeywordInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.LegendInfo;
+import org.geoserver.catalog.MetadataLinkInfo;
+import org.geoserver.catalog.MetadataMap;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.PublishedInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StoreInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WMSLayerInfo;
+import org.geoserver.catalog.WMSStoreInfo;
+import org.geoserver.catalog.WMTSLayerInfo;
+import org.geoserver.catalog.WMTSStoreInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.AttributionInfoImpl;
+import org.geoserver.catalog.impl.AuthorityURL;
+import org.geoserver.catalog.impl.CoverageDimensionImpl;
+import org.geoserver.catalog.impl.DataLinkInfoImpl;
+import org.geoserver.catalog.impl.DataStoreInfoImpl;
+import org.geoserver.catalog.impl.DimensionInfoImpl;
+import org.geoserver.catalog.impl.LayerGroupInfoImpl;
+import org.geoserver.catalog.impl.LayerIdentifier;
+import org.geoserver.catalog.impl.LegendInfoImpl;
+import org.geoserver.catalog.impl.MetadataLinkInfoImpl;
+import org.geoserver.config.ContactInfo;
+import org.geoserver.config.CoverageAccessInfo;
+import org.geoserver.config.CoverageAccessInfo.QueueType;
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.GeoServerInfo;
+import org.geoserver.config.GeoServerInfo.WebUIMode;
+import org.geoserver.config.JAIInfo;
+import org.geoserver.config.JAIInfo.PngEncoderType;
+import org.geoserver.config.LoggingInfo;
+import org.geoserver.config.ResourceErrorHandling;
+import org.geoserver.config.SettingsInfo;
+import org.geoserver.config.impl.ContactInfoImpl;
+import org.geoserver.config.impl.CoverageAccessInfoImpl;
+import org.geoserver.config.impl.GeoServerInfoImpl;
+import org.geoserver.config.impl.JAIEXTInfoImpl;
+import org.geoserver.config.impl.JAIInfoImpl;
+import org.geoserver.config.impl.LoggingInfoImpl;
+import org.geoserver.config.impl.ServiceInfoImpl;
+import org.geoserver.config.impl.SettingsInfoImpl;
+import org.geoserver.ows.util.OwsUtils;
+import org.geoserver.wfs.GMLInfo;
+import org.geoserver.wfs.GMLInfo.SrsNameStyle;
+import org.geoserver.wfs.GMLInfoImpl;
+import org.geotools.util.GrowableInternationalString;
+import org.geotools.util.NumberRange;
+import org.geotools.util.SimpleInternationalString;
+import org.geotools.util.Version;
+import org.opengis.coverage.SampleDimensionType;
+import org.opengis.util.InternationalString;
+import org.springframework.util.Assert;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Accessors(fluent = true)
+public class CatalogFaker {
+
+    private final @Getter Faker faker;
+    private Supplier<Catalog> catalog;
+    private Supplier<GeoServer> geoserver;
+
+    public CatalogFaker(@NonNull Catalog catalog, @NonNull GeoServer geoserver) {
+        this(() -> catalog, () -> geoserver);
+    }
+
+    public CatalogFaker(
+            @NonNull Catalog catalog, @NonNull GeoServer geoserver, @NonNull Locale locale) {
+        this(() -> catalog, () -> geoserver, locale);
+    }
+
+    public CatalogFaker(Supplier<Catalog> catalog, Supplier<GeoServer> geoserver) {
+        this(catalog, geoserver, Locale.ENGLISH);
+    }
+
+    public CatalogFaker(
+            @NonNull Supplier<Catalog> catalog,
+            @NonNull Supplier<GeoServer> geoserver,
+            @NonNull Locale locale) {
+        this.catalog = catalog;
+        this.geoserver = geoserver;
+        this.faker = new Faker(locale);
+    }
+
+    public CatalogFaker italian() {
+        return to(Locale.ITALIAN);
+    }
+
+    public CatalogFaker german() {
+        return to(Locale.GERMAN);
+    }
+
+    public CatalogFaker to(@NonNull Locale locale) {
+        return new CatalogFaker(catalog, geoserver, locale);
+    }
+
+    private Catalog catalog() {
+        return catalog.get();
+    }
+
+    private CatalogFactory catalogFactory() {
+        return catalog().getFactory();
+    }
+
+    public LayerGroupInfo layerGroupInfo(
+            String id, WorkspaceInfo workspace, String name, PublishedInfo layer, StyleInfo style) {
+        // not using factory cause SecuredCatalog would return SecuredLayerGroupInfo which has no id
+        // setter
+        LayerGroupInfo lg = new LayerGroupInfoImpl();
+        OwsUtils.set(lg, "id", id);
+        lg.setName(name);
+        lg.setWorkspace(workspace);
+        lg.getLayers().add(layer);
+        lg.getStyles().add(style);
+        OwsUtils.resolveCollections(lg);
+        return lg;
+    }
+
+    public LayerInfo layerInfo(ResourceInfo resource, StyleInfo defaultStyle) {
+
+        return layerInfo(
+                resource.getName() + "-layer-id",
+                resource,
+                resource.getName() + " title",
+                true,
+                defaultStyle);
+    }
+
+    public LayerInfo layerInfo(
+            String id,
+            ResourceInfo resource,
+            String title,
+            boolean enabled,
+            StyleInfo defaultStyle,
+            StyleInfo... additionalStyles) {
+        LayerInfo lyr = catalogFactory().createLayer();
+        OwsUtils.set(lyr, "id", id);
+        lyr.setResource(resource);
+        lyr.setEnabled(enabled);
+        lyr.setDefaultStyle(defaultStyle);
+        lyr.setTitle(title);
+        for (int i = 0; null != additionalStyles && i < additionalStyles.length; i++) {
+            lyr.getStyles().add(additionalStyles[i]);
+        }
+        OwsUtils.resolveCollections(lyr);
+        return lyr;
+    }
+
+    public StyleInfo styleInfo(@NonNull String name) {
+        return styleInfo(name, (WorkspaceInfo) null);
+    }
+
+    public StyleInfo styleInfo(@NonNull String name, WorkspaceInfo workspace) {
+        return styleInfo(name + "-id", workspace, name, name + ".sld");
+    }
+
+    public StyleInfo styleInfo(String id, WorkspaceInfo workspace, String name, String fileName) {
+        StyleInfo st = catalogFactory().createStyle();
+        OwsUtils.set(st, "id", id);
+        st.setWorkspace(workspace);
+        st.setName(name);
+        st.setFilename(fileName);
+        OwsUtils.resolveCollections(st);
+        return st;
+    }
+
+    public WMTSLayerInfo wmtsLayerInfo(
+            String id, StoreInfo store, NamespaceInfo namespace, String name, boolean enabled) {
+        WMTSLayerInfo wmtsl = catalogFactory().createWMTSLayer();
+        OwsUtils.set(wmtsl, "id", id);
+        wmtsl.setStore(store);
+        wmtsl.setNamespace(namespace);
+        wmtsl.setName(name);
+        wmtsl.setEnabled(enabled);
+        OwsUtils.resolveCollections(wmtsl);
+        return wmtsl;
+    }
+
+    public WMTSStoreInfo wmtsStoreInfo(
+            String id, WorkspaceInfo workspace, String name, String url, boolean enabled) {
+        WMTSStoreInfo wmtss = catalogFactory().createWebMapTileServer();
+        OwsUtils.set(wmtss, "id", id);
+        wmtss.setWorkspace(workspace);
+        wmtss.setName(name);
+        wmtss.setType("WMTS");
+        wmtss.setCapabilitiesURL(url);
+        wmtss.setEnabled(enabled);
+        OwsUtils.resolveCollections(wmtss);
+        return wmtss;
+    }
+
+    public WMSLayerInfo wmsLayerInfo(
+            String id, StoreInfo store, NamespaceInfo namespace, String name, boolean enabled) {
+        WMSLayerInfo wmsl = catalogFactory().createWMSLayer();
+        OwsUtils.set(wmsl, "id", id);
+        wmsl.setStore(store);
+        wmsl.setNamespace(namespace);
+        wmsl.setName(name);
+        wmsl.setEnabled(enabled);
+        OwsUtils.resolveCollections(wmsl);
+        return wmsl;
+    }
+
+    public WMSStoreInfo wmsStoreInfo(
+            String id, WorkspaceInfo wspace, String name, String url, boolean enabled) {
+        WMSStoreInfo wms = catalogFactory().createWebMapServer();
+        OwsUtils.set(wms, "id", id);
+        wms.setName(name);
+        wms.setType("WMS");
+        wms.setCapabilitiesURL(url);
+        wms.setWorkspace(wspace);
+        wms.setEnabled(enabled);
+        OwsUtils.resolveCollections(wms);
+        return wms;
+    }
+
+    public CoverageInfo coverageInfo(String id, CoverageStoreInfo cstore, String name) {
+        CoverageInfo coverage = catalogFactory().createCoverage();
+        OwsUtils.set(coverage, "id", id);
+        coverage.setName(name);
+        coverage.setStore(cstore);
+        OwsUtils.resolveCollections(coverage);
+        return coverage;
+    }
+
+    public CoverageStoreInfo coverageStoreInfo(
+            String id, WorkspaceInfo ws, String name, String coverageType, String uri) {
+        CoverageStoreInfo cstore = catalogFactory().createCoverageStore();
+        OwsUtils.set(cstore, "id", id);
+        cstore.setName(name);
+        cstore.setType(coverageType);
+        cstore.setURL(uri);
+        cstore.setWorkspace(ws);
+        OwsUtils.resolveCollections(cstore);
+        return cstore;
+    }
+
+    public FeatureTypeInfo featureTypeInfo(
+            String id,
+            DataStoreInfo ds,
+            NamespaceInfo ns,
+            String name,
+            String ftAbstract,
+            String ftDescription,
+            boolean enabled) {
+        FeatureTypeInfo fttype = catalogFactory().createFeatureType();
+        OwsUtils.set(fttype, "id", id);
+        fttype.setEnabled(true);
+        fttype.setName(name);
+        fttype.setAbstract(ftAbstract);
+        fttype.setDescription(ftDescription);
+        fttype.setStore(ds);
+        fttype.setNamespace(ns);
+        OwsUtils.resolveCollections(fttype);
+        return fttype;
+    }
+
+    public DataStoreInfo dataStoreInfo(String name, WorkspaceInfo ws) {
+        return dataStoreInfo(name + "-id", ws, name, name + " description", true);
+    }
+
+    public DataStoreInfo dataStoreInfo(
+            String id, WorkspaceInfo ws, String name, String description, boolean enabled) {
+        DataStoreInfoImpl dstore = (DataStoreInfoImpl) catalogFactory().createDataStore();
+        OwsUtils.set(dstore, "id", id);
+        dstore.setEnabled(enabled);
+        dstore.setName(name);
+        dstore.setDescription(description);
+        dstore.setWorkspace(ws);
+        dstore.setConnectionParameters(new HashMap<>());
+        // note: using only string param values to avoid assertEquals() failures due to
+        // serialization/deserialization losing type of parameter values
+        dstore.getConnectionParameters().put("param1", "test value");
+        dstore.getConnectionParameters().put("param2", "1000");
+        OwsUtils.resolveCollections(dstore);
+        return dstore;
+    }
+
+    public WorkspaceInfo workspaceInfo(String name) {
+        return workspaceInfo(name + "-id", name);
+    }
+
+    public WorkspaceInfo workspaceInfo(String id, String name) {
+        WorkspaceInfo workspace = catalogFactory().createWorkspace();
+        OwsUtils.set(workspace, "id", id);
+        workspace.setName(name);
+        OwsUtils.resolveCollections(workspace);
+        return workspace;
+    }
+
+    private String url() {
+        return faker().company().url();
+    }
+
+    private String id() {
+        return faker().idNumber().valid();
+    }
+
+    public NamespaceInfo namespace() {
+        return namespace(id(), faker().letterify("ns-????"), url());
+    }
+
+    public NamespaceInfo namespace(String name) {
+        return namespace(id(), name, url());
+    }
+
+    public NamespaceInfo namespace(String id, String name, String uri) {
+        NamespaceInfo namesapce = catalogFactory().createNamespace();
+        OwsUtils.set(namesapce, "id", id);
+        namesapce.setPrefix(name);
+        namesapce.setURI(uri);
+        OwsUtils.resolveCollections(namesapce);
+        return namesapce;
+    }
+
+    public GeoServerInfo geoServerInfo() {
+        GeoServerInfoImpl g = new GeoServerInfoImpl();
+
+        g.setId("GeoServer.global");
+        g.setAdminPassword("geoserver");
+        g.setAdminUsername("admin");
+        g.setAllowStoredQueriesPerWorkspace(true);
+        g.setCoverageAccess(createCoverageAccessInfo());
+        g.setFeatureTypeCacheSize(1000);
+        g.setGlobalServices(true);
+        g.setId("GeoServer.global");
+        g.setJAI(jaiInfo());
+        // don't set lock provider to avoid a warning stack trace that the bean does not exist
+        // g.setLockProviderName("testLockProvider");
+        g.setMetadata(metadataMap("k1", Integer.valueOf(1), "k2", "2", "k3", Boolean.FALSE));
+        g.setResourceErrorHandling(ResourceErrorHandling.OGC_EXCEPTION_REPORT);
+        g.setSettings(settingsInfo(null));
+        g.setUpdateSequence(999);
+        g.setUseHeadersProxyURL(true);
+        g.setWebUIMode(WebUIMode.DO_NOT_REDIRECT);
+        g.setXmlExternalEntitiesEnabled(Boolean.TRUE);
+        g.setXmlPostRequestLogBufferSize(1024);
+
+        return g;
+    }
+
+    public MetadataMap metadataMap(Serializable... kvps) {
+        Assert.isTrue(kvps == null || kvps.length % 2 == 0, "expected even number");
+        MetadataMap m = new MetadataMap();
+        if (kvps != null) {
+            for (int i = 0; i < kvps.length; i += 2) {
+                m.put((String) kvps[i], kvps[i + 1]);
+            }
+        }
+        return m;
+    }
+
+    public JAIInfo jaiInfo() {
+        JAIInfo jai = new JAIInfoImpl();
+        jai.setAllowInterpolation(true);
+        jai.setAllowNativeMosaic(true);
+        jai.setAllowNativeWarp(true);
+
+        JAIEXTInfoImpl jaiext = new JAIEXTInfoImpl();
+        jaiext.setJAIEXTOperations(Collections.singleton("categorize"));
+        jaiext.setJAIOperations(Collections.singleton("band"));
+        jai.setJAIEXTInfo(jaiext);
+
+        jai.setJpegAcceleration(true);
+        jai.setMemoryCapacity(4096);
+        jai.setMemoryThreshold(0.75);
+        jai.setPngEncoderType(PngEncoderType.PNGJ);
+        jai.setRecycling(true);
+        jai.setTilePriority(1);
+        jai.setTileThreads(7);
+        return jai;
+    }
+
+    private CoverageAccessInfo createCoverageAccessInfo() {
+        CoverageAccessInfoImpl c = new CoverageAccessInfoImpl();
+        c.setCorePoolSize(9);
+        c.setImageIOCacheThreshold(11);
+        c.setKeepAliveTime(1000);
+        c.setMaxPoolSize(18);
+        c.setQueueType(QueueType.UNBOUNDED);
+        return c;
+    }
+
+    public ContactInfo contactInfo() {
+        ContactInfoImpl c = new ContactInfoImpl();
+
+        Address fakeAddress = faker.address();
+
+        c.setId(faker.idNumber().valid());
+        c.setAddress(fakeAddress.fullAddress());
+        c.setAddressCity(fakeAddress.cityName());
+        c.setAddressCountry(fakeAddress.country());
+        c.setAddressDeliveryPoint(fakeAddress.secondaryAddress());
+        c.setAddressPostalCode(fakeAddress.zipCode());
+        c.setAddressState(fakeAddress.state());
+
+        // c.setContactEmail(faker.hacker().);
+        c.setContactFacsimile(faker.phoneNumber().phoneNumber());
+        c.setContactOrganization(faker.company().name());
+        c.setContactPerson(faker.name().fullName());
+        c.setContactVoice(faker.phoneNumber().cellPhone());
+        c.setOnlineResource(faker.company().url());
+
+        Address it = italian().faker().address();
+        Address de = german().faker().address();
+        c.setInternationalAddress(
+                internationalString(
+                        Locale.ITALIAN, it.fullAddress(), Locale.GERMAN, de.fullAddress()));
+        return c;
+    }
+
+    public LoggingInfo loggingInfo() {
+        LoggingInfoImpl l = new LoggingInfoImpl();
+        l.setId("weird-this-has-id");
+        l.setLevel("super");
+        l.setLocation("there");
+        l.setStdOutLogging(true);
+        return l;
+    }
+
+    public SettingsInfo settingsInfo(WorkspaceInfo workspace) {
+        SettingsInfo s = new SettingsInfoImpl();
+        s.setWorkspace(workspace);
+        String id = workspace == null ? "global-settings-id" : workspace.getName() + "-settings-id";
+        OwsUtils.set(s, "id", id);
+
+        s.setTitle(workspace == null ? "Global Settings" : workspace.getName() + " Settings");
+        s.setCharset("UTF-8");
+        s.setContact(contactInfo());
+        s.getMetadata()
+                .putAll(metadataMap("k1", Integer.valueOf(1), "k2", "2", "k3", Boolean.FALSE));
+        s.setNumDecimals(9);
+        s.setOnlineResource("http://geoserver.org");
+        s.setProxyBaseUrl("http://test.geoserver.org");
+        s.setSchemaBaseUrl("file:data/schemas");
+        s.setVerbose(true);
+        s.setVerboseExceptions(true);
+        return s;
+    }
+
+    public <S extends ServiceInfoImpl> S serviceInfo(String name, Supplier<S> factory) {
+        S s = factory.get();
+        s.setId(name + "-id");
+        s.setName(name);
+        s.setTitle(name + " Title");
+        s.setAbstract(name + " Abstract");
+        s.setInternationalTitle(
+                internationalString(
+                        Locale.ENGLISH,
+                        name + " english title",
+                        Locale.CANADA_FRENCH,
+                        name + "titre anglais"));
+        s.setInternationalAbstract(
+                internationalString(
+                        Locale.ENGLISH,
+                        name + " english abstract",
+                        Locale.CANADA_FRENCH,
+                        name + "résumé anglais"));
+        s.setAccessConstraints("NONE");
+        s.setCiteCompliant(true);
+        s.setEnabled(true);
+        s.setExceptionFormats(Collections.singletonList("fake-" + name + "-exception-format"));
+        s.setFees("NONE");
+        s.setKeywords(Lists.newArrayList(keywordInfo(), keywordInfo()));
+        s.setMaintainer("Claudious whatever");
+        s.setMetadata(metadataMap(name, "something"));
+        MetadataLinkInfoImpl metadataLink = new MetadataLinkInfoImpl();
+        metadataLink.setAbout("about");
+        metadataLink.setContent("content");
+        metadataLink.setId("medatata-link-" + name);
+        metadataLink.setMetadataType("fake");
+        metadataLink.setType("void");
+        s.setMetadataLink(metadataLink);
+        s.setOnlineResource("http://geoserver.org/" + name);
+        s.setOutputStrategy("SPEED");
+        s.setSchemaBaseURL("file:data/" + name);
+        s.setVerbose(true);
+        List<Version> versions = Lists.newArrayList(new Version("1.0.0"), new Version("2.0.0"));
+        s.getVersions().addAll(versions);
+        return s;
+    }
+
+    public KeywordInfo keywordInfo() {
+        Keyword k1 = new Keyword(faker().chuckNorris().fact());
+        k1.setLanguage("eng");
+        k1.setVocabulary("watchit");
+        return k1;
+    }
+
+    public AuthorityURLInfo authorityURLInfo() {
+        AuthorityURL a1 = new AuthorityURL();
+        a1.setHref(faker().company().url());
+        a1.setName(faker().numerify("test-auth-url-####"));
+        return a1;
+    }
+
+    public List<AuthorityURLInfo> authUrls(int count) {
+        return IntStream.range(0, count)
+                .mapToObj(i -> this.authorityURLInfo())
+                .collect(Collectors.toList());
+    }
+
+    public InternationalString internationalString(String val) {
+        return new SimpleInternationalString(val);
+    }
+
+    public GrowableInternationalString internationalString(Locale l, String val) {
+        GrowableInternationalString s = new GrowableInternationalString();
+        s.add(l, val);
+        return s;
+    }
+
+    public GrowableInternationalString internationalString(
+            Locale l1, String val1, Locale l2, String val2) {
+        GrowableInternationalString s = new GrowableInternationalString();
+        s.add(l1, val1);
+        s.add(l2, val2);
+        return s;
+    }
+
+    public AttributionInfo attributionInfo() throws Exception {
+        AttributionInfoImpl attinfo = new AttributionInfoImpl();
+        attinfo.setId(faker.idNumber().valid());
+        attinfo.setHref(faker.company().url());
+        attinfo.setLogoWidth(faker.number().numberBetween(128, 512));
+        attinfo.setLogoHeight(faker.number().numberBetween(128, 512));
+        attinfo.setTitle(faker.company().bs());
+        return attinfo;
+    }
+
+    public MetadataLinkInfo metadataLink() {
+        MetadataLinkInfoImpl link = new MetadataLinkInfoImpl();
+        link.setId(faker().idNumber().valid());
+        link.setAbout(faker().company().buzzword());
+        link.setContent(faker().company().url());
+        link.setMetadataType("metadataType");
+        link.setType("type");
+        return link;
+    }
+
+    public CoverageDimensionInfo coverageDimensionInfo() {
+        CoverageDimensionImpl c = new CoverageDimensionImpl();
+        c.setDescription(faker().company().bs());
+        c.setDimensionType(SampleDimensionType.UNSIGNED_1BIT);
+        c.setId(faker.idNumber().valid());
+        c.setName(faker.internet().domainName());
+        c.setNullValues(Lists.newArrayList(0.0)); // , Double.NEGATIVE_INFINITY,
+        // Double.POSITIVE_INFINITY));
+        c.setRange(NumberRange.create(0.0, 255.0));
+        c.setUnit("unit");
+        return c;
+    }
+
+    public DimensionInfo dimensionInfo() {
+        DimensionInfoImpl di = new DimensionInfoImpl();
+        di.setAcceptableInterval("searchRange");
+        di.setAttribute("attribute");
+        DimensionDefaultValueSetting defaultValue = new DimensionDefaultValueSetting();
+        defaultValue.setReferenceValue("referenceValue");
+        defaultValue.setStrategyType(Strategy.MAXIMUM);
+        di.setDefaultValue(defaultValue);
+        di.setEnabled(faker.bool().bool());
+        di.setNearestMatchEnabled(faker.bool().bool());
+        di.setResolution(BigDecimal.valueOf(faker.number().randomDouble(4, 0, 1000)));
+        di.setUnits("metre");
+        di.setUnitSymbol("m");
+        di.setPresentation(DimensionPresentation.DISCRETE_INTERVAL);
+        return di;
+    }
+
+    public DataLinkInfo dataLinkInfo() {
+        DataLinkInfoImpl dl = new DataLinkInfoImpl();
+        dl.setAbout(faker.yoda().quote());
+        dl.setContent(faker.internet().url());
+        dl.setId(faker.idNumber().valid());
+        dl.setType(faker.internet().domainWord());
+        return dl;
+    }
+
+    public LayerIdentifier layerIdentifierInfo() {
+        org.geoserver.catalog.impl.LayerIdentifier li = new LayerIdentifier();
+        li.setAuthority(faker.company().url());
+        li.setIdentifier(faker.idNumber().valid());
+        return li;
+    }
+
+    public LegendInfo legendInfo() {
+        LegendInfoImpl l = new LegendInfoImpl();
+        l.setFormat("image/png");
+        l.setHeight(faker.number().numberBetween(10, 20));
+        l.setWidth(faker.number().numberBetween(10, 20));
+        l.setOnlineResource(faker.internet().url());
+        l.setId(faker.idNumber().valid());
+        return l;
+    }
+
+    public GMLInfo gmlInfo() {
+        GMLInfo info = new GMLInfoImpl();
+        info.setMimeTypeToForce("application/gml;test=true");
+        info.setOverrideGMLAttributes(true);
+        info.setSrsNameStyle(SrsNameStyle.URN);
+        return info;
+    }
+}

--- a/src/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/NamespaceRepositoryTest.java
+++ b/src/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/NamespaceRepositoryTest.java
@@ -9,19 +9,16 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
-import lombok.Getter;
-import lombok.experimental.Accessors;
-
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.NamespaceRepository;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.experimental.Accessors;
 
 @EnableAutoConfiguration
 @Accessors(fluent = true)
@@ -45,8 +42,8 @@ public class NamespaceRepositoryTest
     }
 
     public @Override @Test void testFindAllByType() {
-        super.testFindAllIncludeFilter(
-                NamespaceInfo.class, testData.namespaceA, testData.namespaceB, testData.namespaceC);
+        super.testFindAllIncludeFilter(NamespaceInfo.class, testData.namespaceA,
+                testData.namespaceB, testData.namespaceC);
     }
 
     public @Override @Test void testFindById() {
@@ -82,17 +79,13 @@ public class NamespaceRepositoryTest
     }
 
     private void testFindByPrefix(NamespaceInfo expected) {
-        assertEquals(
-                expected,
+        assertEquals(expected,
                 repository.findFirstByName(expected.getPrefix(), NamespaceInfo.class).get());
     }
 
     public @Test void testNamespaceInfo_CRUD() throws IOException {
-        NamespaceInfo ns = testData.createNamespace("namedpaceCRUD", "http://namespace.crud.test");
-        crudTest(
-                ns,
-                serverCatalog::getNamespace,
-                n -> n.setPrefix("modified-prefix"),
+        NamespaceInfo ns = testData.faker().namespace();
+        crudTest(ns, serverCatalog::getNamespace, n -> n.setPrefix("modified-prefix"),
                 (old, updated) -> assertEquals("modified-prefix", updated.getPrefix()));
     }
 
@@ -120,7 +113,7 @@ public class NamespaceRepositoryTest
     public @Test void testSetDefaultNamespaceNonExistent() {
         assertEquals(testData.namespaceA, serverCatalog.getDefaultNamespace());
 
-        NamespaceInfo nonExistent = testData.createNamespace("invalid", "nonExistentURI");
+        NamespaceInfo nonExistent = testData.faker().namespace();
         repository.setDefaultNamespace(nonExistent);
         assertEquals(testData.namespaceA, repository.getDefaultNamespace().get());
         assertEquals(testData.namespaceA, serverCatalog.getDefaultNamespace());
@@ -152,8 +145,8 @@ public class NamespaceRepositoryTest
 
     public @Test void testFindOneNamespaceByURI() {
         NamespaceInfo ns1 = testData.namespaceA;
-        NamespaceInfo ns2 =
-                testData.createNamespace("second-ns-with-duplicate-uri", "prefix2", ns1.getURI());
+        NamespaceInfo ns2 = testData.faker().namespace();
+        ns2.setURI(ns1.getURI());
         ns2.setIsolated(true);
         serverCatalog.add(ns2);
 
@@ -165,8 +158,8 @@ public class NamespaceRepositoryTest
 
     public @Test void testFindAllNamespacesByURI() {
         NamespaceInfo ns1 = testData.namespaceA;
-        NamespaceInfo ns2 =
-                testData.createNamespace("second-ns-with-duplicate-uri", "prefix2", ns1.getURI());
+        NamespaceInfo ns2 = testData.faker().namespace();
+        ns2.setURI(ns1.getURI());
         ns2.setIsolated(true);
         serverCatalog.add(ns2);
 
@@ -179,8 +172,8 @@ public class NamespaceRepositoryTest
 
     public @Test void testCreateNamespaceDuplicateURI() {
         NamespaceInfo ns1 = testData.namespaceA;
-        NamespaceInfo ns2 =
-                testData.createNamespace("second-ns-with-duplicate-uri", "prefix2", ns1.getURI());
+        NamespaceInfo ns2 = testData.faker().namespace();
+        ns2.setURI(ns1.getURI());
         try {
             repository.add(ns2);
             fail("expected exception");

--- a/src/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/StoreRepositoryTest.java
+++ b/src/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/StoreRepositoryTest.java
@@ -132,7 +132,7 @@ public class StoreRepositoryTest
     public @Test void testSetDefaultDataStore() {
         WorkspaceInfo ws = testData.workspaceA;
         DataStoreInfo ds1 = testData.dataStoreA;
-        DataStoreInfo ds2 = testData.createDataStore("wsA-ds2", ws);
+        DataStoreInfo ds2 = testData.faker().dataStoreInfo("wsA-ds2", ws);
         serverCatalog.add(ds2);
         assertEquals(ds1.getId(), repository().getDefaultDataStore(ws).get().getId());
 
@@ -170,8 +170,8 @@ public class StoreRepositoryTest
         WorkspaceInfo wsA = testData.workspaceA;
         WorkspaceInfo wsB = testData.workspaceB;
 
-        DataStoreInfo dsA2 = testData.createDataStore("wsA-ds2", wsA);
-        DataStoreInfo dsB2 = testData.createDataStore("wsB-ds2", wsB);
+        DataStoreInfo dsA2 = testData.faker().dataStoreInfo("wsA-ds2", wsA);
+        DataStoreInfo dsB2 = testData.faker().dataStoreInfo("wsB-ds2", wsB);
         serverCatalog.add(dsA2);
         serverCatalog.add(dsB2);
 
@@ -198,8 +198,8 @@ public class StoreRepositoryTest
     public @Test void testGetDefaultDataStores() {
         WorkspaceInfo wsA = testData.workspaceA;
         WorkspaceInfo wsB = testData.workspaceB;
-        DataStoreInfo dsA2 = testData.createDataStore("wsA-ds2", wsA);
-        DataStoreInfo dsB2 = testData.createDataStore("wsB-ds2", wsB);
+        DataStoreInfo dsA2 = testData.faker().dataStoreInfo("wsA-ds2", wsA);
+        DataStoreInfo dsB2 = testData.faker().dataStoreInfo("wsB-ds2", wsB);
         serverCatalog.add(dsA2);
         serverCatalog.add(dsB2);
 
@@ -242,7 +242,7 @@ public class StoreRepositoryTest
 
     public @Test void testDataStoreInfo_CRUD() throws IOException {
         DataStoreInfo store =
-                testData.createDataStore(
+                testData.faker().dataStoreInfo(
                         "dataStoreCRUD-id",
                         testData.workspaceB,
                         "dataStoreCRUD",
@@ -426,8 +426,8 @@ public class StoreRepositoryTest
                 testData.wmsStoreA,
                 testData.wmtsStoreA);
         testFindStoresByWorkspace(testData.workspaceB, testData.dataStoreB);
-        WorkspaceInfo emptyWs = testData.createWorkspace("emptyws");
-        NamespaceInfo emptyNs = testData.createNamespace("emptyns", "http://test.com/emptyns");
+        WorkspaceInfo emptyWs = testData.faker().workspaceInfo("emptyws");
+        NamespaceInfo emptyNs = testData.faker().namespace();
         serverCatalog.add(emptyWs);
         serverCatalog.add(emptyNs);
         testFindStoresByWorkspace(emptyWs);

--- a/src/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/WorkspaceRepositoryTest.java
+++ b/src/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/catalog/client/reactivefeign/WorkspaceRepositoryTest.java
@@ -73,7 +73,7 @@ public class WorkspaceRepositoryTest
     }
 
     public @Test void testWorkspaceCRUD() {
-        WorkspaceInfo ws = testData.createWorkspace("workspaceCRUD");
+        WorkspaceInfo ws = testData.faker().workspaceInfo("workspaceCRUD");
         crudTest(
                 ws,
                 serverCatalog::getWorkspace,

--- a/src/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/integration/jdbcconfig/JDBCConfigCatalogConcurrencyIT.java
+++ b/src/integration-tests/catalog-service-it/src/test/java/org/geoserver/cloud/integration/jdbcconfig/JDBCConfigCatalogConcurrencyIT.java
@@ -70,7 +70,7 @@ public class JDBCConfigCatalogConcurrencyIT {
 
     @Before
     public void setUp() throws Exception {
-        data = CatalogTestData.empty(() -> rawCatalog, () -> geoServer).createCatalogObjects();
+        data = CatalogTestData.empty(() -> rawCatalog, () -> geoServer).initialize();
         data.deleteAll();
     }
 

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -93,6 +93,12 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
+        <groupId>com.github.javafaker</groupId>
+        <artifactId>javafaker</artifactId>
+        <version>1.0.2</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-platform</artifactId>
         <version>${gs.version}</version>
@@ -654,6 +660,11 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.javafaker</groupId>
+      <artifactId>javafaker</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/src/starters/catalog-backend/src/test/java/org/geoserver/cloud/bus/incoming/caching/RemoteEventCacheEvictorTest.java
+++ b/src/starters/catalog-backend/src/test/java/org/geoserver/cloud/bus/incoming/caching/RemoteEventCacheEvictorTest.java
@@ -54,8 +54,8 @@ import org.geoserver.config.impl.SettingsInfoImpl;
 import org.geoserver.config.plugin.GeoServerImpl;
 import org.geoserver.security.SecuredResourceNameChangeListener;
 import org.geoserver.wms.WMSInfoImpl;
+import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -115,20 +115,25 @@ public class RemoteEventCacheEvictorTest {
     // ApplicationContext, used to publish remote events as if the'd be coming from the bus
     private @Autowired ApplicationEventPublisher publisher;
 
-    public @Rule CatalogTestData data =
-            CatalogTestData.initialized(() -> rawCatalog, () -> geoServer);
+    protected CatalogTestData data;
 
     private @SpyBean RemoteEventCacheEvictor evictor;
 
     public @Before void before() {
         assertTrue(rawCatalog.getRawFacade() instanceof CachingCatalogFacade);
         assertTrue(geoServer.getFacade() instanceof CachingGeoServerFacade);
+        data = CatalogTestData.initialized(() -> rawCatalog, () -> geoServer).initialize();
+
         this.catalogCache = cacheManager.getCache(CachingCatalogFacade.CACHE_NAME);
         this.configCache = cacheManager.getCache(CachingGeoServerFacade.CACHE_NAME);
         this.catalogCache.clear();
         this.configCache.clear();
 
         catalog.removeListeners(SecuredResourceNameChangeListener.class);
+    }
+
+    public @After void after() {
+        data.after();
     }
 
     public @Test void testRemoteDefaultWorkspaceEvent() {


### PR DESCRIPTION
Remote update events sends complete values of CatalogInfoObjects that should be sent as references.
As a consequence, the value that's applied to the event receiving nodes is a full new copy instead of a reference to an existing object.

For example, when updating a LayerInfo's styles list, the `StyleInfo`s in the list shall already be present in the catalog and the patch reference those. Instead it sends full `StyleInfo` objects, that when deserialized, by one side won't be the ones in the catalog but copies, and their Catalog instance variable is null, rendering the WMS unusable.

This patch fixes those issues by determining clearly which objects shall be encoded as references and which as values in a Patch.

Some, like SettingsInfo, oughta be passed by value, while all CatalogInfo's as references
