### PR TITLE
Support jackson-databind encoding of CogSettings in gs-jackson-databind

### DIFF
--- a/src/apps/geoserver/wfs/pom.xml
+++ b/src/apps/geoserver/wfs/pom.xml
@@ -32,6 +32,12 @@
       <artifactId>gs-cloud-starter-vector-formats</artifactId>
     </dependency>
     <dependency>
+      <!-- the catalog and distributed catalog change events could eventually need access to raster formats -->
+      <!-- in the future some sort of limited catalog support could be implemented to ignore certain store types -->
+      <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-starter-raster-formats</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wfs</artifactId>
     </dependency>

--- a/src/starters/raster-formats/src/main/java/org/geoserver/cloud/autoconfigure/cog/COGAutoConfiguration.java
+++ b/src/starters/raster-formats/src/main/java/org/geoserver/cloud/autoconfigure/cog/COGAutoConfiguration.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.cloud.autoconfigure.cog;
 
+import org.geoserver.cloud.autoconfigure.cog.jackson.CogSettingsModule;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.geoserver.cog.CogSettings;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -16,6 +17,7 @@ import org.springframework.context.annotation.ImportResource;
  * @implNote importing {@literal classpath:pgrasterApplicationContext.xml} instead of defining the
  *     bean in place because of parameterized class incompatibility on {@link
  *     org.geoserver.web.data.resource.DataStorePanelInfo#setComponentClass(Class)}
+ * @see CogSettingsModule
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass({CogSettings.class})

--- a/src/starters/raster-formats/src/main/java/org/geoserver/cloud/autoconfigure/cog/jackson/CogSettings.java
+++ b/src/starters/raster-formats/src/main/java/org/geoserver/cloud/autoconfigure/cog/jackson/CogSettings.java
@@ -1,0 +1,21 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.cog.jackson;
+
+import lombok.Data;
+
+/** */
+@Data
+public class CogSettings {
+    public enum RangeReaderType {
+        HTTP,
+        S3,
+        GS,
+        Azure;
+    }
+
+    private RangeReaderType rangeReaderSettings = RangeReaderType.HTTP;
+    private boolean useCachingStream;
+}

--- a/src/starters/raster-formats/src/main/java/org/geoserver/cloud/autoconfigure/cog/jackson/CogSettingsMapper.java
+++ b/src/starters/raster-formats/src/main/java/org/geoserver/cloud/autoconfigure/cog/jackson/CogSettingsMapper.java
@@ -1,0 +1,51 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.cog.jackson;
+
+import org.geoserver.cloud.autoconfigure.cog.jackson.CogSettings.RangeReaderType;
+
+class CogSettingsMapper {
+
+    public CogSettings toJackson(org.geoserver.cog.CogSettings model) {
+        return toJackson(model, new CogSettings());
+    }
+
+    public org.geoserver.cog.CogSettings toModel(CogSettings pojo) {
+        return toModel(pojo, new org.geoserver.cog.CogSettings());
+    }
+
+    public CogSettingsStore toJackson(org.geoserver.cog.CogSettingsStore model) {
+        CogSettingsStore pojo = new CogSettingsStore();
+        pojo.setUsername(model.getUsername());
+        pojo.setPassword(model.getPassword());
+        return toJackson(model, pojo);
+    }
+
+    public org.geoserver.cog.CogSettingsStore toModel(CogSettingsStore pojo) {
+        org.geoserver.cog.CogSettingsStore model = new org.geoserver.cog.CogSettingsStore();
+        model.setUsername(pojo.getUsername());
+        model.setPassword(pojo.getPassword());
+        return toModel(pojo, model);
+    }
+
+    private <C extends CogSettings> C toJackson(org.geoserver.cog.CogSettings model, C pojo) {
+        pojo.setUseCachingStream(model.isUseCachingStream());
+        if (null != model.getRangeReaderSettings()) {
+            pojo.setRangeReaderSettings(
+                    CogSettings.RangeReaderType.valueOf(model.getRangeReaderSettings().toString()));
+        }
+        return pojo;
+    }
+
+    private <M extends org.geoserver.cog.CogSettings> M toModel(CogSettings pojo, M model) {
+        model.setUseCachingStream(pojo.isUseCachingStream());
+        RangeReaderType r = pojo.getRangeReaderSettings();
+        if (null != r) {
+            model.setRangeReaderSettings(
+                    org.geoserver.cog.CogSettings.RangeReaderType.valueOf(r.toString()));
+        }
+        return model;
+    }
+}

--- a/src/starters/raster-formats/src/main/java/org/geoserver/cloud/autoconfigure/cog/jackson/CogSettingsModule.java
+++ b/src/starters/raster-formats/src/main/java/org/geoserver/cloud/autoconfigure/cog/jackson/CogSettingsModule.java
@@ -1,0 +1,56 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.cog.jackson;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import org.geoserver.catalog.CoverageStoreInfo;
+import org.geoserver.cog.CogSettings;
+
+import java.util.function.Function;
+
+/**
+ * Jackson-databind module to enable encoding {@link CogSettings} as part of {@link
+ * CoverageStoreInfo}'s metadata map for {@literal gs-jackson-databind}
+ *
+ * <p>The module is exposed through the {@literal com.fasterxml.jackson.databind.Module} SPI.
+ *
+ * @since 1.0
+ */
+public class CogSettingsModule extends SimpleModule {
+
+    private static final long serialVersionUID = 1L;
+
+    private final CogSettingsMapper mapper = new CogSettingsMapper();
+
+    public CogSettingsModule() {
+        super("CogSettingsModule");
+
+        register(
+                org.geoserver.cog.CogSettings.class,
+                mapper::toJackson,
+                org.geoserver.cloud.autoconfigure.cog.jackson.CogSettings.class,
+                mapper::toModel);
+
+        register(
+                org.geoserver.cog.CogSettingsStore.class,
+                mapper::toJackson,
+                org.geoserver.cloud.autoconfigure.cog.jackson.CogSettingsStore.class,
+                mapper::toModel);
+    }
+
+    private <T, DTO> void register(
+            Class<T> type,
+            Function<T, DTO> serializerMapper,
+            Class<DTO> dtoType,
+            Function<DTO, T> deserializerMapper) {
+
+        MapperSerializer<T, DTO> serializer = new MapperSerializer<>(type, serializerMapper);
+        MapperDeserializer<DTO, T> deserializer =
+                new MapperDeserializer<>(dtoType, deserializerMapper);
+        super.addSerializer(type, serializer);
+        super.addDeserializer(type, deserializer);
+    }
+}

--- a/src/starters/raster-formats/src/main/java/org/geoserver/cloud/autoconfigure/cog/jackson/CogSettingsStore.java
+++ b/src/starters/raster-formats/src/main/java/org/geoserver/cloud/autoconfigure/cog/jackson/CogSettingsStore.java
@@ -1,0 +1,17 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.cog.jackson;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/** */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class CogSettingsStore extends CogSettings {
+
+    private String username;
+    private String password;
+}

--- a/src/starters/raster-formats/src/main/java/org/geoserver/cloud/autoconfigure/cog/jackson/MapperDeserializer.java
+++ b/src/starters/raster-formats/src/main/java/org/geoserver/cloud/autoconfigure/cog/jackson/MapperDeserializer.java
@@ -1,0 +1,45 @@
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.cog.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+@Slf4j
+@RequiredArgsConstructor
+class MapperDeserializer<DTO, T> extends JsonDeserializer<T> {
+
+    private final @NonNull Class<DTO> from;
+    private final Function<DTO, T> mapper;
+
+    public @Override T deserialize(JsonParser parser, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+
+        DTO dto;
+        T value;
+        try {
+            dto = parser.readValueAs(from);
+        } catch (RuntimeException e) {
+            log.error("Error reading object of type {}", from.getCanonicalName(), e);
+            throw e;
+        }
+        try {
+            value = mapper.apply(dto);
+        } catch (RuntimeException e) {
+            log.error("Error mapping read object of type {}", dto.getClass().getCanonicalName(), e);
+            throw e;
+        }
+        return value;
+    }
+}

--- a/src/starters/raster-formats/src/main/java/org/geoserver/cloud/autoconfigure/cog/jackson/MapperSerializer.java
+++ b/src/starters/raster-formats/src/main/java/org/geoserver/cloud/autoconfigure/cog/jackson/MapperSerializer.java
@@ -1,0 +1,67 @@
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.cog.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.type.WritableTypeId;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+@Slf4j
+class MapperSerializer<I, DTO> extends StdSerializer<I> {
+
+    private static final long serialVersionUID = 1L;
+
+    private Function<I, DTO> mapper;
+
+    private Class<I> type;
+
+    public MapperSerializer(Class<I> type, java.util.function.Function<I, DTO> serializerMapper) {
+        super(type);
+        this.type = type;
+        this.mapper = serializerMapper;
+    }
+
+    public @Override void serializeWithType(
+            I value, JsonGenerator gen, SerializerProvider serializers, TypeSerializer typeSer)
+            throws IOException {
+
+        WritableTypeId typeIdDef =
+                typeSer.writeTypePrefix(gen, typeSer.typeId(value, type, JsonToken.VALUE_STRING));
+
+        serialize(value, gen, null);
+
+        typeSer.writeTypeSuffix(gen, typeIdDef);
+    }
+
+    public @Override void serialize(I value, JsonGenerator gen, SerializerProvider provider)
+            throws IOException {
+
+        DTO dto;
+        try {
+            dto = mapper.apply(value);
+        } catch (RuntimeException e) {
+            log.error("Error mapping {}", value.getClass().getCanonicalName(), e);
+            throw e;
+        }
+        try {
+            gen.writeObject(dto);
+        } catch (RuntimeException e) {
+            log.error(
+                    "Error writing value mapped from {} to {}",
+                    value.getClass().getCanonicalName(),
+                    dto == null ? "null" : dto.getClass().getCanonicalName(),
+                    e);
+            throw e;
+        }
+    }
+}

--- a/src/starters/raster-formats/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module
+++ b/src/starters/raster-formats/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module
@@ -1,0 +1,1 @@
+org.geoserver.cloud.autoconfigure.cog.jackson.CogSettingsModule

--- a/src/starters/raster-formats/src/test/java/org/geoserver/cloud/autoconfigure/cog/jackson/CogSettingsModuleTest.java
+++ b/src/starters/raster-formats/src/test/java/org/geoserver/cloud/autoconfigure/cog/jackson/CogSettingsModuleTest.java
@@ -1,0 +1,96 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.cog.jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.geoserver.cog.CogSettings;
+import org.geoserver.cog.CogSettings.RangeReaderType;
+import org.geoserver.cog.CogSettingsStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Test suite for {@link CogSettingsModule} */
+class CogSettingsModuleTest {
+
+    private ObjectMapper objectMapper;
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @BeforeEach
+    void setUp() throws Exception {
+        objectMapper = new ObjectMapper();
+        objectMapper.findAndRegisterModules();
+    }
+
+    @Test
+    void testSPI() {
+        assertThat(objectMapper.getRegisteredModuleIds())
+                .as("ObjectMapper.findAndRegisterModules() did not find CogSettingsModule")
+                .contains("CogSettingsModule");
+    }
+
+    @Test
+    void testCogSettings() throws JsonProcessingException {
+        CogSettings cs = new CogSettings();
+        cs.setUseCachingStream(true);
+
+        for (RangeReaderType rtype : RangeReaderType.values()) {
+            cs.setRangeReaderSettings(rtype);
+            String serialized = objectMapper.writeValueAsString(cs);
+            CogSettings read = objectMapper.readValue(serialized, CogSettings.class);
+            assertThat(read).isNotInstanceOf(CogSettingsStore.class);
+            assertSettings(cs, read);
+        }
+    }
+
+    @Test
+    void testCogSettingsStore() throws JsonProcessingException {
+        CogSettingsStore cs = new CogSettingsStore();
+        cs.setUseCachingStream(true);
+
+        testCogSettingsStore(cs);
+
+        cs.setUsername("");
+        testCogSettingsStore(cs);
+
+        cs.setPassword("");
+        testCogSettingsStore(cs);
+
+        cs.setUsername("user");
+        cs.setPassword("secret");
+        testCogSettingsStore(cs);
+    }
+
+    protected void testCogSettingsStore(CogSettingsStore cs)
+            throws JsonProcessingException, JsonMappingException {
+
+        String serialized = objectMapper.writeValueAsString(cs);
+        CogSettingsStore read = objectMapper.readValue(serialized, CogSettingsStore.class);
+        assertSettingsStore(cs, read);
+    }
+
+    private void assertSettings(
+            org.geoserver.cog.CogSettings expected, org.geoserver.cog.CogSettings actual) {
+        assertThat(actual).isNotSameAs(expected);
+        // org.geoserver.cog.CogSettings does not implement equals
+        assertThat(actual.isUseCachingStream()).isEqualTo(expected.isUseCachingStream());
+        assertThat(actual.isUseCachingStream()).isEqualTo(expected.isUseCachingStream());
+    }
+
+    private void assertSettingsStore(
+            org.geoserver.cog.CogSettingsStore expected,
+            org.geoserver.cog.CogSettingsStore actual) {
+        assertSettings(expected, actual);
+        // org.geoserver.cog.CogSettingsStore does not implement equals
+        assertThat(actual.getUsername()).isEqualTo(expected.getUsername());
+        assertThat(actual.getPassword()).isEqualTo(expected.getPassword());
+    }
+}


### PR DESCRIPTION
Make the `gs-cloud-starter-raster-formats` module contribute a Jackson-databind module to serialize
`org.geoserver.cog.CogSettings/Store`.

`CogSettings` is added to the `GeoServerInfo` and `CoverageStoreInfo` `MetadtaMap`s, and need to be properly serialized when sending distributed events, for the pods to react accordingly to configuration changes.

Fixes #297