### PR TITLE
GWC Azure blob store throws exception initializing aws client

### DIFF
--- a/src/catalog/backends/pom.xml
+++ b/src/catalog/backends/pom.xml
@@ -14,7 +14,6 @@
     <module>common</module>
     <module>datadir</module>
     <module>jdbcconfig</module>
-    <module>catalog-service</module>
   </modules>
   <dependencies>
     <dependency>
@@ -41,4 +40,15 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <profiles>
+    <profile>
+      <id>catalog-service</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <modules>
+        <module>catalog-service</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>

--- a/src/catalog/catalog-server/pom.xml
+++ b/src/catalog/catalog-server/pom.xml
@@ -12,7 +12,6 @@
   <name>Reactive Catalog Server and Client Libraries</name>
   <modules>
     <module>client</module>
-    <!-- temporarily disabled -->
-    <!---module>server</module-->
+    <module>server</module>
   </modules>
 </project>

--- a/src/catalog/pom.xml
+++ b/src/catalog/pom.xml
@@ -16,7 +16,6 @@
     <module>cache</module>
     <module>jackson-bindings</module>
     <module>event-bus</module>
-    <module>catalog-server</module>
     <module>backends</module>
   </modules>
   <dependencies>
@@ -26,4 +25,15 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <profiles>
+    <profile>
+      <id>catalog-service</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <modules>
+        <module>catalog-server</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/repository/ResourceStoreTileLayerCatalog.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/repository/ResourceStoreTileLayerCatalog.java
@@ -12,7 +12,6 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.apache.commons.configuration.DefaultConfigurationBuilder.XMLConfigurationProvider;
 import org.geoserver.config.util.SecureXStream;
 import org.geoserver.gwc.layer.GeoServerTileLayerInfo;
 import org.geoserver.gwc.layer.TileLayerCatalog;
@@ -65,8 +64,8 @@ public class ResourceStoreTileLayerCatalog implements TileLayerCatalog {
 
     /**
      * Used by {@link XMLConfiguration#getConfiguredXStreamWithContext}, at {@link #initialize()},
-     * to lookup implementations of {@link XMLConfigurationProvider}, such as {@code
-     * S3BlobStoreConfigProvider}, etc. This could be improved.
+     * to lookup implementations of {@link org.geowebcache.config.XMLConfigurationProvider}, such as
+     * {@code S3BlobStoreConfigProvider}, etc. This could be improved.
      */
     private @Autowired WebApplicationContext applicationContext;
 

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -27,6 +27,9 @@
     <gs.version>2.23.0-CLOUD</gs.version>
     <gs.community.version>2.23.0-CLOUD</gs.community.version>
     <gt.version>29.0</gt.version>
+    <!-- downgrade netty.version used by spring-boot to the one used by geoserver azure client -->
+    <!-- (software.amazon.awssdk:netty-nio-client:jar:2.9.24) for COG and GWC Azure plugin -->
+    <netty.version>4.1.41.Final</netty.version>
     <lombok.version>1.18.24</lombok.version>
     <mapstruct.version>1.4.2.Final</mapstruct.version>
     <fork.javac>true</fork.javac>
@@ -47,6 +50,15 @@
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
         <version>2.17.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <!-- downgrade netty.version used by spring-boot to the one used by geoserver azure client -->
+        <!-- (software.amazon.awssdk:netty-nio-client:jar:2.9.24) for COG and GWC Azure plugin -->
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/starters/catalog-backend/pom.xml
+++ b/src/starters/catalog-backend/pom.xml
@@ -18,10 +18,12 @@
       <groupId>org.geoserver.cloud.catalog.backend</groupId>
       <artifactId>gs-cloud-catalog-backend-jdbcconfig</artifactId>
     </dependency>
+    <!--
     <dependency>
       <groupId>org.geoserver.cloud.catalog.backend</groupId>
       <artifactId>gs-cloud-catalog-backend-catalog-service</artifactId>
     </dependency>
+    -->
     <dependency>
       <groupId>org.geoserver.cloud.catalog</groupId>
       <artifactId>gs-cloud-catalog-cache</artifactId>

--- a/src/starters/catalog-backend/pom.xml
+++ b/src/starters/catalog-backend/pom.xml
@@ -18,12 +18,6 @@
       <groupId>org.geoserver.cloud.catalog.backend</groupId>
       <artifactId>gs-cloud-catalog-backend-jdbcconfig</artifactId>
     </dependency>
-    <!--
-    <dependency>
-      <groupId>org.geoserver.cloud.catalog.backend</groupId>
-      <artifactId>gs-cloud-catalog-backend-catalog-service</artifactId>
-    </dependency>
-    -->
     <dependency>
       <groupId>org.geoserver.cloud.catalog</groupId>
       <artifactId>gs-cloud-catalog-cache</artifactId>
@@ -33,4 +27,18 @@
       <artifactId>gs-cloud-catalog-events</artifactId>
     </dependency>
   </dependencies>
+  <profiles>
+    <profile>
+      <id>catalog-service</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.geoserver.cloud.catalog.backend</groupId>
+          <artifactId>gs-cloud-catalog-backend-catalog-service</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Fixes #325

Downgrade spring-boot's netty.version from 4.1.90 to 4.1.41 as used by GeoServer

Downgrade `netty.version` used by spring-boot to the one used by geoserver's
azure client (`software.amazon.awssdk:netty-nio-client:jar:2.9.24`) for COG
and GWC Azure plugin (`4.1.41.Final`).
