### PR TITLE
Replace instanceof checks in CatalogValidationRules by a CatalogVisitor.

### DIFF
--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/AbstractCatalogVisitor.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/AbstractCatalogVisitor.java
@@ -1,0 +1,73 @@
+/*
+ * (c) 2023 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.catalog.plugin;
+
+import org.geoserver.catalog.CatalogVisitorAdapter;
+import org.geoserver.catalog.CoverageInfo;
+import org.geoserver.catalog.CoverageStoreInfo;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StoreInfo;
+import org.geoserver.catalog.WMSLayerInfo;
+import org.geoserver.catalog.WMSStoreInfo;
+import org.geoserver.catalog.WMTSLayerInfo;
+import org.geoserver.catalog.WMTSStoreInfo;
+
+/**
+ * {@link CatalogVisitorAdapter} that proxies all concrete {@link ResourceInfo} visit methods to
+ * {@link #visit(ResourceInfo)} and all concrete {@link StoreInfo} visit methods to {@link
+ * #visit(StoreInfo)}
+ */
+public abstract class AbstractCatalogVisitor extends CatalogVisitorAdapter {
+
+    @Override
+    public void visit(DataStoreInfo dataStore) {
+        visit((StoreInfo) dataStore);
+    }
+
+    @Override
+    public void visit(CoverageStoreInfo coverageStore) {
+        visit((StoreInfo) coverageStore);
+    }
+
+    @Override
+    public void visit(WMSStoreInfo wmsStore) {
+        visit((StoreInfo) wmsStore);
+    }
+
+    @Override
+    public void visit(WMTSStoreInfo wmtsStore) {
+        visit((StoreInfo) wmtsStore);
+    }
+
+    protected void visit(StoreInfo store) {
+        // to be overridden to catch all concrete StoreInfos
+    }
+
+    @Override
+    public void visit(FeatureTypeInfo featureType) {
+        visit((ResourceInfo) featureType);
+    }
+
+    @Override
+    public void visit(CoverageInfo coverage) {
+        visit((ResourceInfo) coverage);
+    }
+
+    @Override
+    public void visit(WMSLayerInfo wmsLayer) {
+        visit((ResourceInfo) wmsLayer);
+    }
+
+    @Override
+    public void visit(WMTSLayerInfo wmtsLayer) {
+        visit((ResourceInfo) wmtsLayer);
+    }
+
+    protected void visit(ResourceInfo resource) {
+        // to be overridden to catch all concrete ResourceInfos
+    }
+}

--- a/src/catalog/plugin/src/test/java/org/geoserver/catalog/plugin/AbstractCatalogVisitorTest.java
+++ b/src/catalog/plugin/src/test/java/org/geoserver/catalog/plugin/AbstractCatalogVisitorTest.java
@@ -1,0 +1,104 @@
+package org.geoserver.catalog.plugin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.geoserver.catalog.CoverageInfo;
+import org.geoserver.catalog.CoverageStoreInfo;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StoreInfo;
+import org.geoserver.catalog.WMSLayerInfo;
+import org.geoserver.catalog.WMSStoreInfo;
+import org.geoserver.catalog.WMTSLayerInfo;
+import org.geoserver.catalog.WMTSStoreInfo;
+import org.geoserver.catalog.impl.CoverageInfoImpl;
+import org.geoserver.catalog.impl.CoverageStoreInfoImpl;
+import org.geoserver.catalog.impl.DataStoreInfoImpl;
+import org.geoserver.catalog.impl.FeatureTypeInfoImpl;
+import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.catalog.impl.WMSLayerInfoImpl;
+import org.geoserver.catalog.impl.WMSStoreInfoImpl;
+import org.geoserver.catalog.impl.WMTSLayerInfoImpl;
+import org.geoserver.catalog.impl.WMTSStoreInfoImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AbstractCatalogVisitorTest {
+
+    private StoreInfo visitedStore;
+    private ResourceInfo visitedResource;
+    private AbstractCatalogVisitor visitor;
+
+    @BeforeEach
+    void setup() {
+        visitor =
+                new AbstractCatalogVisitor() {
+                    @Override
+                    protected void visit(StoreInfo store) {
+                        visitedStore = store;
+                    }
+
+                    @Override
+                    protected void visit(ResourceInfo resource) {
+                        visitedResource = resource;
+                    }
+                };
+    }
+
+    @Test
+    void testResourceInfo_FeatureType() {
+        assertResource(new FeatureTypeInfoImpl(null), FeatureTypeInfo.class);
+    }
+
+    @Test
+    void testResourceInfo_Coverage() {
+        assertResource(new CoverageInfoImpl(null), CoverageInfo.class);
+    }
+
+    @Test
+    void testResourceInfo_WMSLayer() {
+        assertResource(new WMSLayerInfoImpl(null), WMSLayerInfo.class);
+    }
+
+    @Test
+    void testResourceInfo_WMTSLayer() {
+        assertResource(new WMTSLayerInfoImpl(null), WMTSLayerInfo.class);
+    }
+
+    @Test
+    void testResourceInfo_CoverageStore() {
+        assertStore(new CoverageStoreInfoImpl(null), CoverageStoreInfo.class);
+    }
+
+    @Test
+    void testResourceInfo_DataStore() {
+        assertStore(new DataStoreInfoImpl(null), DataStoreInfo.class);
+    }
+
+    @Test
+    void testResourceInfo_WMSStore() {
+        assertStore(new WMSStoreInfoImpl(null), WMSStoreInfo.class);
+    }
+
+    @Test
+    void testResourceInfo_WMTSStore() {
+        assertStore(new WMTSStoreInfoImpl(null), WMTSStoreInfo.class);
+    }
+
+    private <T extends ResourceInfo> void assertResource(T resource, Class<T> type) {
+        resource.accept(visitor);
+        assertThat(visitedResource).isSameAs(resource);
+        T proxy = ModificationProxy.create(resource, type);
+        proxy.accept(visitor);
+        assertThat(visitedResource).isSameAs(proxy);
+    }
+
+    private <T extends StoreInfo> void assertStore(T resource, Class<T> type) {
+        resource.accept(visitor);
+        assertThat(visitedStore).isSameAs(resource);
+        T proxy = ModificationProxy.create(resource, type);
+        proxy.accept(visitor);
+        assertThat(visitedStore).isSameAs(proxy);
+    }
+}


### PR DESCRIPTION
Requires fix for (GEOS-11241)[https://osgeo-org.atlassian.net/browse/GEOS-11241] ModificationProxy breaks information hidding on CatalogInfo.accept(CatalogVisitor) exposing the proxied object