### PR TITLE
Fix CatalogPlugin.doSave() upoon further business rules changes

### DIFF
--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/rules/CatalogOpContext.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/rules/CatalogOpContext.java
@@ -82,6 +82,11 @@ public class CatalogOpContext<T extends CatalogInfo> {
         return diff;
     }
 
+    public void setDiff(PropertyDiff diff) {
+        requireNonNull(diff);
+        this.diff = diff;
+    }
+
     public CatalogOpContext<T> setError(RuntimeException error) {
         this.error = error;
         return this;


### PR DESCRIPTION
Fix `CatalogPlugin.doSave()` to account for changes to the `CatalogInfo`
object being saved applied by business rules.

For instance, renaming a style results in `DefaultStyleInfoRules`
also updating the `StyleInfo`'s `fileName`, which wasn't being
propagated as a changed property, breaking the WMS service.