### PR TITLE
Fix catalog facade's getStyleByName(String name)

### DIFF
--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/RepositoryCatalogFacadeImpl.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/RepositoryCatalogFacadeImpl.java
@@ -411,7 +411,7 @@ public class RepositoryCatalogFacadeImpl extends CatalogInfoRepositoryHolderImpl
 
     public @Override StyleInfo getStyleByName(String name) {
         Optional<StyleInfo> match = styles.findByNameAndWordkspaceNull(name);
-        if (match == null) {
+        if (match.isEmpty()) {
             match = styles.findFirstByName(name, StyleInfo.class);
         }
         return match.orElse(null);


### PR DESCRIPTION
`RepositoryCatalogFacade.getStyleByName(String name)` had a bug
that made it not match the behavior of upstream's
`DefaultCatalogFacade.getStyleByName(String name)`.

As a consequence, `GetLegendGraphic` requests with JSON output format
produced kml icon urls with missing workspace path
(e.g. `/kml/icon/<stylename>?...` instead of
`/kml/icon/<workspace>/<stylename>?...`, when the GetLegendGraphic
request itself did not contain the workspace in the URLi and the
`StyleInfo` does belong to a workspace).

That said, the way `JSONLegendGraphicBuilder.processGraphic(...)`
resolves the icon URL is WRONG, as it uses the unqualified style
name to call `Catalog.getStyleByName(String name)`, relying in
`DefaultCatalogFacade.getStyleByName(String name)`, which will
look for a global style with that name, if none exists will look
for one in the "default workspace", and eventually for one in
any workspace, with no order guarantee. This is on itself a buggy
behaviour and only works by accident sometimes, but can easily
lead to returning a URL for a style named the same that belongs
to a different workspace than the layer for which the request
is being performed.