### PR TITLE
SettingsInfo's contact was being sent as a proxy

### DIFF
--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/CatalogInfoModifyEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/CatalogInfoModifyEvent.java
@@ -71,7 +71,7 @@ public class CatalogInfoModifyEvent
                         .clean()
                         .toPatch();
 
-        if (info instanceof Catalog) {
+        if (!patch.isEmpty() && info instanceof Catalog) {
             Optional<Property> defaultWorkspace = patch.get("defaultWorkspace");
             if (defaultWorkspace.isPresent()) {
                 WorkspaceInfo ws = (WorkspaceInfo) defaultWorkspace.get().getValue();

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/DefaultDataStoreEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/DefaultDataStoreEvent.java
@@ -19,6 +19,7 @@ import org.geoserver.catalog.plugin.PropertyDiff;
 import org.geoserver.catalog.plugin.PropertyDiff.Change;
 import org.geoserver.cloud.event.info.ConfigInfoType;
 import org.geoserver.cloud.event.info.InfoEvent;
+import org.springframework.core.style.ToStringCreator;
 
 import java.util.Objects;
 
@@ -43,11 +44,10 @@ public class DefaultDataStoreEvent extends CatalogInfoModifyEvent {
         this.defaultDataStoreId = defaultDataStoreId;
     }
 
-    public @Override String toString() {
-        return toStringBuilder()
+    protected @Override ToStringCreator toStringBuilder() {
+        return super.toStringBuilder()
                 .append("workspace", getWorkspaceId())
-                .append("store", getDefaultDataStoreId())
-                .toString();
+                .append("store", getDefaultDataStoreId());
     }
 
     public static DefaultDataStoreEvent createLocal(@NonNull CatalogPostModifyEvent event) {

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/DefaultNamespaceEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/DefaultNamespaceEvent.java
@@ -14,6 +14,7 @@ import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.cloud.event.info.ConfigInfoType;
 import org.geoserver.cloud.event.info.InfoEvent;
+import org.springframework.core.style.ToStringCreator;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonTypeName("DefaultNamespaceSet")
@@ -28,8 +29,8 @@ public class DefaultNamespaceEvent extends CatalogInfoModifyEvent {
         this.newNamespaceId = newNamespaceId;
     }
 
-    public @Override String toString() {
-        return toStringBuilder().append("namespace", getNewNamespaceId()).toString();
+    protected @Override ToStringCreator toStringBuilder() {
+        return super.toStringBuilder().append("namespace", getNewNamespaceId());
     }
 
     public static DefaultNamespaceEvent createLocal(NamespaceInfo defaultNamespace) {

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/DefaultWorkspaceEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/DefaultWorkspaceEvent.java
@@ -15,6 +15,7 @@ import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.cloud.event.info.ConfigInfoType;
 import org.geoserver.cloud.event.info.InfoEvent;
+import org.springframework.core.style.ToStringCreator;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonTypeName("DefaultWorkspaceSet")
@@ -32,8 +33,8 @@ public class DefaultWorkspaceEvent extends CatalogInfoModifyEvent {
         this.newWorkspaceId = newWorkspaceId;
     }
 
-    public @Override String toString() {
-        return toStringBuilder().append("workspace", getNewWorkspaceId()).toString();
+    protected @Override ToStringCreator toStringBuilder() {
+        return super.toStringBuilder().append("workspace", getNewWorkspaceId());
     }
 
     public static DefaultWorkspaceEvent createLocal(WorkspaceInfo defaultWorkspace) {

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ConfigInfoModifyEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ConfigInfoModifyEvent.java
@@ -11,7 +11,6 @@ import lombok.NonNull;
 
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.plugin.Patch;
-import org.geoserver.catalog.plugin.PropertyDiff;
 import org.geoserver.cloud.event.info.ConfigInfoType;
 import org.geoserver.cloud.event.info.InfoPostModifyEvent;
 import org.geoserver.config.GeoServerInfo;
@@ -40,10 +39,9 @@ public abstract class ConfigInfoModifyEvent<SELF, INFO extends Info>
 
     @SuppressWarnings("unchecked")
     public static @NonNull <I extends Info> ConfigInfoModifyEvent<?, I> createLocal(
-            @NonNull Info info, @NonNull PropertyDiff diff) {
+            @NonNull Info info, @NonNull Patch patch) {
 
         final ConfigInfoType type = ConfigInfoType.valueOf(info);
-        final Patch patch = diff.toPatch();
         switch (type) {
             case GeoServerInfo:
                 {

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ConfigInfoPreModifyEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ConfigInfoPreModifyEvent.java
@@ -11,7 +11,6 @@ import lombok.NonNull;
 
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.plugin.Patch;
-import org.geoserver.catalog.plugin.PropertyDiff;
 import org.geoserver.cloud.event.info.ConfigInfoType;
 import org.geoserver.cloud.event.info.InfoPreModifyEvent;
 
@@ -30,11 +29,10 @@ public class ConfigInfoPreModifyEvent<SELF, INFO extends Info>
     }
 
     public static @NonNull <I extends Info> ConfigInfoPreModifyEvent<?, I> createLocal(
-            @NonNull Info object, @NonNull PropertyDiff diff) {
+            @NonNull Info object, @NonNull Patch patch) {
 
         final @NonNull String id = resolveId(object);
         final ConfigInfoType type = ConfigInfoType.valueOf(object);
-        final Patch patch = diff.toPatch();
         return new ConfigInfoPreModifyEvent<>(id, type, patch);
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ServiceInfoModifyEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ServiceInfoModifyEvent.java
@@ -16,6 +16,7 @@ import org.geoserver.cloud.event.info.ConfigInfoType;
 import org.geoserver.cloud.event.info.InfoEvent;
 import org.geoserver.config.LoggingInfo;
 import org.geoserver.config.ServiceInfo;
+import org.springframework.core.style.ToStringCreator;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonTypeName("ServiceInfoModified")
@@ -37,8 +38,8 @@ public class ServiceInfoModifyEvent
         this.workspaceId = workspaceId;
     }
 
-    public @Override String toString() {
-        return toStringBuilder().append("workspace", getWorkspaceId()).toString();
+    protected @Override ToStringCreator toStringBuilder() {
+        return super.toStringBuilder().append("workspace", getWorkspaceId());
     }
 
     public static ServiceInfoModifyEvent createLocal(

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/SettingsInfoModifyEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/SettingsInfoModifyEvent.java
@@ -15,6 +15,7 @@ import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.cloud.event.info.ConfigInfoType;
 import org.geoserver.cloud.event.info.InfoEvent;
 import org.geoserver.config.SettingsInfo;
+import org.springframework.core.style.ToStringCreator;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonTypeName("SettingsInfoModified")
@@ -36,8 +37,8 @@ public class SettingsInfoModifyEvent
         this.workspaceId = workspaceId;
     }
 
-    public @Override String toString() {
-        return toStringBuilder().append("workspace", getWorkspaceId()).toString();
+    protected @Override ToStringCreator toStringBuilder() {
+        return super.toStringBuilder().append("workspace", getWorkspaceId());
     }
 
     public static SettingsInfoModifyEvent createLocal(

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/UpdateSequenceEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/UpdateSequenceEvent.java
@@ -13,6 +13,7 @@ import lombok.NonNull;
 
 import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.config.GeoServerInfo;
+import org.springframework.core.style.ToStringCreator;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonTypeName("UpdateSequence")
@@ -35,8 +36,8 @@ public class UpdateSequenceEvent extends GeoServerInfoModifyEvent {
         this.updateSequence = updateSequence;
     }
 
-    public @Override String toString() {
-        return toStringBuilder().append("updateSequence", getUpdateSequence()).toString();
+    protected @Override ToStringCreator toStringBuilder() {
+        return super.toStringBuilder().append("updateSequence", getUpdateSequence());
     }
 
     public static UpdateSequenceEvent createLocal(GeoServerInfo info) {

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/info/InfoModifyEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/info/InfoModifyEvent.java
@@ -13,6 +13,7 @@ import lombok.Setter;
 
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.plugin.Patch;
+import org.springframework.core.style.ToStringCreator;
 
 import java.util.stream.Collectors;
 
@@ -33,11 +34,10 @@ public abstract class InfoModifyEvent<SELF, INFO extends Info> extends InfoEvent
         this.patch = patch;
     }
 
-    public @Override String toString() {
-        return toStringBuilder()
+    protected @Override ToStringCreator toStringBuilder() {
+        return super.toStringBuilder()
                 .append(
                         "changes",
-                        getPatch().getPropertyNames().stream().collect(Collectors.joining(",")))
-                .toString();
+                        getPatch().getPropertyNames().stream().collect(Collectors.joining(",")));
     }
 }

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/ProxyUtils.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/ProxyUtils.java
@@ -185,11 +185,11 @@ public class ProxyUtils {
         return info;
     }
 
-    public <T extends Info> boolean isResolvingProxy(final T info) {
+    public static <T extends Info> boolean isResolvingProxy(final T info) {
         return null != org.geoserver.catalog.impl.ProxyUtils.handler(info, ResolvingProxy.class);
     }
 
-    public <T extends Info> boolean isModificationProxy(final T info) {
+    public static <T extends Info> boolean isModificationProxy(final T info) {
         return null != org.geoserver.catalog.impl.ProxyUtils.handler(info, ModificationProxy.class);
     }
 

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/PatchDto.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/PatchDto.java
@@ -10,14 +10,20 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.Data;
 import lombok.Generated;
 
-import org.geotools.jackson.databind.filter.dto.Expression.Literal;
+import org.geotools.jackson.databind.filter.dto.Expression;
 
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.ArrayList;
+import java.util.List;
 
 /** DTO for {@link org.geoserver.catalog.plugin.Patch} */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonTypeName("Patch")
 public @Data @Generated class PatchDto {
-    private Map<String, Literal> patches = new TreeMap<>();
+    private List<PatchPropertyDto> patches = new ArrayList<>();
+
+    @JsonTypeName("Property")
+    public static @Data class PatchPropertyDto {
+        private String name;
+        private Expression.Literal value;
+    }
 }

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/GeoServerConfigModule.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/GeoServerConfigModule.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import lombok.extern.slf4j.Slf4j;
 
 import org.geoserver.catalog.Info;
+import org.geoserver.config.ContactInfo;
 import org.geoserver.config.CoverageAccessInfo;
 import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.JAIInfo;
@@ -20,6 +21,7 @@ import org.geoserver.config.SettingsInfo;
 import org.geoserver.gwc.wmts.WMTSInfo;
 import org.geoserver.jackson.databind.catalog.GeoServerCatalogModule;
 import org.geoserver.jackson.databind.catalog.dto.InfoDto;
+import org.geoserver.jackson.databind.config.dto.Contact;
 import org.geoserver.jackson.databind.config.dto.CoverageAccess;
 import org.geoserver.jackson.databind.config.dto.GeoServer;
 import org.geoserver.jackson.databind.config.dto.JaiDto;
@@ -100,13 +102,24 @@ public class GeoServerConfigModule extends SimpleModule {
         addSerializer(WMTSInfo.class);
         addDeserializer(WMTSInfo.class, Service.WmtsService.class);
 
+        registerValueSerializers();
+    }
+
+    protected void registerValueSerializers() {
         addMapperSerializer(
                 CoverageAccessInfo.class,
-                VALUE_MAPPER::toDto,
+                VALUE_MAPPER::coverageAccessInfo,
                 CoverageAccess.class,
-                VALUE_MAPPER::toInfo);
+                VALUE_MAPPER::coverageAccessInfo);
 
-        addMapperSerializer(JAIInfo.class, VALUE_MAPPER::toDto, JaiDto.class, VALUE_MAPPER::toInfo);
+        addMapperSerializer(
+                JAIInfo.class, VALUE_MAPPER::jaiInfo, JaiDto.class, VALUE_MAPPER::jaiInfo);
+
+        addMapperSerializer(
+                ContactInfo.class,
+                VALUE_MAPPER::contactInfo,
+                Contact.class,
+                VALUE_MAPPER::contactInfo);
     }
 
     private <T, DTO> void addMapperSerializer(

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/GeoServerConfigMapper.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/GeoServerConfigMapper.java
@@ -13,7 +13,6 @@ import org.geoserver.config.JAIInfo;
 import org.geoserver.config.LoggingInfo;
 import org.geoserver.config.ServiceInfo;
 import org.geoserver.config.SettingsInfo;
-import org.geoserver.config.impl.ContactInfoImpl;
 import org.geoserver.gwc.wmts.WMTSInfo;
 import org.geoserver.gwc.wmts.WMTSInfoImpl;
 import org.geoserver.jackson.databind.catalog.dto.CatalogInfoDto;
@@ -96,9 +95,9 @@ public interface GeoServerConfigMapper {
 
     @Mapping(target = "tileCache", ignore = true)
     @Mapping(target = "JAI", ignore = true)
-    JAIInfo toInfo(JaiDto dto);
+    JAIInfo jaiInfo(JaiDto dto);
 
-    JaiDto toDto(JAIInfo info);
+    JaiDto jaiInfo(JAIInfo info);
 
     @Mapping(target = "id", ignore = true) // set by factory method
     LoggingInfo toInfo(Logging dto);
@@ -106,14 +105,14 @@ public interface GeoServerConfigMapper {
     Logging toDto(LoggingInfo info);
 
     @Mapping(target = "threadPoolExecutor", ignore = true)
-    CoverageAccessInfo toInfo(CoverageAccess dto);
+    CoverageAccessInfo coverageAccessInfo(CoverageAccess dto);
 
-    CoverageAccess toDto(CoverageAccessInfo info);
+    CoverageAccess coverageAccessInfo(CoverageAccessInfo info);
 
     @Mapping(target = "id", ignore = true) // set by factory method
-    ContactInfoImpl toInfo(Contact dto);
+    ContactInfo contactInfo(Contact dto);
 
-    Contact toDto(ContactInfo info);
+    Contact contactInfo(ContactInfo info);
 
     default ServiceInfo toInfo(Service dto) {
         if (dto == null) return null;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/ObjectFacotries.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/ObjectFacotries.java
@@ -5,11 +5,13 @@
 package org.geoserver.jackson.databind.config.dto.mapper;
 
 import org.geoserver.catalog.Info;
+import org.geoserver.config.ContactInfo;
 import org.geoserver.config.CoverageAccessInfo;
 import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.JAIInfo;
 import org.geoserver.config.LoggingInfo;
 import org.geoserver.config.SettingsInfo;
+import org.geoserver.config.impl.ContactInfoImpl;
 import org.geoserver.config.impl.CoverageAccessInfoImpl;
 import org.geoserver.config.impl.GeoServerInfoImpl;
 import org.geoserver.config.impl.JAIEXTInfoImpl;
@@ -61,5 +63,9 @@ public class ObjectFacotries {
 
     public @ObjectFactory org.geoserver.config.JAIEXTInfo jaiExtInfo(JAIEXTInfo source) {
         return new JAIEXTInfoImpl();
+    }
+
+    public @ObjectFactory ContactInfo contactInfo() {
+        return new ContactInfoImpl();
     }
 }

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/Patch.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/Patch.java
@@ -4,11 +4,9 @@
  */
 package org.geoserver.catalog.plugin;
 
-import lombok.AccessLevel;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.Value;
+import lombok.NonNull;
 
 import org.geoserver.catalog.impl.ModificationProxy;
 import org.geoserver.ows.util.OwsUtils;
@@ -22,20 +20,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 @NoArgsConstructor
-public @Value class Patch implements Serializable {
+public @Data class Patch implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    public static @Value class Property {
+    public static @Data class Property {
         private final String name;
         private final Object value;
-
-        public Property withValue(Object newValue) {
-            return new Property(name, newValue);
-        }
 
         @SuppressWarnings("unchecked")
         public <V> V value() {
@@ -43,17 +36,15 @@ public @Value class Patch implements Serializable {
         }
     }
 
-    @Getter(AccessLevel.NONE)
-    @Setter(AccessLevel.NONE)
-    private final Map<String, Property> patches = new TreeMap<>();
+    private final List<Property> patches = new ArrayList<>();
 
     public Patch(List<Property> patches) {
         patches.forEach(this::add);
     }
 
-    public List<Property> getPatches() {
-        return new ArrayList<Patch.Property>(patches.values());
-    }
+    //    public List<Property> getPatches() {
+    //        return new ArrayList<Patch.Property>(patches.values());
+    //    }
 
     public int size() {
         return patches.size();
@@ -63,8 +54,8 @@ public @Value class Patch implements Serializable {
         return patches.isEmpty();
     }
 
-    public void add(Property prop) {
-        patches.put(prop.getName(), prop);
+    public void add(@NonNull Property prop) {
+        patches.add(prop);
     }
 
     public Property add(String name, Object value) {
@@ -80,12 +71,11 @@ public @Value class Patch implements Serializable {
     }
 
     public List<String> getPropertyNames() {
-        return new ArrayList<>(patches.keySet());
+        return patches.stream().map(Property::getName).toList();
     }
 
     public Optional<Property> get(String propertyName) {
-        Property property = this.patches.get(propertyName);
-        return Optional.ofNullable(property);
+        return patches.stream().filter(p -> p.getName().equals(propertyName)).findFirst();
     }
 
     public Optional<Object> getValue(String propertyName) {
@@ -106,7 +96,7 @@ public @Value class Patch implements Serializable {
     }
 
     public void applyTo(Object target, Class<?> objectType) {
-        patches.values().forEach(p -> apply(target, objectType, p));
+        patches.forEach(p -> apply(target, objectType, p));
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/src/catalog/plugin/src/main/java/org/geoserver/config/plugin/RepositoryGeoServerFacadeImpl.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/config/plugin/RepositoryGeoServerFacadeImpl.java
@@ -87,9 +87,10 @@ public class RepositoryGeoServerFacadeImpl implements RepositoryGeoServerFacade 
     public @Override void save(GeoServerInfo global) {
         ModificationProxy proxy = (ModificationProxy) Proxy.getInvocationHandler(global);
 
-        List<String> propertyNames = proxy.getPropertyNames();
-        List<Object> oldValues = proxy.getOldValues();
-        List<Object> newValues = proxy.getNewValues();
+        PropertyDiff diff = PropertyDiff.valueOf(proxy);
+        List<String> propertyNames = diff.getPropertyNames();
+        List<Object> oldValues = diff.getOldValues();
+        List<Object> newValues = diff.getNewValues();
 
         geoServer.fireGlobalModified(global, propertyNames, oldValues, newValues);
 
@@ -113,9 +114,10 @@ public class RepositoryGeoServerFacadeImpl implements RepositoryGeoServerFacade 
     public @Override void save(SettingsInfo settings) {
         ModificationProxy proxy = (ModificationProxy) Proxy.getInvocationHandler(settings);
 
-        List<String> propertyNames = proxy.getPropertyNames();
-        List<Object> oldValues = proxy.getOldValues();
-        List<Object> newValues = proxy.getNewValues();
+        PropertyDiff diff = PropertyDiff.valueOf(proxy);
+        List<String> propertyNames = diff.getPropertyNames();
+        List<Object> oldValues = diff.getOldValues();
+        List<Object> newValues = diff.getNewValues();
 
         settings = (SettingsInfo) proxy.getProxyObject();
         geoServer.fireSettingsModified(settings, propertyNames, oldValues, newValues);
@@ -143,9 +145,10 @@ public class RepositoryGeoServerFacadeImpl implements RepositoryGeoServerFacade 
     public @Override void save(LoggingInfo logging) {
         ModificationProxy proxy = (ModificationProxy) Proxy.getInvocationHandler(logging);
 
-        List<String> propertyNames = proxy.getPropertyNames();
-        List<Object> oldValues = proxy.getOldValues();
-        List<Object> newValues = proxy.getNewValues();
+        PropertyDiff diff = PropertyDiff.valueOf(proxy);
+        List<String> propertyNames = diff.getPropertyNames();
+        List<Object> oldValues = diff.getOldValues();
+        List<Object> newValues = diff.getNewValues();
 
         geoServer.fireLoggingModified(logging, propertyNames, oldValues, newValues);
 
@@ -165,9 +168,10 @@ public class RepositoryGeoServerFacadeImpl implements RepositoryGeoServerFacade 
     public @Override void save(ServiceInfo service) {
         ModificationProxy proxy = ModificationProxy.handler(service);
 
-        List<String> propertyNames = proxy.getPropertyNames();
-        List<Object> oldValues = proxy.getOldValues();
-        List<Object> newValues = proxy.getNewValues();
+        PropertyDiff diff = PropertyDiff.valueOf(proxy);
+        List<String> propertyNames = diff.getPropertyNames();
+        List<Object> oldValues = diff.getOldValues();
+        List<Object> newValues = diff.getNewValues();
 
         geoServer.fireServiceModified(service, propertyNames, oldValues, newValues);
         Patch patch = PropertyDiff.valueOf(proxy).clean().toPatch();


### PR DESCRIPTION
- Missed explicit jackson binding for ContactInfo
- Some GeoServerFacade.save() methods were commiting
the ModificationProxy and rendering the change nil.
Computing the PropertyDiff first makes sure it the
ModificationProxy.commit() won't override the changes
for the events.

Improve `PatchMapper` to make proper use of the
other MapStruct mappers.

This fixes the issue where the webui edits of per-workspace settings
saves both the settings and its contact info as ModificationProxies.