### PR TITLE
Upgrade to spring-cloud 2021.0.6/spring-boot 2.7.9

### DIFF
--- a/src/apps/geoserver/wms/pom.xml
+++ b/src/apps/geoserver/wms/pom.xml
@@ -54,6 +54,13 @@
       <groupId>org.geoserver.cloud</groupId>
       <artifactId>gwc-cloud-spring-boot-starter</artifactId>
     </dependency>
+    <dependency>
+      <!-- jdbcconfig can't create the tables with a newer version than this old one used in geoserver -->
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>1.4.200</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/src/catalog/backends/jdbcconfig/pom.xml
+++ b/src/catalog/backends/jdbcconfig/pom.xml
@@ -77,8 +77,10 @@
       <artifactId>postgresql</artifactId>
     </dependency>
     <dependency>
+      <!-- jdbcconfig can't create the tables with a newer version than this old one used in geoserver -->
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
+      <version>1.4.200</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -20,8 +20,8 @@
   <properties>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <spring-cloud.version>2021.0.5</spring-cloud.version>
-    <spring-boot.version>2.6.14</spring-boot.version>
+    <spring-cloud.version>2021.0.6</spring-cloud.version>
+    <spring-boot.version>2.7.9</spring-boot.version>
     <feign-reactor.version>3.2.6</feign-reactor.version>
     <gs.version>2.22.3-SNAPSHOT</gs.version>
     <gs.community.version>2.22.3-SNAPSHOT</gs.community.version>


### PR DESCRIPTION
Follow up with the [spring-cloud:2021.0.6 Release](https://spring.io/blog/2023/02/24/spring-cloud-2021-0-6-has-been-released)