### PR TITLE
Avoid GeoTools logging redirection to Log4J

### DIFF
--- a/src/starters/webmvc/src/main/java/org/geoserver/cloud/autoconfigure/context/GeoServerContextInitializer.java
+++ b/src/starters/webmvc/src/main/java/org/geoserver/cloud/autoconfigure/context/GeoServerContextInitializer.java
@@ -29,8 +29,11 @@ public class GeoServerContextInitializer
 
     @Override
     public void initialize(ConfigurableApplicationContext applicationContext) {
+        // tell geoserver not to control logging, spring-boot will do
         System.setProperty("RELINQUISH_LOG4J_CONTROL", "true");
-
+        // and tell geotools not to redirect to Log4J nor any other framework, we'll use
+        // spring-boot's logging redirection
+        System.setProperty("GT2_LOGGING_REDIRECTION", "JavaLogging");
         ServletContext source = mockServletContext();
         ServletContextEvent sce = new ServletContextEvent(source);
         GeoserverInitStartupListener startupInitializer = new GeoserverInitStartupListener();


### PR DESCRIPTION
Missed to tell geotools not to redirect logging. Defaults to Log4J and may cause errors like the following:
```
java.lang.NoSuchMethodError: 'org.apache.logging.log4j.Logger org.apache.logging.log4j.core.config.Configurator.setLevel(org.apache.logging.log4j.Logger, org.apache.logging.log4j.Level)'
	at org.geotools.util.logging.Log4J2Logger.setLevel(Log4J2Logger.java:171)
	at org.geotools.xml.XMLSAXHandler.<init>(XMLSAXHandler.java:152)
	at org.geotools.xml.DocumentFactory.getInstance(DocumentFactory.java:124)
	at org.geotools.ows.wms.response.WMSGetCapabilitiesResponse.<init>(WMSGetCapabilitiesResponse.java:56)
	at org.geotools.ows.wms.WMS1_0_0$GetCapsRequest.createResponse(WMS1_0_0.java:230)
```

Current gs-cloud deployments can just add the following env variable or system property (`-D...`):
```
GT2_LOGGING_REDIRECTION=JavaLogging
```
