### PR TITLE
Allow configuring the admin user name and password through environment variables

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -109,3 +109,23 @@ services:
       HTTP_PROXYPASSWORD: insecure
 ...
 ```
+
+## Configure admin user through environment variables
+
+For Cloud-Native deployments, an `AuthenticationProvider` exists 
+that allows to set an administrator account (username and password)
+through environment variables `GEOSERVER_ADMIN_USERNAME`/`GOSERVER_ADMIN_PASSWORD`,
+or Java System Properties `geoserver.admin.username` and `geoserver.admin.password`.
+
+Useful for devOps to set the admin password through a Kubernetes secret,
+instead of having to tweak the security configuration XML files with an init container or similar.
+
+This authentication provider will be the first one tested for an HTTP Basic authorization, only
+if a password is provided, and regardless of the authentication chain configured in GeoServer.
+
+If enabled (i.e. password provided), a failed attempt to log in will cancel the authentication
+chain, and no other authentication providers will be tested.
+
+If the default `admin` username is used, it effectively overrides the admin password set in the
+xml configuration. If a separate administrator username is given, the regular
+`admin` user is still active, so it's up to the devOps to handle its password as usual.

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/security/CloudGeoServerSecurityManager.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/security/CloudGeoServerSecurityManager.java
@@ -20,8 +20,11 @@ import org.geoserver.security.password.MasterPasswordConfig;
 import org.geoserver.security.password.MasterPasswordProviderConfig;
 import org.geoserver.security.validation.SecurityConfigException;
 import org.springframework.context.event.EventListener;
+import org.springframework.security.authentication.AuthenticationProvider;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -40,15 +43,25 @@ public class CloudGeoServerSecurityManager extends GeoServerSecurityManager {
 
     private final AtomicBoolean reloading = new AtomicBoolean(false);
     private boolean changedDuringReload = false;
+    private List<AuthenticationProvider> additionalAuthenticationProviders;
 
     public CloudGeoServerSecurityManager(
             GeoServerDataDirectory dataDir,
             @NonNull Consumer<SecurityConfigChanged> eventPublisher,
-            @NonNull Supplier<Long> updateSequenceIncrementor)
+            @NonNull Supplier<Long> updateSequenceIncrementor,
+            @NonNull List<AuthenticationProvider> additionalAuthenticationProviders)
             throws Exception {
         super(dataDir);
+        this.additionalAuthenticationProviders = additionalAuthenticationProviders;
         this.eventPublisher = eventPublisher;
         this.updateSequenceIncrementor = updateSequenceIncrementor;
+    }
+
+    @Override
+    public void setProviders(List<AuthenticationProvider> providers) throws Exception {
+        providers = new ArrayList<>(providers);
+        providers.addAll(0, additionalAuthenticationProviders);
+        super.setProviders(providers);
     }
 
     public @Override void reload() {

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/security/EnvironmentAdminAuthenticationProvider.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/security/EnvironmentAdminAuthenticationProvider.java
@@ -1,0 +1,81 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.security;
+
+import static org.springframework.util.StringUtils.hasText;
+
+import org.geoserver.security.impl.GeoServerRole;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.env.Environment;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+
+import java.util.List;
+
+/**
+ * {@link AuthenticationProvider} that allows to set an administrator account (username and
+ * password) through {@link Environment} properties {@code ${geoserver.admin.username:admin}} and
+ * {@code ${geoserver.admin.password:}}.
+ *
+ * <p>Useful for devOps to set the admin password through a Kubernetes secret, instead of having to
+ * tweak the security configuration XML files with an init container or similar.
+ *
+ * <p>This authentication provider will be the first one tested for an HTTP Basic authorization,
+ * only if a password is provided, and regardless of the authentication chain configured in
+ * GeoServer.
+ *
+ * <p>If enabled (i.e. password provided), a failed attempt to log in will cancel the authentication
+ * chain, and no other authentication providers will be tested. If the default {@literal admin}
+ * username is used, it effectively overrides the admin password set in the xml configuration. If a
+ * separate administrator username is given, the regular {@literal admin} user is still active, so
+ * it's up to the devOps to handle the {@literal admin} user password as usual.
+ *
+ * @since 1.0
+ */
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class EnvironmentAdminAuthenticationProvider implements AuthenticationProvider {
+
+    @Value("${geoserver.admin.username:admin}")
+    private String adminUserName;
+
+    @Value("${geoserver.admin.password:}")
+    private String adminPassword;
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+
+    @Override
+    public Authentication authenticate(Authentication token) throws AuthenticationException {
+        final String adminUserName = this.adminUserName;
+        final String adminPassword = this.adminPassword;
+
+        final boolean sameName = hasText(adminUserName) && adminUserName.equals(token.getName());
+        final boolean checkPwd = sameName && hasText(adminPassword);
+        UsernamePasswordAuthenticationToken authenticated = null;
+        if (checkPwd) {
+            final String pwd =
+                    token.getCredentials() == null ? null : token.getCredentials().toString();
+            if (adminPassword.equals(pwd)) {
+                authenticated =
+                        new UsernamePasswordAuthenticationToken(
+                                adminUserName, null, List.of(GeoServerRole.ADMIN_ROLE));
+                authenticated.setDetails(token.getDetails());
+            } else {
+                // this breaks the cycle through other providers, as opposed to
+                // BadCredentialsException
+                throw new InternalAuthenticationServiceException(
+                        "Bad credentials for: " + token.getPrincipal());
+            }
+        }
+        return authenticated;
+    }
+}

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/security/GeoServerSecurityConfiguration.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/security/GeoServerSecurityConfiguration.java
@@ -21,6 +21,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.ImportResource;
 
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -61,6 +62,11 @@ public class GeoServerSecurityConfiguration {
                 "GeoServer security being configured through classpath*:/applicationSecurityContext.xml");
     }
 
+    @Bean
+    public EnvironmentAdminAuthenticationProvider environmentAdminAuthenticationProvider() {
+        return new EnvironmentAdminAuthenticationProvider();
+    }
+
     /**
      * Override the {@code authenticationManager} bean defined in {@code gs-main}'s {@code
      * applicationSecurityContext.xml} with a version that notifies other services of any security
@@ -74,12 +80,14 @@ public class GeoServerSecurityConfiguration {
     public CloudGeoServerSecurityManager cloudAuthenticationManager( //
             GeoServerDataDirectory dataDir, //
             ApplicationEventPublisher localContextPublisher, //
-            UpdateSequence updateSequence //
+            UpdateSequence updateSequence, //
+            EnvironmentAdminAuthenticationProvider envAuth //
             ) throws Exception {
 
         Consumer<SecurityConfigChanged> publisher = localContextPublisher::publishEvent;
         Supplier<Long> updateSequenceIncrementor = updateSequence::nextValue;
 
-        return new CloudGeoServerSecurityManager(dataDir, publisher, updateSequenceIncrementor);
+        return new CloudGeoServerSecurityManager(
+                dataDir, publisher, updateSequenceIncrementor, List.of(envAuth));
     }
 }


### PR DESCRIPTION
For Cloud-Native deployments, an `AuthenticationProvider` exists that allows to set an administrator account (username and password) through environment variables `GEOSERVER_ADMIN_USERNAME`/`GOSERVER_ADMIN_PASSWORD`, or Java System Properties `geoserver.admin.username` and `geoserver.admin.password`.

Useful for devOps to set the admin password through a Kubernetes secret, instead of having to tweak the security configuration XML files with an init container or similar.

This authentication provider will be the first one tested for an HTTP Basic authorization, only if a password is provided, and regardless of the authentication chain configured in GeoServer.

If enabled (i.e. password provided), a failed attempt to log in will cancel the authentication chain, and no other authentication providers will be tested.

If the default `admin` username is used, it effectively overrides the admin password set in the xml configuration. If a separate administrator username is given, the regular `admin` user is still active, so it's up to the devOps to handle its password as usual.