### PR TITLE
Annotate auto-configurations with @AutoConfiguration

### DIFF
--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebUIApplicationAutoConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebUIApplicationAutoConfiguration.java
@@ -19,15 +19,13 @@ import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.GeoServerInfo.WebUIMode;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
 
 import javax.annotation.PostConstruct;
 
-@Configuration
-@AutoConfigureAfter({GeoServerWebMvcMainAutoConfiguration.class})
+@AutoConfiguration(after = {GeoServerWebMvcMainAutoConfiguration.class})
 @Import({ //
     WebCoreConfiguration.class, // this one is mandatory
     SecurityAutoConfiguration.class,

--- a/src/apps/geoserver/wfs/src/main/java/org/geoserver/cloud/wfs/config/WfsAutoConfiguration.java
+++ b/src/apps/geoserver/wfs/src/main/java/org/geoserver/cloud/wfs/config/WfsAutoConfiguration.java
@@ -7,13 +7,11 @@ package org.geoserver.cloud.wfs.config;
 import org.geoserver.cloud.autoconfigure.core.GeoServerWebMvcMainAutoConfiguration;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.geoserver.cloud.virtualservice.VirtualServiceVerifier;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
-@Configuration(proxyBeanMethods = true)
-@AutoConfigureAfter({GeoServerWebMvcMainAutoConfiguration.class})
+@AutoConfiguration(after = GeoServerWebMvcMainAutoConfiguration.class)
 @ImportResource( //
         reader = FilteringXmlBeanDefinitionReader.class, //
         locations = {

--- a/src/apps/geoserver/wms/src/main/java/org/geoserver/cloud/autoconfigure/wms/WmsApplicationAutoConfiguration.java
+++ b/src/apps/geoserver/wms/src/main/java/org/geoserver/cloud/autoconfigure/wms/WmsApplicationAutoConfiguration.java
@@ -19,16 +19,14 @@ import org.geoserver.wms.capabilities.GetCapabilitiesTransformer;
 import org.geoserver.wms.capabilities.LegendSample;
 import org.geoserver.wms.capabilities.LegendSampleImpl;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
-@Configuration
 // auto-configure before GWC's wms-integration to avoid it precluding to load beans from
 // jar:gs-wms-.*
-@AutoConfigureBefore(WMSIntegrationAutoConfiguration.class)
+@AutoConfiguration(before = WMSIntegrationAutoConfiguration.class)
 @ImportResource( //
         reader = FilteringXmlBeanDefinitionReader.class, //
         locations = { //

--- a/src/catalog/backends/catalog-service/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/catalogservice/CatalogClientBackendAutoConfiguration.java
+++ b/src/catalog/backends/catalog-service/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/catalogservice/CatalogClientBackendAutoConfiguration.java
@@ -7,9 +7,8 @@ package org.geoserver.cloud.autoconfigure.catalog.backend.catalogservice;
 import org.geoserver.cloud.autoconfigure.catalog.backend.core.DefaultUpdateSequenceAutoConfiguration;
 import org.geoserver.cloud.config.catalog.backend.catalogservice.CatalogClientBackendConfigurer;
 import org.geoserver.cloud.config.catalog.backend.core.GeoServerBackendConfigurer;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 /**
@@ -22,8 +21,7 @@ import org.springframework.context.annotation.Import;
  *
  * @see ConditionalOnCatalogServiceClientEnabled
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(before = DefaultUpdateSequenceAutoConfiguration.class)
 @ConditionalOnCatalogServiceClientEnabled
 @Import(CatalogClientBackendConfigurer.class)
-@AutoConfigureBefore(DefaultUpdateSequenceAutoConfiguration.class)
 public class CatalogClientBackendAutoConfiguration {}

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/core/DefaultUpdateSequenceAutoConfiguration.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/core/DefaultUpdateSequenceAutoConfiguration.java
@@ -6,12 +6,12 @@ package org.geoserver.cloud.autoconfigure.catalog.backend.core;
 
 import org.geoserver.platform.config.DefaultUpdateSequence;
 import org.geoserver.platform.config.UpdateSequence;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
+@AutoConfiguration
 @ConditionalOnMissingBean(UpdateSequence.class)
-@Configuration
 public class DefaultUpdateSequenceAutoConfiguration {
     @Bean
     UpdateSequence defaultUpdateSequence() {

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/core/GeoServerBackendAutoConfiguration.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/core/GeoServerBackendAutoConfiguration.java
@@ -7,8 +7,8 @@ package org.geoserver.cloud.autoconfigure.catalog.backend.core;
 import org.geoserver.cloud.autoconfigure.geotools.GeoToolsHttpClientAutoConfiguration;
 import org.geoserver.cloud.config.catalog.backend.core.CoreBackendConfiguration;
 import org.geoserver.cloud.config.jndidatasource.JNDIDataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 /**
@@ -22,10 +22,7 @@ import org.springframework.context.annotation.Import;
  *
  * @see CoreBackendConfiguration
  */
-@Configuration(proxyBeanMethods = false)
-@AutoConfigureAfter({
-    GeoToolsHttpClientAutoConfiguration.class,
-    JNDIDataSourceAutoConfiguration.class
-})
+@AutoConfiguration(
+        after = {GeoToolsHttpClientAutoConfiguration.class, JNDIDataSourceAutoConfiguration.class})
 @Import(CoreBackendConfiguration.class)
 public class GeoServerBackendAutoConfiguration {}

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/core/RemoteEventResourcePoolCleaupUpAutoConfiguration.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/core/RemoteEventResourcePoolCleaupUpAutoConfiguration.java
@@ -10,16 +10,16 @@ import org.geoserver.cloud.autoconfigure.catalog.event.ConditionalOnCatalogEvent
 import org.geoserver.cloud.event.info.InfoEvent;
 import org.geoserver.cloud.event.remote.resourcepool.RemoteEventResourcePoolProcessor;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 /**
  * Cleans up cached {@link ResourcePool} entries upon remote Catalog events
  *
  * @since 1.0
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnClass(InfoEvent.class)
 @ConditionalOnCatalogEvents
 public class RemoteEventResourcePoolCleaupUpAutoConfiguration {

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/core/XstreamServiceLoadersAutoConfiguration.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/core/XstreamServiceLoadersAutoConfiguration.java
@@ -18,9 +18,9 @@ import org.geoserver.wms.WMSFactoryExtension;
 import org.geoserver.wms.WMSXStreamLoader;
 import org.geoserver.wps.WPSFactoryExtension;
 import org.geoserver.wps.WPSXStreamLoader;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 /**
  * Configuration to make sure all {@link XStreamServiceLoader} extensions are loaded regardless of
@@ -28,7 +28,7 @@ import org.springframework.context.annotation.Configuration;
  *
  * @since 1.0
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @Slf4j(topic = "org.geoserver.cloud.config.catalog")
 public class XstreamServiceLoadersAutoConfiguration {
 

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/geotools/GeoToolsHttpClientAutoConfiguration.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/geotools/GeoToolsHttpClientAutoConfiguration.java
@@ -9,11 +9,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.geoserver.cloud.autoconfigure.geotools.GeoToolsHttpClientProxyConfigurationProperties.ProxyHostConfig;
 import org.geotools.http.HTTPClientFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 /**
  * {@link EnableAutoConfiguration @EnableAutoConfiguration} auto configuration for a GeoTools {@link
@@ -66,7 +66,7 @@ import org.springframework.context.annotation.Configuration;
  * </code>
  * </pre>
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @EnableConfigurationProperties(GeoToolsHttpClientProxyConfigurationProperties.class)
 @ConditionalOnProperty(
         name = "geotools.httpclient.proxy.enabled",

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/metrics/catalog/CatalogMetricsAutoConfiguration.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/metrics/catalog/CatalogMetricsAutoConfiguration.java
@@ -12,11 +12,10 @@ import org.geoserver.platform.config.UpdateSequence;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for {@link Catalog} and {@link GeoServer}
@@ -25,8 +24,8 @@ import org.springframework.context.annotation.Configuration;
  * @see CatalogMetrics
  * @since 1.0
  */
-@Configuration(proxyBeanMethods = false)
-@AutoConfigureAfter({MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
+@AutoConfiguration(
+        after = {MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
 @ConditionalOnGeoServerMetricsEnabled
 @EnableConfigurationProperties(GeoSeverMetricsConfigProperties.class)
 public class CatalogMetricsAutoConfiguration {

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/security/GeoServerSecurityAutoConfiguration.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/security/GeoServerSecurityAutoConfiguration.java
@@ -11,7 +11,7 @@ import org.geoserver.cloud.event.security.SecurityConfigChanged;
 import org.geoserver.cloud.security.GeoServerSecurityConfiguration;
 import org.geoserver.config.util.XStreamPersisterFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,8 +20,7 @@ import org.springframework.context.event.EventListener;
 
 import javax.annotation.PostConstruct;
 
-@Configuration
-@AutoConfigureAfter(GeoServerBackendAutoConfiguration.class)
+@AutoConfiguration(after = GeoServerBackendAutoConfiguration.class)
 @Import({
     GeoServerSecurityAutoConfiguration.Enabled.class,
     GeoServerSecurityAutoConfiguration.Disabled.class

--- a/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/datadir/DataDirectoryAutoConfiguration.java
+++ b/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/datadir/DataDirectoryAutoConfiguration.java
@@ -6,12 +6,10 @@ package org.geoserver.cloud.autoconfigure.catalog.backend.datadir;
 
 import org.geoserver.cloud.autoconfigure.catalog.backend.core.DefaultUpdateSequenceAutoConfiguration;
 import org.geoserver.cloud.config.catalog.backend.datadirectory.DataDirectoryBackendConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Import;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(before = DefaultUpdateSequenceAutoConfiguration.class)
 @ConditionalOnDataDirectoryEnabled
 @Import(DataDirectoryBackendConfiguration.class)
-@AutoConfigureBefore(DefaultUpdateSequenceAutoConfiguration.class)
 public class DataDirectoryAutoConfiguration {}

--- a/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/datadir/RemoteEventDataDirectoryAutoConfiguration.java
+++ b/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/datadir/RemoteEventDataDirectoryAutoConfiguration.java
@@ -9,10 +9,10 @@ import org.geoserver.cloud.autoconfigure.catalog.event.ConditionalOnCatalogEvent
 import org.geoserver.cloud.event.remote.datadir.RemoteEventDataDirectoryProcessor;
 import org.geoserver.config.plugin.RepositoryGeoServerFacade;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnDataDirectoryEnabled
 @ConditionalOnCatalogEvents
 public class RemoteEventDataDirectoryAutoConfiguration {

--- a/src/catalog/backends/jdbcconfig/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/jdbcconfig/JDBCConfigAutoConfiguration.java
+++ b/src/catalog/backends/jdbcconfig/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/jdbcconfig/JDBCConfigAutoConfiguration.java
@@ -6,12 +6,10 @@ package org.geoserver.cloud.autoconfigure.catalog.backend.jdbcconfig;
 
 import org.geoserver.cloud.autoconfigure.catalog.backend.core.DefaultUpdateSequenceAutoConfiguration;
 import org.geoserver.cloud.config.catalog.backend.jdbcconfig.JDBCConfigBackendConfigurer;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Import;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(before = DefaultUpdateSequenceAutoConfiguration.class)
 @ConditionalOnJdbcConfigEnabled
 @Import(JDBCConfigBackendConfigurer.class)
-@AutoConfigureBefore(DefaultUpdateSequenceAutoConfiguration.class)
 public class JDBCConfigAutoConfiguration {}

--- a/src/catalog/backends/jdbcconfig/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/jdbcconfig/JDBCConfigWebAutoConfiguration.java
+++ b/src/catalog/backends/jdbcconfig/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/jdbcconfig/JDBCConfigWebAutoConfiguration.java
@@ -5,9 +5,11 @@
 package org.geoserver.cloud.autoconfigure.catalog.backend.jdbcconfig;
 
 import org.geoserver.cloud.config.catalog.backend.jdbcconfig.JDBCConfigWebConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Import;
 
 /** Auto configuration for the wicket ui components of the jdbcconfig extension */
+@AutoConfiguration
 @ConditionalOnJdbcConfigWebUIEnabled
 @Import({JDBCConfigWebConfiguration.class})
 public class JDBCConfigWebAutoConfiguration {}

--- a/src/catalog/cache/src/main/java/org/geoserver/cloud/autoconfigure/catalog/cache/BackendCacheAutoConfiguration.java
+++ b/src/catalog/cache/src/main/java/org/geoserver/cloud/autoconfigure/catalog/cache/BackendCacheAutoConfiguration.java
@@ -5,9 +5,9 @@
 package org.geoserver.cloud.autoconfigure.catalog.cache;
 
 import org.geoserver.cloud.catalog.cache.GeoServerBackendCacheConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.cache.CacheManager;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 /**
@@ -19,7 +19,7 @@ import org.springframework.context.annotation.Import;
  *
  * @see GeoServerBackendCacheConfiguration
  */
-@Configuration
+@AutoConfiguration
 @ConditionalOnBackendCacheEnabled
 @Import(GeoServerBackendCacheConfiguration.class)
 public class BackendCacheAutoConfiguration {}

--- a/src/catalog/event-bus/src/main/java/org/geoserver/cloud/autoconfigure/event/bus/GeoServerBusIntegrationAutoConfiguration.java
+++ b/src/catalog/event-bus/src/main/java/org/geoserver/cloud/autoconfigure/event/bus/GeoServerBusIntegrationAutoConfiguration.java
@@ -6,6 +6,7 @@ package org.geoserver.cloud.autoconfigure.event.bus;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.cloud.bus.BusAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
@@ -14,7 +15,7 @@ import org.springframework.context.annotation.Import;
 import javax.annotation.PostConstruct;
 
 /** Log a message if spring-cloud-bus is explicitly disables */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @Import({
     GeoServerBusIntegrationAutoConfiguration.Enabled.class,
     GeoServerBusIntegrationAutoConfiguration.Disabled.class

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/autoconfigure/catalog/event/LocalCatalogEventsAutoConfiguration.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/autoconfigure/catalog/event/LocalCatalogEventsAutoConfiguration.java
@@ -5,15 +5,15 @@
 package org.geoserver.cloud.autoconfigure.catalog.event;
 
 import org.geoserver.cloud.config.catalog.events.CatalogApplicationEventsConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 /**
  * {@link EnableAutoConfiguration auto-configuration} for {@link
  * CatalogApplicationEventsConfiguration}
  */
-@Configuration
+@AutoConfiguration
 @ConditionalOnCatalogEvents
 @Import(CatalogApplicationEventsConfiguration.class)
 public class LocalCatalogEventsAutoConfiguration {}

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/autoconfigure/catalog/event/UpdateSequenceControllerAutoConfiguration.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/autoconfigure/catalog/event/UpdateSequenceControllerAutoConfiguration.java
@@ -6,16 +6,16 @@ package org.geoserver.cloud.autoconfigure.catalog.event;
 
 import org.geoserver.config.GeoServer;
 import org.geoserver.platform.config.UpdateSequence;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 
 /**
  * @since 1.0
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnWebApplication
 @EnableGlobalMethodSecurity(jsr250Enabled = true)
 public class UpdateSequenceControllerAutoConfiguration {

--- a/src/catalog/jackson-bindings/starter/src/main/java/org/geoserver/cloud/autoconfigure/jackson/GeoServerJacksonBindingsAutoConfiguration.java
+++ b/src/catalog/jackson-bindings/starter/src/main/java/org/geoserver/cloud/autoconfigure/jackson/GeoServerJacksonBindingsAutoConfiguration.java
@@ -8,12 +8,11 @@ import com.fasterxml.jackson.databind.Module;
 
 import org.geoserver.jackson.databind.catalog.GeoServerCatalogModule;
 import org.geoserver.jackson.databind.config.GeoServerConfigModule;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 /**
  * Spring boot {@link EnableAutoConfiguration @EnableAutoConfiguration} to register GeoServer
@@ -26,8 +25,7 @@ import org.springframework.context.annotation.Configuration;
  * despite them being register-able through Jackson's SPI; a configuration like this is needed to
  * set up the application required ones.
  */
-@Configuration
-@AutoConfigureAfter(GeoToolsJacksonBindingsAutoConfiguration.class)
+@AutoConfiguration(after = GeoToolsJacksonBindingsAutoConfiguration.class)
 @ConditionalOnClass(GeoServerCatalogModule.class)
 public class GeoServerJacksonBindingsAutoConfiguration {
 

--- a/src/catalog/jackson-bindings/starter/src/main/java/org/geoserver/cloud/autoconfigure/jackson/GeoToolsJacksonBindingsAutoConfiguration.java
+++ b/src/catalog/jackson-bindings/starter/src/main/java/org/geoserver/cloud/autoconfigure/jackson/GeoToolsJacksonBindingsAutoConfiguration.java
@@ -9,11 +9,11 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import org.geotools.jackson.databind.filter.GeoToolsFilterModule;
 import org.geotools.jackson.databind.geojson.GeoToolsGeoJsonModule;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 /**
  * Spring boot {@link EnableAutoConfiguration @EnableAutoConfiguration} to register GeoTools and
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.Configuration;
  * despite them being register-able through Jackson's SPI; a configuration like this is needed to
  * set up the application required ones.
  */
-@Configuration
+@AutoConfiguration
 @ConditionalOnClass(GeoToolsFilterModule.class)
 public class GeoToolsJacksonBindingsAutoConfiguration {
 

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/blobstore/AzureBlobstoreAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/blobstore/AzureBlobstoreAutoConfiguration.java
@@ -12,6 +12,7 @@ import org.geoserver.cloud.autoconfigure.gwc.blobstore.S3BlobstoreAutoConfigurat
 import org.geoserver.cloud.gwc.config.blobstore.AzureBlobstoreConfiguration;
 import org.geoserver.cloud.gwc.config.blobstore.AzureBlobstoreGsWebUIConfiguration;
 import org.geoserver.gwc.web.blob.BlobStorePage;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -22,7 +23,7 @@ import javax.annotation.PostConstruct;
  * @see ConditionalOnAzureBlobstoreEnabled
  * @since 1.0
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnAzureBlobstoreEnabled
 @Import({AzureBlobstoreConfiguration.class, GsWebUIAutoConfiguration.class})
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.blobstore")

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/blobstore/S3BlobstoreAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/blobstore/S3BlobstoreAutoConfiguration.java
@@ -12,6 +12,7 @@ import org.geoserver.cloud.autoconfigure.gwc.blobstore.S3BlobstoreAutoConfigurat
 import org.geoserver.cloud.gwc.config.blobstore.S3BlobstoreConfiguration;
 import org.geoserver.cloud.gwc.config.blobstore.S3BlobstoreGsWebUIConfiguration;
 import org.geoserver.gwc.web.blob.BlobStorePage;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -21,7 +22,7 @@ import javax.annotation.PostConstruct;
 /**
  * @since 1.0
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnS3BlobstoreEnabled
 @Import({S3BlobstoreConfiguration.class, GsWebUIAutoConfiguration.class})
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.blobstore")

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/CacheSeedingWebMapServiceAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/CacheSeedingWebMapServiceAutoConfiguration.java
@@ -13,6 +13,7 @@ import org.geoserver.cloud.gwc.config.core.WebMapServiceMinimalConfiguration;
 import org.geoserver.gwc.layer.GeoServerTileLayer;
 import org.geoserver.wms.DefaultWebMapService;
 import org.geoserver.wms.WebMapService;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Configuration;
@@ -26,7 +27,7 @@ import javax.annotation.PostConstruct;
  *
  * @since 1.0
  */
-@Configuration
+@AutoConfiguration
 @ConditionalOnGeoWebCacheEnabled
 @Import({MinimalWebMapServiceAutoConfiguration.class, WebMapServiceCacheSeedingConfiguration.class})
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.integration")

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/GeoWebCacheAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/GeoWebCacheAutoConfiguration.java
@@ -6,8 +6,7 @@ package org.geoserver.cloud.autoconfigure.gwc.core;
 
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoWebCacheEnabled;
 import org.geoserver.cloud.gwc.config.core.GeoWebCacheConfigurationProperties;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Import;
 
 /**
@@ -19,9 +18,8 @@ import org.springframework.context.annotation.Import;
  * @see GeoServerIntegrationAutoConfiguration
  * @since 1.0
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = CacheSeedingWebMapServiceAutoConfiguration.class)
 @ConditionalOnGeoWebCacheEnabled
-@AutoConfigureAfter(CacheSeedingWebMapServiceAutoConfiguration.class)
 @Import({ //
     GeoWebCacheCoreAutoConfiguration.class, //
     GeoServerIntegrationAutoConfiguration.class

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/GeoWebCacheEventsAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/GeoWebCacheEventsAutoConfiguration.java
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoWebCacheEnabled;
 import org.geoserver.cloud.gwc.config.core.GeoWebCacheLocalEventsConfiguration;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Import;
 
 import javax.annotation.PostConstruct;
@@ -18,7 +18,7 @@ import javax.annotation.PostConstruct;
  * @see ConditionalOnGeoWebCacheEnabled
  * @since 1.0
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnGeoWebCacheEnabled
 @Import(GeoWebCacheLocalEventsConfiguration.class)
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.core")

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/GeoWebCacheRemoteEventsAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/GeoWebCacheRemoteEventsAutoConfiguration.java
@@ -9,9 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.geoserver.cloud.autoconfigure.event.bus.ConditionalOnGeoServerRemoteEventsEnabled;
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoWebCacheEnabled;
 import org.geoserver.cloud.gwc.config.bus.GeoWebCacheRemoteEventsConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.cloud.bus.BusAutoConfiguration;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 import javax.annotation.PostConstruct;
@@ -22,10 +21,9 @@ import javax.annotation.PostConstruct;
  * @see ConditionalOnGeoServerRemoteEventsEnabled
  * @since 1.0
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = BusAutoConfiguration.class)
 @ConditionalOnGeoWebCacheEnabled
 @ConditionalOnGeoServerRemoteEventsEnabled
-@AutoConfigureAfter(BusAutoConfiguration.class)
 @Import(GeoWebCacheRemoteEventsConfiguration.class)
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.integration")
 public class GeoWebCacheRemoteEventsAutoConfiguration {

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/WMSIntegrationAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/WMSIntegrationAutoConfiguration.java
@@ -37,6 +37,7 @@ import org.geowebcache.conveyor.ConveyorTile;
 import org.geowebcache.io.ByteArrayResource;
 import org.geowebcache.io.Resource;
 import org.geowebcache.layer.TileLayer;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -57,7 +58,7 @@ import javax.servlet.http.HttpServletResponse;
  *
  * @since 1.0
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @Import({
     WMSIntegrationAutoConfiguration.Enabled.class,
     WMSIntegrationAutoConfiguration.Disabled.class

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/WMTSIntegrationAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/WMTSIntegrationAutoConfiguration.java
@@ -9,8 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnWMTSIntegrationEnabled;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.geowebcache.service.wmts.WMTSService;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
 import javax.annotation.PostConstruct;
@@ -18,7 +18,7 @@ import javax.annotation.PostConstruct;
 /**
  * @since 1.0
  */
-@Configuration(proxyBeanMethods = true)
+@AutoConfiguration
 @ConditionalOnWMTSIntegrationEnabled
 @ConditionalOnClass(WMTSService.class)
 @ImportResource(

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/GoogleMapsAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/GoogleMapsAutoConfiguration.java
@@ -8,9 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.geoserver.cloud.gwc.config.core.GeoWebCacheConfigurationProperties;
 import org.geoserver.cloud.gwc.config.services.GoogleMapsConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 import javax.annotation.PostConstruct;
@@ -18,7 +18,7 @@ import javax.annotation.PostConstruct;
 /**
  * @since 1.0
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnProperty(
         name = GeoWebCacheConfigurationProperties.SERVICE_GMAPS_ENABLED,
         havingValue = "true",

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/KMLAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/KMLAutoConfiguration.java
@@ -8,9 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.geoserver.cloud.gwc.config.core.GeoWebCacheConfigurationProperties;
 import org.geoserver.cloud.gwc.config.services.KMLConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 import javax.annotation.PostConstruct;
@@ -18,7 +18,7 @@ import javax.annotation.PostConstruct;
 /**
  * @since 1.0
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnProperty(
         name = GeoWebCacheConfigurationProperties.SERVICE_KML_ENABLED,
         havingValue = "true",

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/MGMapsAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/MGMapsAutoConfiguration.java
@@ -8,9 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.geoserver.cloud.gwc.config.core.GeoWebCacheConfigurationProperties;
 import org.geoserver.cloud.gwc.config.services.MGMapsConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 import javax.annotation.PostConstruct;
@@ -18,7 +18,7 @@ import javax.annotation.PostConstruct;
 /**
  * @since 1.0
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnProperty(
         name = GeoWebCacheConfigurationProperties.SERVICE_MGMAPS_ENABLED,
         havingValue = "true",

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/RESTConfigAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/RESTConfigAutoConfiguration.java
@@ -10,8 +10,8 @@ import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoWebCacheRestConfigE
 import org.geoserver.cloud.autoconfigure.gwc.core.DiskQuotaAutoConfiguration;
 import org.geoserver.cloud.gwc.config.core.GeoWebCacheConfigurationProperties;
 import org.geoserver.cloud.gwc.config.services.RESTConfigConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 import javax.annotation.PostConstruct;
@@ -37,7 +37,7 @@ import javax.annotation.PostConstruct;
  *
  * @since 1.0
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnGeoWebCacheRestConfigEnabled
 @ConditionalOnClass(RESTConfigConfiguration.class)
 @Import(RESTConfigConfiguration.class)

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/TileMapServiceAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/TileMapServiceAutoConfiguration.java
@@ -8,9 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.geoserver.cloud.gwc.config.core.GeoWebCacheConfigurationProperties;
 import org.geoserver.cloud.gwc.config.services.TileMapServiceConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 import javax.annotation.PostConstruct;
@@ -18,7 +18,7 @@ import javax.annotation.PostConstruct;
 /**
  * @since 1.0
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnProperty(
         name = GeoWebCacheConfigurationProperties.SERVICE_TMS_ENABLED,
         havingValue = "true",

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/WebMapServiceAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/WebMapServiceAutoConfiguration.java
@@ -8,9 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.geoserver.cloud.gwc.config.core.GeoWebCacheConfigurationProperties;
 import org.geoserver.cloud.gwc.config.services.WebMapServiceConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 import javax.annotation.PostConstruct;
@@ -18,7 +18,7 @@ import javax.annotation.PostConstruct;
 /**
  * @since 1.0
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnProperty(
         name = GeoWebCacheConfigurationProperties.SERVICE_WMS_ENABLED,
         havingValue = "true",

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/WebMapTileServiceAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/service/WebMapTileServiceAutoConfiguration.java
@@ -8,9 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.geoserver.cloud.gwc.config.core.GeoWebCacheConfigurationProperties;
 import org.geoserver.cloud.gwc.config.services.WebMapTileServiceConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 import javax.annotation.PostConstruct;
@@ -18,7 +18,7 @@ import javax.annotation.PostConstruct;
 /**
  * @since 1.0
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnProperty(
         name = GeoWebCacheConfigurationProperties.SERVICE_WMTS_ENABLED,
         havingValue = "true",

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/web/gwc/GeoWebCacheUIAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/web/gwc/GeoWebCacheUIAutoConfiguration.java
@@ -11,13 +11,13 @@ import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnWebUIEnabled;
 import org.geoserver.cloud.gwc.config.core.GeoWebCacheConfigurationProperties;
 import org.geowebcache.rest.controller.ByteStreamController;
 import org.gwc.web.rest.GeoWebCacheController;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 import javax.annotation.PostConstruct;
 
-@Configuration
+@AutoConfiguration
 @ConditionalOnWebUIEnabled
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.web.gwc")
 public class GeoWebCacheUIAutoConfiguration {

--- a/src/library/spring-boot-simplejndi/src/main/java/org/geoserver/cloud/config/jndidatasource/JNDIDataSourceAutoConfiguration.java
+++ b/src/library/spring-boot-simplejndi/src/main/java/org/geoserver/cloud/config/jndidatasource/JNDIDataSourceAutoConfiguration.java
@@ -10,9 +10,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationContextException;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.support.DatabaseStartupValidator;
 
 import java.util.Map;
@@ -25,9 +25,9 @@ import javax.sql.DataSource;
 /**
  * @since 1.0
  */
-@Slf4j(topic = "org.geoserver.cloud.config.jndidatasource")
-@Configuration
+@AutoConfiguration
 @EnableConfigurationProperties(JNDIDataSourcesConfigurationProperties.class)
+@Slf4j(topic = "org.geoserver.cloud.config.jndidatasource")
 public class JNDIDataSourceAutoConfiguration implements InitializingBean {
 
     private @Autowired JNDIDataSourcesConfigurationProperties config;

--- a/src/library/spring-factory/pom.xml
+++ b/src/library/spring-factory/pom.xml
@@ -11,12 +11,8 @@
   <description>Customizable xml bean definition reader</description>
   <dependencies>
     <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-context</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-beans</artifactId>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/library/spring-factory/src/main/java/org/geoserver/cloud/autoconfigure/factory/FilteringXmlBeanDefinitionReaderAutoConfiguration.java
+++ b/src/library/spring-factory/src/main/java/org/geoserver/cloud/autoconfigure/factory/FilteringXmlBeanDefinitionReaderAutoConfiguration.java
@@ -5,7 +5,7 @@
 package org.geoserver.cloud.autoconfigure.factory;
 
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 
@@ -13,7 +13,7 @@ import org.springframework.context.event.EventListener;
  * Calls {@link FilteringXmlBeanDefinitionReader#clearCaches()} once the application context is
  * refreshed
  */
-@Configuration
+@AutoConfiguration
 public class FilteringXmlBeanDefinitionReaderAutoConfiguration {
 
     @EventListener

--- a/src/starters/raster-formats/src/main/java/org/geoserver/cloud/autoconfigure/cog/COGAutoConfiguration.java
+++ b/src/starters/raster-formats/src/main/java/org/geoserver/cloud/autoconfigure/cog/COGAutoConfiguration.java
@@ -6,12 +6,12 @@ package org.geoserver.cloud.autoconfigure.cog;
 
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.geoserver.cog.CogSettings;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
 /** Auto configuration to enable the COG (Cloud Optimized GeoTIFF) support as raster data format. */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnClass({CogSettings.class})
 @ImportResource(
         reader = FilteringXmlBeanDefinitionReader.class, //

--- a/src/starters/raster-formats/src/main/java/org/geoserver/cloud/autoconfigure/pgraster/PostgisRasterWebUIAutoConfiguration.java
+++ b/src/starters/raster-formats/src/main/java/org/geoserver/cloud/autoconfigure/pgraster/PostgisRasterWebUIAutoConfiguration.java
@@ -7,8 +7,8 @@ package org.geoserver.cloud.autoconfigure.pgraster;
 import org.geoserver.web.GeoServerApplication;
 import org.geoserver.web.data.resource.DataStorePanelInfo;
 import org.geoserver.web.data.store.pgraster.PGRasterCoverageStoreEditPanel;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
 /**
@@ -18,7 +18,7 @@ import org.springframework.context.annotation.ImportResource;
  *     bean in place because of parameterized class incompatibility on {@link
  *     org.geoserver.web.data.resource.DataStorePanelInfo#setComponentClass(Class)}
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnClass({
     GeoServerApplication.class,
     DataStorePanelInfo.class,

--- a/src/starters/reactive/src/main/java/org/geoserver/cloud/autoconfigure/core/ReactiveGeoServerMainAutoConfiguration.java
+++ b/src/starters/reactive/src/main/java/org/geoserver/cloud/autoconfigure/core/ReactiveGeoServerMainAutoConfiguration.java
@@ -7,9 +7,8 @@ package org.geoserver.cloud.autoconfigure.core;
 import org.geoserver.cloud.autoconfigure.catalog.backend.core.GeoServerBackendAutoConfiguration;
 import org.geoserver.cloud.config.catalog.backend.core.GeoServerBackendConfigurer;
 import org.geoserver.cloud.config.main.GeoServerMainModuleConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 /**
@@ -21,7 +20,6 @@ import org.springframework.context.annotation.Import;
  *
  * @see GeoServerMainModuleConfiguration
  */
-@Configuration
-@AutoConfigureAfter(value = GeoServerBackendAutoConfiguration.class)
+@AutoConfiguration(after = GeoServerBackendAutoConfiguration.class)
 @Import({GeoServerMainModuleConfiguration.class})
 public class ReactiveGeoServerMainAutoConfiguration {}

--- a/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/AuthKeyAutoConfiguration.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/AuthKeyAutoConfiguration.java
@@ -11,6 +11,7 @@ import org.geoserver.platform.ModuleStatus;
 import org.geoserver.platform.ModuleStatusImpl;
 import org.geoserver.security.web.auth.AuthenticationFilterPanel;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,7 +23,7 @@ import javax.annotation.PostConstruct;
 /**
  * @since 1.0
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @Import({AuthKeyAutoConfiguration.Enabled.class, AuthKeyAutoConfiguration.WebUI.class})
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.authzn")
 public class AuthKeyAutoConfiguration {

--- a/src/starters/spring-boot/src/main/java/org/geoserver/cloud/app/StartupLoggerAutoConfiguration.java
+++ b/src/starters/spring-boot/src/main/java/org/geoserver/cloud/app/StartupLoggerAutoConfiguration.java
@@ -4,9 +4,9 @@
  */
 package org.geoserver.cloud.app;
 
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 
 /**
@@ -17,7 +17,7 @@ import org.springframework.core.env.Environment;
  *
  * @since 1.0
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 public class StartupLoggerAutoConfiguration {
 
     @Bean

--- a/src/starters/webmvc/src/main/java/org/geoserver/cloud/autoconfigure/core/GeoServerWebMvcMainAutoConfiguration.java
+++ b/src/starters/webmvc/src/main/java/org/geoserver/cloud/autoconfigure/core/GeoServerWebMvcMainAutoConfiguration.java
@@ -6,12 +6,10 @@ package org.geoserver.cloud.autoconfigure.core;
 
 import org.geoserver.cloud.autoconfigure.catalog.backend.core.GeoServerBackendAutoConfiguration;
 import org.geoserver.cloud.config.main.GeoServerMainModuleConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Import;
 
 /** Autoconfiguration for GeoServer's main module on servlet/webmvc applications */
-@Configuration
-@AutoConfigureAfter(GeoServerBackendAutoConfiguration.class)
+@AutoConfiguration(after = GeoServerBackendAutoConfiguration.class)
 @Import({GeoServerMainModuleConfiguration.class})
 public class GeoServerWebMvcMainAutoConfiguration {}

--- a/src/starters/webmvc/src/main/java/org/geoserver/cloud/autoconfigure/servlet/GeoServerServletContextAutoConfiguration.java
+++ b/src/starters/webmvc/src/main/java/org/geoserver/cloud/autoconfigure/servlet/GeoServerServletContextAutoConfiguration.java
@@ -8,15 +8,13 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.geoserver.cloud.autoconfigure.core.GeoServerWebMvcMainAutoConfiguration;
 import org.geoserver.cloud.config.servlet.GeoServerServletContextConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 import javax.annotation.PostConstruct;
 
-@Configuration
-@AutoConfigureAfter(GeoServerWebMvcMainAutoConfiguration.class)
+@AutoConfiguration(after = GeoServerWebMvcMainAutoConfiguration.class)
 @ConditionalOnProperty(
         prefix = "geoserver.servlet",
         name = "enabled",
@@ -26,6 +24,7 @@ import javax.annotation.PostConstruct;
 @Slf4j
 public class GeoServerServletContextAutoConfiguration {
 
+    @AutoConfiguration
     @ConditionalOnProperty(
             prefix = "geoserver.servlet",
             name = "enabled",

--- a/src/starters/webmvc/src/main/java/org/geoserver/cloud/config/main/GeoServerMainModuleConfiguration.java
+++ b/src/starters/webmvc/src/main/java/org/geoserver/cloud/config/main/GeoServerMainModuleConfiguration.java
@@ -53,7 +53,7 @@ import org.springframework.context.annotation.ImportResource;
  *       microservices approach, as it reads from {@literal <datadir>/logs/geoserver.log}
  * </ul>
  */
-@Configuration(proxyBeanMethods = true)
+@Configuration(proxyBeanMethods = false)
 @ImportResource( //
         reader = FilteringXmlBeanDefinitionReader.class, //
         // exclude beans


### PR DESCRIPTION
technical debt: annotate auto configuration classes with spring-boot's `@AutoConfiguration` instead of spring's `@Configuration`.

`@AutoConfiguration` was introduced in 2.7 with the idea to mark all auto-configurations with its dedicated annotation and move away from spring.factories for auto-configuration imports in 3.0 as described in this
[Github issue](https://github.com/spring-projects/spring-boot/issues/29698).