### PR TITLE
Upgrade to spring-cloud 2021.0.5 / spring-boot 2.6.14 / feign-reactor  3.2.6

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -20,9 +20,9 @@
   <properties>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <spring-cloud.version>2021.0.1</spring-cloud.version>
-    <spring-boot.version>2.6.6</spring-boot.version>
-    <feign-reactor.version>3.1.5</feign-reactor.version>
+    <spring-cloud.version>2021.0.5</spring-cloud.version>
+    <spring-boot.version>2.6.14</spring-boot.version>
+    <feign-reactor.version>3.2.6</feign-reactor.version>
     <gs.version>2.21.0-CLOUD</gs.version>
     <gs.community.version>2.21.0-CLOUD</gs.community.version>
     <gt.version>27.0</gt.version>


### PR DESCRIPTION
Upgrade spring-cloud/boot to the latest version of the 2021 series. Moving to the 2022 series will be harder as it requires spring 6 which requires Java 17 as a minimum java version and is not binary compatible with spring 5.x (vanilla geoserver is still on `5.2.22`, we're on `5.3.24` transitively from spring-boot)