### PR TITLE
Fix gwc's direct WMS integration, bean registration race condition

### DIFF
--- a/src/apps/geoserver/wms/src/main/java/org/geoserver/cloud/autoconfigure/wms/WmsApplicationAutoConfiguration.java
+++ b/src/apps/geoserver/wms/src/main/java/org/geoserver/cloud/autoconfigure/wms/WmsApplicationAutoConfiguration.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.cloud.autoconfigure.wms;
 
+import org.geoserver.cloud.autoconfigure.gwc.integration.WMSIntegrationAutoConfiguration;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.geoserver.cloud.virtualservice.VirtualServiceVerifier;
 import org.geoserver.cloud.wms.controller.GetMapReflectorController;
@@ -12,16 +13,20 @@ import org.geoserver.config.GeoServer;
 import org.geoserver.wfs.xml.FeatureTypeSchemaBuilder;
 import org.geoserver.wfs.xml.v1_1_0.WFS;
 import org.geoserver.wfs.xml.v1_1_0.WFSConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
 @Configuration
+// auto-configure before GWC's wms-integration to avoid it precluding to load beans from
+// jar:gs-wms-.*
+@AutoConfigureBefore(WMSIntegrationAutoConfiguration.class)
 @ImportResource( //
         reader = FilteringXmlBeanDefinitionReader.class, //
         locations = { //
-            "jar:gs-wms-.*!/applicationContext.xml", //
+            "jar:gs-wms-.*!/applicationContext.xml#name=.*", //
             "jar:gs-wfs-.*!/applicationContext.xml#name="
                     + WmsApplicationAutoConfiguration.WFS_INCLUDED_BEANS_REGEX //
         })

--- a/src/apps/geoserver/wms/src/test/java/org/geoserver/cloud/wms/app/WmsApplicationDataDirectoryTest.java
+++ b/src/apps/geoserver/wms/src/test/java/org/geoserver/cloud/wms/app/WmsApplicationDataDirectoryTest.java
@@ -13,7 +13,7 @@ import org.springframework.test.context.DynamicPropertySource;
 import java.io.File;
 
 /** See {@code src/test/resources/bootstrap-testdatadir.yml} */
-@SpringBootTest
+@SpringBootTest(properties = "gwc.wms-integration=true")
 @ActiveProfiles({"test", "testdatadir"})
 public class WmsApplicationDataDirectoryTest extends WmsApplicationTest {
 
@@ -23,5 +23,6 @@ public class WmsApplicationDataDirectoryTest extends WmsApplicationTest {
     static void registerPgProperties(DynamicPropertyRegistry registry) {
         String datadir = tmpDataDir.getAbsolutePath();
         registry.add("data_directory", () -> datadir);
+        registry.add("gwc.wms-integration", () -> "true");
     }
 }

--- a/src/apps/geoserver/wms/src/test/java/org/geoserver/cloud/wms/app/WmsApplicationJdbcconfigTest.java
+++ b/src/apps/geoserver/wms/src/test/java/org/geoserver/cloud/wms/app/WmsApplicationJdbcconfigTest.java
@@ -8,6 +8,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 /** See {@code src/test/resources/bootstrap-testjdbcconfig.yml} */
-@SpringBootTest
+@SpringBootTest(properties = "gwc.wms-integration=true")
 @ActiveProfiles({"test", "testjdbcconfig"})
 public class WmsApplicationJdbcconfigTest extends WmsApplicationTest {}

--- a/src/apps/geoserver/wms/src/test/java/org/geoserver/cloud/wms/app/WmsApplicationTest.java
+++ b/src/apps/geoserver/wms/src/test/java/org/geoserver/cloud/wms/app/WmsApplicationTest.java
@@ -6,9 +6,11 @@ package org.geoserver.cloud.wms.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.geoserver.cloud.autoconfigure.gwc.integration.WMSIntegrationAutoConfiguration.ForwardGetMapToGwcAspect;
 import org.geoserver.cloud.virtualservice.VirtualServiceVerifier;
 import org.geoserver.cloud.wms.controller.GetMapReflectorController;
 import org.geoserver.cloud.wms.controller.WMSController;
+import org.geoserver.gwc.wms.CachingExtendedCapabilitiesProvider;
 import org.geoserver.ows.FlatKvpParser;
 import org.geoserver.ows.kvp.CQLFilterKvpParser;
 import org.geoserver.ows.kvp.SortByKvpParser;
@@ -18,24 +20,25 @@ import org.geoserver.wfs.kvp.BBoxKvpParser;
 import org.geoserver.wfs.xml.v1_1_0.WFSConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ConfigurableApplicationContext;
 
-@SpringBootTest
 abstract class WmsApplicationTest {
 
     protected @Autowired ConfigurableApplicationContext context;
 
     @Test
-    void testExpectedBeansFromWmsApplicationAutoConfiguration() {
+    public void testExpectedBeansFromWmsApplicationAutoConfiguration() {
         expecteBean("wfsConfiguration", WFSConfiguration.class);
         expecteBean("webMapServiceController", WMSController.class);
         expecteBean("virtualServiceVerifier", VirtualServiceVerifier.class);
         expecteBean("getMapReflectorController", GetMapReflectorController.class);
+        expecteBean(
+                "wms_1_1_1_GetCapabilitiesResponse",
+                org.geoserver.wms.capabilities.GetCapabilitiesResponse.class);
     }
 
     @Test
-    void testExpectedBeansFromGsWfsJarFile() {
+    public void testExpectedBeansFromGsWfsJarFile() {
         expecteBean("bboxKvpParser", BBoxKvpParser.class);
         expecteBean("featureIdKvpParser", FlatKvpParser.class);
         expecteBean("cqlKvpParser", CQLFilterKvpParser.class);
@@ -62,6 +65,13 @@ abstract class WmsApplicationTest {
         expecteBean("gml2OutputFormat", org.geoserver.wfs.xml.GML2OutputFormat.class);
         expecteBean("gml3OutputFormat", org.geoserver.wfs.xml.GML3OutputFormat.class);
         expecteBean("gml32OutputFormat", org.geoserver.wfs.xml.GML32OutputFormat.class);
+    }
+
+    @Test
+    public void testGwcWmsIntegration() {
+        expecteBean(
+                "gwcWMSExtendedCapabilitiesProvider", CachingExtendedCapabilitiesProvider.class);
+        expecteBean("gwcGetMapAdvise", ForwardGetMapToGwcAspect.class);
     }
 
     protected void expecteBean(String name, Class<?> type) {

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/WMSIntegrationAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/WMSIntegrationAutoConfiguration.java
@@ -129,7 +129,7 @@ public class WMSIntegrationAutoConfiguration {
     @Aspect
     @Slf4j(topic = "org.geoserver.cloud.gwc.integration.wms")
     @RequiredArgsConstructor
-    static class ForwardGetMapToGwcAspect {
+    public static class ForwardGetMapToGwcAspect {
 
         private final GWC gwc;
 


### PR DESCRIPTION
Make wms-service's application autoconfiguration run before
gwc's `WMSIntegrationAutoConfiguration`. They both load
beans from `gs-wms.jar` but of gwc's autoconfiguration runs
first, precludes wms's autoconfiguration from loading some
beans, as they're already marked to be ignored.

This resulted in direct-wms-integration being absent despite
the configuration property `gwc.wms-integration=true`.