### PR TITLE
Disable default activation of docker image building profiles

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -38,11 +38,11 @@ jobs:
         cache: 'maven'
 
     - name: Validate source code formatting
-      run: ./mvnw fmt:check -f src/ -ntp
+      run: make check
 
     - name: Build GeoServer 2.21.0-CLOUD
       run: |
-        ./mvnw install -f ./geoserver_submodule -ntp -DskipTests -Dfmt.skip -T1C 
+        make install 
 
     - name: Build and push Hotspot and OpenJ9 docker images
       run: ./mvnw install -f src/ -Ddockerfile.push.skip=false -ntp -Dfmt.skip -T1 -DskipTests

--- a/.github/workflows/config-service-native-image.yaml
+++ b/.github/workflows/config-service-native-image.yaml
@@ -52,8 +52,7 @@ jobs:
 
     - name: Build config-service native image
       run: |
-        ./mvnw -pl :gs-cloud-config-service install -am -Dfmt.action=check -ntp -P-geoserver,-docker,-docker-openj9
-        ./mvnw -pl :gs-cloud-config-service spring-boot:build-image -Pnative,-geoserver -ntp -DskipTests -Dfmt.skip
+        make build-config-native-image
 
     - name: Push image to docker.io
       if: ${{ (github.repository == 'geoserver/geoserver-cloud') && (github.event_name != 'pull_request') }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -29,17 +29,19 @@ jobs:
         cache: 'maven'
 
     - name: Validate source code formatting
-      run: ./mvnw -f src/ fmt:check -ntp
+      run: make check
 
     - name: Build GeoServer 2.21.0-CLOUD
       run: |
-        ./mvnw install -f ./geoserver_submodule -ntp -DskipTests -Dfmt.skip -T1C 
+        make deps 
 
     - name: Build without tests
-      run: ./mvnw -f src/ install -P-docker,-docker-openj9 -ntp -Dfmt.skip -T1C -DskipTests
+      run: |
+        make install
 
     - name: Test
-      run: ./mvnw -f src/ verify -P-docker,-docker-openj9 -ntp -T1C -fae
+      run: |
+        make test
 
     - name: Remove project jars from cached repository
       run: |

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,41 @@
 all: deps install test docker
 
-
+# run `make build-image[-*] PUSH=true` to push the images to dockerhub
 PUSH?="false"
 
-format-chek:
-	./mvnw -f src/ fmt:check -DskipTests -ntp -T4
+check:
+	./mvnw -f src/ -P-geoserver fmt:check -DskipTests -ntp -T4
 
 deps:
 	./mvnw -f geoserver_submodule/ clean install -DskipTests -ntp -T4
 
 install:
-	./mvnw -f src/ clean install -DskipTests -ntp -T4 -P-docker,-docker-openj9
+	./mvnw clean install -P-geoserver -DskipTests -ntp -T4
 
 test:
-	./mvnw -f src/ verify -ntp -T4 -P-docker,-docker-openj9
+	./mvnw verify -P-geoserver -ntp -T4
 
-docker:
-	./mvnw clean package -f src/apps -Ddockerfile.push.skip=$(PUSH) -ntp -Dfmt.skip -T4 -DskipTests -P-docker-openj9
+build-image: build-image-infrastructure build-image-geoserver
 
-docker-openj9:
-	./mvnw clean package -f src/apps -Ddockerfile.push.skip=$(PUSH) -ntp -Dfmt.skip -T4 -DskipTests -P-docker
+build-image-openj9: build-image-infrastructure-openj9 build-image-geoserver-openj9
+
+build-image-infrastructure:
+	./mvnw clean package -f src/apps/infrastructure \
+	-Ddocker -P-geoserver -Ddockerfile.push.skip=$(PUSH) -ntp -Dfmt.skip -DskipTests
+
+build-image-infrastructure-openj9:
+	./mvnw clean package -f src/apps/infrastructure \
+	-Dopenj9 -P-geoserver -Ddockerfile.push.skip=$(PUSH) -ntp -Dfmt.skip -DskipTests
+
+build-image-geoserver:
+	./mvnw clean package -f src/apps/geoserver \
+	-Ddocker -P-geoserver -Ddockerfile.push.skip=$(PUSH) -ntp -Dfmt.skip -DskipTests
+  
+build-image-geoserver-openj9:
+	./mvnw clean package -f src/apps/geoserver \
+	-Dopenj9 -P-geoserver -Ddockerfile.push.skip=$(PUSH) -ntp -Dfmt.skip -DskipTests
+
+build-config-native-image:
+	./mvnw -pl :gs-cloud-config-service package -am -Dfmt.action=check -ntp -P-geoserver
+	./mvnw -pl :gs-cloud-config-service spring-boot:build-image -Pnative,-geoserver -ntp -DskipTests -Dfmt.skip
+

--- a/README.md
+++ b/README.md
@@ -47,16 +47,25 @@ Requirements:
  * [Docker](https://docs.docker.com/engine/install/) version >= `19.03.3`
  * [docker-compose](https://docs.docker.com/compose/) version >= `1.26.2`
 
-The simple `./mvnw install` command from the project root directory will
+The simple `make` command from the project root directory will
 build and install all the required components, including upstream GeoServer
-dependencies and GeoServer-Cloud Docker images.
-
-If its your first run, you may want to build without running tests to
-speed up the build, not including a full upstream GeoServer build. Read
-the sections bellow for more information.
+dependencies and GeoServer-Cloud Docker images. So for a full build just run:
 
 ```bash
-$ ./mvnw clean install -DskipTests
+make
+```
+
+Then for further builds, unless the `geoserver_submodule/` has changed,
+you can build without running tests with
+
+```bash
+make install
+```
+
+and run tests with
+
+```bash
+make test
 ```
 
 ### Custom upstream GeoServer version
@@ -85,7 +94,17 @@ So in general, you may chose to only eventually build the
 frequently, with
 
 ```bash
-./mvnw clean install -f geoserver_submodule -DskipTests
+make deps
+```
+
+### Build the docker images
+
+As mentioned above, a `make` with no arguments will build everything.
+
+But to build only the docker images, run:
+
+```bash
+make build-image
 ```
 
 ### Targeted builds
@@ -105,7 +124,7 @@ Or
 
 ```bash
 $ cd src/
-$ ./mvnw clean install
+$ ../mvnw clean install
 ```
 
 ## Running

--- a/src/apps/geoserver/catalog/pom.xml
+++ b/src/apps/geoserver/catalog/pom.xml
@@ -35,7 +35,10 @@
     <profile>
       <id>docker</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>docker</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -49,7 +52,10 @@
     <profile>
       <id>docker-openj9</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>openj9</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -73,7 +79,7 @@
               </execution>
               <execution>
                 <id>push-openj9-image</id>
-                <phase>install</phase>
+                <phase>package</phase>
                 <goals>
                   <goal>push</goal>
                 </goals>

--- a/src/apps/geoserver/gwc/pom.xml
+++ b/src/apps/geoserver/gwc/pom.xml
@@ -96,7 +96,10 @@
     <profile>
       <id>docker</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>docker</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -110,7 +113,10 @@
     <profile>
       <id>docker-openj9</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>openj9</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -136,7 +142,7 @@
                 <id>push-openj9-image</id>
                 <phase>install</phase>
                 <goals>
-                  <goal>push</goal>
+                  <goal>package</goal>
                 </goals>
                 <configuration>
                   <skip>${dockerfile.push.skip}</skip>

--- a/src/apps/geoserver/restconfig/pom.xml
+++ b/src/apps/geoserver/restconfig/pom.xml
@@ -56,7 +56,10 @@
     <profile>
       <id>docker</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>docker</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -70,7 +73,10 @@
     <profile>
       <id>docker-openj9</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>openj9</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -96,7 +102,7 @@
                 <id>push-openj9-image</id>
                 <phase>install</phase>
                 <goals>
-                  <goal>push</goal>
+                  <goal>package</goal>
                 </goals>
                 <configuration>
                   <skip>${dockerfile.push.skip}</skip>

--- a/src/apps/geoserver/wcs/pom.xml
+++ b/src/apps/geoserver/wcs/pom.xml
@@ -48,7 +48,10 @@
     <profile>
       <id>docker</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>docker</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -62,7 +65,10 @@
     <profile>
       <id>docker-openj9</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>openj9</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -86,7 +92,7 @@
               </execution>
               <execution>
                 <id>push-openj9-image</id>
-                <phase>install</phase>
+                <phase>package</phase>
                 <goals>
                   <goal>push</goal>
                 </goals>

--- a/src/apps/geoserver/webui/pom.xml
+++ b/src/apps/geoserver/webui/pom.xml
@@ -155,7 +155,10 @@
     <profile>
       <id>docker</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>docker</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -169,7 +172,10 @@
     <profile>
       <id>docker-openj9</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>openj9</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -193,7 +199,7 @@
               </execution>
               <execution>
                 <id>push-openj9-image</id>
-                <phase>install</phase>
+                <phase>package</phase>
                 <goals>
                   <goal>push</goal>
                 </goals>

--- a/src/apps/geoserver/wfs/pom.xml
+++ b/src/apps/geoserver/wfs/pom.xml
@@ -45,7 +45,10 @@
     <profile>
       <id>docker</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>docker</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -59,7 +62,10 @@
     <profile>
       <id>docker-openj9</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>openj9</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -83,7 +89,7 @@
               </execution>
               <execution>
                 <id>push-openj9-image</id>
-                <phase>install</phase>
+                <phase>package</phase>
                 <goals>
                   <goal>push</goal>
                 </goals>

--- a/src/apps/geoserver/wms/pom.xml
+++ b/src/apps/geoserver/wms/pom.xml
@@ -55,7 +55,10 @@
     <profile>
       <id>docker</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>docker</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -69,7 +72,10 @@
     <profile>
       <id>docker-openj9</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>openj9</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -93,7 +99,7 @@
               </execution>
               <execution>
                 <id>push-openj9-image</id>
-                <phase>install</phase>
+                <phase>package</phase>
                 <goals>
                   <goal>push</goal>
                 </goals>

--- a/src/apps/geoserver/wps/pom.xml
+++ b/src/apps/geoserver/wps/pom.xml
@@ -49,7 +49,10 @@
     <profile>
       <id>docker</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>docker</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -63,7 +66,10 @@
     <profile>
       <id>docker-openj9</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>openj9</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -87,7 +93,7 @@
               </execution>
               <execution>
                 <id>push-openj9-image</id>
-                <phase>install</phase>
+                <phase>package</phase>
                 <goals>
                   <goal>push</goal>
                 </goals>

--- a/src/apps/infrastructure/admin/pom.xml
+++ b/src/apps/infrastructure/admin/pom.xml
@@ -82,7 +82,10 @@
     <profile>
       <id>docker</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>docker</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -96,7 +99,10 @@
     <profile>
       <id>docker-openj9</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>openj9</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -120,7 +126,7 @@
               </execution>
               <execution>
                 <id>push-openj9-image</id>
-                <phase>install</phase>
+                <phase>package</phase>
                 <goals>
                   <goal>push</goal>
                 </goals>

--- a/src/apps/infrastructure/config/pom.xml
+++ b/src/apps/infrastructure/config/pom.xml
@@ -118,7 +118,10 @@
     <profile>
       <id>docker</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>docker</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -147,7 +150,10 @@
     <profile>
       <id>docker-openj9</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>openj9</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -186,7 +192,7 @@
               </execution>
               <execution>
                 <id>push-openj9-image</id>
-                <phase>install</phase>
+                <phase>package</phase>
                 <goals>
                   <goal>push</goal>
                 </goals>

--- a/src/apps/infrastructure/discovery/pom.xml
+++ b/src/apps/infrastructure/discovery/pom.xml
@@ -62,7 +62,10 @@
     <profile>
       <id>docker</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>docker</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -76,7 +79,10 @@
     <profile>
       <id>docker-openj9</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>openj9</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -100,7 +106,7 @@
               </execution>
               <execution>
                 <id>push-openj9-image</id>
-                <phase>install</phase>
+                <phase>package</phase>
                 <goals>
                   <goal>push</goal>
                 </goals>

--- a/src/apps/infrastructure/gateway/pom.xml
+++ b/src/apps/infrastructure/gateway/pom.xml
@@ -55,7 +55,10 @@
     <profile>
       <id>docker</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>docker</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -69,7 +72,10 @@
     <profile>
       <id>docker-openj9</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>openj9</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -93,7 +99,7 @@
               </execution>
               <execution>
                 <id>push-openj9-image</id>
-                <phase>install</phase>
+                <phase>package</phase>
                 <goals>
                   <goal>push</goal>
                 </goals>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -706,7 +706,7 @@
             </execution>
             <execution>
               <id>push</id>
-              <phase>install</phase>
+              <phase>package</phase>
               <goals>
                 <goal>push</goal>
               </goals>


### PR DESCRIPTION
Use the `-Ddocker` and `-Dopenj9` properties instead
to activate building the temurin and openj9 docker
images instead.