### PR TITLE
pgconfig: ensure CatalogFacade bean is a resolving facade

### DIFF
--- a/src/catalog/backends/pgsql/src/main/java/org/geoserver/cloud/backend/pgsql/PgsqlBackendBuilder.java
+++ b/src/catalog/backends/pgsql/src/main/java/org/geoserver/cloud/backend/pgsql/PgsqlBackendBuilder.java
@@ -19,7 +19,6 @@ import org.geoserver.catalog.plugin.resolving.ResolvingProxyResolver;
 import org.geoserver.cloud.backend.pgsql.catalog.PgsqlCatalogFacade;
 import org.geoserver.cloud.backend.pgsql.config.PgsqlGeoServerFacade;
 import org.geoserver.config.plugin.GeoServerImpl;
-import org.geoserver.config.plugin.RepositoryGeoServerFacade;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.util.function.UnaryOperator;
@@ -39,13 +38,13 @@ public class PgsqlBackendBuilder {
     }
 
     public GeoServerImpl createGeoServer(Catalog catalog) {
-        RepositoryGeoServerFacade facade = createGeoServerFacade();
+        PgsqlGeoServerFacade facade = createGeoServerFacade();
         GeoServerImpl gs = new GeoServerImpl(facade);
         gs.setCatalog(catalog);
         return gs;
     }
 
-    public RepositoryGeoServerFacade createGeoServerFacade() {
+    public PgsqlGeoServerFacade createGeoServerFacade() {
         return new PgsqlGeoServerFacade(new JdbcTemplate(dataSource));
     }
 

--- a/src/catalog/backends/pgsql/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgsql/PgsqlBackendAutoConfigurationTest.java
+++ b/src/catalog/backends/pgsql/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgsql/PgsqlBackendAutoConfigurationTest.java
@@ -7,11 +7,14 @@ package org.geoserver.cloud.autoconfigure.catalog.backend.pgsql;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.geoserver.GeoServerConfigurationLock;
+import org.geoserver.catalog.plugin.CatalogPlugin;
+import org.geoserver.catalog.plugin.forwarding.ResolvingCatalogFacadeDecorator;
 import org.geoserver.cloud.backend.pgsql.catalog.PgsqlCatalogFacade;
 import org.geoserver.cloud.backend.pgsql.config.PgsqlConfigRepository;
 import org.geoserver.cloud.backend.pgsql.config.PgsqlGeoServerFacade;
 import org.geoserver.cloud.backend.pgsql.config.PgsqlUpdateSequence;
 import org.geoserver.cloud.backend.pgsql.resource.PgsqlLockProvider;
+import org.geoserver.cloud.backend.pgsql.resource.PgsqlResourceStore;
 import org.geoserver.cloud.config.catalog.backend.pgsql.PgsqlGeoServerLoader;
 import org.geoserver.cloud.config.catalog.backend.pgsql.PgsqlGeoServerResourceLoader;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,6 +27,8 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
+ * Test suite for {@link PgsqlBackendAutoConfiguration}
+ *
  * @since 1.4
  */
 @Testcontainers(disabledWithoutDocker = true)
@@ -62,13 +67,20 @@ class PgsqlBackendAutoConfigurationTest {
                             .hasSingleBean(JdbcTemplate.class)
                             .hasSingleBean(GeoServerConfigurationLock.class)
                             .hasSingleBean(PgsqlUpdateSequence.class)
-                            .hasSingleBean(PgsqlCatalogFacade.class)
+                            .hasSingleBean(ResolvingCatalogFacadeDecorator.class)
                             .hasSingleBean(PgsqlGeoServerLoader.class)
                             .hasSingleBean(PgsqlConfigRepository.class)
                             .hasSingleBean(PgsqlGeoServerFacade.class)
-                            // .hasSingleBean(PgsqlResourceStore.class)
+                            .hasSingleBean(PgsqlResourceStore.class)
                             .hasSingleBean(PgsqlGeoServerResourceLoader.class)
                             .hasSingleBean(PgsqlLockProvider.class);
+
+                    ResolvingCatalogFacadeDecorator catalogFacade =
+                            context.getBean("catalogFacade", ResolvingCatalogFacadeDecorator.class);
+                    assertThat(catalogFacade.getFacade()).isInstanceOf(PgsqlCatalogFacade.class);
+
+                    CatalogPlugin catalog = context.getBean("rawCatalog", CatalogPlugin.class);
+                    assertThat(catalog.getRawFacade()).isSameAs(catalogFacade);
                 });
     }
 }

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingCatalogFacade.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingCatalogFacade.java
@@ -4,6 +4,8 @@
  */
 package org.geoserver.catalog.plugin.forwarding;
 
+import lombok.Getter;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogCapabilities;
 import org.geoserver.catalog.CatalogFacade;
@@ -35,7 +37,7 @@ import javax.annotation.Nullable;
 public class ForwardingCatalogFacade implements CatalogFacade {
 
     // wrapped catalog facade
-    protected final CatalogFacade facade;
+    @Getter protected final CatalogFacade facade;
 
     public ForwardingCatalogFacade(CatalogFacade facade) {
         this.facade = facade;


### PR DESCRIPTION
`PgsqlBackendConfiguration` must set up the `catalogFacade` bean as intended. In this case, it wasn't being created as a `ResolvingCatalogFacade`, meaning any additional decorator would get the raw `PsqlCatalogFacade` and the returned `CatalogInfo` object wouldn't be resolving according to the required inbound and outbound resolving functions (e.g. to initialize the `Catalog` property where appropriate, possibly leading to NPE, or replacing `ResolvingProxy` references with actual `CatalogInfo` references, etc).