### PR TITLE
Fix startup failures with jdbcconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,19 +24,19 @@ build-image-openj9: build-image-infrastructure-openj9 build-image-geoserver-open
 
 build-image-infrastructure:
 	./mvnw clean package -f src/apps/infrastructure \
-	-Ddocker -P-geoserver -Ddockerfile.push.skip=$(SKIP_PUSH) -ntp -Dfmt.skip -DskipTests
+	-Ddocker -P-geoserver -Ddockerfile.push.skip=$(SKIP_PUSH) -ntp -Dfmt.skip -DskipTests -T1C
 
 build-image-infrastructure-openj9:
 	./mvnw clean package -f src/apps/infrastructure \
-	-Dopenj9 -P-geoserver -Ddockerfile.push.skip=$(SKIP_PUSH) -ntp -Dfmt.skip -DskipTests
+	-Dopenj9 -P-geoserver -Ddockerfile.push.skip=$(SKIP_PUSH) -ntp -Dfmt.skip -DskipTests -T1C
 
 build-image-geoserver:
 	./mvnw clean package -f src/apps/geoserver \
-	-Ddocker -P-geoserver -Ddockerfile.push.skip=$(SKIP_PUSH) -ntp -Dfmt.skip -DskipTests
+	-Ddocker -P-geoserver -Ddockerfile.push.skip=$(SKIP_PUSH) -ntp -Dfmt.skip -DskipTests -T1C
   
 build-image-geoserver-openj9:
 	./mvnw clean package -f src/apps/geoserver \
-	-Dopenj9 -P-geoserver -Ddockerfile.push.skip=$(SKIP_PUSH) -ntp -Dfmt.skip -DskipTests
+	-Dopenj9 -P-geoserver -Ddockerfile.push.skip=$(SKIP_PUSH) -ntp -Dfmt.skip -DskipTests -T1C
 
 build-config-native-image:
 	./mvnw -pl :gs-cloud-config-service install -am -Dfmt.action=check -ntp -P-geoserver

--- a/src/apps/geoserver/wms/src/main/java/org/geoserver/cloud/autoconfigure/wms/WmsApplicationAutoConfiguration.java
+++ b/src/apps/geoserver/wms/src/main/java/org/geoserver/cloud/autoconfigure/wms/WmsApplicationAutoConfiguration.java
@@ -58,7 +58,7 @@ public class WmsApplicationAutoConfiguration {
             prefix = "geoserver.wms",
             name = "reflector.enabled",
             havingValue = "true",
-            matchIfMissing = false)
+            matchIfMissing = true)
     public @Bean GetMapReflectorController getMapReflectorController() {
         return new GetMapReflectorController();
     }

--- a/src/apps/geoserver/wms/src/test/java/org/geoserver/cloud/wms/app/KMLAutoConfigurationTest.java
+++ b/src/apps/geoserver/wms/src/test/java/org/geoserver/cloud/wms/app/KMLAutoConfigurationTest.java
@@ -19,7 +19,7 @@ import org.springframework.test.context.ActiveProfiles;
  * @since 1.0
  */
 @SpringBootTest
-@ActiveProfiles("test")
+@ActiveProfiles({"test", "testdatadir"})
 class KMLAutoConfigurationTest {
 
     private @Autowired ConfigurableApplicationContext context;

--- a/src/apps/geoserver/wms/src/test/java/org/geoserver/cloud/wms/app/WmsApplicationDataDirectoryTest.java
+++ b/src/apps/geoserver/wms/src/test/java/org/geoserver/cloud/wms/app/WmsApplicationDataDirectoryTest.java
@@ -1,0 +1,27 @@
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.wms.app;
+
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.io.File;
+
+/** See {@code src/test/resources/bootstrap-testdatadir.yml} */
+@SpringBootTest
+@ActiveProfiles({"test", "testdatadir"})
+public class WmsApplicationDataDirectoryTest extends WmsApplicationTest {
+
+    private static @TempDir File tmpDataDir;
+
+    @DynamicPropertySource
+    static void registerPgProperties(DynamicPropertyRegistry registry) {
+        String datadir = tmpDataDir.getAbsolutePath();
+        registry.add("data_directory", () -> datadir);
+    }
+}

--- a/src/apps/geoserver/wms/src/test/java/org/geoserver/cloud/wms/app/WmsApplicationJdbcconfigTest.java
+++ b/src/apps/geoserver/wms/src/test/java/org/geoserver/cloud/wms/app/WmsApplicationJdbcconfigTest.java
@@ -1,0 +1,13 @@
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.wms.app;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+/** See {@code src/test/resources/bootstrap-testjdbcconfig.yml} */
+@SpringBootTest
+@ActiveProfiles({"test", "testjdbcconfig"})
+public class WmsApplicationJdbcconfigTest extends WmsApplicationTest {}

--- a/src/apps/geoserver/wms/src/test/java/org/geoserver/cloud/wms/app/WmsApplicationTest.java
+++ b/src/apps/geoserver/wms/src/test/java/org/geoserver/cloud/wms/app/WmsApplicationTest.java
@@ -6,23 +6,33 @@ package org.geoserver.cloud.wms.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.geoserver.cloud.virtualservice.VirtualServiceVerifier;
+import org.geoserver.cloud.wms.controller.GetMapReflectorController;
+import org.geoserver.cloud.wms.controller.WMSController;
 import org.geoserver.ows.FlatKvpParser;
 import org.geoserver.ows.kvp.CQLFilterKvpParser;
 import org.geoserver.ows.kvp.SortByKvpParser;
 import org.geoserver.ows.kvp.ViewParamsKvpParser;
 import org.geoserver.ows.util.NumericKvpParser;
 import org.geoserver.wfs.kvp.BBoxKvpParser;
+import org.geoserver.wfs.xml.v1_1_0.WFSConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("test")
-public class WmsApplicationTest {
+abstract class WmsApplicationTest {
 
-    private @Autowired ConfigurableApplicationContext context;
+    protected @Autowired ConfigurableApplicationContext context;
+
+    @Test
+    void testExpectedBeansFromWmsApplicationAutoConfiguration() {
+        expecteBean("wfsConfiguration", WFSConfiguration.class);
+        expecteBean("webMapServiceController", WMSController.class);
+        expecteBean("virtualServiceVerifier", VirtualServiceVerifier.class);
+        expecteBean("getMapReflectorController", GetMapReflectorController.class);
+    }
 
     @Test
     void testExpectedBeansFromGsWfsJarFile() {
@@ -54,7 +64,7 @@ public class WmsApplicationTest {
         expecteBean("gml32OutputFormat", org.geoserver.wfs.xml.GML32OutputFormat.class);
     }
 
-    private void expecteBean(String name, Class<?> type) {
+    protected void expecteBean(String name, Class<?> type) {
         assertThat(context.getBean(name)).isInstanceOf(type);
     }
 }

--- a/src/apps/geoserver/wms/src/test/resources/bootstrap-test.yml
+++ b/src/apps/geoserver/wms/src/test/resources/bootstrap-test.yml
@@ -6,26 +6,10 @@ spring:
   cloud.config.enabled: false
   cloud.config.discovery.enabled: false
   cloud.discovery.enabled: false
+  cloud.bus.enabled: false
 eureka.client.enabled: false
 
-gwc:
-  cache-directory: ${java.io.tmpdir}/gs-wms-tmp
-
-geoserver:
-  backend:
-    data-directory:
-      enabled: true
-      location: ${data_directory:${java.io.tmpdir}/geoserver_cloud_data_directory}
-    jdbcconfig:
-      enabled: false
-      web.enabled: false
-      initdb: true
-      cache-directory: ${java.io.tmpdir}/geoserver-jdbcconfig-cache
-      datasource:
-        driverClassname: org.h2.Driver
-        url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
-        username: sa
-        password:
+gwc.cache-directory: ${java.io.tmpdir}/gs-wms-tmp
 
 logging:
   level:

--- a/src/apps/geoserver/wms/src/test/resources/bootstrap-testdatadir.yml
+++ b/src/apps/geoserver/wms/src/test/resources/bootstrap-testdatadir.yml
@@ -1,0 +1,5 @@
+geoserver:
+  backend:
+    data-directory:
+      enabled: true
+      location: ${data_directory:${java.io.tmpdir}/geoserver_cloud_data_directory}

--- a/src/apps/geoserver/wms/src/test/resources/bootstrap-testjdbcconfig.yml
+++ b/src/apps/geoserver/wms/src/test/resources/bootstrap-testjdbcconfig.yml
@@ -1,0 +1,12 @@
+geoserver:
+  backend:
+    jdbcconfig:
+      enabled: true
+      web.enabled: true
+      initdb: true
+      cache-directory: ${java.io.tmpdir}/geoserver-jdbcconfig-cache
+      datasource:
+        driverClassname: org.h2.Driver
+        url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+        username: sa
+        password:

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/security/CloudGeoServerSecurityManager.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/security/CloudGeoServerSecurityManager.java
@@ -50,7 +50,7 @@ public class CloudGeoServerSecurityManager extends GeoServerSecurityManager {
         this.updateSequenceIncrementor = updateSequenceIncrementor;
     }
 
-    public @Override void reload() {
+    public synchronized @Override void reload() {
         reloading = true;
         changedDuringReload = false;
         try {
@@ -88,9 +88,9 @@ public class CloudGeoServerSecurityManager extends GeoServerSecurityManager {
                     event);
             return;
         }
-        log.info("Reloading security configuration due to change event: {}", event);
         synchronized (this) {
-            super.reload();
+            log.info("Reloading security configuration due to change event: {}", event);
+            reload();
             log.debug("Security configuration reloaded due to change event:", event);
         }
     }

--- a/src/catalog/backends/jdbcconfig/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/jdbcconfig/ConditionalOnJdbcConfigWebUIEnabled.java
+++ b/src/catalog/backends/jdbcconfig/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/jdbcconfig/ConditionalOnJdbcConfigWebUIEnabled.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.cloud.autoconfigure.catalog.backend.jdbcconfig;
 
-import org.geoserver.web.GeoServerHomePageContentProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
@@ -18,10 +17,10 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Documented
 @ConditionalOnJdbcConfigEnabled
+@ConditionalOnClass(name = "org.geoserver.web.GeoServerHomePageContentProvider")
 @ConditionalOnProperty(
         prefix = "geoserver.backend.jdbcconfig.web",
         name = "enabled",
         havingValue = "true",
         matchIfMissing = true)
-@ConditionalOnClass(GeoServerHomePageContentProvider.class)
 public @interface ConditionalOnJdbcConfigWebUIEnabled {}


### PR DESCRIPTION
*  Fix ClassNotFoundException at startup with jdbcconfig
*  Disable caching for `JDBCDirectoryStructure`
    `JDBCDirectoryStructure` gets its cache only from
    `DefaultCacheProvider.findProvider()`.
    Unfortunately, there's no sane way of disabling it other than setting the
    default provider to no-op cache.
    And it is necessary because the resources in the cache will never be up
    to date with the database contents, which prevents starting up from an
    empty database, since all instances will think the geoserver security
    manager resources are uninitialized and hence try to upgrade the
    configuration;

