### PR TITLE
web-ui: Fix WMS service links gone when gwc.disabled=true

### DIFF
--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/wms/WmsConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/wms/WmsConfiguration.java
@@ -24,7 +24,7 @@ public class WmsConfiguration {
     static final String WMS_BEANS_REGEX =
             """
             ^(?!\
-            |legendSample\
+            legendSample\
             |getMapKvpReader\
             |wmsCapabilitiesXmlReader\
             |getMapXmlReader\
@@ -48,7 +48,7 @@ public class WmsConfiguration {
             |.*LegendGraphicResponse\
             |wmsGIFLegendOutputFormat\
             |wmsJPEGLegendGraphicOutputFormat\
-            |wmsJSONLegendOutputFormat
+            |wmsJSONLegendOutputFormat\
             ).*$\
             """;
 }

--- a/src/apps/geoserver/webui/src/test/java/org/geoserver/cloud/web/app/WebUIApplicationTest.java
+++ b/src/apps/geoserver/webui/src/test/java/org/geoserver/cloud/web/app/WebUIApplicationTest.java
@@ -9,12 +9,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
+import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.util.tester.TagTester;
 import org.apache.wicket.util.tester.WicketTester;
 import org.geoserver.web.GeoServerApplication;
 import org.geoserver.web.GeoServerHomePage;
 import org.geoserver.web.GeoServerLoginPage;
+import org.geoserver.web.ServicesPanel;
 import org.geoserver.web.admin.GlobalSettingsPage;
 import org.geoserver.web.wicket.WicketHierarchyPrinter;
 import org.junit.jupiter.api.AfterEach;
@@ -133,6 +135,29 @@ public class WebUIApplicationTest {
         assertHidden("loggingSettingsContainer");
         assertHidden("lockProviderContainer");
         assertHidden("webUISettingsContainer");
+    }
+
+    @Test
+    public void GeoServerHomePage_smoke_test_service_links() {
+        GeoServerHomePage page = tester.startPage(GeoServerHomePage.class);
+        assertNotNull(page);
+        // print(page);
+        tester.assertComponent("serviceList", ServicesPanel.class);
+        tester.assertVisible("serviceList");
+        tester.assertComponent("serviceList:serviceDescriptions:0", ListItem.class);
+        tester.assertComponent("serviceList:serviceDescriptions:0:links:0", ListItem.class);
+
+        tester.assertComponent("serviceList:serviceDescriptions:1", ListItem.class);
+        tester.assertComponent("serviceList:serviceDescriptions:1:links:0", ListItem.class);
+
+        tester.assertComponent("serviceList:serviceDescriptions:2", ListItem.class);
+        tester.assertComponent("serviceList:serviceDescriptions:2:links:0", ListItem.class);
+
+        tester.assertComponent("serviceList:serviceDescriptions:3", ListItem.class);
+        tester.assertComponent("serviceList:serviceDescriptions:3:links:0", ListItem.class);
+
+        tester.assertComponent("serviceList:serviceDescriptions:4", ListItem.class);
+        tester.assertComponent("serviceList:serviceDescriptions:4:links:0", ListItem.class);
     }
 
     protected void assertHidden(String id) {

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/WebMapServiceMinimalConfiguration.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/WebMapServiceMinimalConfiguration.java
@@ -62,7 +62,7 @@ public class WebMapServiceMinimalConfiguration {
             |.*LegendGraphicResponse\
             |wmsGIFLegendOutputFormat\
             |wmsJPEGLegendGraphicOutputFormat\
-            |wmsJSONLegendOutputFormat
+            |wmsJSONLegendOutputFormat\
             ).*$\
             """;
 

--- a/src/library/spring-factory/src/main/java/org/geoserver/cloud/config/factory/FilteringXmlBeanDefinitionReader.java
+++ b/src/library/spring-factory/src/main/java/org/geoserver/cloud/config/factory/FilteringXmlBeanDefinitionReader.java
@@ -360,20 +360,18 @@ public class FilteringXmlBeanDefinitionReader extends XmlBeanDefinitionReader {
 
         protected @Override void processBeanDefinition(
                 Element ele, BeanDefinitionParserDelegate delegate) {
-            if (!isFiltering()) {
-                super.processBeanDefinition(ele, delegate);
-                return;
-            }
-
             final String beanNameOrId = getBeanNameOrId(ele);
-            if (shallInclude(beanNameOrId, ele)) {
-                if (hasText(beanNameOrId)) {
+            if (isFiltering()) {
+                if (shallInclude(beanNameOrId, ele)) {
                     logIncludingBeanMessage(beanNameOrId);
+                    super.processBeanDefinition(ele, delegate);
+                } else if (hasText(beanNameOrId)) {
+                    blackListedBeanNames.add(beanNameOrId);
+                    logExcludedBeanMessage(beanNameOrId);
                 }
+            } else {
+                logUnfiltered(beanNameOrId);
                 super.processBeanDefinition(ele, delegate);
-            } else if (hasText(beanNameOrId)) {
-                blackListedBeanNames.add(beanNameOrId);
-                logExcludedBeanMessage(beanNameOrId);
             }
         }
 
@@ -404,14 +402,25 @@ public class FilteringXmlBeanDefinitionReader extends XmlBeanDefinitionReader {
             return nameAtt;
         }
 
+        private void logUnfiltered(String beanName) {
+            if (hasText(beanName)) {
+                String msgFormat = "Include bean '{}', no regular expression provided";
+                log.trace(msgFormat, beanName);
+            }
+        }
+
         private void logIncludingBeanMessage(String beanName) {
-            String msgFormat = "Registering   '{}', matches regular expression";
-            log.trace(msgFormat, beanName);
+            if (hasText(beanName)) {
+                String msgFormat = "Include bean '{}', matches regular expression";
+                log.trace(msgFormat, beanName);
+            }
         }
 
         private void logExcludedBeanMessage(String beanName) {
-            String msgFormat = "Excluded bean '{}', no regular expression matches";
-            log.trace(msgFormat, beanName);
+            if (hasText(beanName)) {
+                String msgFormat = "Exclude bean '{}', no regular expression matches";
+                log.trace(msgFormat, beanName);
+            }
         }
     }
 }


### PR DESCRIPTION
The `wms-1*-ServiceDescriptor` beans where not being loaded from `gs-wms.jar!/applicationContext.xml` from the
`org.geoserver.cloud.autoconfigure.web.wms.WmsConfiguration` due to a regex problem, but they were loaded from the GWC
`WebMapServiceMinimalConfiguration` when enabled, hence missing when disabled.