### PR TITLE
Fix JNDI lookup error using InitialContext

### DIFF
--- a/src/library/spring-boot-simplejndi/src/main/java/org/geoserver/cloud/jndi/SimpleNamingContext.java
+++ b/src/library/spring-boot-simplejndi/src/main/java/org/geoserver/cloud/jndi/SimpleNamingContext.java
@@ -158,8 +158,8 @@ public class SimpleNamingContext implements Context {
 
     @Override
     public void close() {
-        this.environment.clear();
-        this.bindings.clear();
+        // no-op method. The context is not closed because the resources are not obtained from a
+        // remote source
     }
 
     /**

--- a/src/library/spring-boot-simplejndi/src/test/java/org/geoserver/cloud/config/jndi/SimpleJNDIStaticContextInitializerTest.java
+++ b/src/library/spring-boot-simplejndi/src/test/java/org/geoserver/cloud/config/jndi/SimpleJNDIStaticContextInitializerTest.java
@@ -31,9 +31,21 @@ class SimpleJNDIStaticContextInitializerTest {
         runner.run(
                 context -> {
                     InitialContext initialContext = new InitialContext();
-                    assertThat(initialContext).isNotNull();
                     Context ctx = NamingManager.getInitialContext(new Hashtable<>());
                     assertThat(ctx).isInstanceOf(SimpleNamingContext.class);
+
+                    Object value = new Object();
+                    initialContext.bind("java:comp/env/test", value);
+
+                    initialContext.close();
+
+                    assertThat(ctx.lookup("java:comp/env/test")).isSameAs(value);
+
+                    initialContext = new InitialContext();
+                    ctx = NamingManager.getInitialContext(new Hashtable<>());
+                    assertThat(ctx).isInstanceOf(SimpleNamingContext.class);
+
+                    assertThat(initialContext.lookup("java:comp/env/test")).isSameAs(value);
                 });
     }
 }


### PR DESCRIPTION
SimpleInitialContext's `close()` shall be a no-op. Bound names are not being looked up from a remote resource but held locally, so closing the context invalidates all names.