### PR TITLE
Avoid LayerGroupContainmentCache rebuilding the cache on every ApplicationEvent

### DIFF
--- a/src/starters/webmvc/src/main/java/org/geoserver/cloud/config/main/GeoServerMainModuleConfiguration.java
+++ b/src/starters/webmvc/src/main/java/org/geoserver/cloud/config/main/GeoServerMainModuleConfiguration.java
@@ -94,6 +94,7 @@ public class GeoServerMainModuleConfiguration {
             |xstreamPersisterFactory\
             |loggingInitializer\
             |configurationLock\
+            |layerGroupContainmentCache\
             """;
 
     static final String EXCLUDE_BEANS_REGEX =


### PR DESCRIPTION
`LayerGroupContainmentCache` rebuilds the cache on every `ApplicationEvent instead of only on `ContextRefreshedEvent`. This causes constant cache rebuilds, especially on application events that trigger on a scheduled task such as `HeartbeatEvent`.

Replace it with a version that fixes that behaviour.