### PR TITLE
Force hiding the default admin user when the admin username and password is provided through env variables

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -121,11 +121,15 @@ Useful for devOps to set the admin password through a Kubernetes secret,
 instead of having to tweak the security configuration XML files with an init container or similar.
 
 This authentication provider will be the first one tested for an HTTP Basic authorization, only
-if a password is provided, and regardless of the authentication chain configured in GeoServer.
+if both the above mentioned username and password config properties are provided,
+and regardless of the authentication chain configured in GeoServer.
 
-If enabled (i.e. password provided), a failed attempt to log in will cancel the authentication
-chain, and no other authentication providers will be tested.
+If only one of the `geoserver.admin.username` and `geoserver.admin.password` config properties
+is provided, the application will fail to start.
+
+If enabled (i.e. both admin username and password provided), a failed attempt to log
+in will cancel the authentication chain, and no other authentication providers will be tested.
 
 If the default `admin` username is used, it effectively overrides the admin password set in the
 xml configuration. If a separate administrator username is given, the regular
-`admin` user is still active, so it's up to the devOps to handle its password as usual.
+`admin` user is **disabled**.

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/security/EnvironmentAdminAuthenticationProvider.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/security/EnvironmentAdminAuthenticationProvider.java
@@ -6,7 +6,11 @@ package org.geoserver.cloud.security;
 
 import static org.springframework.util.StringUtils.hasText;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.geoserver.security.impl.GeoServerRole;
+import org.geoserver.security.impl.GeoServerUser;
+import org.springframework.beans.BeanInstantiationException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -16,8 +20,12 @@ import org.springframework.security.authentication.InternalAuthenticationService
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
+
+import javax.annotation.PostConstruct;
 
 /**
  * {@link AuthenticationProvider} that allows to set an administrator account (username and
@@ -28,54 +36,118 @@ import java.util.List;
  * tweak the security configuration XML files with an init container or similar.
  *
  * <p>This authentication provider will be the first one tested for an HTTP Basic authorization,
- * only if a password is provided, and regardless of the authentication chain configured in
- * GeoServer.
+ * only if both the username and password are provided, and regardless of the authentication chain
+ * configured in GeoServer.
  *
- * <p>If enabled (i.e. password provided), a failed attempt to log in will cancel the authentication
- * chain, and no other authentication providers will be tested. If the default {@literal admin}
- * username is used, it effectively overrides the admin password set in the xml configuration. If a
- * separate administrator username is given, the regular {@literal admin} user is still active, so
- * it's up to the devOps to handle the {@literal admin} user password as usual.
+ * <p>If enabled (i.e. both username and password provided), a failed attempt to log in will cancel
+ * the authentication chain, and no other authentication providers will be tested.
+ *
+ * <p>If the default {@literal admin} username is used, it effectively overrides the admin password
+ * set in the xml configuration. If a separate administrator username is given, the regular
+ * {@literal admin} user is disabled.
  *
  * @since 1.0
  */
+@Slf4j
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class EnvironmentAdminAuthenticationProvider implements AuthenticationProvider {
 
-    @Value("${geoserver.admin.username:admin}")
+    @Value("${geoserver.admin.username:}")
     private String adminUserName;
 
     @Value("${geoserver.admin.password:}")
     private String adminPassword;
+
+    private boolean enabled;
+
+    @PostConstruct
+    void validateConfig() {
+        final boolean userSet = StringUtils.hasText(adminUserName);
+        final boolean passwordSet = StringUtils.hasText(adminPassword);
+        if (userSet && !passwordSet) {
+            String msg =
+                    String.format(
+                            """
+                    Found overriding admin username config property geoserver.admin.username=%s, \
+                    but password not provided through config property geoserver.admin.password
+                    """,
+                            adminUserName);
+            throw new BeanInstantiationException(getClass(), msg);
+        }
+        if (passwordSet && !userSet) {
+            String msg =
+                    String.format(
+                            """
+                    Found overriding admin password config property geoserver.admin.password, \
+                    but admin username not provided through config property geoserver.admin.username
+                    """,
+                            adminUserName);
+            throw new BeanInstantiationException(getClass(), msg);
+        }
+        enabled = userSet && passwordSet;
+        if (enabled) {
+            log.info(
+                    "The default admin username and password are overridden by the externalized geoserver.admin.username and geoserver.admin.password config properties.");
+        }
+    }
+
+    public static List<GrantedAuthority> adminRoles() {
+        return List.of(
+                new GeoServerRole("ADMIN"),
+                GeoServerRole.ADMIN_ROLE,
+                GeoServerRole.AUTHENTICATED_ROLE);
+    }
 
     @Override
     public boolean supports(Class<?> authentication) {
         return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @return a fully authenticated {@link UsernamePasswordAuthenticationToken} if {@code token} is
+     *     a {@code UsernamePasswordAuthenticationToken}, and both the username and password match
+     *     the ones provided by the configuration properties {@literal geoserver.admin.username} and
+     *     {@literal geoserver.admin.password}
+     * @throws InternalAuthenticationServiceException to break the authentication chain if the
+     *     credentials don't match, or the
+     */
     @Override
     public Authentication authenticate(Authentication token) throws AuthenticationException {
+        if (!enabled) {
+            // proceed with the authentication chain
+            return null;
+        }
         final String adminUserName = this.adminUserName;
         final String adminPassword = this.adminPassword;
 
-        final boolean sameName = hasText(adminUserName) && adminUserName.equals(token.getName());
-        final boolean checkPwd = sameName && hasText(adminPassword);
-        UsernamePasswordAuthenticationToken authenticated = null;
-        if (checkPwd) {
-            final String pwd =
-                    token.getCredentials() == null ? null : token.getCredentials().toString();
-            if (adminPassword.equals(pwd)) {
-                authenticated =
-                        new UsernamePasswordAuthenticationToken(
-                                adminUserName, null, List.of(GeoServerRole.ADMIN_ROLE));
-                authenticated.setDetails(token.getDetails());
-            } else {
-                // this breaks the cycle through other providers, as opposed to
-                // BadCredentialsException
-                throw new InternalAuthenticationServiceException(
-                        "Bad credentials for: " + token.getPrincipal());
-            }
+        final String name = token.getName();
+        if (GeoServerUser.ADMIN_USERNAME.equals(name) && !adminUserName.equals(name)) {
+            throw new InternalAuthenticationServiceException("Default admin user is disabled");
         }
-        return authenticated;
+
+        final boolean sameName = hasText(adminUserName) && adminUserName.equals(name);
+        if (!sameName) {
+            // not the configured admin username, proceed with the authentication chain
+            return null;
+        }
+        // enabled and requesting authentication against the configured admin user name, perform the
+        // auth checks
+
+        final String pwd =
+                token.getCredentials() == null ? null : token.getCredentials().toString();
+        if (adminPassword.equals(pwd)) {
+            List<GrantedAuthority> adminRoles = adminRoles();
+            UsernamePasswordAuthenticationToken authenticated =
+                    UsernamePasswordAuthenticationToken.authenticated(
+                            adminUserName, null, adminRoles);
+            authenticated.setDetails(token.getDetails());
+            return authenticated;
+        }
+        // this breaks the cycle through other providers, as opposed to
+        // BadCredentialsException
+        throw new InternalAuthenticationServiceException(
+                "Bad credentials for: " + token.getPrincipal());
     }
 }

--- a/src/catalog/backends/common/src/test/java/org/geoserver/cloud/autoconfigure/security/EnvironmentAdminAuthenticationProviderTest.java
+++ b/src/catalog/backends/common/src/test/java/org/geoserver/cloud/autoconfigure/security/EnvironmentAdminAuthenticationProviderTest.java
@@ -1,0 +1,185 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.geoserver.cloud.security.EnvironmentAdminAuthenticationProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+import java.io.File;
+
+/**
+ * {@link EnableAutoConfiguration @EnableAutoConfiguration} tests for {@link
+ * GeoServerSecurityAutoConfiguration}'s {@link EnvironmentAdminAuthenticationProvider}
+ *
+ * @since 1.0
+ */
+class EnvironmentAdminAuthenticationProviderTest {
+
+    @TempDir File tempDir;
+
+    private ApplicationContextRunner runner;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        runner = GeoServerSecurityAutoConfigurationTest.createContextRunner(tempDir);
+    }
+
+    @Test
+    @DisplayName(
+            "When username is set and password is not set Then FAILS to load the application context")
+    void fails_if_password_not_set() {
+        runner.withPropertyValues(
+                        // USERNAME SET
+                        "geoserver.admin.username=myAdmin",
+                        // PASSWORD NOT SET
+                        "geoserver.admin.password=")
+                .run(
+                        context -> {
+                            assertThat(context)
+                                    .hasFailed()
+                                    .getFailure()
+                                    .hasMessageContaining(
+                                            "password not provided through config property geoserver.admin.password");
+                        });
+    }
+
+    @Test
+    @DisplayName(
+            "When password is set and username is not set Then FAILS to load the application context")
+    void fails_if_username_not_set() {
+        runner.withPropertyValues(
+                        // USERNAME NOT SET
+                        "geoserver.admin.username=",
+                        // PASSWORD SET
+                        "geoserver.admin.password=s3cr3t")
+                .run(
+                        context -> {
+                            assertThat(context)
+                                    .hasFailed()
+                                    .getFailure()
+                                    .hasMessageContaining(
+                                            "admin username not provided through config property geoserver.admin.username");
+                        });
+    }
+
+    // success case with default admin user
+    @Test
+    @DisplayName(
+            "When using default admin username and password matches Then returns an authenticated token")
+    void default_admin_and_password_matches() {
+        runner.withPropertyValues(
+                        "geoserver.admin.username=admin", "geoserver.admin.password=s3cr3t")
+                .run(
+                        context -> {
+                            assertThat(context).hasNotFailed();
+                            Authentication token = userNamePasswordToken("admin", "s3cr3t");
+                            Authentication authenticated =
+                                    envAuthProvider(context).authenticate(token);
+                            assertThat(authenticated)
+                                    .isInstanceOf(UsernamePasswordAuthenticationToken.class)
+                                    .isNotSameAs(token);
+
+                            assertThat(authenticated)
+                                    .as("should return a fully authenticated token")
+                                    .hasFieldOrPropertyWithValue("authenticated", true);
+
+                            assertThat(authenticated)
+                                    .as("should have the expected admin roles")
+                                    .hasFieldOrPropertyWithValue(
+                                            "authorities",
+                                            EnvironmentAdminAuthenticationProvider.adminRoles());
+                        });
+    }
+
+    // success case with a non default admin username
+    @Test
+    @DisplayName(
+            "When NOT using default admin username and password matches Then returns an authenticated token")
+    void non_default_admin_and_password_matches() {
+        runner.withPropertyValues(
+                        "geoserver.admin.username=JohnTheAdmin", "geoserver.admin.password=s3cr3t")
+                .run(
+                        context -> {
+                            assertThat(context).hasNotFailed();
+                            Authentication token = userNamePasswordToken("JohnTheAdmin", "s3cr3t");
+                            Authentication authenticated =
+                                    envAuthProvider(context).authenticate(token);
+                            assertThat(authenticated)
+                                    .isInstanceOf(UsernamePasswordAuthenticationToken.class)
+                                    .isNotSameAs(token);
+
+                            assertThat(authenticated)
+                                    .as("should return a fully authenticated token")
+                                    .hasFieldOrPropertyWithValue("authenticated", true);
+
+                            assertThat(authenticated)
+                                    .as("should have the expected admin roles")
+                                    .hasFieldOrPropertyWithValue(
+                                            "authorities",
+                                            EnvironmentAdminAuthenticationProvider.adminRoles());
+                        });
+    }
+
+    @Test
+    @DisplayName(
+            "When using default admin username and password does not match Then breaks the auth chain")
+    void default_admin_bad_credentials() {
+        runner.withPropertyValues(
+                        "geoserver.admin.username=admin", "geoserver.admin.password=s3cr3t")
+                .run(
+                        context -> {
+                            assertThat(context).hasNotFailed();
+                            Authentication token = userNamePasswordToken("admin", "badPWD");
+
+                            assertThrows(
+                                    InternalAuthenticationServiceException.class,
+                                    () -> envAuthProvider(context).authenticate(token));
+                        });
+    }
+
+    @Test
+    @DisplayName("When not using admin as username Then the default admin username cannot be used")
+    void if_configured_hides_default_admin() {
+        runner.withPropertyValues(
+                        "geoserver.admin.username=MyCustomAdmin", "geoserver.admin.password=s3cr3t")
+                .run(
+                        context -> {
+                            assertThat(context).hasNotFailed();
+
+                            Authentication defaultAdminCredentials =
+                                    userNamePasswordToken("admin", "geoserver");
+                            EnvironmentAdminAuthenticationProvider authProvider =
+                                    envAuthProvider(context);
+                            assertThrows(
+                                    InternalAuthenticationServiceException.class,
+                                    () -> authProvider.authenticate(defaultAdminCredentials),
+                                    "The admin user should be disabled if geoserver.admin.username is set to another value");
+                        });
+    }
+
+    protected UsernamePasswordAuthenticationToken userNamePasswordToken(
+            String principal, String credentials) {
+        return new UsernamePasswordAuthenticationToken(principal, credentials);
+    }
+
+    protected EnvironmentAdminAuthenticationProvider envAuthProvider(
+            AssertableApplicationContext context) {
+        EnvironmentAdminAuthenticationProvider provider =
+                context.getBean(EnvironmentAdminAuthenticationProvider.class);
+        return provider;
+    }
+}

--- a/src/catalog/backends/common/src/test/java/org/geoserver/cloud/autoconfigure/security/GeoServerSecurityAutoConfigurationTest.java
+++ b/src/catalog/backends/common/src/test/java/org/geoserver/cloud/autoconfigure/security/GeoServerSecurityAutoConfigurationTest.java
@@ -43,6 +43,10 @@ class GeoServerSecurityAutoConfigurationTest {
 
     @BeforeEach
     void setUp() throws Exception {
+        runner = createContextRunner(tempDir);
+    }
+
+    static ApplicationContextRunner createContextRunner(File tempDir) {
         Catalog catalog = mock(Catalog.class);
         GeoServer geoserver = mock(GeoServer.class);
         ResourceStore resourceStore = new FileSystemResourceStore(tempDir);
@@ -50,19 +54,17 @@ class GeoServerSecurityAutoConfigurationTest {
         GeoServerDataDirectory datadir = new GeoServerDataDirectory(resourceLoader);
         UpdateSequence updateSequence = mock(UpdateSequence.class);
 
-        runner =
-                new ApplicationContextRunner()
-                        .withConfiguration(
-                                AutoConfigurations.of(GeoServerSecurityAutoConfiguration.class))
-                        .withBean("extensions", GeoServerExtensions.class)
-                        .withBean(ResourceStore.class, () -> resourceStore)
-                        .withBean(GeoServerResourceLoader.class, () -> resourceLoader)
-                        .withBean("dataDirectory", GeoServerDataDirectory.class, () -> datadir)
-                        .withBean("catalog", Catalog.class, () -> catalog)
-                        .withBean("rawCatalog", Catalog.class, () -> catalog)
-                        .withBean("geoServer", GeoServer.class, () -> geoserver)
-                        .withBean("updateSequence", UpdateSequence.class, () -> updateSequence)
-                        .withPropertyValues("logging.level.org.geoserver.platform: off");
+        return new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(GeoServerSecurityAutoConfiguration.class))
+                .withBean("extensions", GeoServerExtensions.class)
+                .withBean(ResourceStore.class, () -> resourceStore)
+                .withBean(GeoServerResourceLoader.class, () -> resourceLoader)
+                .withBean("dataDirectory", GeoServerDataDirectory.class, () -> datadir)
+                .withBean("catalog", Catalog.class, () -> catalog)
+                .withBean("rawCatalog", Catalog.class, () -> catalog)
+                .withBean("geoServer", GeoServer.class, () -> geoserver)
+                .withBean("updateSequence", UpdateSequence.class, () -> updateSequence)
+                .withPropertyValues("logging.level.org.geoserver.platform: off");
     }
 
     @Test


### PR DESCRIPTION
If the admin username is overridden throuh the config properties
`geoserver.admin.username` and `geoserver.admin.username`, then
and the configured username is different than the default
`admin` username, then the default admin user is effectively disabled.
