### PR TITLE
Set Java 21 as the required and used Java version

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '21'
         cache: 'maven'
 
     - name: Validate source code formatting

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '21'
         cache: 'maven'
 
     - name: Validate source code formatting

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '21'
         cache: 'maven'
 
     - name: Validate source code formatting

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '21'
         cache: 'maven'
     - name: Cache SonarCloud packages
       uses: actions/cache@v3

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Follow the development progress on these [GitHub Kanban boards](https://github.c
 
 Requirements:
 
- * Java >= 17 JDK
+ * Java >= 21 JDK
  * [Maven](https://maven.apache.org/) >= `3.6.3`
  * A recent [Docker](https://docs.docker.com/engine/install/) version with the [Compose](https://docs.docker.com/compose/) plugin.
 

--- a/pom.xml
+++ b/pom.xml
@@ -187,8 +187,11 @@
       <url>https://repo.osgeo.org/repository/snapshot/</url>
     </repository>
     <repository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
       <snapshots>
-        <enabled>false</enabled>
+        <enabled>true</enabled>
       </snapshots>
       <id>geoserver-github-packages</id>
       <name>Customized Geoserver Packages</name>

--- a/src/apps/base-images/jre/Dockerfile
+++ b/src/apps/base-images/jre/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:21-jre
 
 LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 

--- a/src/apps/geoserver/wps/src/main/java/org/geoserver/cloud/wps/WpsApplicationConfiguration.java
+++ b/src/apps/geoserver/wps/src/main/java/org/geoserver/cloud/wps/WpsApplicationConfiguration.java
@@ -17,14 +17,11 @@ import org.springframework.context.annotation.ImportResource;
         reader = FilteringXmlBeanDefinitionReader.class, //
         locations = { //
             "jar:gs-wps-.*!/applicationContext.xml", //
-            "jar:gs-wfs-.*!/applicationContext.xml", //
             "jar:gs-wcs-.*!/applicationContext.xml", //
             "jar:gs-wcs1_0-.*!/applicationContext.xml", //
             "jar:gs-wcs1_1-.*!/applicationContext.xml", //
-            "jar:gs-wcs2_0-.*!/applicationContext.xml" //
-            // // REVISIT: wps won't start without the web components! see note in pom.xml
-            // "jar:gs-web-core-.*!/applicationContext.xml", //
-            // "jar:gs-web-wps-.*!/applicationContext.xml", //
+            "jar:gs-wcs2_0-.*!/applicationContext.xml", //
+            "jar:gs-wfs-.*!/applicationContext.xml#name=^(?!wfsInsertElementHandler|wfsUpdateElementHandler|wfsDeleteElementHandler|wfsReplaceElementHandler).*$", //
         })
 public class WpsApplicationConfiguration {
 

--- a/src/apps/geoserver/wps/src/test/java/org/geoserver/cloud/wps/WpsApplicationTest.java
+++ b/src/apps/geoserver/wps/src/test/java/org/geoserver/cloud/wps/WpsApplicationTest.java
@@ -29,7 +29,8 @@ class WpsApplicationTest {
 
     @DynamicPropertySource
     static void setUpDataDir(DynamicPropertyRegistry registry) throws IOException {
-        datadir = Files.createDirectory(tmpdir.resolve("datadir"));
+        datadir = tmpdir.resolve("datadir");
+        if (!Files.exists(datadir)) datadir = Files.createDirectory(datadir);
         registry.add("geoserver.backend.data-directory.location", datadir::toAbsolutePath);
     }
 

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -793,7 +793,7 @@
           <version>3.11.0</version>
           <inherited>true</inherited>
           <configuration>
-            <release>17</release>
+            <release>21</release>
             <debug>true</debug>
             <encoding>UTF-8</encoding>
             <fork>${fork.javac}</fork>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -886,7 +886,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[17,)</version>
+                  <version>[21,)</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
                   <version>[3.6.3,)</version>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -23,9 +23,9 @@
     <spring-cloud.version>2021.0.8</spring-cloud.version>
     <spring-boot.version>2.7.18</spring-boot.version>
     <jackson.version>2.15.3</jackson.version>
-    <gs.version>2.24.2-CLOUD</gs.version>
-    <gs.community.version>2.24.2-CLOUD</gs.community.version>
-    <gt.version>30.2</gt.version>
+    <gs.version>2.25.0-SNAPSHOT</gs.version>
+    <gs.community.version>2.25.0-SNAPSHOT</gs.community.version>
+    <gt.version>31-SNAPSHOT</gt.version>
     <acl.version>2.0-SNAPSHOT</acl.version>
     <!-- Downgrade netty.version used by spring-boot to the one used by geoserver azure client
     (software.amazon.awssdk:netty-nio-client:jar:2.9.24) for COG and GWC Azure plugin -->


### PR DESCRIPTION
* Set Java 21 as the required minimum version
* Set Java 21 as `maven-compiler-plugin`'s target release
* Update base docker image to `eclipse-temurin:21-jre`
* Update github actions build jobs to use Java 21
* Upgrade to gs `2.25.0-SNAPSHOT`/gt `31-SNAPSHOT`
