### PR TITLE
Fix caching catalog errors with layers and layer groups that affect jdbcconfig backend

### DIFF
--- a/src/catalog/cache/src/test/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeTest.java
+++ b/src/catalog/cache/src/test/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeTest.java
@@ -39,6 +39,7 @@ import org.geoserver.cloud.autoconfigure.catalog.event.LocalCatalogEventsAutoCon
 import org.geoserver.config.GeoServerFacade;
 import org.geoserver.config.plugin.GeoServerImpl;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -329,6 +330,7 @@ public class CachingCatalogFacadeTest {
         assertEquals(expected, layersWrapper.get());
     }
 
+    @Disabled("LayerGroups are not cached")
     public @Test void testAddLayerGroupInfo() {
         LayerGroupInfo info = this.lg;
         LayerGroupInfo added = stub(LayerGroupInfo.class, 1); // same id
@@ -337,14 +339,17 @@ public class CachingCatalogFacadeTest {
         assertSame(added, cache.get(new CatalogInfoKey(info)).get(), "expected cache put");
     }
 
+    @Disabled("LayerGroups are not cached")
     public @Test void testRemoveLayerGroupInfo() {
         testEvicts(lg, caching::remove);
     }
 
+    @Disabled("LayerGroups are not cached")
     public @Test void testSaveLayerGroupInfo() {
         testEvicts(lg, caching::save);
     }
 
+    @Disabled("LayerGroups are not cached")
     public @Test void testGetLayerGroup() {
         CatalogInfo info = lg;
         assertSameTimesN(info, caching::getLayerGroup, 3);

--- a/src/catalog/cache/src/test/java/org/geoserver/cloud/event/remote/cache/RemoteEventCacheEvictorTest.java
+++ b/src/catalog/cache/src/test/java/org/geoserver/cloud/event/remote/cache/RemoteEventCacheEvictorTest.java
@@ -180,7 +180,8 @@ public class RemoteEventCacheEvictorTest {
     }
 
     public @Test void testCatalogInfoEvictingEvents() {
-        testModifyThenRemoveCatalogInfo(data.layerGroup1, catalog::getLayerGroup);
+        // layergroups are not cached
+        // testModifyThenRemoveCatalogInfo(data.layerGroup1, catalog::getLayerGroup);
         testModifyThenRemoveCatalogInfo(data.layerFeatureTypeA, catalog::getLayer);
         testModifyThenRemoveCatalogInfo(data.style1, catalog::getStyle);
         testModifyThenRemoveCatalogInfo(data.coverageA, catalog::getCoverage);

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -706,6 +706,14 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.1</version>
+          <inherited>true</inherited>
+          <configuration>
+            <release>17</release>
+            <debug>true</debug>
+            <encoding>UTF-8</encoding>
+            <fork>${fork.javac}</fork>
+            <maxmem>${javac.maxHeapSize}</maxmem>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -848,13 +856,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <release>17</release>
-          <debug>true</debug>
-          <encoding>UTF-8</encoding>
-          <fork>${fork.javac}</fork>
-          <maxmem>${javac.maxHeapSize}</maxmem>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
* CachingCatalogFacade.getLayers(ResourceInfo) cached an empty list, fixed with `@Cacheable(unless = "#result.isEmpty()", ...)`

* Not caching `LayerGroupInfo` anymore to avoid stale objects on the cached layergroup's layers list.

These issues were only found when using the `jdbcconfig` catalog backend because that's the one that has `geoserver.catalog.caching.enabled=true` by default (through the `jdbcconfig` spring profile).