### PR TITLE
 Data-directory backend cluster-wide locking on configuration changes

### DIFF
--- a/src/catalog/backends/catalog-service/src/main/java/org/geoserver/cloud/config/catalog/backend/catalogservice/CatalogClientBackendConfigurer.java
+++ b/src/catalog/backends/catalog-service/src/main/java/org/geoserver/cloud/config/catalog/backend/catalogservice/CatalogClientBackendConfigurer.java
@@ -6,6 +6,7 @@ package org.geoserver.cloud.config.catalog.backend.catalogservice;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.geoserver.GeoServerConfigurationLock;
 import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
 import org.geoserver.cloud.catalog.client.impl.CatalogClientCatalogFacade;
 import org.geoserver.cloud.catalog.client.impl.CatalogClientConfiguration;
@@ -48,6 +49,11 @@ public class CatalogClientBackendConfigurer implements GeoServerBackendConfigure
 
     @Bean
     public @Override UpdateSequence updateSequence() {
+        throw new UnsupportedOperationException("implement");
+    }
+
+    @Bean
+    public @Override GeoServerConfigurationLock configurationLock() {
         throw new UnsupportedOperationException("implement");
     }
 

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/config/catalog/backend/core/CoreBackendConfiguration.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/config/catalog/backend/core/CoreBackendConfiguration.java
@@ -21,6 +21,7 @@ import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.security.SecureCatalogImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -47,6 +48,7 @@ public class CoreBackendConfiguration {
         return new GeoServerExtensions();
     }
 
+    @ConditionalOnMissingBean(CatalogPlugin.class)
     @DependsOn({"resourceLoader", "catalogFacade"})
     public @Bean CatalogPlugin rawCatalog(
             GeoServerResourceLoader resourceLoader,
@@ -106,7 +108,7 @@ public class CoreBackendConfiguration {
                 : advertisedCatalog;
     }
 
-    @Autowired
+    @ConditionalOnMissingBean(GeoServerImpl.class)
     public @Bean(name = "geoServer") GeoServerImpl geoServer(
             @Qualifier("catalog") Catalog catalog,
             @Qualifier("geoserverFacade") GeoServerFacade facade)

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/config/catalog/backend/core/GeoServerBackendConfigurer.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/config/catalog/backend/core/GeoServerBackendConfigurer.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.cloud.config.catalog.backend.core;
 
+import org.geoserver.GeoServerConfigurationLock;
 import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
 import org.geoserver.config.GeoServerFacade;
 import org.geoserver.config.GeoServerLoader;
@@ -34,6 +35,9 @@ import org.springframework.context.annotation.Bean;
  * etc.
  */
 public interface GeoServerBackendConfigurer {
+
+    @Bean
+    GeoServerConfigurationLock configurationLock();
 
     @Bean
     UpdateSequence updateSequence();

--- a/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/catalog/locking/LockProviderGeoServerConfigurationLock.java
+++ b/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/catalog/locking/LockProviderGeoServerConfigurationLock.java
@@ -1,0 +1,143 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.catalog.locking;
+
+import static org.geoserver.GeoServerConfigurationLock.LockType.WRITE;
+
+import static java.lang.String.format;
+
+import lombok.NonNull;
+
+import org.geoserver.GeoServerConfigurationLock;
+import org.geoserver.platform.resource.LockProvider;
+import org.geoserver.platform.resource.Resource.Lock;
+
+/**
+ * Extends {@link GeoServerConfigurationLock} with cluster-wide locking semantics provided by {@link
+ * LockProvider}.
+ *
+ * @since 1.0
+ */
+public class LockProviderGeoServerConfigurationLock extends GeoServerConfigurationLock {
+
+    private static final String LOCK_NAME = "global_datadir_lock";
+
+    private @NonNull LockProvider lockProvider;
+
+    private static class ReentrantGlobalLock {
+
+        private int writeHoldCount;
+        private Lock globalLock;
+
+        public void lock(LockProvider lockProvider) {
+            if (0 == writeHoldCount) {
+                globalLock = lockProvider.acquire(LOCK_NAME);
+            }
+            writeHoldCount++;
+        }
+
+        public boolean unlock() {
+            if (null != globalLock) {
+                --writeHoldCount;
+                if (writeHoldCount == 0) {
+                    globalLock.release();
+                    globalLock = null;
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public boolean isWriteLocked() {
+            return globalLock != null;
+        }
+
+        public void forceUnlock() {
+            writeHoldCount = 1;
+            unlock();
+            writeHoldCount = 0;
+        }
+    }
+
+    private static final ThreadLocal<ReentrantGlobalLock> GLOBAL =
+            ThreadLocal.withInitial(ReentrantGlobalLock::new);
+
+    public LockProviderGeoServerConfigurationLock(@NonNull LockProvider lockProvider) {
+        super();
+        this.lockProvider = lockProvider;
+    }
+
+    public @Override boolean isWriteLocked() {
+        if (isEnabled()) {
+            final boolean jvmWriteLocked = super.isWriteLocked();
+            final boolean globalWriteLocked = GLOBAL.get().isWriteLocked();
+            if (jvmWriteLocked != globalWriteLocked) {
+                String msg =
+                        format(
+                                "local JVM and global write lock status discrepancy: globally held lock count: %d, jvm locked: %s. The global lock will forcedly be released.",
+                                GLOBAL.get().writeHoldCount, jvmWriteLocked);
+
+                GLOBAL.get().forceUnlock();
+                GLOBAL.remove();
+                throw new IllegalStateException(msg);
+            }
+            return jvmWriteLocked || globalWriteLocked;
+        }
+        return false;
+    }
+
+    private void unlockGloblal() {
+        if (GLOBAL.get().unlock()) {
+            GLOBAL.remove();
+        }
+    }
+
+    private void lockGloblal() {
+        try {
+            GLOBAL.get().lock(lockProvider);
+        } catch (RuntimeException e) {
+            super.unlock();
+            throw e;
+        }
+    }
+
+    public @Override void lock(LockType type) {
+        if (isEnabled()) {
+            // JVM lock
+            super.lock(type);
+            // cluster lock
+            if (WRITE == type) {
+                lockGloblal();
+            }
+        }
+    }
+
+    public @Override boolean tryLock(LockType type) {
+        if (isEnabled()) {
+            final boolean jvmLock = super.tryLock(type);
+            if (jvmLock && WRITE == type) {
+                lockGloblal();
+            }
+            return jvmLock;
+        }
+        return true;
+    }
+
+    public @Override void tryUpgradeLock() {
+        if (isEnabled()) {
+            super.tryUpgradeLock();
+        }
+    }
+
+    public @Override void unlock() {
+        if (isEnabled()) {
+            try {
+                unlockGloblal();
+            } finally {
+                super.unlock();
+            }
+        }
+    }
+}

--- a/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/catalog/locking/LockingCatalog.java
+++ b/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/catalog/locking/LockingCatalog.java
@@ -1,0 +1,125 @@
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.catalog.locking;
+
+import static org.geoserver.cloud.catalog.locking.LockingSupport.nameOf;
+import static org.geoserver.cloud.catalog.locking.LockingSupport.typeOf;
+
+import static java.lang.String.format;
+
+import lombok.NonNull;
+
+import org.geoserver.GeoServerConfigurationLock;
+import org.geoserver.catalog.CatalogFacade;
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.LockingCatalogFacade;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.plugin.CatalogPlugin;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * A locking catalog, akin to {@link LockingCatalogFacade}, but at a higher level of granularity,
+ * because a single catalog operation (e.g. save()), can imply multiple config changes (e.g. sets
+ * the default workspace/namespace/datastore), and we want all those automatic batch operations to
+ * run inside the same lock, which is not possible with {@link LockingCatalogFacade}.
+ *
+ * <p>The consistency guarantees are the ones provided by the {@link GeoServerConfigurationLock},
+ * whether it guarantees atomicity at the JVM or cluster-wide level.
+ *
+ * <p>This {@link CatalogPlugin} implementation overrides all mutating methods to run inside a
+ * cluster-wide lock. For instance, {@link #doAdd}, {@link #doSave}, {@link #doRemove}, and all the
+ * {@code setDefault*} methods.
+ */
+@SuppressWarnings("serial")
+public class LockingCatalog extends CatalogPlugin {
+
+    private final GeoServerConfigurationLock configurationLock;
+    private LockingSupport locking;
+
+    public LockingCatalog(@NonNull GeoServerConfigurationLock configurationLock) {
+        super();
+        this.configurationLock = configurationLock;
+        enableLocking();
+    }
+
+    public LockingCatalog(@NonNull GeoServerConfigurationLock configurationLock, boolean isolated) {
+        super(isolated);
+        this.configurationLock = configurationLock;
+        enableLocking();
+    }
+
+    public LockingCatalog(
+            @NonNull GeoServerConfigurationLock configurationLock, CatalogFacade facade) {
+        super(facade);
+        this.configurationLock = configurationLock;
+        enableLocking();
+    }
+
+    public LockingCatalog(
+            @NonNull GeoServerConfigurationLock configurationLock,
+            CatalogFacade facade,
+            boolean isolated) {
+        super(facade, isolated);
+        this.configurationLock = configurationLock;
+        enableLocking();
+    }
+
+    public void enableLocking() {
+        this.locking = LockingSupport.locking(configurationLock);
+    }
+
+    public void disableLocking() {
+        this.locking = LockingSupport.ignoringLocking();
+    }
+
+    public @Override void setDefaultDataStore(
+            @NonNull WorkspaceInfo workspace, DataStoreInfo store) {
+        locking.runInWriteLock(
+                () -> super.setDefaultDataStore(workspace, store),
+                format(
+                        "setDefaultDataStore(%s, %s)",
+                        workspace.getName(), store == null ? "null" : store.getName()));
+    }
+
+    public @Override void setDefaultNamespace(NamespaceInfo defaultNamespace) {
+        locking.runInWriteLock(
+                () -> super.setDefaultNamespace(defaultNamespace),
+                format(
+                        "setDefaultNamespace(%s)",
+                        defaultNamespace == null ? "null" : defaultNamespace.getName()));
+    }
+
+    public @Override void setDefaultWorkspace(WorkspaceInfo defaultWorkspace) {
+        locking.runInWriteLock(
+                () -> super.setDefaultWorkspace(defaultWorkspace),
+                format(
+                        "setDefaultWorkspace(%s)",
+                        defaultWorkspace == null ? "null" : defaultWorkspace.getName()));
+    }
+
+    /** {@inheritDoc} */
+    protected @Override <T extends CatalogInfo> void doAdd(T info, Function<T, T> inserter) {
+        locking.runInWriteLock(
+                () -> super.doAdd(info, inserter),
+                format("add(%s[%s])", typeOf(info), nameOf(info)));
+    }
+
+    /** {@inheritDoc} */
+    protected @Override <I extends CatalogInfo> void doSave(final I info) {
+        locking.runInWriteLock(
+                () -> super.doSave(info), format("save(%s[%s])", typeOf(info), nameOf(info)));
+    }
+
+    /** {@inheritDoc} */
+    protected @Override <T extends CatalogInfo> void doRemove(T info, Consumer<T> remover) {
+        locking.runInWriteLock(
+                () -> super.doRemove(info, remover),
+                format("remove(%s[%s])", typeOf(info), nameOf(info)));
+    }
+}

--- a/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/catalog/locking/LockingGeoServer.java
+++ b/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/catalog/locking/LockingGeoServer.java
@@ -1,0 +1,107 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.catalog.locking;
+
+import static org.geoserver.cloud.catalog.locking.LockingSupport.nameOf;
+import static org.geoserver.cloud.catalog.locking.LockingSupport.typeOf;
+
+import static java.lang.String.format;
+
+import lombok.NonNull;
+
+import org.geoserver.GeoServerConfigurationLock;
+import org.geoserver.config.GeoServerFacade;
+import org.geoserver.config.GeoServerInfo;
+import org.geoserver.config.LoggingInfo;
+import org.geoserver.config.ServiceInfo;
+import org.geoserver.config.SettingsInfo;
+import org.geoserver.config.plugin.GeoServerImpl;
+
+/**
+ * @since 1.0
+ */
+public class LockingGeoServer extends GeoServerImpl {
+
+    private LockingSupport lockingSupport;
+    private final GeoServerConfigurationLock configurationLock;
+
+    public LockingGeoServer(@NonNull GeoServerConfigurationLock locking) {
+        super();
+        this.configurationLock = locking;
+        enableLocking();
+    }
+
+    public LockingGeoServer(
+            @NonNull GeoServerConfigurationLock locking, @NonNull GeoServerFacade facade) {
+        super(facade);
+        this.configurationLock = locking;
+        enableLocking();
+    }
+
+    public void enableLocking() {
+        this.lockingSupport = LockingSupport.locking(configurationLock);
+    }
+
+    public void disableLocking() {
+        this.lockingSupport = LockingSupport.ignoringLocking();
+    }
+
+    public @NonNull GeoServerConfigurationLock getConfigurationLock() {
+        return this.configurationLock;
+    }
+
+    public @Override void setGlobal(GeoServerInfo global) {
+        lockingSupport.runInWriteLock(
+                () -> super.setGlobal(global), format("setGlobal(%s)", nameOf(global)));
+    }
+
+    public @Override void save(GeoServerInfo geoServer) {
+        lockingSupport.runInWriteLock(
+                () -> super.save(geoServer), format("save(%s)", nameOf(geoServer)));
+    }
+
+    public @Override void add(SettingsInfo settings) {
+        lockingSupport.runInWriteLock(
+                () -> super.add(settings),
+                format("add(%s[%s])", typeOf(settings), nameOf(settings)));
+    }
+
+    public @Override void save(SettingsInfo settings) {
+        lockingSupport.runInWriteLock(
+                () -> super.save(settings),
+                format("save(%s[%s])", typeOf(settings), nameOf(settings)));
+    }
+
+    public @Override void remove(SettingsInfo settings) {
+        lockingSupport.runInWriteLock(
+                () -> super.remove(settings),
+                format("remove(%s[%s])", typeOf(settings), nameOf(settings)));
+    }
+
+    public @Override void setLogging(LoggingInfo logging) {
+        lockingSupport.runInWriteLock(() -> super.setLogging(logging), "setLogging(LoggingInfo)");
+    }
+
+    public @Override void save(LoggingInfo logging) {
+        lockingSupport.runInWriteLock(() -> super.setLogging(logging), "save(LoggingInfo)");
+    }
+
+    public @Override void add(ServiceInfo service) {
+        lockingSupport.runInWriteLock(
+                () -> super.add(service), format("add(%s[%s])", typeOf(service), nameOf(service)));
+    }
+
+    public @Override void remove(ServiceInfo service) {
+        lockingSupport.runInWriteLock(
+                () -> super.remove(service),
+                format("remove(%s[%s])", typeOf(service), nameOf(service)));
+    }
+
+    public @Override void save(ServiceInfo service) {
+        lockingSupport.runInWriteLock(
+                () -> super.save(service),
+                format("save(%s[%s])", typeOf(service), nameOf(service)));
+    }
+}

--- a/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/catalog/locking/LockingSupport.java
+++ b/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/catalog/locking/LockingSupport.java
@@ -1,0 +1,150 @@
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.catalog.locking;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.geoserver.GeoServerConfigurationLock;
+import org.geoserver.GeoServerConfigurationLock.LockType;
+import org.geoserver.catalog.Info;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.cloud.event.info.ConfigInfoType;
+import org.geoserver.config.SettingsInfo;
+import org.geoserver.ows.util.OwsUtils;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.concurrent.Callable;
+
+/** */
+@Slf4j(topic = "org.geoserver.cloud.catalog.locking")
+public abstract class LockingSupport {
+
+    public abstract void runInWriteLock(Runnable action, String reason);
+
+    public abstract <V, E extends Exception> V callInWriteLock(
+            Class<E> exceptionType, Callable<V> action, String reason) throws E;
+
+    @RequiredArgsConstructor
+    private static class Enabled extends LockingSupport {
+
+        private final @NonNull GeoServerConfigurationLock configurationLock;
+
+        private void lock(String reason) {
+            final LockType currentLock = configurationLock.getCurrentLock();
+            if (null == currentLock) {
+
+                log.debug(" Acquiring write lock during {}", reason);
+                configurationLock.lock(LockType.WRITE);
+                log.debug("  Acquired write lock during {}", reason);
+
+            } else if (currentLock == LockType.WRITE) {
+
+                log.debug("Reentering write lock during {}", reason);
+                configurationLock.lock(LockType.WRITE);
+                log.debug(" Reentered write lock during {}", reason);
+
+            } else if (currentLock == LockType.READ) {
+
+                log.debug(" Upgrading read lock to write lock during {}", reason);
+                configurationLock.tryUpgradeLock();
+                log.debug("  Upgraded to write lock during {}", reason);
+            }
+        }
+
+        private void unlock(String reason) {
+            final LockType currentLock = configurationLock.getCurrentLock();
+            if (null == currentLock) {
+                log.info(" Attempted to release a lock while not holding it");
+                configurationLock.unlock();
+            } else {
+                log.debug(" Releasing write lock after  {}", reason);
+                configurationLock.unlock();
+                log.debug("  Released write lock after  {}", reason);
+            }
+        }
+
+        public void runInWriteLock(Runnable action, String reason) {
+            try {
+                callInWriteLock(
+                        Exception.class,
+                        () -> {
+                            action.run();
+                            return null;
+                        },
+                        reason);
+            } catch (Exception e) {
+                if (e instanceof IOException) throw new UncheckedIOException((IOException) e);
+                if (e instanceof RuntimeException) throw (RuntimeException) e;
+                throw new RuntimeException(e);
+            }
+        }
+
+        public <V, E extends Exception> V callInWriteLock(
+                Class<E> exceptionType, Callable<V> action, String reason) throws E {
+            lock(reason);
+            try {
+                return action.call();
+            } catch (Exception e) {
+                if (exceptionType.isInstance(e)) throw exceptionType.cast(e);
+                throw new RuntimeException(e);
+            } finally {
+                unlock(reason);
+            }
+        }
+    }
+
+    private static class Calling extends LockingSupport {
+
+        public @Override void runInWriteLock(Runnable action, String reason) {
+            action.run();
+        }
+
+        public @Override <V, E extends Exception> V callInWriteLock(
+                Class<E> exceptionType, Callable<V> action, String reason) throws E {
+
+            try {
+                return action.call();
+            } catch (Exception e) {
+                if (exceptionType.isInstance(e)) throw exceptionType.cast(e);
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static String nameOf(Info object) {
+        if (null == object) return null;
+        if (object instanceof SettingsInfo) {
+            WorkspaceInfo ws = ((SettingsInfo) object).getWorkspace();
+            if (ws != null) return ws.getName();
+        }
+        String property = object instanceof NamespaceInfo ? "prefix" : "name";
+        String name = null;
+        if (OwsUtils.has(ModificationProxy.unwrap(object), property)) {
+            name = (String) OwsUtils.get(object, property);
+            if (null == name) {
+                name = (String) OwsUtils.get(object, "id");
+            }
+        }
+        return null == name ? ConfigInfoType.valueOf(object).name() : name;
+    }
+
+    public static ConfigInfoType typeOf(Info object) {
+        if (null == object) return null;
+        return ConfigInfoType.valueOf(object);
+    }
+
+    public static LockingSupport locking(@NonNull GeoServerConfigurationLock configurationLock) {
+        return new Enabled(configurationLock);
+    }
+
+    public static LockingSupport ignoringLocking() {
+        return new Calling();
+    }
+}

--- a/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/config/catalog/backend/datadirectory/DataDirectoryBackendConfiguration.java
+++ b/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/config/catalog/backend/datadirectory/DataDirectoryBackendConfiguration.java
@@ -7,14 +7,24 @@ package org.geoserver.cloud.config.catalog.backend.datadirectory;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
+import org.geoserver.GeoServerConfigurationLock;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.plugin.CatalogPlugin;
 import org.geoserver.catalog.plugin.DefaultMemoryCatalogFacade;
+import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
+import org.geoserver.cloud.catalog.locking.LockProviderGeoServerConfigurationLock;
+import org.geoserver.cloud.catalog.locking.LockingCatalog;
+import org.geoserver.cloud.catalog.locking.LockingGeoServer;
+import org.geoserver.cloud.config.catalog.backend.core.CatalogProperties;
 import org.geoserver.cloud.config.catalog.backend.core.GeoServerBackendConfigurer;
 import org.geoserver.config.GeoServerLoader;
 import org.geoserver.config.plugin.RepositoryGeoServerFacade;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.platform.config.UpdateSequence;
+import org.geoserver.platform.resource.LockProvider;
 import org.geoserver.platform.resource.ResourceStore;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,6 +40,8 @@ import java.util.Objects;
 @Slf4j(topic = "org.geoserver.cloud.config.datadirectory")
 public class DataDirectoryBackendConfiguration implements GeoServerBackendConfigurer {
 
+    private @Autowired CatalogProperties properties;
+
     private DataDirectoryProperties dataDirectoryConfig;
 
     @Autowired
@@ -40,9 +52,34 @@ public class DataDirectoryBackendConfiguration implements GeoServerBackendConfig
                 DataDirectoryBackendConfiguration.class.getSimpleName());
     }
 
+    public @Bean CatalogPlugin rawCatalog() {
+        boolean isolated = properties.isIsolated();
+        GeoServerConfigurationLock configurationLock = configurationLock();
+        ExtendedCatalogFacade catalogFacade = catalogFacade();
+        GeoServerResourceLoader resourceLoader = resourceLoader();
+        CatalogPlugin rawCatalog = new LockingCatalog(configurationLock, catalogFacade, isolated);
+        rawCatalog.setResourceLoader(resourceLoader);
+        return rawCatalog;
+    }
+
+    @Bean(name = "geoServer")
+    public LockingGeoServer geoServer(@Qualifier("catalog") Catalog catalog) {
+
+        GeoServerConfigurationLock configurationLock = configurationLock();
+        LockingGeoServer gs = new LockingGeoServer(configurationLock, geoserverFacade());
+        gs.setCatalog(catalog);
+        return gs;
+    }
+
     @Bean
     public @Override UpdateSequence updateSequence() {
         return new DataDirectoryUpdateSequence();
+    }
+
+    @Bean
+    public @Override GeoServerConfigurationLock configurationLock() {
+        LockProvider lockProvider = resourceStoreImpl().getLockProvider();
+        return new LockProviderGeoServerConfigurationLock(lockProvider);
     }
 
     public @Override @Bean DefaultMemoryCatalogFacade catalogFacade() {
@@ -62,14 +99,19 @@ public class DataDirectoryBackendConfiguration implements GeoServerBackendConfig
         "wmtsLoader"
     })
     public @Override @Bean GeoServerLoader geoServerLoaderImpl() {
-        return new DataDirectoryGeoServerLoader(resourceLoader());
+        UpdateSequence updateSequence = updateSequence();
+        GeoServerResourceLoader resourceLoader = resourceLoader();
+        Catalog rawCatalog = rawCatalog();
+        LockingGeoServer geoserver = geoServer(rawCatalog);
+        return new DataDirectoryGeoServerLoader(
+                updateSequence, resourceLoader, geoserver, rawCatalog);
     }
 
     public @Override @Bean GeoServerResourceLoader resourceLoader() {
         ResourceStore resourceStoreImpl = resourceStoreImpl();
         GeoServerResourceLoader resourceLoader = new GeoServerResourceLoader(resourceStoreImpl);
         final @NonNull Path datadir = dataDirectoryFile();
-        log.debug("geoserver.backend.data-directory.location:" + datadir);
+        log.debug("geoserver.backend.data-directory.location: {}", datadir);
         resourceLoader.setBaseDirectory(datadir.toFile());
         return resourceLoader;
     }

--- a/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/config/catalog/backend/datadirectory/DataDirectoryUpdateSequence.java
+++ b/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/config/catalog/backend/datadirectory/DataDirectoryUpdateSequence.java
@@ -45,7 +45,9 @@ public class DataDirectoryUpdateSequence implements UpdateSequence {
 
     private static final String CLUSTER_LOCK_NAME = "UPDATE_SEQUENCE";
 
+    /** Provides the cluster aware {@link ResourceStore#getLockProvider LockProvider} */
     private @Autowired @Qualifier("resourceStoreImpl") ResourceStore resourceStore;
+
     private @Autowired @Qualifier("geoServer") GeoServer geoServer;
     private @Autowired GeoServerDataDirectory dd;
     private @Autowired XStreamPersisterFactory xpf;

--- a/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/event/remote/datadir/RemoteEventDataDirectoryProcessor.java
+++ b/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/event/remote/datadir/RemoteEventDataDirectoryProcessor.java
@@ -52,7 +52,7 @@ public class RemoteEventDataDirectoryProcessor {
     public void onUpdateSequenceEvent(UpdateSequenceEvent updateSequenceEvent) {
         if (updateSequenceEvent.isRemote()) {
             final Long updateSequence = updateSequenceEvent.getUpdateSequence();
-            log.info("applying update sequence {} from {}", updateSequence, updateSequenceEvent);
+            log.debug("processing update sequence {} from {}", updateSequence, updateSequenceEvent);
             GeoServerInfo info = ModificationProxy.unwrap(configFacade.getGlobal());
             long current = info.getUpdateSequence();
             info.setUpdateSequence(updateSequence);

--- a/src/catalog/backends/datadir/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/datadir/DataDirectoryAutoConfigurationTest.java
+++ b/src/catalog/backends/datadir/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/datadir/DataDirectoryAutoConfigurationTest.java
@@ -10,13 +10,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import org.geoserver.GeoServerConfigurationLock;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogFacade;
+import org.geoserver.cloud.catalog.locking.LockProviderGeoServerConfigurationLock;
+import org.geoserver.cloud.catalog.locking.LockingCatalog;
+import org.geoserver.cloud.catalog.locking.LockingGeoServer;
 import org.geoserver.cloud.config.catalog.backend.datadirectory.DataDirectoryBackendConfiguration;
+import org.geoserver.cloud.config.catalog.backend.datadirectory.DataDirectoryGeoServerLoader;
 import org.geoserver.cloud.config.catalog.backend.datadirectory.DataDirectoryProperties;
 import org.geoserver.cloud.config.catalog.backend.datadirectory.DataDirectoryUpdateSequence;
 import org.geoserver.cloud.config.catalog.backend.datadirectory.NoServletContextDataDirectoryResourceStore;
-import org.geoserver.config.DefaultGeoServerLoader;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerFacade;
 import org.geoserver.config.GeoServerLoader;
@@ -64,7 +68,11 @@ public class DataDirectoryAutoConfigurationTest {
     }
 
     public @Test void testCatalog() {
-        assertThat(rawCatalog, instanceOf(org.geoserver.catalog.plugin.CatalogPlugin.class));
+        assertThat(rawCatalog, instanceOf(LockingCatalog.class));
+    }
+
+    public @Test void testGeoServer() {
+        assertThat(geoServer, instanceOf(LockingGeoServer.class));
     }
 
     public @Test void testCatalogFacadeIsRawCatalogFacade() {
@@ -93,7 +101,7 @@ public class DataDirectoryAutoConfigurationTest {
     }
 
     public @Test void testGeoserverLoader() {
-        assertThat(geoserverLoader, instanceOf(DefaultGeoServerLoader.class));
+        assertThat(geoserverLoader, instanceOf(DataDirectoryGeoServerLoader.class));
     }
 
     public @Test void testResourceStoreImpl() {
@@ -104,5 +112,11 @@ public class DataDirectoryAutoConfigurationTest {
         assertThat(
                 context.getBean(UpdateSequence.class),
                 instanceOf(DataDirectoryUpdateSequence.class));
+    }
+
+    public @Test void testGeoServerConfigurationLock() {
+        assertThat(
+                context.getBean(GeoServerConfigurationLock.class),
+                instanceOf(LockProviderGeoServerConfigurationLock.class));
     }
 }

--- a/src/catalog/backends/datadir/src/test/java/org/geoserver/cloud/catalog/locking/LockProviderGeoServerConfigurationLockTest.java
+++ b/src/catalog/backends/datadir/src/test/java/org/geoserver/cloud/catalog/locking/LockProviderGeoServerConfigurationLockTest.java
@@ -1,0 +1,280 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.catalog.locking;
+
+import static org.geoserver.GeoServerConfigurationLock.LockType.READ;
+import static org.geoserver.GeoServerConfigurationLock.LockType.WRITE;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.geoserver.GeoServerConfigurationLock.LockType;
+import org.geoserver.cloud.config.catalog.backend.datadirectory.NoServletContextFileLockProvider;
+import org.geoserver.platform.resource.LockProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * @since 1.0
+ */
+class LockProviderGeoServerConfigurationLockTest {
+
+    @TempDir File mockDataDir;
+
+    private LockProviderGeoServerConfigurationLock lock;
+
+    @BeforeEach
+    public void beforeEach() {
+        System.setProperty("CONFIGURATION_TRYLOCK_TIMEOUT", "100");
+        LockProvider lockProvider = new NoServletContextFileLockProvider(mockDataDir);
+        lock = new LockProviderGeoServerConfigurationLock(lockProvider);
+    }
+
+    @AfterEach
+    public void afterEach() {
+        System.clearProperty("CONFIGURATION_TRYLOCK_TIMEOUT");
+        assertFalse(lock.isWriteLocked(), "all locks shall have been released");
+    }
+
+    @Test
+    @Timeout(1)
+    public void testLock_WriteLock() {
+        assertNull(lock.getCurrentLock());
+        lock.lock(WRITE);
+        assertEquals(WRITE, lock.getCurrentLock());
+        lock.unlock();
+        assertNull(lock.getCurrentLock());
+    }
+
+    @Test
+    @Timeout(1)
+    public void testLock_ReadLock() {
+        assertNull(lock.getCurrentLock());
+        lock.lock(READ);
+        assertEquals(READ, lock.getCurrentLock());
+        lock.unlock();
+        assertNull(lock.getCurrentLock());
+    }
+
+    @Test
+    @Timeout(1)
+    public void testLock_ReadLock_preserves_write_lock_if_alread_held() {
+        assertNull(lock.getCurrentLock());
+        lock.lock(WRITE);
+        assertEquals(WRITE, lock.getCurrentLock());
+
+        lock.lock(READ);
+        assertEquals(
+                WRITE,
+                lock.getCurrentLock(),
+                "A read lock request shall preserve the write lock if already held");
+        lock.unlock();
+    }
+
+    @Test
+    @Timeout(1)
+    public void testTryUpgradeLock_fais_if_no_previous_lock_is_held() {
+        assertNull(lock.getCurrentLock());
+        IllegalStateException ex = assertThrows(IllegalStateException.class, lock::tryUpgradeLock);
+        assertThat(ex.getMessage(), containsString("No lock currently held"));
+    }
+
+    @Test
+    @Timeout(1)
+    public void testTryUpgradeLock_fails_if_already_holds_a_write_lock() {
+        assertNull(lock.getCurrentLock());
+        lock.lock(WRITE);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class, lock::tryUpgradeLock);
+        assertThat(ex.getMessage(), containsString("Already owning a write lock"));
+        // this case, contrary to when a read lock is held, but tryUpgradeLock() fails, does not
+        // release the currently held lock
+        assertEquals(WRITE, lock.getCurrentLock());
+        lock.unlock();
+    }
+
+    @Test
+    @Timeout(1)
+    public void testTryUpgradeLock() throws InterruptedException, ExecutionException {
+        ExecutorService secondThread = Executors.newSingleThreadExecutor();
+        try {
+            lock.lock(READ);
+
+            secondThread
+                    .submit(
+                            () -> {
+                                assertTrue(lock.tryLock(READ));
+                            })
+                    .get();
+
+            assertEquals(READ, lock.getCurrentLock());
+
+            RuntimeException ex = assertThrows(RuntimeException.class, () -> lock.tryUpgradeLock());
+            assertThat(
+                    ex.getMessage(),
+                    containsString("Failed to upgrade lock from read to write state"));
+
+            assertNull(
+                    lock.getCurrentLock(),
+                    "lock should have been lost after a failed tryUpgradeLock()");
+
+            lock.lock(READ);
+
+            secondThread.submit(lock::unlock).get();
+
+            lock.tryUpgradeLock();
+            assertEquals(WRITE, lock.getCurrentLock());
+        } finally {
+            secondThread.shutdownNow();
+            lock.unlock();
+        }
+    }
+
+    @Test
+    @Timeout(1)
+    public void testTryLock() {
+        assertTrue(lock.tryLock(READ));
+        assertEquals(READ, lock.getCurrentLock());
+        lock.unlock();
+        assertNull(lock.getCurrentLock());
+
+        assertTrue(lock.tryLock(WRITE));
+        assertEquals(WRITE, lock.getCurrentLock());
+        lock.unlock();
+        assertNull(lock.getCurrentLock());
+    }
+
+    @Test
+    @Timeout(1)
+    public void testTryLock_false_if_write_lock_requested_while_holding_a_read_lock() {
+        assertNull(lock.getCurrentLock());
+
+        assertTrue(lock.tryLock(READ));
+        assertEquals(READ, lock.getCurrentLock());
+
+        assertFalse(lock.tryLock(WRITE));
+        assertEquals(READ, lock.getCurrentLock());
+        lock.unlock();
+        assertNull(lock.getCurrentLock());
+    }
+
+    @Test
+    @Timeout(1)
+    public void testTryLock_true_if_read_lock_requested_while_holding_a_write_lock() {
+        assertTrue(lock.tryLock(WRITE));
+        assertEquals(WRITE, lock.getCurrentLock());
+
+        assertTrue(lock.tryLock(READ));
+        assertEquals(
+                WRITE,
+                lock.getCurrentLock(),
+                "tryLock(READ) while holding a write lock shall preserve the write lock");
+
+        lock.unlock();
+        assertNull(lock.getCurrentLock());
+        assertFalse(lock.isWriteLocked());
+    }
+
+    @Test
+    @Timeout(1)
+    public void testUnlock() {
+        assertNull(lock.getCurrentLock());
+        lock.unlock();
+        lock.unlock();
+        assertNull(lock.getCurrentLock());
+
+        lock.lock(READ);
+        lock.unlock();
+        assertNull(lock.getCurrentLock());
+
+        lock.lock(WRITE);
+        lock.unlock();
+        assertNull(lock.getCurrentLock());
+    }
+
+    @Test
+    @Timeout(1)
+    public void testLock_ReadLockIsReentrant() {
+        testLockIsReentrant(READ);
+    }
+
+    @Test
+    @Timeout(1)
+    public void testLock_WriteLockIsReentrant() {
+        testLockIsReentrant(WRITE);
+    }
+
+    private void testLockIsReentrant(LockType lockType) {
+        assertNull(lock.getCurrentLock());
+        // first time
+        lock.lock(lockType);
+        try {
+            assertEquals(lockType, lock.getCurrentLock());
+            try {
+                // second acquire
+                lock.lock(lockType);
+                assertEquals(lockType, lock.getCurrentLock());
+            } finally {
+                // first release
+                lock.unlock();
+                assertEquals(
+                        lockType, lock.getCurrentLock(), lockType + " lock should still be held");
+            }
+        } finally {
+            // second release
+            lock.unlock();
+            assertNull(lock.getCurrentLock());
+        }
+        assertFalse(lock.isWriteLocked());
+    }
+
+    @Test
+    @Timeout(1)
+    public void testTryReadLockIsReentrant() {
+        testTryLockIsReentrant(READ);
+    }
+
+    @Test
+    @Timeout(1)
+    public void testTryWriteLockIsReentrant() {
+        testTryLockIsReentrant(WRITE);
+    }
+
+    private void testTryLockIsReentrant(final LockType lockType) {
+        assertNull(lock.getCurrentLock());
+        // common case scenario from nested calls:
+
+        // first time
+        try {
+            assertTrue(lock.tryLock(lockType));
+            assertEquals(lockType, lock.getCurrentLock());
+            try {
+                assertTrue(lock.tryLock(lockType));
+                assertEquals(lockType, lock.getCurrentLock());
+            } finally {
+                // first release
+                lock.unlock();
+                assertEquals(
+                        lockType, lock.getCurrentLock(), lockType + " lock should still be held");
+            }
+        } finally {
+            // second release
+            lock.unlock();
+            assertNull(lock.getCurrentLock());
+        }
+    }
+}

--- a/src/catalog/backends/datadir/src/test/java/org/geoserver/cloud/catalog/locking/LockingCatalogDataDirectoryTest.java
+++ b/src/catalog/backends/datadir/src/test/java/org/geoserver/cloud/catalog/locking/LockingCatalogDataDirectoryTest.java
@@ -1,0 +1,35 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.catalog.locking;
+
+import org.geoserver.GeoServerConfigurationLock;
+import org.geoserver.cloud.config.catalog.backend.datadirectory.NoServletContextFileLockProvider;
+import org.geoserver.platform.resource.LockProvider;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+
+/**
+ * @since 1.0
+ */
+public class LockingCatalogDataDirectoryTest extends LockingCatalogTest {
+
+    @TempDir File tmpDir;
+
+    static @BeforeAll void beforeAll() {
+        System.setProperty("CONFIGURATION_TRYLOCK_TIMEOUT", "100");
+    }
+
+    static @AfterAll void afterAll() {
+        System.clearProperty("CONFIGURATION_TRYLOCK_TIMEOUT");
+    }
+
+    protected @Override GeoServerConfigurationLock createConfigLock() {
+        LockProvider lockProvider = new NoServletContextFileLockProvider(tmpDir);
+        return new LockProviderGeoServerConfigurationLock(lockProvider);
+    }
+}

--- a/src/catalog/backends/datadir/src/test/java/org/geoserver/cloud/catalog/locking/LockingCatalogTest.java
+++ b/src/catalog/backends/datadir/src/test/java/org/geoserver/cloud/catalog/locking/LockingCatalogTest.java
@@ -1,0 +1,251 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.catalog.locking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.geoserver.GeoServerConfigurationLock;
+import org.geoserver.GeoServerConfigurationLock.LockType;
+import org.geoserver.catalog.CascadeDeleteVisitor;
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.faker.CatalogFaker;
+import org.geoserver.catalog.plugin.CatalogPlugin;
+import org.geoserver.cloud.event.info.ConfigInfoType;
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.plugin.GeoServerImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * @since 1.0
+ */
+class LockingCatalogTest {
+
+    private GeoServerConfigurationLock configLock;
+    private CatalogPlugin catalog;
+    private CatalogFaker faker;
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @BeforeEach
+    void setUp() throws Exception {
+        configLock = createConfigLock();
+        catalog = new LockingCatalog(configLock);
+        GeoServer geoserver = new GeoServerImpl();
+        geoserver.setCatalog(catalog);
+        // GeoServerResourceLoader resourceLoader;
+        // XStreamPersister xstreamPersister;
+        // catalog.addListener(new GeoServerConfigPersister(resourceLoader, xstreamPersister));
+        faker = new CatalogFaker(catalog, geoserver);
+    }
+
+    protected GeoServerConfigurationLock createConfigLock() {
+        return new GeoServerConfigurationLock();
+    }
+
+    @Test
+    void testConfigLockIsReentrant() {
+        configLock.lock(LockType.WRITE);
+        assertEquals(LockType.WRITE, configLock.getCurrentLock());
+        configLock.unlock();
+        assertNull(configLock.getCurrentLock());
+
+        // lock twice
+        configLock.lock(LockType.WRITE);
+        assertEquals(LockType.WRITE, configLock.getCurrentLock());
+
+        configLock.lock(LockType.WRITE);
+        assertEquals(LockType.WRITE, configLock.getCurrentLock());
+
+        // first unlock, shall still hold the lock
+        configLock.unlock();
+        assertEquals(LockType.WRITE, configLock.getCurrentLock());
+
+        // second unlock, must actually release the lock
+        configLock.unlock();
+        assertNull(configLock.getCurrentLock());
+    }
+
+    @Test
+    void simpleMultiThreadTest() {
+        List<WorkspaceInfo> workspaces =
+                IntStream.range(0, 100).parallel().mapToObj(i -> faker.workspaceInfo()).toList();
+
+        workspaces.stream().forEach(catalog::add);
+
+        List<WorkspaceInfo> catalogs = catalog.getWorkspaces();
+        assertEquals(workspaces.size(), catalogs.size());
+        assertNotNull(catalog.getDefaultWorkspace());
+        assertEquals(Set.copyOf(workspaces), Set.copyOf(catalogs));
+    }
+
+    @Test
+    void preAcquiredLockMultiThreadTest() {
+        List<WorkspaceInfo> workspaces =
+                IntStream.range(0, 100)
+                        .parallel()
+                        .mapToObj(i -> faker.workspaceInfo("ws-" + i))
+                        .toList();
+
+        List<List<CatalogInfo>> created =
+                workspaces //
+                        .stream() //
+                        .parallel() //
+                        .map(this::batchCreateSubTree)
+                        .toList();
+
+        assertNotNull(catalog.getDefaultWorkspace());
+
+        assertThat(catalog.getLayers()).size().isEqualTo(workspaces.size());
+        assertThat(catalog.getStyles()).size().isEqualTo(workspaces.size());
+        assertThat(catalog.getFeatureTypes()).size().isEqualTo(workspaces.size());
+        assertThat(catalog.getDataStores()).size().isEqualTo(workspaces.size());
+        assertThat(catalog.getNamespaces()).size().isEqualTo(workspaces.size());
+        assertThat(catalog.getWorkspaces()).size().isEqualTo(workspaces.size());
+
+        created //
+                .stream() //
+                .parallel() //
+                .forEach(this::batchUpdate);
+
+        Stream<List<? extends CatalogInfo>> updated =
+                created //
+                        .stream()
+                        .map(
+                                list -> {
+                                    List<? extends CatalogInfo> sublist =
+                                            list.stream()
+                                                    .map(CatalogInfo::getId)
+                                                    .map(catalog::findById)
+                                                    .map(Optional::orElseThrow)
+                                                    .toList();
+                                    return sublist;
+                                });
+
+        updated //
+                .parallel() //
+                .forEach(this::batchDelete);
+
+        assertThat(catalog.getLayers()).isEmpty();
+        assertThat(catalog.getStyles()).isEmpty();
+        assertThat(catalog.getFeatureTypes()).isEmpty();
+        assertThat(catalog.getDataStores()).isEmpty();
+        assertThat(catalog.getNamespaces()).isEmpty();
+        assertThat(catalog.getWorkspaces()).isEmpty();
+    }
+
+    private void batchUpdate(List<? extends CatalogInfo> infos) {
+        configLock.lock(LockType.WRITE);
+        try {
+            for (CatalogInfo info : infos) {
+                final ConfigInfoType type = ConfigInfoType.valueOf(info);
+                switch (type) {
+                    case WorkspaceInfo:
+                        ((WorkspaceInfo) info).setName(faker.name());
+                        break;
+                    case NamespaceInfo:
+                        ((NamespaceInfo) info).setURI(faker.url());
+                        break;
+                    case DataStoreInfo:
+                        ((DataStoreInfo) info).setName(faker.name());
+                        ((DataStoreInfo) info)
+                                .getConnectionParameters()
+                                .put("someparam", "somevalue");
+                        ((DataStoreInfo) info).getMetadata().put("somekey", "key value");
+                        break;
+                    case FeatureTypeInfo:
+                        ((FeatureTypeInfo) info).setName(faker.name());
+                        break;
+                    case LayerInfo:
+                        // ((LayerInfo) info).setName(faker.name());
+                        ((LayerInfo) info).setAdvertised(false);
+                        break;
+                    case StyleInfo:
+                        ((StyleInfo) info).setDateModified(new Date());
+                        ((StyleInfo) info).getMetadata().put("somekey", "key value");
+                        break;
+                    default:
+                        throw new IllegalStateException("Unexpected catalog info type " + type);
+                }
+                catalog.save(info);
+            }
+        } finally {
+            assertEquals(
+                    LockType.WRITE, configLock.getCurrentLock(), "lock should have been upgraded");
+            configLock.unlock();
+        }
+    }
+
+    private void batchDelete(List<? extends CatalogInfo> infos) {
+        configLock.lock(LockType.WRITE);
+        try {
+            WorkspaceInfo ws =
+                    infos.stream()
+                            .filter(WorkspaceInfo.class::isInstance)
+                            .map(WorkspaceInfo.class::cast)
+                            .findFirst()
+                            .orElseThrow();
+
+            CascadeDeleteVisitor cascadeDeleteVisitor = new CascadeDeleteVisitor(catalog);
+            ws.accept(cascadeDeleteVisitor);
+
+            infos.stream().forEach(catalog::remove);
+        } finally {
+            assertEquals(
+                    LockType.WRITE, configLock.getCurrentLock(), "lock should have been upgraded");
+            configLock.unlock();
+        }
+    }
+
+    private List<CatalogInfo> batchCreateSubTree(WorkspaceInfo workspace) {
+        configLock.lock(LockType.WRITE);
+        try {
+            catalog.add(workspace);
+            workspace = catalog.getWorkspace(workspace.getId());
+            NamespaceInfo namespace = faker.namespace(workspace.getName());
+            catalog.add(namespace);
+            namespace = catalog.getNamespace(namespace.getId());
+
+            DataStoreInfo ds = faker.dataStoreInfo(workspace);
+            catalog.add(ds);
+            ds = catalog.getDataStore(ds.getId());
+
+            FeatureTypeInfo ft = faker.featureTypeInfo(ds);
+            catalog.add(ft);
+            ft = catalog.getFeatureType(ft.getId());
+
+            StyleInfo style = faker.styleInfo();
+            catalog.add(style);
+            style = catalog.getStyle(style.getId());
+
+            LayerInfo layer = faker.layerInfo(ft, style);
+            catalog.add(layer);
+            layer = catalog.getLayer(layer.getId());
+
+            return List.of(workspace, namespace, ds, ft, style, layer);
+        } finally {
+            assertEquals(
+                    LockType.WRITE, configLock.getCurrentLock(), "lock should have been upgraded");
+            configLock.unlock();
+        }
+    }
+}

--- a/src/catalog/backends/datadir/src/test/resources/application.yml
+++ b/src/catalog/backends/datadir/src/test/resources/application.yml
@@ -28,3 +28,4 @@ logging:
     org.geoserver.cloud.config.factory: warn
     org.geoserver.jdbcconfig: warn
     org.geoserver.jdbcstore: warn
+    org.geoserver.cloud.catalog.locking: debug

--- a/src/catalog/backends/jdbcconfig/src/main/java/org/geoserver/cloud/config/catalog/backend/jdbcconfig/JDBCConfigBackendConfigurer.java
+++ b/src/catalog/backends/jdbcconfig/src/main/java/org/geoserver/cloud/config/catalog/backend/jdbcconfig/JDBCConfigBackendConfigurer.java
@@ -13,6 +13,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
+import org.geoserver.GeoServerConfigurationLock;
 import org.geoserver.catalog.plugin.CatalogFacadeExtensionAdapter;
 import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
 import org.geoserver.cloud.config.catalog.backend.core.GeoServerBackendConfigurer;
@@ -135,6 +136,11 @@ public class JDBCConfigBackendConfigurer implements GeoServerBackendConfigurer {
         DataSource dataSource = jdbcConfigDataSource();
         CloudJdbcConfigProperties props = jdbcConfigProperties();
         return new JdbcConfigUpdateSequence(dataSource, props);
+    }
+
+    @Bean
+    public @Override GeoServerConfigurationLock configurationLock() {
+        return new GeoServerConfigurationLock();
     }
 
     @DependsOn("jdbcConfigDataSourceStartupValidator")

--- a/src/catalog/event-bus/src/test/java/org/geoserver/cloud/event/bus/TestConfigurationAutoConfiguration.java
+++ b/src/catalog/event-bus/src/test/java/org/geoserver/cloud/event/bus/TestConfigurationAutoConfiguration.java
@@ -7,9 +7,11 @@ package org.geoserver.cloud.event.bus;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.plugin.CatalogPlugin;
 import org.geoserver.config.GeoServer;
+import org.geoserver.config.plugin.GeoServerImpl;
 import org.geoserver.config.util.XStreamPersisterFactory;
 import org.geoserver.platform.config.DefaultUpdateSequence;
 import org.geoserver.platform.config.UpdateSequence;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -31,7 +33,9 @@ public class TestConfigurationAutoConfiguration {
         return new CatalogPlugin(false);
     }
 
-    public @Bean GeoServer geoServer() {
-        return new org.geoserver.config.plugin.GeoServerImpl();
+    public @Bean GeoServer geoServer(@Qualifier("catalog") Catalog catalog) {
+        GeoServerImpl gs = new org.geoserver.config.plugin.GeoServerImpl();
+        gs.setCatalog(catalog);
+        return gs;
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/security/SecurityConfigChanged.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/security/SecurityConfigChanged.java
@@ -7,30 +7,32 @@ package org.geoserver.cloud.event.security;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NonNull;
 
 import org.geoserver.cloud.event.UpdateSequenceEvent;
 import org.geoserver.security.GeoServerSecurityManager;
+import org.springframework.core.style.ToStringCreator;
 
 /**
  * Application event to notify services of changes in the {@link GeoServerSecurityManager security
  * configuration}.
  */
-@Data
-@EqualsAndHashCode(callSuper = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonTypeName("SecurityConfigChanged")
 public class SecurityConfigChanged extends UpdateSequenceEvent<SecurityConfigChanged> {
 
-    private @NonNull String reason;
+    private @NonNull @Getter String reason;
 
     protected SecurityConfigChanged() {}
 
     protected SecurityConfigChanged(@NonNull Long updateSequence, @NonNull String reason) {
         super(updateSequence);
         this.reason = reason;
+    }
+
+    protected @Override ToStringCreator toStringBuilder() {
+        return super.toStringBuilder().append("reason", reason);
     }
 
     public static SecurityConfigChanged createLocal(

--- a/src/catalog/events/src/test/java/org/geoserver/cloud/config/catalog/events/CatalogApplicationEventsConfigurationTest.java
+++ b/src/catalog/events/src/test/java/org/geoserver/cloud/config/catalog/events/CatalogApplicationEventsConfigurationTest.java
@@ -4,7 +4,7 @@
  */
 package org.geoserver.cloud.config.catalog.events;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -162,6 +162,8 @@ public class CatalogApplicationEventsConfigurationTest {
 
     public @Test void testConfigAddEvents() {
         catalog.add(testData.workspaceB);
+        assertNotNull(catalog.getWorkspace(testData.workspaceB.getId()));
+        assertSame(catalog, geoserver.getCatalog());
 
         @SuppressWarnings("rawtypes")
         Class<ConfigInfoAdded> eventType = ConfigInfoAdded.class;

--- a/src/catalog/events/src/test/java/org/geoserver/cloud/config/catalog/events/TestConfigurationAutoConfiguration.java
+++ b/src/catalog/events/src/test/java/org/geoserver/cloud/config/catalog/events/TestConfigurationAutoConfiguration.java
@@ -7,9 +7,11 @@ package org.geoserver.cloud.config.catalog.events;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.plugin.CatalogPlugin;
 import org.geoserver.config.GeoServer;
+import org.geoserver.config.plugin.GeoServerImpl;
 import org.geoserver.config.util.XStreamPersisterFactory;
 import org.geoserver.platform.config.DefaultUpdateSequence;
 import org.geoserver.platform.config.UpdateSequence;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -32,7 +34,9 @@ class TestConfigurationAutoConfiguration {
         return new CatalogPlugin(isolated);
     }
 
-    public @Bean GeoServer geoServer() {
-        return new org.geoserver.config.plugin.GeoServerImpl();
+    public @Bean GeoServer geoServer(@Qualifier("catalog") Catalog catalog) {
+        GeoServerImpl gs = new org.geoserver.config.plugin.GeoServerImpl();
+        gs.setCatalog(catalog);
+        return gs;
     }
 }

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModuleTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModuleTest.java
@@ -116,6 +116,7 @@ public class GeoServerCatalogModuleTest {
     public @BeforeEach void before() {
         catalog = new CatalogPlugin();
         geoserver = new GeoServerImpl();
+        geoserver.setCatalog(catalog);
         data = CatalogTestData.initialized(() -> catalog, () -> geoserver).initialize();
         proxyResolver = new ProxyUtils(catalog, geoserver);
     }

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/PatchSerializationTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/PatchSerializationTest.java
@@ -117,6 +117,7 @@ public class PatchSerializationTest {
     public @BeforeEach void before() {
         catalog = new CatalogPlugin();
         geoserver = new GeoServerImpl();
+        geoserver.setCatalog(catalog);
         data = CatalogTestData.initialized(() -> catalog, () -> geoserver).initialize();
         proxyResolver = new ProxyUtils(catalog, geoserver);
     }

--- a/src/catalog/plugin/src/main/java/org/geoserver/config/plugin/GeoServerImpl.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/config/plugin/GeoServerImpl.java
@@ -37,6 +37,7 @@ import org.springframework.context.ApplicationContextAware;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -180,10 +181,20 @@ public class GeoServerImpl implements GeoServer, ApplicationContextAware {
     }
 
     void validate(SettingsInfo settings) {
-        WorkspaceInfo workspace = settings.getWorkspace();
+        final WorkspaceInfo workspace = settings.getWorkspace();
         if (workspace == null) {
             throw new IllegalArgumentException("Settings must be part of a workspace");
         }
+        Catalog catalog = getCatalog();
+        // make sure the workspace exists and is not dettached from the catalog
+        final WorkspaceInfo realws = catalog.getWorkspace(workspace.getId());
+        Objects.requireNonNull(
+                realws,
+                () ->
+                        String.format(
+                                "Workspace %s(%s) attached to SettingsInfo does not exist",
+                                workspace.getName(), workspace.getId()));
+        settings.setWorkspace(realws);
     }
 
     void resolve(SettingsInfo settings) {

--- a/src/catalog/plugin/src/test/java/org/geoserver/catalog/CatalogTestData.java
+++ b/src/catalog/plugin/src/test/java/org/geoserver/catalog/CatalogTestData.java
@@ -304,6 +304,9 @@ public class CatalogTestData {
                 throw new IllegalStateException(
                         "No GeoServer provided, either disable config initialization or provide a GeoServer instance");
             }
+            if (geoServer.getCatalog() == null) {
+                throw new IllegalStateException("GeoServer.getCatalog() is null");
+            }
             deleteAll(geoServer);
 
             geoServer.setGlobal(global);

--- a/src/catalog/plugin/src/test/java/org/geoserver/catalog/faker/CatalogFaker.java
+++ b/src/catalog/plugin/src/test/java/org/geoserver/catalog/faker/CatalogFaker.java
@@ -90,6 +90,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -187,6 +188,10 @@ public class CatalogFaker {
         return lyr;
     }
 
+    public StyleInfo styleInfo() {
+        return styleInfo(name());
+    }
+
     public StyleInfo styleInfo(@NonNull String name) {
         return styleInfo(name, (WorkspaceInfo) null);
     }
@@ -276,6 +281,19 @@ public class CatalogFaker {
         return cstore;
     }
 
+    public FeatureTypeInfo featureTypeInfo(DataStoreInfo ds) {
+        String prefix = ds.getWorkspace().getName();
+        NamespaceInfo ns = catalog().getNamespaceByPrefix(prefix);
+        Objects.requireNonNull(ns, "Namespace " + prefix + " does not exist");
+
+        String id = "FeatureType." + id();
+        String name = name();
+        String abstracT = faker().company().bs();
+        String description = faker().company().buzzword();
+        boolean enabled = true;
+        return featureTypeInfo(id, ds, ns, name, abstracT, description, enabled);
+    }
+
     public FeatureTypeInfo featureTypeInfo(
             String id,
             DataStoreInfo ds,
@@ -296,8 +314,12 @@ public class CatalogFaker {
         return fttype;
     }
 
+    public DataStoreInfo dataStoreInfo(WorkspaceInfo ws) {
+        return dataStoreInfo(name(), ws);
+    }
+
     public DataStoreInfo dataStoreInfo(String name, WorkspaceInfo ws) {
-        return dataStoreInfo(name + "-id", ws, name, name + " description", true);
+        return dataStoreInfo("DataStoreInfo." + id(), ws, name, name + " description", true);
     }
 
     public DataStoreInfo dataStoreInfo(
@@ -317,8 +339,16 @@ public class CatalogFaker {
         return dstore;
     }
 
+    public WorkspaceInfo workspaceInfo() {
+        return workspaceInfo(name());
+    }
+
+    public String name() {
+        return faker.internet().domainName() + "_" + faker.random().hex();
+    }
+
     public WorkspaceInfo workspaceInfo(String name) {
-        return workspaceInfo(name + "-id", name);
+        return workspaceInfo("WorkspaceInfo." + id(), name);
     }
 
     public WorkspaceInfo workspaceInfo(String id, String name) {
@@ -329,8 +359,8 @@ public class CatalogFaker {
         return workspace;
     }
 
-    private String url() {
-        return faker().company().url();
+    public String url() {
+        return faker().company().url() + "/" + faker.random().hex();
     }
 
     private String id() {

--- a/src/starters/webmvc/src/main/java/org/geoserver/cloud/config/main/GeoServerMainModuleConfiguration.java
+++ b/src/starters/webmvc/src/main/java/org/geoserver/cloud/config/main/GeoServerMainModuleConfiguration.java
@@ -93,6 +93,7 @@ public class GeoServerMainModuleConfiguration {
             |resourceStoreImpl\
             |xstreamPersisterFactory\
             |loggingInitializer\
+            |configurationLock\
             """;
 
     static final String EXCLUDE_BEANS_REGEX =


### PR DESCRIPTION
Data-directory backend cluster-wide locking on configuration changes

For the data-directory catalog and configuration back-end, it is important to serialize changes cluster-wide, since there's no concept of transactions.
    
The following changes have been implemented:

- Exclude `configurationLock` from being loaded from gs-main's `applicationContext.xml`
- Make it mandatory for the catalog backend autoconfigurations to provide a `GeoServerConfigurationLock` bean.
- `CoreBackendConfiguration` optionally contributes `rawCatalog:Catalog` and `geoServer:GeoServer`,
- `DataDirectoryBackendConfigurer` contributes `rawCatalog:LockingCatalog`, `geoServer:LockingGeoserver`, and `configurationLock:LockProviderGeoServerConfigurationLock`
- `LockProviderGeoServerConfigurationLock` extends the semantics of `GeoServerConfigurationLock` with the guarantees provided by `ResourceStore`'s `LockProvider`, which in turn is required to be a cluster-wide lock provider specific to the catalog backend in use.
- `GeoServerConfigurationLock` has been made reentrant as of GEOS-10560.
- `LockingCatalog` and `LockingGeoserver` use the `GeoServerConfigurationLock` to guard catalog and config mutating operations.
- `LockingCatalog` operates at a coarser granularity than upstream's `LockingCatalogFacade`, wich is now possible thanks to the reentrant nature of `GeoSeverConfigurationLock`. Locking at the facade level is of no use because a single catalog operation may result in several facade calls, each of which would lock for the single operation instead of all calls triggered by the catalog method (for example, a `Catalog.add(WorkspaceInfo)` could result in calling both `CatalogFacade.add(WorkspaceInfo)` and `CatalogFacade.setDefaultWorkspace()`
- `CatalogPlugin`'s synchronization on `CatalogFacade` for add/remove/save operations has been removed as it doesn't make sense.
