### PR TITLE
Add dependency on aws sts to support IAM roles for service accounts

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -657,6 +657,12 @@
         <version>${aws.version}</version>
       </dependency>
       <dependency>
+        <!--- Additional dependency required to support "IAM roles for service accounts" -->
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>sts</artifactId>
+        <version>${aws.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.geoserver.community</groupId>
         <artifactId>gs-datadir-catalog-loader</artifactId>
         <version>${gs.community.version}</version>

--- a/src/starters/raster-formats/pom.xml
+++ b/src/starters/raster-formats/pom.xml
@@ -39,6 +39,11 @@
       <artifactId>gs-cog</artifactId>
     </dependency>
     <dependency>
+      <!--- Additional dependency required to support "IAM roles for service accounts" -->
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sts</artifactId>
+    </dependency>
+    <dependency>
       <!-- provided scope for pgraster's and cog autoconfiguration when in web-ui -->
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>


### PR DESCRIPTION
Despite since `software.amazon.awssdk:2.10.11`, the `WebIdentityTokenFileCredentialsProvider` is part of the default credentials chain, it will only be enabled if
`software.amazon.awssdk:sts` is on the classpath, which is mentioned in the javadocs: "Use of this credentials provider requires the 'sts' module to be on the classpath".

See https://github.com/aws/aws-sdk-java/issues/2136