### PR TITLE
Simpler jackson binding representation

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -36,7 +36,7 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: '17'
-        #cache: 'maven'
+        cache: 'maven'
 
     - name: Validate source code formatting
       run: make lint

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/AttributeType.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/AttributeType.java
@@ -14,7 +14,7 @@ import java.util.Map;
 @Generated
 public class AttributeType {
     private String name;
-    private InfoReference featureType;
+    private String featureType;
 
     private int minOccurs;
     private int maxOccurs;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/InfoDto.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/InfoDto.java
@@ -12,7 +12,7 @@ import lombok.Generated;
 
 import org.geoserver.jackson.databind.config.dto.ConfigInfoDto;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY)
 @JsonSubTypes({
     @JsonSubTypes.Type(value = CatalogInfoDto.class),
     @JsonSubTypes.Type(value = ConfigInfoDto.class)

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Layer.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Layer.java
@@ -24,9 +24,9 @@ public class Layer extends Published {
     }
 
     protected String path;
-    protected InfoReference defaultStyle;
-    protected Set<InfoReference> styles;
-    protected InfoReference resource;
+    protected String defaultStyle;
+    protected Set<String> styles;
+    protected String resource;
     protected Legend legend;
     private PublishedType type;
     protected Boolean queryable;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/LayerGroup.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/LayerGroup.java
@@ -29,11 +29,11 @@ public class LayerGroup extends Published {
 
     protected Mode mode = Mode.SINGLE;
     protected Boolean queryDisabled;
-    protected InfoReference workspace;
-    protected InfoReference rootLayer;
-    protected InfoReference rootLayerStyle;
-    protected List<InfoReference> layers;
-    protected List<InfoReference> styles;
+    protected String workspace;
+    protected String rootLayer;
+    protected String rootLayerStyle;
+    protected List<String> layers;
+    protected List<String> styles;
     protected List<MetadataLink> metadataLinks;
     protected Envelope bounds;
     private List<Keyword> keywords;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/LayerGroupStyle.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/LayerGroupStyle.java
@@ -26,10 +26,10 @@ public class LayerGroupStyle {
     private Style name;
 
     /** The list of contained PublishedInfo. */
-    private List<InfoReference> layers;
+    private List<String> layers;
 
     /** The List of StyleInfo for {@link #getLayers() the layers} */
-    private List<InfoReference> styles;
+    private List<String> styles;
 
     private String title;
     private Map<String, String> internationalTitle;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Map.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Map.java
@@ -20,5 +20,5 @@ public class Map extends CatalogInfoDto {
 
     private String name;
     private boolean enabled;
-    private List<InfoReference> layers;
+    private List<String> layers;
 }

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Resource.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Resource.java
@@ -30,8 +30,8 @@ public abstract class Resource extends CatalogInfoDto {
     }
 
     private String name;
-    private InfoReference namespace;
-    private InfoReference store;
+    private String namespace;
+    private String store;
     private String nativeName;
     private List<String> alias;
     private String title;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Store.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Store.java
@@ -23,7 +23,7 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 public abstract class Store extends CatalogInfoDto {
     private String name;
-    private InfoReference workspace;
+    private String workspace;
     private String description;
     private String type;
     private boolean enabled;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Style.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Style.java
@@ -17,7 +17,7 @@ import lombok.Generated;
 public class Style extends CatalogInfoDto {
 
     private String name;
-    private InfoReference workspace;
+    private String workspace;
     private String format;
     private VersionDto formatVersion;
     private String filename;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/mapper/CatalogInfoMapperConfig.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/mapper/CatalogInfoMapperConfig.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.jackson.databind.catalog.mapper;
 
+import org.geoserver.jackson.databind.mapper.InfoReferenceMapper;
 import org.geoserver.jackson.databind.mapper.PatchMapper;
 import org.geoserver.jackson.databind.mapper.SharedMappers;
 import org.mapstruct.MapperConfig;
@@ -12,5 +13,11 @@ import org.mapstruct.ReportingPolicy;
 @MapperConfig(
         componentModel = "default",
         unmappedTargetPolicy = ReportingPolicy.ERROR,
-        uses = {ObjectFacotries.class, ValueMappers.class, SharedMappers.class, PatchMapper.class})
+        uses = {
+            ObjectFacotries.class,
+            ValueMappers.class,
+            SharedMappers.class,
+            InfoReferenceMapper.class,
+            PatchMapper.class
+        })
 public class CatalogInfoMapperConfig {}

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/mapper/PublishedMapper.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/mapper/PublishedMapper.java
@@ -7,6 +7,7 @@ package org.geoserver.jackson.databind.catalog.mapper;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.PublishedInfo;
+import org.geoserver.catalog.impl.LayerGroupStyle;
 import org.geoserver.jackson.databind.catalog.dto.Layer;
 import org.geoserver.jackson.databind.catalog.dto.LayerGroup;
 import org.geoserver.jackson.databind.catalog.dto.Published;
@@ -42,11 +43,18 @@ public interface PublishedMapper {
     @Mapping(target = "advertised", ignore = true)
     @Mapping(target = "internationalTitle", ignore = true)
     @Mapping(target = "internationalAbstract", ignore = true)
+    @Mapping(target = "resource", source = "resource", qualifiedByName = "resourceInfo")
     LayerInfo map(Layer o);
 
     Layer map(LayerInfo o);
 
+    @Mapping(source = "layers", target = "layers", qualifiedByName = "publishedInfo")
     LayerGroupInfo map(LayerGroup o);
 
     LayerGroup map(LayerGroupInfo o);
+
+    @Mapping(source = "layers", target = "layers", qualifiedByName = "publishedInfo")
+    LayerGroupStyle map(org.geoserver.jackson.databind.catalog.dto.LayerGroupStyle o);
+
+    org.geoserver.jackson.databind.catalog.dto.LayerGroupStyle map(LayerGroupStyle o);
 }

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/mapper/ResourceMapper.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/mapper/ResourceMapper.java
@@ -40,11 +40,13 @@ public interface ResourceMapper {
 
     @Mapping(target = "catalog", ignore = true)
     @Mapping(target = "featureType", ignore = true)
+    @Mapping(source = "store", target = "store", qualifiedByName = "dataStoreInfo")
     FeatureTypeInfo map(FeatureType o);
 
     FeatureType map(FeatureTypeInfo o);
 
     @Mapping(target = "catalog", ignore = true)
+    @Mapping(source = "store", target = "store", qualifiedByName = "coverageStoreInfo")
     CoverageInfo map(Coverage o);
 
     Coverage map(CoverageInfo o);
@@ -53,11 +55,13 @@ public interface ResourceMapper {
     @Mapping(target = "remoteStyleInfos", ignore = true)
     @Mapping(target = "styles", ignore = true)
     @Mapping(target = "allAvailableRemoteStyles", ignore = true)
+    @Mapping(source = "store", target = "store", qualifiedByName = "wmsStoreInfo")
     WMSLayerInfo map(WMSLayer o);
 
     WMSLayer map(WMSLayerInfo o);
 
     @Mapping(target = "catalog", ignore = true)
+    @Mapping(source = "store", target = "store", qualifiedByName = "wmtsStoreInfo")
     WMTSLayerInfo map(WMTSLayer o);
 
     WMTSLayer map(WMTSLayerInfo o);

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/mapper/ValueMappers.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/mapper/ValueMappers.java
@@ -194,7 +194,6 @@ public interface ValueMappers {
 
     AttributeType infoToDto(AttributeTypeInfo o);
 
-    // @Mapping(target = "featureType", ignore = true)
     @Mapping(target = "attribute", ignore = true)
     AttributeTypeInfo dtoToInfo(AttributeType o);
 

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/Service.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/Service.java
@@ -16,7 +16,6 @@ import org.geoserver.catalog.impl.AuthorityURL;
 import org.geoserver.catalog.impl.LayerIdentifier;
 import org.geoserver.config.ServiceInfo;
 import org.geoserver.gwc.wmts.WMTSInfo;
-import org.geoserver.jackson.databind.catalog.dto.InfoReference;
 import org.geoserver.jackson.databind.catalog.dto.Keyword;
 import org.geoserver.jackson.databind.catalog.dto.MetadataLink;
 import org.geoserver.jackson.databind.catalog.dto.MetadataMapDto;
@@ -47,7 +46,7 @@ import java.util.Set;
 @EqualsAndHashCode(callSuper = true)
 public abstract @Data @Generated class Service extends ConfigInfoDto {
     private String name;
-    private InfoReference workspace;
+    private String workspace;
     private boolean citeCompliant;
     private boolean enabled;
     private String onlineResource;
@@ -206,6 +205,7 @@ public abstract @Data @Generated class Service extends ConfigInfoDto {
             private NameDto name;
             private boolean enabled;
             private List<String> roles;
+            private MetadataMapDto metadata;
         }
     }
 

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/Settings.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/Settings.java
@@ -11,7 +11,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Generated;
 
 import org.geoserver.config.SettingsInfo;
-import org.geoserver.jackson.databind.catalog.dto.InfoReference;
 import org.geoserver.jackson.databind.catalog.dto.MetadataMapDto;
 
 import java.util.Locale;
@@ -20,7 +19,7 @@ import java.util.Locale;
 @EqualsAndHashCode(callSuper = true)
 @JsonTypeName("SettingsInfo")
 public @Data @Generated class Settings extends ConfigInfoDto {
-    private InfoReference workspace;
+    private String workspace;
     private String title;
     private Contact contact;
     private String charset;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/ConfigInfoMapperConfig.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/ConfigInfoMapperConfig.java
@@ -5,6 +5,7 @@
 package org.geoserver.jackson.databind.config.dto.mapper;
 
 import org.geoserver.jackson.databind.catalog.mapper.ValueMappers;
+import org.geoserver.jackson.databind.mapper.InfoReferenceMapper;
 import org.geoserver.jackson.databind.mapper.PatchMapper;
 import org.geoserver.jackson.databind.mapper.SharedMappers;
 import org.mapstruct.MapperConfig;
@@ -18,6 +19,7 @@ import org.mapstruct.ReportingPolicy;
             WPSMapper.class,
             ValueMappers.class,
             SharedMappers.class,
+            InfoReferenceMapper.class,
             PatchMapper.class
         })
 public class ConfigInfoMapperConfig {}

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/WPSMapper.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/WPSMapper.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.jackson.databind.config.dto.mapper;
 
+import org.geoserver.jackson.databind.catalog.mapper.ValueMappers;
 import org.geoserver.jackson.databind.config.dto.Service;
 import org.geoserver.jackson.databind.mapper.SharedMappers;
 import org.geoserver.wps.ProcessGroupInfo;
@@ -12,8 +13,11 @@ import org.geoserver.wps.ProcessInfo;
 import org.geoserver.wps.ProcessInfoImpl;
 import org.mapstruct.Mapper;
 import org.mapstruct.ObjectFactory;
+import org.mapstruct.ReportingPolicy;
 
-@Mapper(uses = SharedMappers.class)
+@Mapper(
+        uses = {ValueMappers.class, SharedMappers.class},
+        unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface WPSMapper {
 
     default @ObjectFactory ProcessGroupInfo processGroupInfo() {

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/mapper/InfoReferenceMapper.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/mapper/InfoReferenceMapper.java
@@ -1,0 +1,155 @@
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.jackson.databind.mapper;
+
+import lombok.NonNull;
+
+import org.geoserver.catalog.CoverageStoreInfo;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.Info;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.MetadataMap;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.PublishedInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StoreInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WMSStoreInfo;
+import org.geoserver.catalog.WMTSStoreInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.ClassMappings;
+import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.catalog.impl.ResolvingProxy;
+import org.geoserver.catalog.impl.StyleInfoImpl;
+import org.geoserver.jackson.databind.catalog.dto.InfoReference;
+import org.mapstruct.Mapper;
+import org.mapstruct.Named;
+
+import java.util.Objects;
+
+@Mapper
+public abstract class InfoReferenceMapper {
+
+    public String id(Info info) {
+        return info == null ? null : info.getId();
+    }
+
+    public WorkspaceInfo workspaceInfo(String id) {
+        return info(id, WorkspaceInfo.class);
+    }
+
+    public NamespaceInfo namespaceInfo(String id) {
+        return info(id, NamespaceInfo.class);
+    }
+
+    @Named("storeInfo")
+    public StoreInfo storeInfo(String id) {
+        return info(id, StoreInfo.class);
+    }
+
+    @Named("coverageStoreInfo")
+    public CoverageStoreInfo coverageStoreInfo(String id) {
+        return info(id, CoverageStoreInfo.class);
+    }
+
+    @Named("dataStoreInfo")
+    public DataStoreInfo dataStoreInfo(String id) {
+        return info(id, DataStoreInfo.class);
+    }
+
+    @Named("wmsStoreInfo")
+    public WMSStoreInfo wmsStoreInfo(String id) {
+        return info(id, WMSStoreInfo.class);
+    }
+
+    @Named("wmtsStoreInfo")
+    public WMTSStoreInfo wmtsStoreInfo(String id) {
+        return info(id, WMTSStoreInfo.class);
+    }
+
+    @Named("resourceInfo")
+    public ResourceInfo resourceInfo(String id) {
+        return info(id, ResourceInfo.class);
+    }
+
+    public FeatureTypeInfo featureTypeInfo(String id) {
+        return info(id, FeatureTypeInfo.class);
+    }
+
+    @Named("publishedInfo")
+    public PublishedInfo publishedInfo(String id) {
+        return info(id, PublishedInfo.class);
+    }
+
+    public LayerInfo layerInfo(String id) {
+        return info(id, LayerInfo.class);
+    }
+
+    public LayerGroupInfo layerGroupInfo(String id) {
+        return info(id, LayerGroupInfo.class);
+    }
+
+    public StyleInfo styleInfo(String id) {
+        return info(id, StyleInfo.class);
+    }
+
+    private <T extends Info> T info(String id, Class<T> type) {
+        return id == null ? null : ResolvingProxy.create(id, type);
+    }
+
+    public <T extends Info> InfoReference infoToReference(final T info) {
+        if (info == null) return null;
+        final String id = info.getId();
+        final ClassMappings type = resolveType(info);
+
+        // beware of remote styles that have no id
+        if (ClassMappings.STYLE.equals(type)) {
+            StyleInfo s = (StyleInfo) info;
+            MetadataMap metadata = s.getMetadata();
+            boolean isRemoteStyle =
+                    metadata != null
+                            && Boolean.valueOf(
+                                    metadata.getOrDefault(StyleInfoImpl.IS_REMOTE, "false")
+                                            .toString());
+            if (isRemoteStyle) {
+                return null;
+            }
+        }
+        Objects.requireNonNull(id, () -> "Object has no id: " + info);
+        Objects.requireNonNull(type, "Bad info class: " + info.getClass());
+        return new InfoReference(type, id);
+    }
+
+    private ClassMappings resolveType(@NonNull Info value) {
+        value = ModificationProxy.unwrap(value);
+        ClassMappings type = ClassMappings.fromImpl(value.getClass());
+        if (type == null) {
+            Class<?>[] interfaces = value.getClass().getInterfaces();
+            for (Class<?> i : interfaces) {
+                if (Info.class.isAssignableFrom(i)) {
+                    @SuppressWarnings("unchecked")
+                    Class<? extends Info> infoClass = (Class<? extends Info>) i;
+                    type = ClassMappings.fromInterface(infoClass);
+                    if (type != null) {
+                        break;
+                    }
+                }
+            }
+        }
+        return type;
+    }
+
+    public <T extends Info> T referenceToInfo(InfoReference ref) {
+        if (ref == null) return null;
+        String id = ref.getId();
+        Objects.requireNonNull(id, () -> "Object Reference has no id: " + ref);
+        @SuppressWarnings("unchecked")
+        Class<T> type = (Class<T>) ref.getType().getInterface();
+        T proxy = ResolvingProxy.create(id, type);
+        return proxy;
+    }
+}

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/mapper/PatchMapper.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/mapper/PatchMapper.java
@@ -19,6 +19,7 @@ import org.geoserver.jackson.databind.config.dto.mapper.WPSMapper;
 import org.geotools.jackson.databind.filter.dto.Literal;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
 import java.util.Collection;
@@ -26,16 +27,18 @@ import java.util.Map;
 import java.util.function.Function;
 
 @Mapper(
+        unmappedTargetPolicy = ReportingPolicy.ERROR,
         uses = {
             ObjectFacotries.class,
             WPSMapper.class,
             ValueMappers.class,
             SharedMappers.class,
+            InfoReferenceMapper.class,
             GeoServerConfigMapper.class
         })
 public abstract class PatchMapper {
 
-    private static SharedMappers SHARED = Mappers.getMapper(SharedMappers.class);
+    private static InfoReferenceMapper REFS = Mappers.getMapper(InfoReferenceMapper.class);
 
     @Mapping(target = "propertyNames", ignore = true)
     public abstract Patch dtoToPatch(PatchDto dto);
@@ -55,7 +58,7 @@ public abstract class PatchMapper {
     private Object dtoToValue(final Object valueDto) {
         Object value = valueDto;
         if (valueDto instanceof InfoReference) {
-            value = SHARED.referenceToInfo((InfoReference) valueDto);
+            value = REFS.referenceToInfo((InfoReference) valueDto);
         } else if (valueDto instanceof Collection) {
             Collection<?> c = (Collection<?>) valueDto;
             value = copyOf(c, this::dtoToValue);
@@ -78,7 +81,7 @@ public abstract class PatchMapper {
         if (value instanceof Info) {
             Info info = (Info) dto;
             if (ProxyUtils.encodeByReference(info)) {
-                dto = (R) SHARED.infoToReference(info);
+                dto = (R) REFS.infoToReference(info);
             }
         } else if (value instanceof Collection) {
             Collection<?> c = (Collection<?>) value;

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/config/GeoServerConfigModuleTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/config/GeoServerConfigModuleTest.java
@@ -44,7 +44,7 @@ public abstract class GeoServerConfigModuleTest {
 
     protected void print(String logmsg, Object... args) {
         boolean debug = Boolean.getBoolean("debug");
-        if (debug) log.debug(logmsg, args);
+        if (debug) log.info(logmsg, args);
     }
 
     private ObjectMapper objectMapper;

--- a/src/catalog/jackson-bindings/geotools/src/main/java/org/geotools/jackson/databind/util/ObjectMapperUtil.java
+++ b/src/catalog/jackson-bindings/geotools/src/main/java/org/geotools/jackson/databind/util/ObjectMapperUtil.java
@@ -38,6 +38,7 @@ public class ObjectMapperUtil {
         objectMapper.setDefaultPropertyInclusion(Include.NON_EMPTY);
         objectMapper.disable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN);
         objectMapper.findAndRegisterModules();
+
         return objectMapper;
     }
 }

--- a/src/catalog/jackson-bindings/geotools/src/test/java/org/geotools/jackson/databind/filter/GeoToolsFilterModuleFiltersTest.java
+++ b/src/catalog/jackson-bindings/geotools/src/test/java/org/geotools/jackson/databind/filter/GeoToolsFilterModuleFiltersTest.java
@@ -27,7 +27,7 @@ public abstract class GeoToolsFilterModuleFiltersTest extends FilterRoundtripTes
 
     protected void print(String logmsg, Object... args) {
         boolean debug = Boolean.getBoolean("debug");
-        if (debug) log.debug(logmsg, args);
+        if (debug) log.info(logmsg, args);
     }
 
     private ObjectMapper objectMapper;


### PR DESCRIPTION
gs-jackson-bindings: encode Info object references as single string ids and move from wrapper-object to property type discriminator for catalog info type hierarcy

Remove usage of extra class `InfoReference` to encode catalog and
config `Info` object references, and use simple id strings.
    
E.g:
before:
```
{
"CoverageStoreInfo":{
  "workspace": {"type":"WORKSPACE", "id": "abc"}
 }
}
```    
after:
```
 { 
  "@type": "CoverageStoreInfo",
   "workspace": "abc"
}
```
