### PR TITLE
Fix GeoTools logging initialization not working with Logback

### DIFF
--- a/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/config/catalog/backend/datadirectory/ParallelDataDirectoryGeoServerLoader.java
+++ b/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/config/catalog/backend/datadirectory/ParallelDataDirectoryGeoServerLoader.java
@@ -198,7 +198,7 @@ public class ParallelDataDirectoryGeoServerLoader
                     },
                     "initializeDefaultStyles()");
         } else {
-            log.info("Default styles already present");
+            log.debug("Default styles already present");
         }
     }
 

--- a/src/library/spring-boot-simplejndi/src/main/java/org/geoserver/cloud/config/jndi/SimpleJNDIStaticContextInitializer.java
+++ b/src/library/spring-boot-simplejndi/src/main/java/org/geoserver/cloud/config/jndi/SimpleJNDIStaticContextInitializer.java
@@ -20,7 +20,7 @@ import javax.naming.spi.NamingManager;
  *
  * @since 1.0
  */
-@Slf4j
+@Slf4j(topic = "org.geoserver.cloud.config.jndi")
 public class SimpleJNDIStaticContextInitializer
         implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 

--- a/src/library/spring-boot-simplejndi/src/main/java/org/geoserver/cloud/config/jndidatasource/JNDIDataSourceAutoConfiguration.java
+++ b/src/library/spring-boot-simplejndi/src/main/java/org/geoserver/cloud/config/jndidatasource/JNDIDataSourceAutoConfiguration.java
@@ -25,7 +25,7 @@ import javax.sql.DataSource;
 /**
  * @since 1.0
  */
-@Slf4j
+@Slf4j(topic = "org.geoserver.cloud.config.jndidatasource")
 @Configuration
 @EnableConfigurationProperties(JNDIDataSourcesConfigurationProperties.class)
 public class JNDIDataSourceAutoConfiguration implements InitializingBean {

--- a/src/starters/webmvc/src/main/java/org/geoserver/cloud/autoconfigure/context/GeoServerContextInitializer.java
+++ b/src/starters/webmvc/src/main/java/org/geoserver/cloud/autoconfigure/context/GeoServerContextInitializer.java
@@ -32,8 +32,12 @@ public class GeoServerContextInitializer
         // tell geoserver not to control logging, spring-boot will do
         System.setProperty("RELINQUISH_LOG4J_CONTROL", "true");
         // and tell geotools not to redirect to Log4J nor any other framework, we'll use
-        // spring-boot's logging redirection
-        System.setProperty("GT2_LOGGING_REDIRECTION", "JavaLogging");
+        // spring-boot's logging redirection. Use Log4J2 redirection policy, JavaLogging
+        // will make GeoserverInitStartupListener's call to GeoTools.init() heuristically set
+        // Logging.ALL.setLoggerFactory("org.geotools.util.logging.LogbackLoggerFactory")
+        // with the caveat that it wrongly maps logging levels and hence if, for example, a logger
+        // with level FINE is called with INFO, it doesn't log at all
+        System.setProperty("GT2_LOGGING_REDIRECTION", "Log4J2");
         ServletContext source = mockServletContext();
         ServletContextEvent sce = new ServletContextEvent(source);
         GeoserverInitStartupListener startupInitializer = new GeoserverInitStartupListener();


### PR DESCRIPTION
Tell GeoTools to use `Log4J2` instead of `JavaLogging` logging redirection.

Upstream's `GeoserverInitStartupListener` clears up the GeoTools logging redirection configuration, which results in GeoTools.init() heuristically setting the logger factory to `"org.geotools.util.logging.LogbackLoggerFactory"`. This, in turn, has a bug in mapping logging levels so log entres get lost when they should be created.