### PR TITLE
Load gs-wms's LegendSample only for wms and gwc applications

### DIFF
--- a/src/apps/geoserver/gwc/src/main/java/org/geoserver/cloud/gwc/app/GeoWebCacheApplicationConfiguration.java
+++ b/src/apps/geoserver/gwc/src/main/java/org/geoserver/cloud/gwc/app/GeoWebCacheApplicationConfiguration.java
@@ -4,9 +4,16 @@
  */
 package org.geoserver.cloud.gwc.app;
 
+import org.geoserver.catalog.Catalog;
+import org.geoserver.cloud.gwc.config.core.WebMapServiceMinimalConfiguration;
+import org.geoserver.gwc.layer.GeoServerTileLayer;
+import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.rest.RequestInfo;
 import org.geoserver.rest.RestConfiguration;
+import org.geoserver.wms.capabilities.LegendSample;
+import org.geoserver.wms.capabilities.LegendSampleImpl;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.support.FormattingConversionService;
@@ -27,6 +34,20 @@ import javax.servlet.http.HttpServletRequestWrapper;
 
 @Configuration
 public class GeoWebCacheApplicationConfiguration extends RestConfiguration {
+
+    /**
+     * Required by {@link GeoServerTileLayer#getLegendSample}, excluded by {@link
+     * WebMapServiceMinimalConfiguration}
+     *
+     * @param catalog using {@code rawCatalog} instead of {@code catalog}, to avoid the local
+     *     workspace and secured catalog decorators
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public LegendSample legendSample(
+            @Qualifier("rawCatalog") Catalog catalog, GeoServerResourceLoader loader) {
+        return new LegendSampleImpl(catalog, loader);
+    }
 
     @SuppressWarnings("deprecation")
     @Override
@@ -99,27 +120,4 @@ public class GeoWebCacheApplicationConfiguration extends RestConfiguration {
             return request;
         }
     }
-
-    /**
-     * "Deprecate use of path extensions in request mapping and content negotiation" {@code
-     * https://github.com/spring-projects/spring-framework/issues/24179}
-     */
-    //    @Bean
-    //    public RequestMappingHandlerMapping requestMappingHandlerMapping(
-    //            @Qualifier("mvcContentNegotiationManager")
-    //                    ContentNegotiationManager contentNegotiationManager,
-    //            @Qualifier("mvcConversionService") FormattingConversionService conversionService,
-    //            @Qualifier("mvcResourceUrlProvider") ResourceUrlProvider resourceUrlProvider) {
-    //
-    //        RequestMappingHandlerMapping handlerMapping =
-    //                super.requestMappingHandlerMapping(
-    //                        contentNegotiationManager, conversionService, resourceUrlProvider);
-    //
-    //        handlerMapping.setUseSuffixPatternMatch(true);
-    //        handlerMapping.setUseRegisteredSuffixPatternMatch(true);
-    //        // handlerMapping.setUseTrailingSlashMatch(true);
-    //        // handlerMapping.setAlwaysUseFullPath(true);
-    //
-    //        return handlerMapping;
-    //    }
 }

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/wms/WmsConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/wms/WmsConfiguration.java
@@ -13,11 +13,42 @@ import org.springframework.context.annotation.ImportResource;
         reader = FilteringXmlBeanDefinitionReader.class, //
         locations = {
             "jar:gs-web-wms-.*!/applicationContext.xml", //
-            "jar:gs-wms-.*!/applicationContext.xml", //
+            "jar:gs-wms-.*!/applicationContext.xml#name=" + WmsConfiguration.WMS_BEANS_REGEX, //
             "jar:gs-wfs-.*!/applicationContext.xml#name=" + WmsConfiguration.WFS_BEANS_REGEX
         })
 public class WmsConfiguration {
 
     static final String WFS_BEANS_REGEX =
             "^(gml.*OutputFormat|bboxKvpParser|xmlConfiguration.*|gml[1-9]*SchemaBuilder|wfsXsd.*|wfsSqlViewKvpParser).*$";
+
+    static final String WMS_BEANS_REGEX =
+            """
+            ^(?!\
+            |legendSample\
+            |getMapKvpReader\
+            |wmsCapabilitiesXmlReader\
+            |getMapXmlReader\
+            |sldXmlReader\
+            |wms_1_1_1_GetCapabilitiesResponse\
+            |wms_1_3_0_GetCapabilitiesResponse\
+            |wmsDescribeLayerXML\
+            |.*DescribeLayerResponse\
+            |.stylesResponse\
+            |.kmlIconService\
+            |.wmsURLMapping\
+            |.wmsXMLTransformerResponse\
+            |.PDFMap.*\
+            |OpenLayers.*\
+            |Atom.*\
+            |RSSGeoRSSMapProducer\
+            |.*SVG.*\
+            |animateURLMapping\
+            |metaTileCache\
+            |wmsClasspathPublisherMapping\
+            |.*LegendGraphicResponse\
+            |wmsGIFLegendOutputFormat\
+            |wmsJPEGLegendGraphicOutputFormat\
+            |wmsJSONLegendOutputFormat
+            ).*$\
+            """;
 }

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/WebMapServiceMinimalConfiguration.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/WebMapServiceMinimalConfiguration.java
@@ -38,7 +38,8 @@ public class WebMapServiceMinimalConfiguration {
     private static final String WMS_BEANS_REGEX =
             """
             ^(?!\
-            getMapKvpReader\
+            legendSample\
+            |getMapKvpReader\
             |wmsCapabilitiesXmlReader\
             |getMapXmlReader\
             |sldXmlReader\


### PR DESCRIPTION
Exclude `legendSample` from default wms auto configurations and load it only on the service apps that need it.