### PR TITLE
QA improvements

### DIFF
--- a/src/apps/geoserver/gwc/pom.xml
+++ b/src/apps/geoserver/gwc/pom.xml
@@ -81,7 +81,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.3.1</version>
         <executions>
           <execution>
             <id>copy-resources</id>

--- a/src/apps/geoserver/gwc/src/main/java/org/geoserver/cloud/gwc/app/GeoWebCacheApplicationConfiguration.java
+++ b/src/apps/geoserver/gwc/src/main/java/org/geoserver/cloud/gwc/app/GeoWebCacheApplicationConfiguration.java
@@ -44,7 +44,7 @@ public class GeoWebCacheApplicationConfiguration extends RestConfiguration {
      */
     @Bean
     @ConditionalOnMissingBean
-    public LegendSample legendSample(
+    LegendSample legendSample(
             @Qualifier("rawCatalog") Catalog catalog, GeoServerResourceLoader loader) {
         return new LegendSampleImpl(catalog, loader);
     }

--- a/src/apps/geoserver/pom.xml
+++ b/src/apps/geoserver/pom.xml
@@ -69,11 +69,5 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <!-- trivy: override commons-collections:3.2.1 by 3.2.2 due to CVE-2015-7501 (CRITICAL), and CVE-2015-6420 (HIGH) -->
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
-      <version>3.2.2</version>
-    </dependency>
   </dependencies>
 </project>

--- a/src/apps/geoserver/restconfig/pom.xml
+++ b/src/apps/geoserver/restconfig/pom.xml
@@ -60,7 +60,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.3.1</version>
         <executions>
           <execution>
             <id>copy-resources</id>

--- a/src/apps/geoserver/wcs/pom.xml
+++ b/src/apps/geoserver/wcs/pom.xml
@@ -52,7 +52,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.3.1</version>
         <executions>
           <execution>
             <id>copy-resources</id>

--- a/src/apps/geoserver/wcs/src/main/java/org/geoserver/cloud/wcs/WCSController.java
+++ b/src/apps/geoserver/wcs/src/main/java/org/geoserver/cloud/wcs/WCSController.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.view.RedirectView;
 
 import javax.servlet.http.HttpServletRequest;
@@ -34,7 +33,7 @@ public @Controller class WCSController {
     }
 
     /** Serve only WCS schemas from classpath (e.g. {@code /schemas/wcs/1.1.1/wcsAll.xsd}) */
-    @RequestMapping(method = RequestMethod.GET, path = "/schemas/wcs/**")
+    @GetMapping(path = "/schemas/wcs/**")
     public void getSchema(HttpServletRequest request, HttpServletResponse response)
             throws Exception {
         classPathPublisher.handleRequest(request, response);

--- a/src/apps/geoserver/wcs/src/main/java/org/geoserver/cloud/wcs/WcsApplicationConfiguration.java
+++ b/src/apps/geoserver/wcs/src/main/java/org/geoserver/cloud/wcs/WcsApplicationConfiguration.java
@@ -21,7 +21,8 @@ import org.springframework.context.annotation.ImportResource;
         })
 public class WcsApplicationConfiguration {
 
-    public @Bean VirtualServiceVerifier virtualServiceVerifier() {
+    @Bean
+    VirtualServiceVerifier virtualServiceVerifier() {
         return new VirtualServiceVerifier();
     }
 }

--- a/src/apps/geoserver/webui/pom.xml
+++ b/src/apps/geoserver/webui/pom.xml
@@ -159,7 +159,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.3.1</version>
         <executions>
           <execution>
             <id>copy-resources</id>

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebCoreConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebCoreConfiguration.java
@@ -27,17 +27,19 @@ public class WebCoreConfiguration {
 
     static final String EXCLUDED_BEANS_PATTERN = "^(?!logsPage).*$";
 
-    public @Bean GeoServerWicketServlet geoServerWicketServlet() {
+    @Bean
+    GeoServerWicketServlet geoServerWicketServlet() {
         return new GeoServerWicketServlet();
     }
 
-    public @Bean TestWfsPost testWfsPostServlet() {
+    @Bean
+    TestWfsPost testWfsPostServlet() {
         return new TestWfsPost();
     }
 
     /** Register the {@link WicketServlet} */
-    public @Bean ServletRegistrationBean<GeoServerWicketServlet>
-            geoServerWicketServletRegistration() {
+    @Bean
+    ServletRegistrationBean<GeoServerWicketServlet> geoServerWicketServletRegistration() {
         GeoServerWicketServlet servlet = geoServerWicketServlet();
         ServletRegistrationBean<GeoServerWicketServlet> registration;
         registration =
@@ -47,7 +49,8 @@ public class WebCoreConfiguration {
     }
 
     /** Register the {@link TestWfsPost servlet} */
-    public @Bean ServletRegistrationBean<TestWfsPost> wfsTestServletRegistration() {
+    @Bean
+    ServletRegistrationBean<TestWfsPost> wfsTestServletRegistration() {
         TestWfsPost servlet = testWfsPostServlet();
         ServletRegistrationBean<TestWfsPost> registration;
         registration = new ServletRegistrationBean<TestWfsPost>(servlet, "/TestWfsPost");
@@ -55,7 +58,8 @@ public class WebCoreConfiguration {
         return registration;
     }
 
-    public @Bean HeaderContribution geoserverCloudCssTheme() {
+    @Bean
+    HeaderContribution geoserverCloudCssTheme() {
         HeaderContribution contribution = new HeaderContribution();
         contribution.setScope(GeoServerBasePage.class);
         contribution.setCSSFilename("geoserver-cloud.css");

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/web/service/WebUiCloudServicesConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/web/service/WebUiCloudServicesConfiguration.java
@@ -20,11 +20,13 @@ import org.springframework.context.annotation.Configuration;
 @Configuration(proxyBeanMethods = true)
 public class WebUiCloudServicesConfiguration {
 
-    public @Bean ServiceInstanceRegistry cloudServiceRegistry(DiscoveryClient client) {
+    @Bean
+    ServiceInstanceRegistry cloudServiceRegistry(DiscoveryClient client) {
         return new ServiceInstanceRegistry(client);
     }
 
-    public @Bean Category cloudCategory() {
+    @Bean
+    Category cloudCategory() {
         Category category = new Category();
         category.setNameKey("category.cloud");
         category.setOrder(150);
@@ -43,7 +45,8 @@ public class WebUiCloudServicesConfiguration {
     // <property name="authorizer" ref="workspaceAdminAuthorizer"/>
     // </bean>
 
-    public @Bean MenuPageInfo<ServiceRegistryPage> serviceRegistryMenuPage(
+    @Bean
+    MenuPageInfo<ServiceRegistryPage> serviceRegistryMenuPage(
             @Qualifier("aboutStatusCategory") Category aboutStatusCategory) {
         MenuPageInfo<ServiceRegistryPage> menu = new MenuPageInfo<>();
         menu.setId("serviceRegistry");
@@ -57,7 +60,8 @@ public class WebUiCloudServicesConfiguration {
         return menu;
     }
 
-    public @Bean GeoServerCloudHomePageContentProvider geoServerCloudHomePageContentProvider() {
+    @Bean
+    GeoServerCloudHomePageContentProvider geoServerCloudHomePageContentProvider() {
         return new GeoServerCloudHomePageContentProvider();
     }
 }

--- a/src/apps/geoserver/webui/src/test/java/org/geoserver/cloud/web/app/WebUIApplicationTest.java
+++ b/src/apps/geoserver/webui/src/test/java/org/geoserver/cloud/web/app/WebUIApplicationTest.java
@@ -88,6 +88,7 @@ public class WebUIApplicationTest {
                 .setAuthentication(new UsernamePasswordAuthenticationToken(username, password, l));
     }
 
+    @SuppressWarnings("unused")
     private void print(Component component) {
         boolean dumpClass = true;
         boolean dumpValue = false;
@@ -129,6 +130,7 @@ public class WebUIApplicationTest {
         tester.startPage(GlobalSettingsPage.class);
         tester.assertRenderedPage(GlobalSettingsPage.class);
         GlobalSettingsPage page = (GlobalSettingsPage) tester.getLastRenderedPage();
+        assertNotNull(page);
         // print(page);
         assertHidden("proxyBaseUrlContainer");
         assertHidden("useHeadersProxyURL");

--- a/src/apps/geoserver/wfs/pom.xml
+++ b/src/apps/geoserver/wfs/pom.xml
@@ -49,7 +49,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.3.1</version>
         <executions>
           <execution>
             <id>copy-resources</id>

--- a/src/apps/geoserver/wfs/src/main/java/org/geoserver/cloud/wfs/app/WFSController.java
+++ b/src/apps/geoserver/wfs/src/main/java/org/geoserver/cloud/wfs/app/WFSController.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.view.RedirectView;
 
 import javax.servlet.http.HttpServletRequest;
@@ -35,7 +34,7 @@ public class WFSController {
     }
 
     /** Serve only WFS schemas from classpath (e.g. {@code /schemas/wfs/2.0/wfs.xsd}) */
-    @RequestMapping(method = RequestMethod.GET, path = "/schemas/wfs/**")
+    @GetMapping(path = "/schemas/wfs/**")
     public void getSchema(HttpServletRequest request, HttpServletResponse response)
             throws Exception {
         classPathPublisher.handleRequest(request, response);

--- a/src/apps/geoserver/wfs/src/main/java/org/geoserver/cloud/wfs/config/WfsAutoConfiguration.java
+++ b/src/apps/geoserver/wfs/src/main/java/org/geoserver/cloud/wfs/config/WfsAutoConfiguration.java
@@ -21,7 +21,8 @@ import org.springframework.context.annotation.ImportResource;
         )
 public class WfsAutoConfiguration {
 
-    public @Bean VirtualServiceVerifier virtualServiceVerifier() {
+    @Bean
+    VirtualServiceVerifier virtualServiceVerifier() {
         return new VirtualServiceVerifier();
     }
 }

--- a/src/apps/geoserver/wms/pom.xml
+++ b/src/apps/geoserver/wms/pom.xml
@@ -66,7 +66,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.3.1</version>
         <executions>
           <execution>
             <id>copy-resources</id>

--- a/src/apps/geoserver/wms/src/main/java/org/geoserver/cloud/autoconfigure/wms/KMLAutoConfiguration.java
+++ b/src/apps/geoserver/wms/src/main/java/org/geoserver/cloud/autoconfigure/wms/KMLAutoConfiguration.java
@@ -30,11 +30,13 @@ import org.springframework.context.annotation.ImportResource;
         })
 public class KMLAutoConfiguration {
 
-    public @Bean KMLIconsController kmlIconsController() {
+    @Bean
+    KMLIconsController kmlIconsController() {
         return new KMLIconsController();
     }
 
-    public @Bean KMLReflectorController kmlReflectorController() {
+    @Bean
+    KMLReflectorController kmlReflectorController() {
         return new KMLReflectorController();
     }
 }

--- a/src/apps/geoserver/wms/src/main/java/org/geoserver/cloud/autoconfigure/wms/WmsApplicationAutoConfiguration.java
+++ b/src/apps/geoserver/wms/src/main/java/org/geoserver/cloud/autoconfigure/wms/WmsApplicationAutoConfiguration.java
@@ -69,21 +69,24 @@ public class WmsApplicationAutoConfiguration {
      *     workspace and secured catalog decorators
      */
     @Bean
-    public LegendSample legendSample(
+    LegendSample legendSample(
             @Qualifier("rawCatalog") Catalog catalog, GeoServerResourceLoader loader) {
         return new LegendSampleImpl(catalog, loader);
     }
 
-    public @Bean WFSConfiguration wfsConfiguration(GeoServer geoServer) {
+    @Bean
+    WFSConfiguration wfsConfiguration(GeoServer geoServer) {
         FeatureTypeSchemaBuilder schemaBuilder = new FeatureTypeSchemaBuilder.GML3(geoServer);
         return new WFSConfiguration(geoServer, schemaBuilder, new WFS(schemaBuilder));
     }
 
-    public @Bean WMSController webMapServiceController() {
+    @Bean
+    WMSController webMapServiceController() {
         return new WMSController();
     }
 
-    public @Bean VirtualServiceVerifier virtualServiceVerifier() {
+    @Bean
+    VirtualServiceVerifier virtualServiceVerifier() {
         return new VirtualServiceVerifier();
     }
 
@@ -92,7 +95,8 @@ public class WmsApplicationAutoConfiguration {
             name = "reflector.enabled",
             havingValue = "true",
             matchIfMissing = true)
-    public @Bean GetMapReflectorController getMapReflectorController() {
+    @Bean
+    GetMapReflectorController getMapReflectorController() {
         return new GetMapReflectorController();
     }
 }

--- a/src/apps/geoserver/wms/src/main/java/org/geoserver/cloud/wms/controller/GetMapReflectorController.java
+++ b/src/apps/geoserver/wms/src/main/java/org/geoserver/cloud/wms/controller/GetMapReflectorController.java
@@ -4,12 +4,10 @@
  */
 package org.geoserver.cloud.wms.controller;
 
-import static org.springframework.web.bind.annotation.RequestMethod.GET;
-
 import org.geoserver.ows.Dispatcher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -18,9 +16,7 @@ public @Controller class GetMapReflectorController {
 
     private @Autowired Dispatcher geoserverDispatcher;
 
-    @RequestMapping(
-            method = {GET},
-            path = {"/wms/reflect", "/{workspace}/wms/reflect"})
+    @GetMapping(path = {"/wms/reflect", "/{workspace}/wms/reflect"})
     public void getMapReflect(HttpServletRequest request, HttpServletResponse response)
             throws Exception {
         geoserverDispatcher.handleRequest(request, response);

--- a/src/apps/geoserver/wms/src/main/java/org/geoserver/cloud/wms/controller/WMSController.java
+++ b/src/apps/geoserver/wms/src/main/java/org/geoserver/cloud/wms/controller/WMSController.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.view.RedirectView;
 
 import javax.servlet.http.HttpServletRequest;
@@ -43,9 +42,7 @@ public @Controller class WMSController {
      *   <li>{@code /schemas/wms/1.1.1/WMS_MS_Capabilities.dtd}
      * </ul>
      */
-    @RequestMapping(
-            method = RequestMethod.GET,
-            path = {"/schemas/wms/**"})
+    @GetMapping(path = {"/schemas/wms/**"})
     public void getWmsSchema(HttpServletRequest request, HttpServletResponse response)
             throws Exception {
         classPathPublisher.handleRequest(request, response);
@@ -61,9 +58,7 @@ public @Controller class WMSController {
      *   <li>{@code /openlayers3/**}
      * </ul>
      */
-    @RequestMapping(
-            method = RequestMethod.GET,
-            path = {"/openlayers/**", "/openlayers3/**"})
+    @GetMapping(path = {"/openlayers/**", "/openlayers3/**"})
     public void getStaticResource(HttpServletRequest request, HttpServletResponse response)
             throws Exception {
         classPathPublisher.handleRequest(request, response);

--- a/src/apps/geoserver/wms/src/main/java/org/geoserver/cloud/wms/controller/kml/KMLIconsController.java
+++ b/src/apps/geoserver/wms/src/main/java/org/geoserver/cloud/wms/controller/kml/KMLIconsController.java
@@ -9,8 +9,7 @@ import org.geoserver.wms.icons.IconService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
@@ -42,7 +41,7 @@ public @Controller class KMLIconsController {
 
     private @Autowired @Qualifier("kmlIconService") IconService kmlIconService;
 
-    @RequestMapping(method = RequestMethod.GET, path = "/kml/icon/**")
+    @GetMapping(path = "/kml/icon/**")
     public void getKmlIcon(HttpServletRequest request, HttpServletResponse response)
             throws Exception {
         kmlIconService.handleRequest(adaptRequest(request), response);

--- a/src/apps/geoserver/wms/src/main/java/org/geoserver/cloud/wms/controller/kml/KMLReflectorController.java
+++ b/src/apps/geoserver/wms/src/main/java/org/geoserver/cloud/wms/controller/kml/KMLReflectorController.java
@@ -4,13 +4,11 @@
  */
 package org.geoserver.cloud.wms.controller.kml;
 
-import static org.springframework.web.bind.annotation.RequestMethod.GET;
-
 import org.geoserver.kml.KMLReflector;
 import org.geoserver.ows.Dispatcher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -28,9 +26,7 @@ public @Controller class KMLReflectorController {
 
     private @Autowired Dispatcher geoserverDispatcher;
 
-    @RequestMapping(
-            method = {GET},
-            path = {"/wms/kml", "/{workspace}/wms/kml"})
+    @GetMapping(path = {"/wms/kml", "/{workspace}/wms/kml"})
     public void kmlReflect(HttpServletRequest request, HttpServletResponse response)
             throws Exception {
 

--- a/src/apps/geoserver/wps/pom.xml
+++ b/src/apps/geoserver/wps/pom.xml
@@ -53,7 +53,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.3.1</version>
         <executions>
           <execution>
             <id>copy-resources</id>

--- a/src/apps/geoserver/wps/src/main/java/org/geoserver/cloud/wps/WPSController.java
+++ b/src/apps/geoserver/wps/src/main/java/org/geoserver/cloud/wps/WPSController.java
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.view.RedirectView;
 
 import javax.servlet.http.HttpServletRequest;
@@ -30,7 +29,7 @@ public @Controller class WPSController {
     }
 
     /** Serve only WPS schemas from classpath (e.g. {@code /schemas/wps/1.0.0/wpsAll.xsd}) */
-    @RequestMapping(method = RequestMethod.GET, path = "/schemas/wps/**")
+    @GetMapping(path = "/schemas/wps/**")
     public void getSchema(HttpServletRequest request, HttpServletResponse response)
             throws Exception {
         classPathPublisher.handleRequest(request, response);

--- a/src/apps/infrastructure/config/pom.xml
+++ b/src/apps/infrastructure/config/pom.xml
@@ -98,7 +98,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.3.1</version>
         <executions>
           <execution>
             <id>copy-resources</id>
@@ -122,7 +121,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${spring-boot.version}</version>
         <executions>
           <execution>
             <id>build-info</id>

--- a/src/apps/infrastructure/config/src/test/java/org/geoserver/cloud/config/ConfigApplicationTest.java
+++ b/src/apps/infrastructure/config/src/test/java/org/geoserver/cloud/config/ConfigApplicationTest.java
@@ -17,7 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;

--- a/src/apps/infrastructure/discovery/pom.xml
+++ b/src/apps/infrastructure/discovery/pom.xml
@@ -37,7 +37,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.3.1</version>
         <executions>
           <execution>
             <id>copy-resources</id>

--- a/src/apps/infrastructure/gateway/pom.xml
+++ b/src/apps/infrastructure/gateway/pom.xml
@@ -59,7 +59,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.3.1</version>
         <executions>
           <execution>
             <id>copy-resources</id>

--- a/src/apps/infrastructure/gateway/src/main/java/org/geoserver/cloud/gateway/GatewayApplication.java
+++ b/src/apps/infrastructure/gateway/src/main/java/org/geoserver/cloud/gateway/GatewayApplication.java
@@ -22,7 +22,8 @@ public class GatewayApplication {
         new SpringApplicationBuilder(GatewayApplication.class).run(args);
     }
 
-    public @Bean RouteLocator customRouteLocator(RouteLocatorBuilder builder) {
+    @Bean
+    RouteLocator customRouteLocator(RouteLocatorBuilder builder) {
         return builder.routes().build();
     }
 
@@ -30,16 +31,19 @@ public class GatewayApplication {
      * Custom gateway predicate factory to support matching by regular expressions on both name and
      * value of query parameters
      */
-    public @Bean RegExpQueryRoutePredicateFactory regExpQueryRoutePredicateFactory() {
+    @Bean
+    RegExpQueryRoutePredicateFactory regExpQueryRoutePredicateFactory() {
         return new RegExpQueryRoutePredicateFactory();
     }
 
     /** Allows to enable routes only if a given spring profile is enabled */
-    public @Bean RouteProfileGatewayFilterFactory routeProfileGatewayFilterFactory() {
+    @Bean
+    RouteProfileGatewayFilterFactory routeProfileGatewayFilterFactory() {
         return new RouteProfileGatewayFilterFactory();
     }
 
-    public @Bean StripBasePathGatewayFilterFactory stripBasePathGatewayFilterFactory() {
+    @Bean
+    StripBasePathGatewayFilterFactory stripBasePathGatewayFilterFactory() {
         return new StripBasePathGatewayFilterFactory();
     }
 }

--- a/src/catalog/backends/catalog-service/src/main/java/org/geoserver/cloud/config/catalog/backend/catalogservice/CatalogClientBackendConfigurer.java
+++ b/src/catalog/backends/catalog-service/src/main/java/org/geoserver/cloud/config/catalog/backend/catalogservice/CatalogClientBackendConfigurer.java
@@ -33,7 +33,7 @@ import java.io.File;
 @EnableConfigurationProperties(CatalogClientProperties.class)
 @Import(CatalogClientConfiguration.class)
 @Slf4j(topic = "org.geoserver.cloud.config.catalogclient")
-public class CatalogClientBackendConfigurer implements GeoServerBackendConfigurer {
+public class CatalogClientBackendConfigurer extends GeoServerBackendConfigurer {
 
     private @Autowired CatalogClientCatalogFacade catalogClientFacade;
     private @Autowired CatalogClientGeoServerFacade configClientFacade;
@@ -47,26 +47,24 @@ public class CatalogClientBackendConfigurer implements GeoServerBackendConfigure
                 CatalogClientBackendConfigurer.class.getSimpleName());
     }
 
-    @Bean
-    public @Override UpdateSequence updateSequence() {
+    protected @Bean @Override UpdateSequence updateSequence() {
         throw new UnsupportedOperationException("implement");
     }
 
-    @Bean
-    public @Override GeoServerConfigurationLock configurationLock() {
+    protected @Bean @Override GeoServerConfigurationLock configurationLock() {
         throw new UnsupportedOperationException("implement");
     }
 
-    public @Override @Bean ExtendedCatalogFacade catalogFacade() {
+    protected @Bean @Override ExtendedCatalogFacade catalogFacade() {
         return catalogClientFacade;
     }
 
-    public @Override @Bean GeoServerFacade geoserverFacade() {
+    protected @Bean @Override GeoServerFacade geoserverFacade() {
         return configClientFacade;
     }
 
     @Bean(name = {"resourceStoreImpl"})
-    public @Override CatalogClientResourceStore resourceStoreImpl() {
+    protected @Override CatalogClientResourceStore resourceStoreImpl() {
         CatalogClientResourceStore store = catalogServiceResourceStore;
         File cacheDirectory = catalogClientConfig.getCacheDirectory();
         if (null != cacheDirectory) {
@@ -83,11 +81,11 @@ public class CatalogClientBackendConfigurer implements GeoServerBackendConfigure
         "wpsServiceLoader",
         "wmtsLoader"
     })
-    public @Override @Bean GeoServerLoader geoServerLoaderImpl() {
+    protected @Bean @Override GeoServerLoader geoServerLoaderImpl() {
         return new CatalogClientGeoServerLoader(resourceLoader());
     }
 
-    public @Override @Bean GeoServerResourceLoader resourceLoader() {
+    protected @Bean @Override GeoServerResourceLoader resourceLoader() {
         CatalogClientResourceStore resourceStore = resourceStoreImpl();
         GeoServerResourceLoader resourceLoader = new GeoServerResourceLoader(resourceStore);
         File cacheDirectory = catalogClientConfig.getCacheDirectory();
@@ -97,8 +95,8 @@ public class CatalogClientBackendConfigurer implements GeoServerBackendConfigure
         return resourceLoader;
     }
 
-    public @Bean ResourceStore catalogServiceFallbackResourceStore(
-            @Autowired Environment springEnv) {
+    @Bean
+    ResourceStore catalogServiceFallbackResourceStore(@Autowired Environment springEnv) {
         File dir =
                 springEnv.getProperty(
                         "geoserver.backend.catalog-service.fallback-resource-directory",

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/core/RemoteEventResourcePoolCleaupUpAutoConfiguration.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/core/RemoteEventResourcePoolCleaupUpAutoConfiguration.java
@@ -24,7 +24,8 @@ import org.springframework.context.annotation.Bean;
 @ConditionalOnCatalogEvents
 public class RemoteEventResourcePoolCleaupUpAutoConfiguration {
 
-    public @Bean RemoteEventResourcePoolProcessor remoteEventResourcePoolProcessor(
+    @Bean
+    RemoteEventResourcePoolProcessor remoteEventResourcePoolProcessor(
             @Qualifier("rawCatalog") CatalogPlugin rawCatalog) {
 
         return new RemoteEventResourcePoolProcessor(rawCatalog);

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/core/XstreamServiceLoadersAutoConfiguration.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/core/XstreamServiceLoadersAutoConfiguration.java
@@ -33,56 +33,66 @@ import org.springframework.context.annotation.Bean;
 public class XstreamServiceLoadersAutoConfiguration {
 
     @ConditionalOnMissingBean(WFSXStreamLoader.class)
-    public @Bean WFSXStreamLoader wfsLoader(GeoServerResourceLoader resourceLoader) {
+    @Bean
+    WFSXStreamLoader wfsLoader(GeoServerResourceLoader resourceLoader) {
         return log(new WFSXStreamLoader(resourceLoader));
     }
 
     @ConditionalOnMissingBean(WFSFactoryExtension.class)
-    public @Bean WFSFactoryExtension wfsFactoryExtension(GeoServerResourceLoader resourceLoader) {
+    @Bean
+    WFSFactoryExtension wfsFactoryExtension(GeoServerResourceLoader resourceLoader) {
         log.info("Automatically contributing {}", WFSFactoryExtension.class.getSimpleName());
         return new WFSFactoryExtension() {}; // constructor is protected!
     }
 
     @ConditionalOnMissingBean(WMSXStreamLoader.class)
-    public @Bean WMSXStreamLoader wmsLoader(GeoServerResourceLoader resourceLoader) {
+    @Bean
+    WMSXStreamLoader wmsLoader(GeoServerResourceLoader resourceLoader) {
         return log(new WMSXStreamLoader(resourceLoader));
     }
 
     @ConditionalOnMissingBean(WMSFactoryExtension.class)
-    public @Bean WMSFactoryExtension wmsFactoryExtension() {
+    @Bean
+    WMSFactoryExtension wmsFactoryExtension() {
         log.info("Automatically contributing {}", WMSFactoryExtension.class.getSimpleName());
         return new WMSFactoryExtension();
     }
 
     @ConditionalOnMissingBean(WCSXStreamLoader.class)
-    public @Bean WCSXStreamLoader wcsLoader(GeoServerResourceLoader resourceLoader) {
+    @Bean
+    WCSXStreamLoader wcsLoader(GeoServerResourceLoader resourceLoader) {
         return log(new WCSXStreamLoader(resourceLoader));
     }
 
     @ConditionalOnMissingBean(WCSFactoryExtension.class)
-    public @Bean WCSFactoryExtension wcsFactoryExtension() {
+    @Bean
+    WCSFactoryExtension wcsFactoryExtension() {
         log.info("Automatically contributing {}", WCSFactoryExtension.class.getSimpleName());
         return new WCSFactoryExtension();
     }
 
     @ConditionalOnMissingBean(WMTSXStreamLoader.class)
-    public @Bean WMTSXStreamLoader wmtsLoader(GeoServerResourceLoader resourceLoader) {
+    @Bean
+    WMTSXStreamLoader wmtsLoader(GeoServerResourceLoader resourceLoader) {
         return log(new WMTSXStreamLoader(resourceLoader));
     }
 
     @ConditionalOnMissingBean(WMTSFactoryExtension.class)
-    public @Bean WMTSFactoryExtension wmtsFactoryExtension() {
+    @Bean
+    WMTSFactoryExtension wmtsFactoryExtension() {
         log.info("Automatically contributing {}", WMTSFactoryExtension.class.getSimpleName());
         return new WMTSFactoryExtension() {}; // constructor is protected!
     }
 
     @ConditionalOnMissingBean(WPSXStreamLoader.class)
-    public @Bean WPSXStreamLoader wpsServiceLoader(GeoServerResourceLoader resourceLoader) {
+    @Bean
+    WPSXStreamLoader wpsServiceLoader(GeoServerResourceLoader resourceLoader) {
         return log(new WPSXStreamLoader(resourceLoader));
     }
 
     @ConditionalOnMissingBean(WPSFactoryExtension.class)
-    public @Bean WPSFactoryExtension WPSFactoryExtension() {
+    @Bean
+    WPSFactoryExtension WPSFactoryExtension() {
         log.info("Automatically contributing {}", WPSFactoryExtension.class.getSimpleName());
         return new WPSFactoryExtension() {}; // constructor is protected!
     }

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/geotools/GeoToolsHttpClientAutoConfiguration.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/geotools/GeoToolsHttpClientAutoConfiguration.java
@@ -75,9 +75,9 @@ import org.springframework.context.annotation.Bean;
 @Slf4j(topic = "org.geotools.autoconfigure.httpclient")
 public class GeoToolsHttpClientAutoConfiguration {
 
-    public @Bean SpringEnvironmentAwareGeoToolsHttpClientFactory
-            springEnvironmentAwareGeoToolsHttpClientFactory(
-                    @Autowired GeoToolsHttpClientProxyConfigurationProperties proxyConfig) {
+    @Bean
+    SpringEnvironmentAwareGeoToolsHttpClientFactory springEnvironmentAwareGeoToolsHttpClientFactory(
+            @Autowired GeoToolsHttpClientProxyConfigurationProperties proxyConfig) {
 
         log.info("Using spring environment aware GeoTools HTTPClientFactory");
         log(proxyConfig.getHttp(), "HTTP");

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/config/catalog/backend/core/CoreBackendConfiguration.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/config/catalog/backend/core/CoreBackendConfiguration.java
@@ -39,31 +39,35 @@ import org.springframework.context.event.ContextRefreshedEvent;
 @EnableConfigurationProperties(CatalogProperties.class)
 public class CoreBackendConfiguration {
 
-    public @Bean XStreamPersisterFactory xstreamPersisterFactory() {
+    @Bean
+    XStreamPersisterFactory xstreamPersisterFactory() {
         return new XStreamPersisterFactory();
     }
 
     // @Autowired
     // @DependsOn("geoServerLoaderImpl")
-    // public @Bean GeoServerLoaderProxy geoServerLoader(GeoServerResourceLoader resourceLoader)
+    // @Bean GeoServerLoaderProxy geoServerLoader(GeoServerResourceLoader resourceLoader)
     // {
     // return new GeoServerLoaderProxy(resourceLoader);
     // }
 
-    public @Bean GeoServerExtensions extensions() {
+    @Bean
+    GeoServerExtensions extensions() {
         return new GeoServerExtensions();
     }
 
     /** Usually provided by gs-main */
     @ConditionalOnMissingBean
     @DependsOn("extensions")
-    public @Bean GeoServerEnvironment environments() {
+    @Bean
+    GeoServerEnvironment environments() {
         return new GeoServerEnvironment();
     }
 
     @ConditionalOnMissingBean(CatalogPlugin.class)
     @DependsOn({"resourceLoader", "catalogFacade"})
-    public @Bean CatalogPlugin rawCatalog(
+    @Bean
+    CatalogPlugin rawCatalog(
             GeoServerResourceLoader resourceLoader,
             @Qualifier("catalogFacade") ExtendedCatalogFacade catalogFacade,
             CatalogProperties properties) {
@@ -80,8 +84,8 @@ public class CoreBackendConfiguration {
      */
     @DependsOn({"extensions", "dataDirectory", "accessRulesDao"})
     @ConditionalOnGeoServerSecurityEnabled
-    public @Bean Catalog secureCatalog(
-            @Qualifier("rawCatalog") Catalog rawCatalog, CatalogProperties properties)
+    @Bean
+    Catalog secureCatalog(@Qualifier("rawCatalog") Catalog rawCatalog, CatalogProperties properties)
             throws Exception {
         if (properties.isSecure()) return new SecureCatalogImpl(rawCatalog);
         return rawCatalog;
@@ -101,7 +105,8 @@ public class CoreBackendConfiguration {
      */
     @ConditionalOnMissingBean
     @DependsOn("layerGroupContainmentCache")
-    public @Bean DefaultResourceAccessManager defaultResourceAccessManager( //
+    @Bean
+    DefaultResourceAccessManager defaultResourceAccessManager( //
             DataAccessRuleDAO dao, //
             @Qualifier("rawCatalog") Catalog rawCatalog,
             LayerGroupContainmentCache layerGroupContainmentCache) {
@@ -129,14 +134,15 @@ public class CoreBackendConfiguration {
      * <p>
      * Update: as of geoserver 2.23.2, {@code LayerGroupContainmentCache} implements {@code ApplicationListener<ContextRefreshedEvent>}
      */
-    public @Bean LayerGroupContainmentCache layerGroupContainmentCache(
+    @Bean
+    LayerGroupContainmentCache layerGroupContainmentCache(
             @Qualifier("rawCatalog") Catalog rawCatalog) {
         return new LayerGroupContainmentCache(rawCatalog);
     }
 
     @ConditionalOnGeoServerSecurityDisabled
     @Bean(name = {"catalog", "secureCatalog"})
-    public Catalog secureCatalogDisabled(@Qualifier("rawCatalog") Catalog rawCatalog) {
+    Catalog secureCatalogDisabled(@Qualifier("rawCatalog") Catalog rawCatalog) {
         return rawCatalog;
     }
 
@@ -144,7 +150,8 @@ public class CoreBackendConfiguration {
      * @return {@link AdvertisedCatalog} decorator if {@code properties.isAdvertised() == true},
      *     {@code secureCatalog} otherwise.
      */
-    public @Bean Catalog advertisedCatalog(
+    @Bean
+    Catalog advertisedCatalog(
             @Qualifier("secureCatalog") Catalog secureCatalog, CatalogProperties properties)
             throws Exception {
         if (properties.isAdvertised()) {
@@ -160,7 +167,7 @@ public class CoreBackendConfiguration {
      *     true}, {@code advertisedCatalog} otherwise
      */
     @Bean(name = {"catalog", "localWorkspaceCatalog"})
-    public Catalog localWorkspaceCatalog(
+    Catalog localWorkspaceCatalog(
             @Qualifier("advertisedCatalog") Catalog advertisedCatalog, CatalogProperties properties)
             throws Exception {
         return properties.isLocalWorkspace()
@@ -169,7 +176,8 @@ public class CoreBackendConfiguration {
     }
 
     @ConditionalOnMissingBean(GeoServerImpl.class)
-    public @Bean(name = "geoServer") GeoServerImpl geoServer(
+    @Bean(name = "geoServer")
+    GeoServerImpl geoServer(
             @Qualifier("catalog") Catalog catalog,
             @Qualifier("geoserverFacade") GeoServerFacade facade)
             throws Exception {
@@ -179,7 +187,8 @@ public class CoreBackendConfiguration {
     }
 
     @Autowired
-    public @Bean GeoServerDataDirectory dataDirectory(GeoServerResourceLoader resourceLoader) {
+    @Bean
+    GeoServerDataDirectory dataDirectory(GeoServerResourceLoader resourceLoader) {
         return new GeoServerDataDirectory(resourceLoader);
     }
 }

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/config/catalog/backend/core/GeoServerBackendConfigurer.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/config/catalog/backend/core/GeoServerBackendConfigurer.java
@@ -14,7 +14,6 @@ import org.geoserver.platform.resource.ResourceStore;
 import org.geoserver.platform.resource.ResourceStoreFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Bean;
 
 /**
  * Unified provider interface for the complete GeoServer backend storage (catalog and config).
@@ -34,31 +33,24 @@ import org.springframework.context.annotation.Bean;
  * ConditionalOnProperty @ConditionalOnProperty}, {@link ConditionalOnClass @ConditionalOnClass},
  * etc.
  */
-public interface GeoServerBackendConfigurer {
+public abstract class GeoServerBackendConfigurer {
 
-    @Bean
-    GeoServerConfigurationLock configurationLock();
+    protected abstract GeoServerConfigurationLock configurationLock();
 
-    @Bean
-    UpdateSequence updateSequence();
+    protected abstract UpdateSequence updateSequence();
 
-    @Bean
-    ExtendedCatalogFacade catalogFacade();
+    protected abstract ExtendedCatalogFacade catalogFacade();
 
-    @Bean
-    GeoServerLoader geoServerLoaderImpl();
+    protected abstract GeoServerLoader geoServerLoaderImpl();
 
-    @Bean
-    GeoServerFacade geoserverFacade();
+    protected abstract GeoServerFacade geoserverFacade();
 
     /**
      * {@link ResourceStore} named {@code resourceStoreImpl}, as looked up in the application
      * context by {@link ResourceStoreFactory}. With this, we don't need a bean called
      * "dataDirectoryResourceStore" at all.
      */
-    @Bean
-    ResourceStore resourceStoreImpl();
+    protected abstract ResourceStore resourceStoreImpl();
 
-    @Bean
-    GeoServerResourceLoader resourceLoader();
+    protected abstract GeoServerResourceLoader resourceLoader();
 }

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/event/remote/resourcepool/RemoteEventResourcePoolProcessor.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/event/remote/resourcepool/RemoteEventResourcePoolProcessor.java
@@ -20,7 +20,6 @@ import org.geoserver.cloud.event.catalog.CatalogInfoModified;
 import org.geoserver.cloud.event.catalog.CatalogInfoRemoved;
 import org.geoserver.cloud.event.info.ConfigInfoType;
 import org.geoserver.cloud.event.info.InfoEvent;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
 
 import java.util.Optional;
@@ -40,7 +39,7 @@ public class RemoteEventResourcePoolProcessor {
      * @param rawCatalog used to evict cached live data sources from its {@link
      *     Catalog#getResourcePool() ResourcePool}
      */
-    public @Autowired RemoteEventResourcePoolProcessor(Catalog rawCatalog) {
+    public RemoteEventResourcePoolProcessor(Catalog rawCatalog) {
         this.rawCatalog = rawCatalog;
     }
 

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/security/GeoServerSecurityConfiguration.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/security/GeoServerSecurityConfiguration.java
@@ -63,7 +63,7 @@ public class GeoServerSecurityConfiguration {
     }
 
     @Bean
-    public EnvironmentAdminAuthenticationProvider environmentAdminAuthenticationProvider() {
+    EnvironmentAdminAuthenticationProvider environmentAdminAuthenticationProvider() {
         return new EnvironmentAdminAuthenticationProvider();
     }
 
@@ -77,7 +77,7 @@ public class GeoServerSecurityConfiguration {
      */
     @Bean(name = {"authenticationManager", "geoServerSecurityManager"})
     @DependsOn({"extensions"})
-    public CloudGeoServerSecurityManager cloudAuthenticationManager( //
+    CloudGeoServerSecurityManager cloudAuthenticationManager( //
             GeoServerDataDirectory dataDir, //
             ApplicationEventPublisher localContextPublisher, //
             UpdateSequence updateSequence, //

--- a/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/datadir/RemoteEventDataDirectoryAutoConfiguration.java
+++ b/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/datadir/RemoteEventDataDirectoryAutoConfiguration.java
@@ -17,7 +17,8 @@ import org.springframework.context.annotation.Bean;
 @ConditionalOnCatalogEvents
 public class RemoteEventDataDirectoryAutoConfiguration {
 
-    public @Bean RemoteEventDataDirectoryProcessor dataDirectoryRemoteEventProcessor(
+    @Bean
+    RemoteEventDataDirectoryProcessor dataDirectoryRemoteEventProcessor(
             @Qualifier("geoserverFacade") RepositoryGeoServerFacade configFacade,
             @Qualifier("catalogFacade") ExtendedCatalogFacade catalogFacade) {
         return new RemoteEventDataDirectoryProcessor(configFacade, catalogFacade);

--- a/src/catalog/backends/jdbcconfig/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/jdbcconfig/RemoteEventJdbcConfigAutoConfiguration.java
+++ b/src/catalog/backends/jdbcconfig/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/jdbcconfig/RemoteEventJdbcConfigAutoConfiguration.java
@@ -15,7 +15,7 @@ import org.springframework.context.annotation.Configuration;
 public class RemoteEventJdbcConfigAutoConfiguration {
 
     @Bean
-    public RemoteEventJdbcConfigProcessor jdbcConfigRemoteEventProcessor() {
+    RemoteEventJdbcConfigProcessor jdbcConfigRemoteEventProcessor() {
         return new RemoteEventJdbcConfigProcessor();
     }
 }

--- a/src/catalog/backends/jdbcconfig/src/main/java/org/geoserver/cloud/config/catalog/backend/jdbcconfig/JDBCConfigWebConfiguration.java
+++ b/src/catalog/backends/jdbcconfig/src/main/java/org/geoserver/cloud/config/catalog/backend/jdbcconfig/JDBCConfigWebConfiguration.java
@@ -17,7 +17,7 @@ public class JDBCConfigWebConfiguration {
      * geoserver.backend.jdbcconfig.web.enabled} is true, defaulting to true
      */
     @Bean("JDBCConfigStatusProvider")
-    public JDBCConfigStatusProvider jdbcConfigStatusProvider(JDBCConfigProperties config) {
+    JDBCConfigStatusProvider jdbcConfigStatusProvider(JDBCConfigProperties config) {
         return new JDBCConfigStatusProvider(config);
     }
 }

--- a/src/catalog/backends/pgsql/src/main/java/org/geoserver/cloud/config/catalog/backend/pgsql/PgsqlBackendConfiguration.java
+++ b/src/catalog/backends/pgsql/src/main/java/org/geoserver/cloud/config/catalog/backend/pgsql/PgsqlBackendConfiguration.java
@@ -4,8 +4,6 @@
  */
 package org.geoserver.cloud.config.catalog.backend.pgsql;
 
-import lombok.extern.slf4j.Slf4j;
-
 import org.geoserver.GeoServerConfigurationLock;
 import org.geoserver.catalog.plugin.CatalogPlugin;
 import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
@@ -42,9 +40,8 @@ import javax.sql.DataSource;
 /**
  * @since 1.4
  */
-@Slf4j
 @Configuration(proxyBeanMethods = true)
-public class PgsqlBackendConfiguration implements GeoServerBackendConfigurer {
+public class PgsqlBackendConfiguration extends GeoServerBackendConfigurer {
 
     private String instanceId;
     private DataSource dataSource;
@@ -80,28 +77,20 @@ public class PgsqlBackendConfiguration implements GeoServerBackendConfigurer {
         return template;
     }
 
-    @Bean
-    @Override
-    public GeoServerConfigurationLock configurationLock() {
+    protected @Bean @Override GeoServerConfigurationLock configurationLock() {
         LockProvider lockProvider = pgsqlLockProvider();
         return new LockProviderGeoServerConfigurationLock(lockProvider);
     }
 
-    @Bean
-    @Override
-    public PgsqlUpdateSequence updateSequence() {
+    protected @Bean @Override PgsqlUpdateSequence updateSequence() {
         return new PgsqlUpdateSequence(dataSource, geoserverFacade());
     }
 
-    @Bean
-    @Override
-    public PgsqlCatalogFacade catalogFacade() {
+    protected @Bean @Override PgsqlCatalogFacade catalogFacade() {
         return new PgsqlCatalogFacade(template());
     }
 
-    @Bean
-    @Override
-    public GeoServerLoader geoServerLoaderImpl() {
+    protected @Bean @Override GeoServerLoader geoServerLoaderImpl() {
         return new PgsqlGeoServerLoader(resourceLoader(), configurationLock());
     }
 
@@ -110,15 +99,11 @@ public class PgsqlBackendConfiguration implements GeoServerBackendConfigurer {
         return new PgsqlConfigRepository(template());
     }
 
-    @Bean
-    @Override
-    public PgsqlGeoServerFacade geoserverFacade() {
+    protected @Bean @Override PgsqlGeoServerFacade geoserverFacade() {
         return new PgsqlGeoServerFacade(configRepository());
     }
 
-    @Bean
-    @Override
-    public ResourceStore resourceStoreImpl() {
+    protected @Bean @Override ResourceStore resourceStoreImpl() {
         FileSystemResourceStoreCache resourceStoreCache = pgsqlFileSystemResourceStoreCache();
         JdbcTemplate template = template();
         PgsqlLockProvider lockProvider = pgsqlLockProvider();
@@ -130,9 +115,7 @@ public class PgsqlBackendConfiguration implements GeoServerBackendConfigurer {
         return FileSystemResourceStoreCache.newTempDirInstance();
     }
 
-    @Bean
-    @Override
-    public PgsqlGeoServerResourceLoader resourceLoader() {
+    protected @Bean @Override PgsqlGeoServerResourceLoader resourceLoader() {
         return new PgsqlGeoServerResourceLoader(resourceStoreImpl());
     }
 

--- a/src/catalog/cache/src/main/java/org/geoserver/cloud/autoconfigure/catalog/cache/RemoteEventCacheAutoConfiguration.java
+++ b/src/catalog/cache/src/main/java/org/geoserver/cloud/autoconfigure/catalog/cache/RemoteEventCacheAutoConfiguration.java
@@ -28,7 +28,8 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnCatalogEvents
 public class RemoteEventCacheAutoConfiguration {
 
-    public @Bean RemoteEventCacheEvictor remoteEventCacheEvictor(
+    @Bean
+    RemoteEventCacheEvictor remoteEventCacheEvictor(
             CachingCatalogFacade cachingCatalogFacade,
             CachingGeoServerFacade cachingGeoServerFacade) {
 

--- a/src/catalog/cache/src/main/java/org/geoserver/cloud/catalog/cache/GeoServerBackendCacheConfiguration.java
+++ b/src/catalog/cache/src/main/java/org/geoserver/cloud/catalog/cache/GeoServerBackendCacheConfiguration.java
@@ -35,7 +35,8 @@ public class GeoServerBackendCacheConfiguration implements BeanPostProcessor {
         return new CacheConfigurationPostProcessor();
     }
 
-    public @Bean CachingCatalogFacade cachingCatalogFacade(
+    @Bean
+    CachingCatalogFacade cachingCatalogFacade(
             @Qualifier("catalogFacade") CatalogFacade rawCatalogFacade) {
         CatalogFacade raw = rawCatalogFacade;
         ExtendedCatalogFacade facade;
@@ -47,7 +48,8 @@ public class GeoServerBackendCacheConfiguration implements BeanPostProcessor {
         return new CachingCatalogFacadeImpl(facade);
     }
 
-    public @Bean CachingGeoServerFacade cachingGeoServerFacade(
+    @Bean
+    CachingGeoServerFacade cachingGeoServerFacade(
             @Qualifier("geoserverFacade") GeoServerFacade rawGeoServerFacade) {
         return new CachingGeoServerFacadeImpl(rawGeoServerFacade);
     }

--- a/src/catalog/catalog-server/client/src/main/java/org/geoserver/cloud/catalog/client/impl/CatalogClientConfiguration.java
+++ b/src/catalog/catalog-server/client/src/main/java/org/geoserver/cloud/catalog/client/impl/CatalogClientConfiguration.java
@@ -40,7 +40,8 @@ public class CatalogClientConfiguration {
     private @Autowired ReactiveConfigClient configClient;
     private @Autowired ReactiveResourceStoreClient resourceStoreClient;
 
-    public @Bean CatalogClientCatalogFacade rawCatalogServiceFacade() {
+    @Bean
+    CatalogClientCatalogFacade rawCatalogServiceFacade() {
         RepositoryCatalogFacade rawFacade = new RepositoryCatalogFacadeImpl();
         rawFacade.setWorkspaceRepository(cloudWorkspaceRepository);
         rawFacade.setNamespaceRepository(cloudNamespaceRepository);
@@ -55,22 +56,25 @@ public class CatalogClientConfiguration {
         return facade;
     }
 
-    public @Bean CatalogClientConfigRepository catalogServiceConfigRepository() {
+    @Bean
+    CatalogClientConfigRepository catalogServiceConfigRepository() {
         return new CatalogClientConfigRepository(configClient);
     }
 
-    public @Bean CatalogClientGeoServerFacade catalogServiceGeoServerFacade() {
+    @Bean
+    CatalogClientGeoServerFacade catalogServiceGeoServerFacade() {
         return new CatalogClientGeoServerFacade(catalogServiceConfigRepository());
     }
 
-    public @Bean CatalogClientResourceStore catalogServiceResourceStore() {
+    @Bean
+    CatalogClientResourceStore catalogServiceResourceStore() {
         BlockingResourceStoreClient blockingClient =
                 new BlockingResourceStoreClient(resourceStoreClient);
         return new CatalogClientResourceStore(blockingClient);
     }
 
     // @ConditionalOnProperty(name = "reactive.feign.jetty", havingValue = "true")
-    // public @Bean JettyHttpClientFactory jettyHttpClientFactory() {
+    // @Bean JettyHttpClientFactory jettyHttpClientFactory() {
     // return new JettyHttpClientFactory() {
     //
     // @Override

--- a/src/catalog/catalog-server/client/src/main/java/org/geoserver/cloud/catalog/client/impl/InnerResolvingProxy.java
+++ b/src/catalog/catalog-server/client/src/main/java/org/geoserver/cloud/catalog/client/impl/InnerResolvingProxy.java
@@ -114,7 +114,7 @@ public class InnerResolvingProxy {
     }
 
     @SuppressWarnings("unchecked")
-    private Set<Object> newSet(Class<? extends Set> class1) {
+    private Set<Object> newSet(@SuppressWarnings("rawtypes") Class<? extends Set> class1) {
         try {
             return class1.getConstructor().newInstance();
         } catch (Exception e) {

--- a/src/catalog/catalog-server/client/src/main/java/org/geoserver/cloud/catalog/client/reactivefeign/ReactiveFeignConfigurationOverrides.java
+++ b/src/catalog/catalog-server/client/src/main/java/org/geoserver/cloud/catalog/client/reactivefeign/ReactiveFeignConfigurationOverrides.java
@@ -19,7 +19,8 @@ import java.util.List;
 @Configuration
 public class ReactiveFeignConfigurationOverrides {
 
-    public @Bean Contract reactiveFeignClientContract() {
+    @Bean
+    Contract reactiveFeignClientContract() {
         return new FallbackContract(new SpringMvcContract(), new Contract.Default());
     }
 

--- a/src/catalog/catalog-server/client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientRepositoryConfiguration.java
+++ b/src/catalog/catalog-server/client/src/main/java/org/geoserver/cloud/catalog/client/repository/CatalogClientRepositoryConfiguration.java
@@ -13,35 +13,43 @@ import org.springframework.context.annotation.Import;
 @Import(ReactiveCatalogApiClientConfiguration.class)
 public class CatalogClientRepositoryConfiguration {
 
-    public @Bean CatalogClientWorkspaceRepository cloudWorkspaceRepository() {
+    @Bean
+    CatalogClientWorkspaceRepository cloudWorkspaceRepository() {
         return new CatalogClientWorkspaceRepository();
     }
 
-    public @Bean CatalogClientNamespaceRepository cloudNamespaceRepository() {
+    @Bean
+    CatalogClientNamespaceRepository cloudNamespaceRepository() {
         return new CatalogClientNamespaceRepository();
     }
 
-    public @Bean CatalogClientStoreRepository cloudStoreRepository() {
+    @Bean
+    CatalogClientStoreRepository cloudStoreRepository() {
         return new CatalogClientStoreRepository();
     }
 
-    public @Bean CatalogClientResourceRepository cloudResourceRepository() {
+    @Bean
+    CatalogClientResourceRepository cloudResourceRepository() {
         return new CatalogClientResourceRepository();
     }
 
-    public @Bean CatalogClientLayerRepository cloudLayerRepository() {
+    @Bean
+    CatalogClientLayerRepository cloudLayerRepository() {
         return new CatalogClientLayerRepository();
     }
 
-    public @Bean CatalogClientLayerGroupRepository cloudLayerGroupRepository() {
+    @Bean
+    CatalogClientLayerGroupRepository cloudLayerGroupRepository() {
         return new CatalogClientLayerGroupRepository();
     }
 
-    public @Bean CatalogClientStyleRepository cloudStyleRepository() {
+    @Bean
+    CatalogClientStyleRepository cloudStyleRepository() {
         return new CatalogClientStyleRepository();
     }
 
-    public @Bean CatalogClientMapRepository cloudMapRepository() {
+    @Bean
+    CatalogClientMapRepository cloudMapRepository() {
         return new CatalogClientMapRepository();
     }
 }

--- a/src/catalog/catalog-server/server/pom.xml
+++ b/src/catalog/catalog-server/server/pom.xml
@@ -25,5 +25,10 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 </project>

--- a/src/catalog/catalog-server/server/src/main/java/org/geoserver/cloud/catalog/server/config/CatalogServerConfiguration.java
+++ b/src/catalog/catalog-server/server/src/main/java/org/geoserver/cloud/catalog/server/config/CatalogServerConfiguration.java
@@ -27,7 +27,8 @@ public class CatalogServerConfiguration implements WebFluxConfigurer {
     // private @Autowired ObjectMapper objectMapper;
 
     @ConfigurationProperties(prefix = "geoserver.catalog-service")
-    public @Bean CatalogServerConfigProperties applicationConfig() {
+    @Bean
+    CatalogServerConfigProperties applicationConfig() {
         return new CatalogServerConfigProperties();
     }
 
@@ -35,7 +36,8 @@ public class CatalogServerConfiguration implements WebFluxConfigurer {
      * Configures the reactive Scheduler thread pool on which {@link ReactiveCatalogService}
      * performs the blocking catalog calls
      */
-    public @Bean Scheduler catalogScheduler() {
+    @Bean
+    Scheduler catalogScheduler() {
         CatalogServerConfigProperties config = applicationConfig();
         SchedulerConfig schedulerConfig = config.getIoThreads();
         int maxThreads = schedulerConfig.getMaxSize();
@@ -61,7 +63,7 @@ public class CatalogServerConfiguration implements WebFluxConfigurer {
      * {"WorkspaceInfo" : {...}}
      * </code>
      */
-    // public @Bean ObjectMapper objectMapper() {
+    // @Bean ObjectMapper objectMapper() {
     // ObjectMapper objectMapper = new ObjectMapper();
     // objectMapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
     // objectMapper.configure(DeserializationFeature.UNWRAP_ROOT_VALUE, false);

--- a/src/catalog/catalog-server/server/src/test/java/org/geoserver/cloud/catalog/server/test/WebTestClientSupportConfiguration.java
+++ b/src/catalog/catalog-server/server/src/test/java/org/geoserver/cloud/catalog/server/test/WebTestClientSupportConfiguration.java
@@ -16,7 +16,8 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 @AutoConfigureWebTestClient(timeout = "360000")
 public class WebTestClientSupportConfiguration {
 
-    public @Bean WebTestClientSupport webTestClientSupport() {
+    @Bean
+    WebTestClientSupport webTestClientSupport() {
         return new WebTestClientSupport();
     }
 }

--- a/src/catalog/event-bus/src/main/java/org/geoserver/cloud/autoconfigure/event/bus/RemoteGeoServerEventsAutoConfiguration.java
+++ b/src/catalog/event-bus/src/main/java/org/geoserver/cloud/autoconfigure/event/bus/RemoteGeoServerEventsAutoConfiguration.java
@@ -57,7 +57,8 @@ public class RemoteGeoServerEventsAutoConfiguration {
      * RemoteGeoServerEvent} payload, especially {@link Literal} expressions.
      */
     @ConditionalOnMissingBean(GeoToolsFilterModule.class)
-    public @Bean GeoToolsFilterModule geoToolsFilterModule() {
+    @Bean
+    GeoToolsFilterModule geoToolsFilterModule() {
         return new GeoToolsFilterModule();
     }
 
@@ -66,7 +67,8 @@ public class RemoteGeoServerEventsAutoConfiguration {
      * present, so {@link CatalogInfo} objects can be used as {@link RemoteGeoServerEvent} payload
      */
     @ConditionalOnMissingBean(GeoServerCatalogModule.class)
-    public @Bean GeoServerCatalogModule geoServerCatalogJacksonModule() {
+    @Bean
+    GeoServerCatalogModule geoServerCatalogJacksonModule() {
         return new GeoServerCatalogModule();
     }
 
@@ -76,7 +78,8 @@ public class RemoteGeoServerEventsAutoConfiguration {
      * payload
      */
     @ConditionalOnMissingBean(GeoServerConfigModule.class)
-    public @Bean GeoServerConfigModule geoServerConfigJacksonModule() {
+    @Bean
+    GeoServerConfigModule geoServerConfigJacksonModule() {
         return new GeoServerConfigModule();
     }
 
@@ -88,12 +91,14 @@ public class RemoteGeoServerEventsAutoConfiguration {
      * <p>This listener ensures the payload object properties are resolved before being catch up by
      * other listeners.
      */
-    public @Bean InfoEventResolver remoteInfoEventInboundResolver(
+    @Bean
+    InfoEventResolver remoteInfoEventInboundResolver(
             @Qualifier("rawCatalog") Catalog rawCatalog, GeoServer geoserver) {
         return new InfoEventResolver(rawCatalog, geoserver);
     }
 
-    public @Bean RemoteGeoServerEventMapper remoteGeoServerEventMapper(
+    @Bean
+    RemoteGeoServerEventMapper remoteGeoServerEventMapper(
             InfoEventResolver remoteEventPropertiesResolver,
             ServiceMatcher serviceMatcher,
             Destination.Factory destinationFactory) {
@@ -102,7 +107,8 @@ public class RemoteGeoServerEventsAutoConfiguration {
                 remoteEventPropertiesResolver, serviceMatcher, destinationFactory);
     }
 
-    public @Bean RemoteGeoServerEventBridge remoteEventBroadcaster(
+    @Bean
+    RemoteGeoServerEventBridge remoteEventBroadcaster(
             ApplicationEventPublisher eventPublisher,
             RemoteGeoServerEventMapper eventMapper,
             ServiceMatcher serviceMatcher) {

--- a/src/catalog/event-bus/src/test/java/org/geoserver/cloud/event/bus/CatalogRemoteApplicationEventsIT.java
+++ b/src/catalog/event-bus/src/test/java/org/geoserver/cloud/event/bus/CatalogRemoteApplicationEventsIT.java
@@ -374,6 +374,7 @@ public class CatalogRemoteApplicationEventsIT extends BusAmqpIntegrationTests {
                         catalog::save);
 
         Property atts = patch.get("attributes").orElseThrow();
+        @SuppressWarnings("unchecked")
         List<AttributeTypeInfo> decodedAtts = (List<AttributeTypeInfo>) atts.getValue();
         assertEquals(attributes.size(), decodedAtts.size());
         IntStream.range(0, attributes.size())

--- a/src/catalog/event-bus/src/test/java/org/geoserver/cloud/event/bus/TestConfigurationAutoConfiguration.java
+++ b/src/catalog/event-bus/src/test/java/org/geoserver/cloud/event/bus/TestConfigurationAutoConfiguration.java
@@ -20,11 +20,13 @@ import org.springframework.context.annotation.Bean;
 @SpringBootConfiguration
 public class TestConfigurationAutoConfiguration {
 
-    public @Bean UpdateSequence testUpdateSequence(GeoServer gs) {
+    @Bean
+    UpdateSequence testUpdateSequence(GeoServer gs) {
         return new DefaultUpdateSequence(gs);
     }
 
-    public @Bean XStreamPersisterFactory xStreamPersisterFactory() {
+    @Bean
+    XStreamPersisterFactory xStreamPersisterFactory() {
         return new XStreamPersisterFactory();
     }
 
@@ -33,7 +35,8 @@ public class TestConfigurationAutoConfiguration {
         return new CatalogPlugin(false);
     }
 
-    public @Bean GeoServer geoServer(@Qualifier("catalog") Catalog catalog) {
+    @Bean
+    GeoServer geoServer(@Qualifier("catalog") Catalog catalog) {
         GeoServerImpl gs = new org.geoserver.config.plugin.GeoServerImpl();
         gs.setCatalog(catalog);
         return gs;

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/autoconfigure/catalog/event/UpdateSequenceControllerAutoConfiguration.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/autoconfigure/catalog/event/UpdateSequenceControllerAutoConfiguration.java
@@ -20,7 +20,8 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 @EnableGlobalMethodSecurity(jsr250Enabled = true)
 public class UpdateSequenceControllerAutoConfiguration {
 
-    public @Bean UpdateSequenceController updateSequenceController( //
+    @Bean
+    UpdateSequenceController updateSequenceController( //
             UpdateSequence updateSequence, //
             ApplicationEventPublisher eventPublisher, //
             GeoServer geoServer //

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/config/catalog/events/CatalogApplicationEventsConfiguration.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/config/catalog/events/CatalogApplicationEventsConfiguration.java
@@ -19,7 +19,8 @@ import java.util.function.Supplier;
 @Configuration(proxyBeanMethods = false)
 public class CatalogApplicationEventsConfiguration {
 
-    public @Bean CatalogApplicationEventPublisher localApplicationEventPublisher( //
+    @Bean
+    CatalogApplicationEventPublisher localApplicationEventPublisher( //
             @Qualifier("catalog") Catalog catalog, //
             @Qualifier("geoServer") GeoServer geoServer, //
             ApplicationEventPublisher localContextPublisher, //

--- a/src/catalog/events/src/test/java/org/geoserver/cloud/config/catalog/events/TestConfigurationAutoConfiguration.java
+++ b/src/catalog/events/src/test/java/org/geoserver/cloud/config/catalog/events/TestConfigurationAutoConfiguration.java
@@ -20,11 +20,13 @@ import org.springframework.context.annotation.Bean;
 @SpringBootConfiguration
 class TestConfigurationAutoConfiguration {
 
-    public @Bean UpdateSequence testUpdateSequence(GeoServer gs) {
+    @Bean
+    UpdateSequence testUpdateSequence(GeoServer gs) {
         return new DefaultUpdateSequence(gs);
     }
 
-    public @Bean XStreamPersisterFactory xStreamPersisterFactory() {
+    @Bean
+    XStreamPersisterFactory xStreamPersisterFactory() {
         return new XStreamPersisterFactory();
     }
 
@@ -34,7 +36,8 @@ class TestConfigurationAutoConfiguration {
         return new CatalogPlugin(isolated);
     }
 
-    public @Bean GeoServer geoServer(@Qualifier("catalog") Catalog catalog) {
+    @Bean
+    GeoServer geoServer(@Qualifier("catalog") Catalog catalog) {
         GeoServerImpl gs = new org.geoserver.config.plugin.GeoServerImpl();
         gs.setCatalog(catalog);
         return gs;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/mapper/ValueMappers.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/mapper/ValueMappers.java
@@ -33,6 +33,7 @@ import org.geoserver.jackson.databind.catalog.dto.MetadataMapDto;
 import org.geoserver.jackson.databind.catalog.dto.NumberRangeDto;
 import org.geoserver.jackson.databind.catalog.dto.QueryDto;
 import org.geoserver.jackson.databind.catalog.dto.VirtualTableDto;
+import org.geoserver.jackson.databind.mapper.InfoReferenceMapper;
 import org.geoserver.jackson.databind.mapper.SharedMappers;
 import org.geotools.api.coverage.SampleDimensionType;
 import org.geotools.api.coverage.grid.GridEnvelope;
@@ -53,6 +54,7 @@ import org.geotools.util.SimpleInternationalString;
 import org.mapstruct.InheritInverseConfiguration;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 import org.slf4j.LoggerFactory;
 
@@ -64,7 +66,10 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-@Mapper(config = CatalogInfoMapperConfig.class)
+@Mapper(
+        componentModel = "default",
+        unmappedTargetPolicy = ReportingPolicy.ERROR,
+        uses = {ObjectFacotries.class, SharedMappers.class, InfoReferenceMapper.class})
 public interface ValueMappers {
 
     org.geotools.util.Converter str2Measure =

--- a/src/catalog/jackson-bindings/geotools/src/main/java/org/geotools/jackson/databind/filter/dto/LiteralDeserializer.java
+++ b/src/catalog/jackson-bindings/geotools/src/main/java/org/geotools/jackson/databind/filter/dto/LiteralDeserializer.java
@@ -77,7 +77,7 @@ public class LiteralDeserializer extends JsonDeserializer<Literal> {
         } else if (Map.class.isAssignableFrom(type)) {
             value = readMap(parser, ctxt);
         } else {
-            JsonToken token = parser.nextToken();
+            parser.nextToken();
             value = ctxt.readValue(parser, type);
         }
         JsonToken token = parser.nextToken();

--- a/src/catalog/jackson-bindings/geotools/src/main/java/org/geotools/jackson/databind/filter/mapper/ExpressionMapper.java
+++ b/src/catalog/jackson-bindings/geotools/src/main/java/org/geotools/jackson/databind/filter/mapper/ExpressionMapper.java
@@ -4,7 +4,6 @@
  */
 package org.geotools.jackson.databind.filter.mapper;
 
-import org.geotools.api.filter.FilterFactory;
 import org.geotools.api.filter.expression.ExpressionVisitor;
 import org.geotools.api.filter.expression.NilExpression;
 import org.geotools.factory.CommonFactoryFinder;
@@ -21,13 +20,17 @@ import org.geotools.jackson.databind.filter.dto.Literal;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ObjectFactory;
+import org.mapstruct.ReportingPolicy;
 
 import java.util.List;
 
-@Mapper(config = FilterMapperConfig.class)
+@Mapper(
+        componentModel = "default",
+        unmappedTargetPolicy = ReportingPolicy.ERROR,
+        uses = {ExpressionFactory.class, FilterFactory.class, ValueMappers.class})
 public abstract class ExpressionMapper {
 
-    private final FilterFactory ff = CommonFactoryFinder.getFilterFactory();
+    private final org.geotools.api.filter.FilterFactory ff = CommonFactoryFinder.getFilterFactory();
 
     private final ExpressionVisitor visitor =
             new ExpressionVisitor() {

--- a/src/catalog/jackson-bindings/geotools/src/main/java/org/geotools/jackson/databind/filter/mapper/ValueMappers.java
+++ b/src/catalog/jackson-bindings/geotools/src/main/java/org/geotools/jackson/databind/filter/mapper/ValueMappers.java
@@ -9,15 +9,15 @@ import org.geotools.jackson.databind.filter.dto.Filter.MultiValuedFilter.MatchAc
 import org.geotools.util.Converters;
 import org.geotools.util.SimpleInternationalString;
 import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
 import org.xml.sax.helpers.NamespaceSupport;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 
-@Mapper(config = FilterMapperConfig.class)
+@Mapper(componentModel = "default", unmappedTargetPolicy = ReportingPolicy.ERROR)
 public abstract class ValueMappers {
 
     public abstract MatchAction matchAction(
@@ -54,13 +54,6 @@ public abstract class ValueMappers {
     }
 
     public String classToCanonicalName(Class<?> value) {
-        //        if (null == value)
-        //            return null;
-        //        if (value.isArray())
-        //            return value.getCanonicalName();
-        //        if (value.isPrimitive())
-        //            return value.getCanonicalName();
-
         return value.getName();
     }
 
@@ -74,40 +67,6 @@ public abstract class ValueMappers {
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
-        //
-        //        final boolean isArray = value.endsWith("[]");
-        //        final String className = isArray ? value.substring(0, value.indexOf('[')) : value;
-        //        try {
-        //            Class<?> binding;
-        //            if (isArray) {
-        //                Optional<Class<?>> primitiveArrayType = primitiveArrayType(className);
-        //                if (primitiveArrayType.isPresent()) {
-        //                    binding = primitiveArrayType.get();
-        //                } else {
-        //                    binding = Class.forName(className).arrayType();
-        //                }
-        //            } else {
-        //                binding = Class.forName(className);
-        //            }
-        //            return binding;
-        //        } catch (ClassNotFoundException e) {
-        //            throw new RuntimeException(e);
-        //        }
-    }
-
-    private Optional<Class<?>> primitiveArrayType(String className) {
-        return Optional.ofNullable(
-                switch (className) {
-                    case "byte" -> byte[].class;
-                    case "boolean" -> boolean[].class;
-                    case "char" -> char[].class;
-                    case "short" -> short[].class;
-                    case "int" -> int[].class;
-                    case "long" -> long[].class;
-                    case "float" -> float[].class;
-                    case "double" -> double[].class;
-                    default -> null;
-                });
     }
 
     private <F, T> T convert(F value, Function<F, T> nonnNullMapper) {

--- a/src/catalog/jackson-bindings/starter/src/main/java/org/geoserver/cloud/autoconfigure/jackson/GeoServerJacksonBindingsAutoConfiguration.java
+++ b/src/catalog/jackson-bindings/starter/src/main/java/org/geoserver/cloud/autoconfigure/jackson/GeoServerJacksonBindingsAutoConfiguration.java
@@ -30,12 +30,14 @@ import org.springframework.context.annotation.Bean;
 public class GeoServerJacksonBindingsAutoConfiguration {
 
     @ConditionalOnMissingBean(GeoServerCatalogModule.class)
-    public @Bean GeoServerCatalogModule geoServerCatalogJacksonModule() {
+    @Bean
+    GeoServerCatalogModule geoServerCatalogJacksonModule() {
         return new GeoServerCatalogModule();
     }
 
     @ConditionalOnMissingBean(GeoServerConfigModule.class)
-    public @Bean GeoServerConfigModule geoServerConfigJacksonModule() {
+    @Bean
+    GeoServerConfigModule geoServerConfigJacksonModule() {
         return new GeoServerConfigModule();
     }
 }

--- a/src/catalog/jackson-bindings/starter/src/main/java/org/geoserver/cloud/autoconfigure/jackson/GeoToolsJacksonBindingsAutoConfiguration.java
+++ b/src/catalog/jackson-bindings/starter/src/main/java/org/geoserver/cloud/autoconfigure/jackson/GeoToolsJacksonBindingsAutoConfiguration.java
@@ -31,15 +31,18 @@ import org.springframework.context.annotation.Bean;
 public class GeoToolsJacksonBindingsAutoConfiguration {
 
     @ConditionalOnMissingBean(JavaTimeModule.class)
-    public @Bean JavaTimeModule javaTimeModule() {
+    @Bean
+    JavaTimeModule javaTimeModule() {
         return new JavaTimeModule();
     }
 
-    public @Bean GeoToolsGeoJsonModule geoToolsGeoJsonModule() {
+    @Bean
+    GeoToolsGeoJsonModule geoToolsGeoJsonModule() {
         return new GeoToolsGeoJsonModule();
     }
 
-    public @Bean GeoToolsFilterModule geoToolsFilterModule() {
+    @Bean
+    GeoToolsFilterModule geoToolsFilterModule() {
         return new GeoToolsFilterModule();
     }
 }

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogPlugin.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogPlugin.java
@@ -1517,7 +1517,7 @@ public class CatalogPlugin extends CatalogImpl implements Catalog {
         }
     }
 
-    <T extends CatalogInfo> T detached(T original, T detached) {
+    private <T extends CatalogInfo> T detached(T original, T detached) {
         return detached != null ? detached : original;
     }
 

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingCatalog.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingCatalog.java
@@ -703,7 +703,7 @@ public class ForwardingCatalog implements Catalog {
         return catalog.list(of, filter, offset, count, sortBy);
     }
 
-    public @Override void removeListeners(@SuppressWarnings("rawtypes") Class listenerClass) {
+    public @Override void removeListeners(Class<? extends CatalogListener> listenerClass) {
         catalog.removeListeners(listenerClass);
     }
 

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/ProxyUtils.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/ProxyUtils.java
@@ -143,7 +143,7 @@ public class ProxyUtils {
     }
 
     @SuppressWarnings("unchecked")
-    private Set<Object> newSet(Class<? extends Set> class1) {
+    private Set<Object> newSet(@SuppressWarnings("rawtypes") Class<? extends Set> class1) {
         try {
             return class1.getConstructor().newInstance();
         } catch (Exception e) {

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/WMSIntegrationAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/WMSIntegrationAutoConfiguration.java
@@ -78,8 +78,8 @@ public class WMSIntegrationAutoConfiguration {
          * @param gwc
          */
         @ConditionalOnBean(name = {"wmsServiceTarget", "wms_1_1_1_GetCapabilitiesResponse"})
-        public @Bean CachingExtendedCapabilitiesProvider gwcWMSExtendedCapabilitiesProvider(
-                GWC gwc) {
+        @Bean
+        CachingExtendedCapabilitiesProvider gwcWMSExtendedCapabilitiesProvider(GWC gwc) {
             log.info("GeoWebCache direct WMS integration enabled");
             return new CachingExtendedCapabilitiesProvider(gwc);
         }
@@ -97,7 +97,8 @@ public class WMSIntegrationAutoConfiguration {
          * @param gwc
          */
         @ConditionalOnBean(name = {"wmsServiceTarget", "wms_1_1_1_GetCapabilitiesResponse"})
-        public @Bean ForwardGetMapToGwcAspect gwcGetMapAdvise(GWC gwc) {
+        @Bean
+        ForwardGetMapToGwcAspect gwcGetMapAdvise(GWC gwc) {
             return new ForwardGetMapToGwcAspect(gwc);
         }
     }
@@ -117,7 +118,8 @@ public class WMSIntegrationAutoConfiguration {
         @ConditionalOnGeoServerWebUIEnabled
         static @Configuration class GeoServerWebUI {
 
-            public @Bean HeaderContribution GWCSettingsPage_WMSIntegationDisabledCssContribution() {
+            @Bean
+            HeaderContribution GWCSettingsPage_WMSIntegationDisabledCssContribution() {
                 log.info("GeoWebCache direct WMS integration disabled in GWCSettingsPage");
                 HeaderContribution contribution = new HeaderContribution();
                 contribution.setScope(GWCSettingsPage.class);

--- a/src/gwc/backends/src/main/java/org/geoserver/cloud/gwc/config/blobstore/AzureBlobstoreConfiguration.java
+++ b/src/gwc/backends/src/main/java/org/geoserver/cloud/gwc/config/blobstore/AzureBlobstoreConfiguration.java
@@ -29,7 +29,7 @@ import org.springframework.context.annotation.Configuration;
 public class AzureBlobstoreConfiguration {
 
     @Bean(name = "AzureBlobStoreConfigProvider")
-    public AzureBlobStoreConfigProvider azureBlobStoreConfigProvider() {
+    AzureBlobStoreConfigProvider azureBlobStoreConfigProvider() {
         return new AzureBlobStoreConfigProvider();
     }
 }

--- a/src/gwc/backends/src/main/java/org/geoserver/cloud/gwc/config/blobstore/AzureBlobstoreGsWebUIConfiguration.java
+++ b/src/gwc/backends/src/main/java/org/geoserver/cloud/gwc/config/blobstore/AzureBlobstoreGsWebUIConfiguration.java
@@ -13,12 +13,12 @@ import org.springframework.context.annotation.Configuration;
 public class AzureBlobstoreGsWebUIConfiguration {
 
     @Bean(name = "AzureBlobStoreType")
-    public AzureBlobStoreType azureBlobStoreType() {
+    AzureBlobStoreType azureBlobStoreType() {
         return new AzureBlobStoreType();
     }
 
     @Bean(name = "GWC-AzureExtension")
-    public ModuleStatusImpl gwcAzureExtension() {
+    ModuleStatusImpl gwcAzureExtension() {
         ModuleStatusImpl module = new ModuleStatusImpl();
         module.setModule("gs-gwc-azure");
         module.setName("GeoWebCache Azure Extension");

--- a/src/gwc/backends/src/main/java/org/geoserver/cloud/gwc/config/blobstore/S3BlobstoreConfiguration.java
+++ b/src/gwc/backends/src/main/java/org/geoserver/cloud/gwc/config/blobstore/S3BlobstoreConfiguration.java
@@ -35,7 +35,7 @@ import org.springframework.context.annotation.Configuration;
 public class S3BlobstoreConfiguration {
 
     @Bean(name = "S3BlobStoreConfigProvider")
-    public S3BlobStoreConfigProvider s3BlobStoreConfigProvider() {
+    S3BlobStoreConfigProvider s3BlobStoreConfigProvider() {
         return new S3BlobStoreConfigProvider();
     }
 }

--- a/src/gwc/backends/src/main/java/org/geoserver/cloud/gwc/config/blobstore/S3BlobstoreGsWebUIConfiguration.java
+++ b/src/gwc/backends/src/main/java/org/geoserver/cloud/gwc/config/blobstore/S3BlobstoreGsWebUIConfiguration.java
@@ -13,7 +13,7 @@ import org.springframework.context.annotation.Configuration;
 public class S3BlobstoreGsWebUIConfiguration {
 
     @Bean(name = "GWC-S3Extension")
-    public ModuleStatusImpl gwcS3Extension() {
+    ModuleStatusImpl gwcS3Extension() {
         ModuleStatusImpl module = new ModuleStatusImpl();
         module.setModule("gs-gwc-s3");
         module.setName("GeoWebCache S3 Extension");
@@ -24,7 +24,7 @@ public class S3BlobstoreGsWebUIConfiguration {
     }
 
     @Bean(name = "S3BlobStoreType")
-    public S3BlobStoreType s3BlobStoreType() {
+    S3BlobStoreType s3BlobStoreType() {
         return new S3BlobStoreType();
     }
 }

--- a/src/gwc/backends/src/test/java/org/geoserver/cloud/gwc/config/blobstore/AzureBlobStoreTest.java
+++ b/src/gwc/backends/src/test/java/org/geoserver/cloud/gwc/config/blobstore/AzureBlobStoreTest.java
@@ -9,7 +9,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.apache.commons.io.IOUtils;
 import org.geowebcache.GeoWebCacheEnvironment;
 import org.geowebcache.GeoWebCacheExtensions;
 import org.geowebcache.azure.AzureBlobStore;
@@ -106,14 +105,16 @@ public class AzureBlobStoreTest {
                         layerName, xyz, gridSetId, format, parameters, blob);
         store.put(tile);
 
+        @SuppressWarnings("unused")
         TileObject query =
                 TileObject.createQueryTileObject(layerName, xyz, gridSetId, format, parameters);
 
         // can't really test get, see https://github.com/Azure/Azurite/issues/217
-        if (true) return;
+        /*
         assertThat(store.get(query)).isTrue();
         assertThat(query.getBlob()).isNotNull();
         byte[] readContents = IOUtils.toByteArray(query.getBlob().getInputStream());
         assertThat(readContents).isEqualTo(contents);
+        */
     }
 }

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/GeoServerIntegrationConfiguration.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/GeoServerIntegrationConfiguration.java
@@ -61,12 +61,13 @@ public class GeoServerIntegrationConfiguration {
 
     @Primary
     @Bean(name = "GeoSeverTileLayerCatalog")
-    public TileLayerCatalog cachingTileLayerCatalog(ResourceStoreTileLayerCatalog delegate) {
+    TileLayerCatalog cachingTileLayerCatalog(ResourceStoreTileLayerCatalog delegate) {
         CacheManager cacheManager = new CaffeineCacheManager();
         return new CachingTileLayerCatalog(cacheManager, delegate);
     }
 
-    public @Bean ResourceStoreTileLayerCatalog resourceStoreTileLayerCatalog(
+    @Bean
+    ResourceStoreTileLayerCatalog resourceStoreTileLayerCatalog(
             @Qualifier("resourceStoreImpl") ResourceStore resourceStore) {
         return new ResourceStoreTileLayerCatalog(resourceStore);
     }

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/GeoWebCacheCoreConfiguration.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/GeoWebCacheCoreConfiguration.java
@@ -162,7 +162,8 @@ public class GeoWebCacheCoreConfiguration {
      * With one that resolves the default {@literal geowebcache.xml} file from {@link
      * #gwcDefaultConfigDirectory}
      */
-    public @Bean ConfigurationResourceProvider gwcXmlConfigResourceProvider(
+    @Bean
+    ConfigurationResourceProvider gwcXmlConfigResourceProvider(
             GeoWebCacheConfigurationProperties config,
             @Qualifier("resourceStoreImpl") ResourceStore resourceStore)
             throws ConfigurationException {
@@ -189,7 +190,7 @@ public class GeoWebCacheCoreConfiguration {
      * @param inFac
      */
     @Bean(name = "gwcXmlConfig")
-    public XMLConfiguration gwcXmlConfig( //
+    XMLConfiguration gwcXmlConfig( //
             ApplicationContextProvider appCtx, //
             @Qualifier("gwcXmlConfigResourceProvider") ConfigurationResourceProvider inFac) {
         return new CloudGwcXmlConfiguration(appCtx, inFac);
@@ -204,7 +205,8 @@ public class GeoWebCacheCoreConfiguration {
      * @param defaultCacheDirectory
      * @param environment
      */
-    public @Bean DefaultStorageFinder gwcDefaultStorageFinder(
+    @Bean
+    DefaultStorageFinder gwcDefaultStorageFinder(
             @Qualifier("gwcDefaultCacheDirectory") Path defaultCacheDirectory,
             Environment environment) {
         return new CloudDefaultStorageFinder(defaultCacheDirectory, environment);

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/GeoWebCacheLocalEventsConfiguration.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/GeoWebCacheLocalEventsConfiguration.java
@@ -14,7 +14,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration(proxyBeanMethods = false)
 public class GeoWebCacheLocalEventsConfiguration {
 
-    public @Bean TileLayerEventPublisher tileLayerEventPublisher() {
+    @Bean
+    TileLayerEventPublisher tileLayerEventPublisher() {
         return new TileLayerEventPublisher();
     }
 }

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/WebMapServiceCacheSeedingConfiguration.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/WebMapServiceCacheSeedingConfiguration.java
@@ -43,7 +43,8 @@ public class WebMapServiceCacheSeedingConfiguration {
      * before the catalog is initialized, making {@link GetMapKvpRequestReader} constructor throw a
      * NPE.
      */
-    public @Bean WmsGetMapSeedingAspect gwcSeedingGetMapAdvise() {
+    @Bean
+    WmsGetMapSeedingAspect gwcSeedingGetMapAdvise() {
         return new WmsGetMapSeedingAspect();
     }
 

--- a/src/gwc/integration-bus/src/main/java/org/geoserver/cloud/gwc/config/bus/GeoWebCacheRemoteEventsConfiguration.java
+++ b/src/gwc/integration-bus/src/main/java/org/geoserver/cloud/gwc/config/bus/GeoWebCacheRemoteEventsConfiguration.java
@@ -27,7 +27,8 @@ import java.util.function.Supplier;
 @RemoteApplicationEventScan(basePackageClasses = {RemoteGeoWebCacheEvent.class})
 public class GeoWebCacheRemoteEventsConfiguration {
 
-    public @Bean GeoWebCacheRemoteEventsBroker tileLayerRemoteEventBroadcaster( //
+    @Bean
+    GeoWebCacheRemoteEventsBroker tileLayerRemoteEventBroadcaster( //
             ApplicationEventPublisher eventPublisher, ServiceMatcher busServiceMatcher) {
 
         Supplier<String> originServiceId = busServiceMatcher::getBusId;

--- a/src/starters/reactive/src/main/java/org/geoserver/cloud/config/main/GeoServerMainModuleConfiguration.java
+++ b/src/starters/reactive/src/main/java/org/geoserver/cloud/config/main/GeoServerMainModuleConfiguration.java
@@ -28,13 +28,14 @@ import org.springframework.context.annotation.Configuration;
 public class GeoServerMainModuleConfiguration {
 
     // TODO: revisit, provide an appropriate notification dispatcher in for the event bus
-    public @Bean org.geoserver.platform.resource.ResourceNotificationDispatcher
+    @Bean
+    org.geoserver.platform.resource.ResourceNotificationDispatcher
             resourceNotificationDispatcher() {
         return new SimpleResourceNotificationDispatcher();
     }
 
-    public @Bean CatalogTimeStampUpdater catalogTimeStampUpdater(
-            @Qualifier("catalog") Catalog catalog) {
+    @Bean
+    CatalogTimeStampUpdater catalogTimeStampUpdater(@Qualifier("catalog") Catalog catalog) {
         return new CatalogTimeStampUpdater(catalog);
     }
 
@@ -42,11 +43,13 @@ public class GeoServerMainModuleConfiguration {
     // <bean id="sldPackageHandler" class="org.geoserver.catalog.SLDPackageHandler">
     // <constructor-arg ref="sldHandler"/>
     // </bean>
-    public @Bean SLDHandler sldHandler() {
+    @Bean
+    SLDHandler sldHandler() {
         return new SLDHandler();
     }
 
-    public @Bean SLDPackageHandler sldPackageHandler() {
+    @Bean
+    SLDPackageHandler sldPackageHandler() {
         return new SLDPackageHandlerHack(sldHandler());
     }
 

--- a/src/starters/webmvc/src/main/java/org/geoserver/cloud/config/servlet/GeoServerServletContextConfiguration.java
+++ b/src/starters/webmvc/src/main/java/org/geoserver/cloud/config/servlet/GeoServerServletContextConfiguration.java
@@ -28,12 +28,14 @@ public class GeoServerServletContextConfiguration {
     private static final int THREAD_LOCALS_CLEANUP_FILTER_ORDER = 5;
 
     // Listeners
-    public @Bean GeoServerServletInitializer contextLoaderListener() {
+    @Bean
+    GeoServerServletInitializer contextLoaderListener() {
         return new GeoServerServletInitializer();
     }
 
     @ConditionalOnMissingBean(RequestContextListener.class)
-    public @Bean RequestContextListener requestContextListener() {
+    @Bean
+    RequestContextListener requestContextListener() {
         return new RequestContextListener();
     }
 
@@ -48,7 +50,8 @@ public class GeoServerServletContextConfiguration {
             name = "enabled",
             havingValue = "true",
             matchIfMissing = true)
-    public @Bean FlushSafeFilter flushSafeFilter() {
+    @Bean
+    FlushSafeFilter flushSafeFilter() {
         return new FlushSafeFilter();
     }
 
@@ -57,7 +60,8 @@ public class GeoServerServletContextConfiguration {
             name = "enabled",
             havingValue = "true",
             matchIfMissing = true)
-    public @Bean FilterRegistrationBean<FlushSafeFilter> flushSafeFilterReg() {
+    @Bean
+    FilterRegistrationBean<FlushSafeFilter> flushSafeFilterReg() {
         return newRegistration(flushSafeFilter(), FLUSH_SAFE_FILTER_ORDER);
     }
 
@@ -66,7 +70,8 @@ public class GeoServerServletContextConfiguration {
             name = "enabled",
             havingValue = "true",
             matchIfMissing = true)
-    public @Bean SessionDebugFilter sessionDebugFilter() {
+    @Bean
+    SessionDebugFilter sessionDebugFilter() {
         return new SessionDebugFilter();
     }
 
@@ -75,7 +80,8 @@ public class GeoServerServletContextConfiguration {
             name = "enabled",
             havingValue = "true",
             matchIfMissing = true)
-    public @Bean FilterRegistrationBean<SessionDebugFilter> sessionDebugFilterFilterReg() {
+    @Bean
+    FilterRegistrationBean<SessionDebugFilter> sessionDebugFilterFilterReg() {
         return newRegistration(sessionDebugFilter(), SESSION_DEBUG_FILTER_ORDER);
     }
 
@@ -89,11 +95,13 @@ public class GeoServerServletContextConfiguration {
      * properly, instead of getting {@code null} from {@code
      * HttpServletRequest.request.getPathInfo()}
      */
-    public @Bean AdvancedDispatchFilter advancedDispatchFilter() {
+    @Bean
+    AdvancedDispatchFilter advancedDispatchFilter() {
         return new AdvancedDispatchFilter();
     }
 
-    public @Bean FilterRegistrationBean<AdvancedDispatchFilter> advancedDispatchFilterReg() {
+    @Bean
+    FilterRegistrationBean<AdvancedDispatchFilter> advancedDispatchFilterReg() {
         return newRegistration(advancedDispatchFilter(), ADVANCED_DISPATCH_FILTER_ORDER);
     }
 
@@ -102,20 +110,24 @@ public class GeoServerServletContextConfiguration {
      * to note is that for such filters init() is not called. INstead any initialization is
      * performed via spring ioc.
      */
-    public @Bean SpringDelegatingFilter springDelegatingFilter() {
+    @Bean
+    SpringDelegatingFilter springDelegatingFilter() {
         return new SpringDelegatingFilter();
     }
 
-    public @Bean FilterRegistrationBean<SpringDelegatingFilter> springDelegatingFilterReg() {
+    @Bean
+    FilterRegistrationBean<SpringDelegatingFilter> springDelegatingFilterReg() {
         return newRegistration(springDelegatingFilter(), SPRING_DELEGATING_FILTER_ORDER);
     }
 
     /** Cleans up thread locals GeoTools is setting up for concurrency and performance reasons */
-    public @Bean ThreadLocalsCleanupFilter threadLocalsCleanupFilter() {
+    @Bean
+    ThreadLocalsCleanupFilter threadLocalsCleanupFilter() {
         return new ThreadLocalsCleanupFilter();
     }
 
-    public @Bean FilterRegistrationBean<ThreadLocalsCleanupFilter> threadLocalsCleanupFilterReg() {
+    @Bean
+    FilterRegistrationBean<ThreadLocalsCleanupFilter> threadLocalsCleanupFilterReg() {
         return newRegistration(threadLocalsCleanupFilter(), THREAD_LOCALS_CLEANUP_FILTER_ORDER);
     }
 

--- a/src/starters/wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/extensions/CssStylingConfiguration.java
+++ b/src/starters/wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/extensions/CssStylingConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.context.annotation.ImportResource;
 @Import(value = {CssStylingConfiguration.Enabled.class, CssStylingConfiguration.Disabled.class})
 class CssStylingConfiguration {
 
+    @Configuration
     @ConditionalOnBean(name = "sldHandler")
     @ConditionalOnProperty(
             name = "geoserver.styling.css.enabled",
@@ -45,6 +46,7 @@ class CssStylingConfiguration {
      *
      * @since 1.0
      */
+    @Configuration
     @ConditionalOnBean(name = "sldHandler")
     @ConditionalOnProperty(
             name = "geoserver.styling.css.enabled",
@@ -52,7 +54,8 @@ class CssStylingConfiguration {
             matchIfMissing = false)
     static class Disabled {
 
-        public @Bean ModuleStatus cssDisabledModuleStatus() {
+        @Bean
+        ModuleStatus cssDisabledModuleStatus() {
             ModuleStatusImpl mod = new ModuleStatusImpl();
             mod.setAvailable(true);
             mod.setEnabled(false);

--- a/src/starters/wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/extensions/MapBoxStylingConfiguration.java
+++ b/src/starters/wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/extensions/MapBoxStylingConfiguration.java
@@ -49,7 +49,8 @@ class MapBoxStylingConfiguration {
     @ConditionalOnClass(MBStyleHandler.class)
     static class Disabled {
 
-        public @Bean(name = "MBStyleExtension") ModuleStatus mbStyleDisabledModuleStatus() {
+        @Bean(name = "MBStyleExtension")
+        ModuleStatus mbStyleDisabledModuleStatus() {
             ModuleStatusImpl mod = new ModuleStatusImpl();
             mod.setAvailable(true);
             mod.setEnabled(false);


### PR DESCRIPTION
- Remove unnecessary `@Autowired` annotations on configuration classes
- Add missing `@Configuration` annotations on configuration classes
- Fix MapStruct warnings on Mappers that referenced themselves
- Remove duplicate dependency/plugin versions
- Make `public @Bean` factory methods package protected as advised by spring-boot 2.x
- Replace `@RequestMapping` with specific `@GetMapping`, `@PostMapping` etc.