### PR TITLE
Fix encoding issue in the gateway

### DIFF
--- a/src/apps/infrastructure/gateway/src/main/java/org/geoserver/cloud/gateway/GatewayApplication.java
+++ b/src/apps/infrastructure/gateway/src/main/java/org/geoserver/cloud/gateway/GatewayApplication.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.cloud.gateway;
 
-import org.geoserver.cloud.gateway.filter.GlobalUriFilter
 import org.geoserver.cloud.gateway.filter.RouteProfileGatewayFilterFactory;
 import org.geoserver.cloud.gateway.filter.StripBasePathGatewayFilterFactory;
 import org.geoserver.cloud.gateway.predicate.RegExpQueryRoutePredicateFactory;

--- a/src/apps/infrastructure/gateway/src/main/java/org/geoserver/cloud/gateway/GatewayApplication.java
+++ b/src/apps/infrastructure/gateway/src/main/java/org/geoserver/cloud/gateway/GatewayApplication.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.cloud.gateway;
 
+import org.geoserver.cloud.gateway.filter.GlobalUriFilter
 import org.geoserver.cloud.gateway.filter.RouteProfileGatewayFilterFactory;
 import org.geoserver.cloud.gateway.filter.StripBasePathGatewayFilterFactory;
 import org.geoserver.cloud.gateway.predicate.RegExpQueryRoutePredicateFactory;

--- a/src/apps/infrastructure/gateway/src/main/java/org/geoserver/cloud/gateway/filter/GlobalUriFilter.java
+++ b/src/apps/infrastructure/gateway/src/main/java/org/geoserver/cloud/gateway/filter/GlobalUriFilter.java
@@ -2,62 +2,70 @@
  * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
  * GPL 2.0 license, available at the root application directory.
  */
-import org.springframework.cloud.gateway.filter.GatewayFilterChain;
-import org.springframework.cloud.gateway.filter.GlobalFilter;
-import org.springframework.cloud.gateway.filter.RouteToRequestUrlFilter;
-import org.springframework.cloud.gateway.route.Route;
-import org.springframework.core.Ordered;
-import org.springframework.stereotype.Component;
-import org.springframework.web.server.ServerWebExchange;
-import reactor.core.publisher.Mono;
-
-import java.net.URI;
+package org.geoserver.cloud.gateway.filter;
 
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR;
 
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.cloud.gateway.filter.ReactiveLoadBalancerClientFilter;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.core.Ordered;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+
 /**
  * See gateway's issue <a
- * href="https://github.com/spring-cloud/spring-cloud-gateway/issues/2065">#2065</a> "Double Encoded URLs"
+ * href="https://github.com/spring-cloud/spring-cloud-gateway/issues/2065">#2065</a> "Double Encoded
+ * URLs"
  */
 @Component
 public class GlobalUriFilter implements GlobalFilter, Ordered {
 
-	@Override
-	public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
-		URI incomingUri = exchange.getRequest().getURI();
-		if (isUriEncoded(incomingUri)) {
-			// Get the original Gateway route (contains the service's original host)
-			Route route = exchange.getAttribute(GATEWAY_ROUTE_ATTR);
-			if (route == null) {
-				return chain.filter(exchange);
-			}
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
 
-			// Use the original incomingUri path and query params
-			final var routeUri = route.getUri();
-			URI mergedUri = createUri(incomingUri, routeUri);
+        URI incomingUri = exchange.getRequest().getURI();
+        if (isUriEncoded(incomingUri)) {
+            // Get the original Gateway route (contains the service's original host)
+            Route route = exchange.getAttribute(GATEWAY_ROUTE_ATTR);
+            if (route == null) {
+                return chain.filter(exchange);
+            }
 
-			// Save it as the outgoing URI to call the service, and override the "wrongly" double encoded URI
-			exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, mergedUri);
-		}
+            // Save it as the outgoing URI to call the service, and override the "wrongly" double
+            // encoded URI
+            // in  ReactiveLoadBalancerClientFilter LoadBalancerUriTools::containsEncodedParts
+            // double encoded URI again
+            URI balanceUrl = exchange.getRequiredAttribute(GATEWAY_REQUEST_URL_ATTR);
+            URI mergedUri = createUri(incomingUri, balanceUrl);
+            exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, mergedUri);
+        }
 
-		return chain.filter(exchange);
-	}
+        return chain.filter(exchange);
+    }
 
-	private URI createUri(URI incomingUri, URI routeUri) {
-		final var port = routeUri.getPort() != -1 ? ":" + routeUri.getPort() : "";
-		final var rawPath = incomingUri.getRawPath() != null ? incomingUri.getRawPath() : "";
-		final var query = incomingUri.getRawQuery() != null ?  "?" + incomingUri.getRawQuery() : "";
-		return URI.create(routeUri.getScheme() + "://" + routeUri.getHost() + port + rawPath + query);
-	}
+    private URI createUri(URI incomingUri, URI balanceUrl) {
+        final var port = balanceUrl.getPort() != -1 ? ":" + balanceUrl.getPort() : "";
+        final var rawPath = balanceUrl.getRawPath() != null ? balanceUrl.getRawPath() : "";
+        final var query = incomingUri.getRawQuery() != null ? "?" + incomingUri.getRawQuery() : "";
+        return URI.create(
+                balanceUrl.getScheme() + "://" + balanceUrl.getHost() + port + rawPath + query);
+    }
 
-	private static boolean isUriEncoded(URI uri) {
-		return (uri.getRawQuery() != null && uri.getRawQuery().contains("%"))
-			|| (uri.getRawPath() != null && uri.getRawPath().contains("%"));
-	}
+    private static boolean isUriEncoded(URI uri) {
+        return (uri.getRawQuery() != null && uri.getRawQuery().contains("%"))
+                || (uri.getRawPath() != null && uri.getRawPath().contains("%"));
+    }
 
-	@Override
-	public int getOrder() {
-		return RouteToRequestUrlFilter.ROUTE_TO_URL_FILTER_ORDER + 1;
-	}
+    // order after ReactiveLoadBalancerClientFilter
+    @Override
+    public int getOrder() {
+        return ReactiveLoadBalancerClientFilter.LOAD_BALANCER_CLIENT_FILTER_ORDER + 1;
+    }
 }

--- a/src/apps/infrastructure/gateway/src/main/java/org/geoserver/cloud/gateway/filter/GlobalUriFilter.java
+++ b/src/apps/infrastructure/gateway/src/main/java/org/geoserver/cloud/gateway/filter/GlobalUriFilter.java
@@ -1,0 +1,55 @@
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.cloud.gateway.filter.RouteToRequestUrlFilter;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.core.Ordered;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR;
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR;
+
+@Component
+public class GlobalUriFilter implements GlobalFilter, Ordered {
+
+	@Override
+	public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+		URI incomingUri = exchange.getRequest().getURI();
+		if (isUriEncoded(incomingUri)) {
+			// Get the original Gateway route (contains the service's original host)
+			Route route = exchange.getAttribute(GATEWAY_ROUTE_ATTR);
+			if (route == null) {
+				return chain.filter(exchange);
+			}
+
+			// Use the original incomingUri path and query params
+			final var routeUri = route.getUri();
+			URI mergedUri = createUri(incomingUri, routeUri);
+
+			// Save it as the outgoing URI to call the service, and override the "wrongly" double encoded URI
+			exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, mergedUri);
+		}
+
+		return chain.filter(exchange);
+	}
+
+	private URI createUri(URI incomingUri, URI routeUri) {
+		final var port = routeUri.getPort() != -1 ? ":" + routeUri.getPort() : "";
+		final var rawPath = incomingUri.getRawPath() != null ? incomingUri.getRawPath() : "";
+		final var query = incomingUri.getRawQuery() != null ?  "?" + incomingUri.getRawQuery() : "";
+		return URI.create(routeUri.getScheme() + "://" + routeUri.getHost() + port + rawPath + query);
+	}
+
+	private static boolean isUriEncoded(URI uri) {
+		return (uri.getRawQuery() != null && uri.getRawQuery().contains("%"))
+			|| (uri.getRawPath() != null && uri.getRawPath().contains("%"));
+	}
+
+	@Override
+	public int getOrder() {
+		return RouteToRequestUrlFilter.ROUTE_TO_URL_FILTER_ORDER + 1;
+	}
+}

--- a/src/apps/infrastructure/gateway/src/main/java/org/geoserver/cloud/gateway/filter/GlobalUriFilter.java
+++ b/src/apps/infrastructure/gateway/src/main/java/org/geoserver/cloud/gateway/filter/GlobalUriFilter.java
@@ -1,3 +1,7 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.cloud.gateway.filter.RouteToRequestUrlFilter;
@@ -12,6 +16,10 @@ import java.net.URI;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR;
 
+/**
+ * See gateway's issue <a
+ * href="https://github.com/spring-cloud/spring-cloud-gateway/issues/2065">#2065</a> "Double Encoded URLs"
+ */
 @Component
 public class GlobalUriFilter implements GlobalFilter, Ordered {
 


### PR DESCRIPTION
As mentioned in issue #229, an issue occured when applying CQL filters with spaces (e.g. `&CQL_FILTER=ogc_fid=1 OR ogc_fid=2`). This issue occurs both on WFS and WMS services, indicating some kind of encoding issue on the gateway and not within the services itself. 

After some digging, I found the issue at the Spring Cloud Gateway as an open issue, see https://github.com/spring-cloud/spring-cloud-gateway/issues/2065. I applied the proposed global filter in the code of the gateway, which resolves the issue at least on our side within these CQL Filters completely. Probably, looking at the kind of issue it is, it could have happened also on other places within the code.