### PR TITLE
Include flatgeobuf wfs output format in webui

### DIFF
--- a/src/apps/geoserver/webui/pom.xml
+++ b/src/apps/geoserver/webui/pom.xml
@@ -123,6 +123,10 @@
       <artifactId>gs-wfs</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.geoserver.community</groupId>
+      <artifactId>gs-flatgeobuf</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wms</artifactId>
     </dependency>

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/wfs/WfsConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/wfs/WfsConfiguration.java
@@ -13,7 +13,8 @@ import org.springframework.context.annotation.ImportResource;
         reader = FilteringXmlBeanDefinitionReader.class, //
         locations = { //
             "jar:gs-web-wfs-.*!/applicationContext.xml", //
-            "jar:gs-wfs-.*!/applicationContext.xml"
+            "jar:gs-wfs-.*!/applicationContext.xml",
+            "jar:gs-flatgeobuf-.*!/applicationContext.xml#name=.*"
         } //
         )
 public class WfsConfiguration {}

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -567,6 +567,7 @@
         <version>${gs.version}</version>
         <exclusions>
           <exclusion>
+            <!-- revisit: exclusion not needed once https://github.com/geoserver/geoserver/pull/7320 is merged -->
             <groupId>org.geoserver.web</groupId>
             <artifactId>gs-web-core</artifactId>
           </exclusion>


### PR DESCRIPTION
When filtering out WFS output formats through the web-ui, the flatgeobuf format wasn't available.