### PR TITLE
Remove geoserver profile including the upstream submodule

### DIFF
--- a/geoserver_submodule/pom.xml
+++ b/geoserver_submodule/pom.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.geoserver.cloud</groupId>
-    <artifactId>gs-cloud-bom</artifactId>
-    <version>${revision}</version>
-  </parent>
+  <groupId>org.geoserver.cloud</groupId>
   <artifactId>gs-upstream</artifactId>
+  <version>2.23-CLOUD</version>
   <packaging>pom</packaging>
   <name>GeoServer upstream dependencies</name>
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -307,15 +307,4 @@
       </plugin>
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <id>geoserver</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <modules>
-        <module>geoserver_submodule</module>
-      </modules>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
Building the submodule is a separate task and the project does not depend on geoserver-cloud's root pom.

This avoids importing all upstream projects when first importing the maven project on an IDE