### PR TITLE
gwc restconfig: fix path extension based content type negotiation

### DIFF
--- a/src/apps/geoserver/gwc/src/main/java/org/geoserver/cloud/gwc/app/GeoWebCacheApplicationConfiguration.java
+++ b/src/apps/geoserver/gwc/src/main/java/org/geoserver/cloud/gwc/app/GeoWebCacheApplicationConfiguration.java
@@ -1,0 +1,125 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.gwc.app;
+
+import org.geoserver.rest.RequestInfo;
+import org.geoserver.rest.RestConfiguration;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.support.FormattingConversionService;
+import org.springframework.web.accept.ContentNegotiationManager;
+import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+import org.springframework.web.servlet.resource.ResourceUrlProvider;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+@Configuration
+public class GeoWebCacheApplicationConfiguration extends RestConfiguration {
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
+        super.configureContentNegotiation(configurer);
+        configurer.favorPathExtension(true);
+    }
+
+    /**
+     * "Deprecate use of path extensions in request mapping and content negotiation" {@code
+     * https://github.com/spring-projects/spring-framework/issues/24179}
+     */
+    @SuppressWarnings("deprecation")
+    @Bean
+    public RequestMappingHandlerMapping requestMappingHandlerMapping(
+            @Qualifier("mvcContentNegotiationManager")
+                    ContentNegotiationManager contentNegotiationManager,
+            @Qualifier("mvcConversionService") FormattingConversionService conversionService,
+            @Qualifier("mvcResourceUrlProvider") ResourceUrlProvider resourceUrlProvider) {
+
+        RequestMappingHandlerMapping handlerMapping =
+                super.requestMappingHandlerMapping(
+                        contentNegotiationManager, conversionService, resourceUrlProvider);
+
+        handlerMapping.setUseSuffixPatternMatch(true);
+        handlerMapping.setUseRegisteredSuffixPatternMatch(true);
+
+        return handlerMapping;
+    }
+
+    @Bean
+    SetRequestPathInfoFilter setRequestPathInfoFilter() {
+        return new SetRequestPathInfoFilter();
+    }
+
+    /**
+     * GeoSever REST API always expect the {@link HttpServletRequest#getServletPath()} to be
+     * {@literal /rest}, and {@link HttpServletRequest#getPathInfo()} whatever comes after in the
+     * request URI.
+     *
+     * <p>for example: {@link RequestInfo} constructor, {@link ResourceController#resource}, etc.
+     */
+    static class SetRequestPathInfoFilter implements Filter {
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+                throws IOException, ServletException {
+
+            request = adaptRequest((HttpServletRequest) request);
+            chain.doFilter(request, response);
+        }
+
+        protected ServletRequest adaptRequest(HttpServletRequest request) {
+            final String requestURI = request.getRequestURI();
+            final int restIdx = requestURI.indexOf("/rest");
+            if (restIdx > -1) {
+                final String pathToRest = requestURI.substring(0, restIdx + "/rest".length());
+                final String pathInfo = requestURI.substring(pathToRest.length());
+
+                return new HttpServletRequestWrapper(request) {
+                    public @Override String getServletPath() {
+                        return "/rest";
+                    }
+
+                    public @Override String getPathInfo() {
+                        return pathInfo;
+                    }
+                };
+            }
+            return request;
+        }
+    }
+
+    /**
+     * "Deprecate use of path extensions in request mapping and content negotiation" {@code
+     * https://github.com/spring-projects/spring-framework/issues/24179}
+     */
+    //    @Bean
+    //    public RequestMappingHandlerMapping requestMappingHandlerMapping(
+    //            @Qualifier("mvcContentNegotiationManager")
+    //                    ContentNegotiationManager contentNegotiationManager,
+    //            @Qualifier("mvcConversionService") FormattingConversionService conversionService,
+    //            @Qualifier("mvcResourceUrlProvider") ResourceUrlProvider resourceUrlProvider) {
+    //
+    //        RequestMappingHandlerMapping handlerMapping =
+    //                super.requestMappingHandlerMapping(
+    //                        contentNegotiationManager, conversionService, resourceUrlProvider);
+    //
+    //        handlerMapping.setUseSuffixPatternMatch(true);
+    //        handlerMapping.setUseRegisteredSuffixPatternMatch(true);
+    //        // handlerMapping.setUseTrailingSlashMatch(true);
+    //        // handlerMapping.setAlwaysUseFullPath(true);
+    //
+    //        return handlerMapping;
+    //    }
+}

--- a/src/apps/geoserver/gwc/src/test/java/org/geoserver/cloud/gwc/app/GeoWebCacheApplicationTest.java
+++ b/src/apps/geoserver/gwc/src/test/java/org/geoserver/cloud/gwc/app/GeoWebCacheApplicationTest.java
@@ -4,14 +4,60 @@
  */
 package org.geoserver.cloud.gwc.app;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.http.MediaType.APPLICATION_XML;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
+import org.json.simple.parser.ParseException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 public class GeoWebCacheApplicationTest {
 
+    @Autowired private TestRestTemplate restTemplate;
+
+    @BeforeEach
+    void before() {
+        restTemplate = restTemplate.withBasicAuth("admin", "geoserver");
+        String rootUri = restTemplate.getRootUri();
+        assertThat(rootUri).isNotEmpty();
+    }
+
     @Test
-    public void contextLoads() {}
+    public void testRESTDefaultContentType() throws ParseException {
+        ResponseEntity<String> response =
+                testGetRequestContentType("/gwc/rest/layers", APPLICATION_JSON);
+        JsonElement parsed = JsonParser.parseString(response.getBody());
+        assertThat(parsed.isJsonArray());
+    }
+
+    @Test
+    public void testRESTPathExtensionContentNegotiation() {
+        ResponseEntity<String> response =
+                testGetRequestContentType("/gwc/rest/layers.json", APPLICATION_JSON);
+        JsonElement parsed = JsonParser.parseString(response.getBody());
+        assertThat(parsed.isJsonArray());
+
+        testGetRequestContentType("/gwc/rest/layers.xml", APPLICATION_XML);
+    }
+
+    protected ResponseEntity<String> testGetRequestContentType(String uri, MediaType expected) {
+        ResponseEntity<String> response = restTemplate.getForEntity(uri, String.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders().getContentType()).isEqualTo(expected);
+        return response;
+    }
 }

--- a/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationTest.java
+++ b/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationTest.java
@@ -33,6 +33,13 @@ public class RestConfigApplicationTest {
     }
 
     @Test
+    public void testDefaultContentType() {
+
+        testPathExtensionContentType("/rest/workspaces", APPLICATION_JSON);
+        testPathExtensionContentType("/rest/layers", APPLICATION_JSON);
+    }
+
+    @Test
     public void testPathExtensionContentNegotiation() {
 
         testPathExtensionContentType("/rest/styles/line.json", APPLICATION_JSON);


### PR DESCRIPTION
Complements commit c9105e2 to fix content type negotiation by extension (e.g. .json/.xml/etc) for gwc-service REST API.

The current spring version (`5.3.18`) is newer than vanilla GeoServer's (`5.2.22`), and though path extension content-type negotiation is deprecated in both, the older one defaults to `true`, and the newer to `false`, which prevents accessing REST config resources using an extension suffix such as `.xml`, `.json`, `.sld`, etc.

This patch makes `GeoWebCacheApplicationConfiguration` to extend vanilla geoserver's `RestConfiguration` and overrides `configureContentNegotiation(...)` to set
`ContentNegotiationConfigurer..favorPathExtension(true)`, restoring the old behavior, the same way than `RestConfigApplicationConfiguration` for the rest-config service.