### PR TITLE
Initialize default styles guarded by a lock for jdbcconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,7 @@ test:
 	./mvnw -f src/ verify -ntp -T4 -P-docker,-docker-openj9
 
 docker:
-	./mvnw package -f src/ -Ddockerfile.push.skip=$(PUSH) -ntp -Dfmt.skip -T4 -DskipTests
+	./mvnw clean package -f src/apps -Ddockerfile.push.skip=$(PUSH) -ntp -Dfmt.skip -T4 -DskipTests -P-docker-openj9
+
+docker-openj9:
+	./mvnw clean package -f src/apps -Ddockerfile.push.skip=$(PUSH) -ntp -Dfmt.skip -T4 -DskipTests -P-docker


### PR DESCRIPTION
`CloudJdbcGeoServerLoader` overrides `initializeDefaultStyles`
to run inside a lock on "styles" to avoid multiple instances
starting up off an empty database trying to create the same
default styles, which results in either a startup error or
multiple styles named the same.

![image](https://user-images.githubusercontent.com/207423/174447344-977b612e-0230-422a-9e72-aa8e30a9c1be.png)
