### PR TITLE
Change GeoTools log redirection from Log4j2 to Logback

### DIFF
--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/geotools/GeoToolsStaticContextInitializer.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/geotools/GeoToolsStaticContextInitializer.java
@@ -7,6 +7,7 @@ package org.geoserver.cloud.autoconfigure.geotools;
 import org.geoserver.GeoserverInitStartupListener;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.web.context.support.GenericWebApplicationContext;
 
 /**
  * {@link ApplicationContextInitializer} replacing upstream's {@link GeoserverInitStartupListener},
@@ -22,6 +23,10 @@ public class GeoToolsStaticContextInitializer
 
     @Override
     public void initialize(ConfigurableApplicationContext applicationContext) {
+        // run once for the webapp context, ignore the actuator context
+        if (!(applicationContext instanceof GenericWebApplicationContext)) {
+            return;
+        }
         System.setProperty("org.geotools.referencing.forceXY", "true");
 
         Boolean useEnvAwareHttpClient =

--- a/src/catalog/backends/common/src/test/java/org/geoserver/cloud/autoconfigure/geotools/GeoToolsHttpClientAutoConfigurationTest.java
+++ b/src/catalog/backends/common/src/test/java/org/geoserver/cloud/autoconfigure/geotools/GeoToolsHttpClientAutoConfigurationTest.java
@@ -5,20 +5,20 @@
 package org.geoserver.cloud.autoconfigure.geotools;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 
 /**
  * @since 1.0
  */
 class GeoToolsHttpClientAutoConfigurationTest {
 
-    private ApplicationContextRunner runner =
-            new ApplicationContextRunner() //
+    private WebApplicationContextRunner runner =
+            new WebApplicationContextRunner() //
                     .withInitializer(new GeoToolsStaticContextInitializer()) //
                     .withConfiguration(
                             AutoConfigurations.of(GeoToolsHttpClientAutoConfiguration.class));

--- a/src/library/spring-boot-simplejndi/src/main/java/org/geoserver/cloud/config/jndi/SimpleJNDIStaticContextInitializer.java
+++ b/src/library/spring-boot-simplejndi/src/main/java/org/geoserver/cloud/config/jndi/SimpleJNDIStaticContextInitializer.java
@@ -24,6 +24,8 @@ import javax.naming.spi.NamingManager;
 public class SimpleJNDIStaticContextInitializer
         implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
+    private static boolean initialized;
+
     /**
      * Register the context builder by registering it with the JNDI NamingManager. Note that once
      * this has been done, {@code new InitialContext()} will always return a context from this
@@ -36,6 +38,8 @@ public class SimpleJNDIStaticContextInitializer
      */
     @Override
     public void initialize(ConfigurableApplicationContext applicationContext) {
+        if (initialized) return;
+        initialized = true;
         if (NamingManager.hasInitialContextFactoryBuilder()) {
             log.info("JNDI InitialContextFactoryBuilder already set");
             return;


### PR DESCRIPTION
GeoTools version of Log4j2 (2.17.2) and the one used by spring-boot (2.21.1) differ in the  API used by GeoTools to set the logging level, which produces an exception due to a missing setLevel(...) method in the new version.

Change log redirection to use Logback, and make sure the ApplicationContextInitializers run only once, as they may be called twice, once for the webapp context, and again for the Actuator context.