### PR TITLE
restconfig: fix path extension based content type negotiation

### DIFF
--- a/src/apps/geoserver/restconfig/src/main/java/org/geoserver/cloud/restconfig/RestConfigApplicationConfiguration.java
+++ b/src/apps/geoserver/restconfig/src/main/java/org/geoserver/cloud/restconfig/RestConfigApplicationConfiguration.java
@@ -4,9 +4,8 @@
  */
 package org.geoserver.cloud.restconfig;
 
-import org.geoserver.rest.CallbackInterceptor;
 import org.geoserver.rest.RequestInfo;
-import org.geoserver.rest.RestInterceptor;
+import org.geoserver.rest.RestConfiguration;
 import org.geoserver.rest.catalog.AdminRequestCallback;
 import org.geoserver.rest.resources.ResourceController;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -16,8 +15,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.format.support.FormattingConversionService;
 import org.springframework.web.accept.ContentNegotiationManager;
-import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
+import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 import org.springframework.web.servlet.resource.ResourceUrlProvider;
 
@@ -39,16 +37,18 @@ import javax.servlet.http.HttpServletRequestWrapper;
          * vanilla geoserver (from gs-restconfig's applicationContext.xml) and causes a difference in behavior. At some
          * point it'll have to be fixed upstream and re-enabled here.
          */
-        excludeFilters =
-                @ComponentScan.Filter(
-                        type = FilterType.ASSIGNABLE_TYPE,
-                        classes = AdminRequestCallback.class))
-public class RestConfigApplicationConfiguration extends WebMvcConfigurationSupport {
+        excludeFilters = {
+            @ComponentScan.Filter(
+                    type = FilterType.ASSIGNABLE_TYPE,
+                    classes = AdminRequestCallback.class)
+        })
+@SuppressWarnings("deprecation")
+public class RestConfigApplicationConfiguration extends RestConfiguration {
 
     @Override
-    protected void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new RestInterceptor());
-        registry.addInterceptor(new CallbackInterceptor());
+    public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
+        super.configureContentNegotiation(configurer);
+        configurer.favorPathExtension(true);
     }
 
     /**
@@ -67,6 +67,7 @@ public class RestConfigApplicationConfiguration extends WebMvcConfigurationSuppo
                         contentNegotiationManager, conversionService, resourceUrlProvider);
 
         handlerMapping.setUseSuffixPatternMatch(true);
+        handlerMapping.setUseRegisteredSuffixPatternMatch(true);
         // handlerMapping.setUseTrailingSlashMatch(true);
         // handlerMapping.setAlwaysUseFullPath(true);
 

--- a/src/apps/geoserver/restconfig/src/main/resources/bootstrap.yml
+++ b/src/apps/geoserver/restconfig/src/main/resources/bootstrap.yml
@@ -34,6 +34,8 @@ spring:
       - org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
       - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
       - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
+      - org.springframework.boot.autoconfigure.freemarker.FreeMarkerAutoConfiguration
+      
 
 # override default of true, this service does not use the registry (when eureka client is enabled)
 eureka.client.fetch-registry: false

--- a/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationTest.java
+++ b/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationTest.java
@@ -4,14 +4,51 @@
  */
 package org.geoserver.cloud.restconfig;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.http.MediaType.APPLICATION_XML;
+import static org.springframework.http.MediaType.TEXT_HTML;
+
+import org.geoserver.catalog.SLDHandler;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 public class RestConfigApplicationTest {
 
+    @Autowired private TestRestTemplate restTemplate;
+
+    @BeforeEach
+    void before() {
+        restTemplate = restTemplate.withBasicAuth("admin", "geoserver");
+    }
+
     @Test
-    public void contextLoads() {}
+    public void testPathExtensionContentNegotiation() {
+
+        testPathExtensionContentType("/rest/styles/line.json", APPLICATION_JSON);
+        testPathExtensionContentType("/rest/styles/line.xml", APPLICATION_XML);
+        testPathExtensionContentType("/rest/styles/line.html", TEXT_HTML);
+        testPathExtensionContentType(
+                "/rest/styles/line.sld", MediaType.valueOf(SLDHandler.MIMETYPE_10));
+
+        testPathExtensionContentType("/rest/workspaces.html", TEXT_HTML);
+        testPathExtensionContentType("/rest/workspaces.xml", APPLICATION_XML);
+        testPathExtensionContentType("/rest/workspaces.json", APPLICATION_JSON);
+    }
+
+    protected void testPathExtensionContentType(String uri, MediaType expected) {
+        ResponseEntity<String> response = restTemplate.getForEntity(uri, String.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders().getContentType()).isEqualTo(expected);
+    }
 }

--- a/src/apps/geoserver/restconfig/src/test/resources/bootstrap-test.yml
+++ b/src/apps/geoserver/restconfig/src/test/resources/bootstrap-test.yml
@@ -6,6 +6,7 @@ spring:
   cloud.config.enabled: false
   cloud.config.discovery.enabled: false
   cloud.discovery.enabled: false
+  cloud.bus.enabled: false
 eureka.client.enabled: false
 
 geoserver:
@@ -13,21 +14,11 @@ geoserver:
     data-directory:
       enabled: true
       location: ${data_directory:${java.io.tmpdir}/geoserver_cloud_data_directory}
-    jdbcconfig:
-      enabled: false
-      web.enabled: false
-      initdb: true
-      cache-directory: ${java.io.tmpdir}/geoserver-jdbcconfig-cache
-      datasource:
-        driverClassname: org.h2.Driver
-        url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
-        username: sa
-        password:
 
 logging:
   level:
-    root: WARN
-    org.geoserver.platform: ERROR
-    org.geoserver.cloud: DEBUG
-    org.geoserver.cloud.config.factory: TRACE
-    org.springframework.test: ERROR
+    root: warn
+    org.geoserver.platform: error
+    org.geoserver.cloud: info
+    org.geoserver.cloud.config.factory: info
+    org.springframework.test: error


### PR DESCRIPTION
The current spring version (`5.3.18`) is newer than vanilla GeoServer's (`5.2.22`), and though path extension content-type negotiation is deprecated in both, the older one defaults to `true`, and the newer to `false`, which prevents accessing REST config resources using an extension suffix such as `.xml`, `.json`, `.sld`, etc.

This patch makes `RestConfigApplicationConfiguration` to extend vanilla geoserver's `RestConfiguration` and overrides `configureContentNegotiation(...)` to set
`ContentNegotiationConfigurer..favorPathExtension(true)`, restoring the old behavior.

Fixes #212
