### PR TITLE
pgconfig: NPE evaluating InternalVolatileFunction

### DIFF
--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/PgsqlBackendBuilder.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/PgsqlBackendBuilder.java
@@ -8,20 +8,13 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 import org.geoserver.catalog.Catalog;
-import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.impl.CatalogImpl;
 import org.geoserver.catalog.plugin.CatalogPlugin;
 import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
-import org.geoserver.catalog.plugin.forwarding.ResolvingCatalogFacadeDecorator;
-import org.geoserver.catalog.plugin.resolving.CatalogPropertyResolver;
-import org.geoserver.catalog.plugin.resolving.CollectionPropertiesInitializer;
-import org.geoserver.catalog.plugin.resolving.ResolvingProxyResolver;
 import org.geoserver.cloud.backend.pgconfig.catalog.PgsqlCatalogFacade;
 import org.geoserver.cloud.backend.pgconfig.config.PgsqlGeoServerFacade;
 import org.geoserver.config.plugin.GeoServerImpl;
 import org.springframework.jdbc.core.JdbcTemplate;
-
-import java.util.function.UnaryOperator;
 
 import javax.sql.DataSource;
 
@@ -50,22 +43,7 @@ public class PgsqlBackendBuilder {
 
     public ExtendedCatalogFacade createCatalogFacade(Catalog catalog) {
         JdbcTemplate template = new JdbcTemplate(dataSource);
-        PgsqlCatalogFacade facade = new PgsqlCatalogFacade(template);
-
-        return createResolvingCatalogFacade(catalog, facade);
-    }
-
-    public static ExtendedCatalogFacade createResolvingCatalogFacade(
-            Catalog catalog, PgsqlCatalogFacade rawFacade) {
-        UnaryOperator<CatalogInfo> resolvingFunction =
-                CatalogPropertyResolver.<CatalogInfo>of(catalog)
-                                .andThen(ResolvingProxyResolver.<CatalogInfo>of(catalog))
-                                .andThen(CollectionPropertiesInitializer.instance())
-                        ::apply;
-
-        ResolvingCatalogFacadeDecorator resolving = new ResolvingCatalogFacadeDecorator(rawFacade);
-        resolving.setOutboundResolver(resolvingFunction);
-        return resolving;
+        return new PgsqlCatalogFacade(template);
     }
 
     public <C extends CatalogImpl> C initCatalog(C catalog) {

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/PgsqlCatalogFacade.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/PgsqlCatalogFacade.java
@@ -6,7 +6,13 @@ package org.geoserver.cloud.backend.pgconfig.catalog;
 
 import lombok.NonNull;
 
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.plugin.RepositoryCatalogFacadeImpl;
+import org.geoserver.catalog.plugin.resolving.CatalogPropertyResolver;
+import org.geoserver.catalog.plugin.resolving.CollectionPropertiesInitializer;
+import org.geoserver.catalog.plugin.resolving.ResolvingProxyResolver;
+import org.geoserver.cloud.backend.pgconfig.catalog.repository.PgsqlCatalogInfoRepository;
 import org.geoserver.cloud.backend.pgconfig.catalog.repository.PgsqlLayerGroupRepository;
 import org.geoserver.cloud.backend.pgconfig.catalog.repository.PgsqlLayerRepository;
 import org.geoserver.cloud.backend.pgconfig.catalog.repository.PgsqlNamespaceRepository;
@@ -16,18 +22,48 @@ import org.geoserver.cloud.backend.pgconfig.catalog.repository.PgsqlStyleReposit
 import org.geoserver.cloud.backend.pgconfig.catalog.repository.PgsqlWorkspaceRepository;
 import org.springframework.jdbc.core.JdbcTemplate;
 
+import java.util.function.UnaryOperator;
+
 /**
  * @since 1.4
  */
 public class PgsqlCatalogFacade extends RepositoryCatalogFacadeImpl {
 
     public PgsqlCatalogFacade(@NonNull JdbcTemplate template) {
-        super.setNamespaceRepository(new PgsqlNamespaceRepository(template));
-        super.setWorkspaceRepository(new PgsqlWorkspaceRepository(template));
-        super.setStoreRepository(new PgsqlStoreRepository(template));
-        super.setResourceRepository(new PgsqlResourceRepository(template));
-        super.setLayerRepository(new PgsqlLayerRepository(template));
-        super.setLayerGroupRepository(new PgsqlLayerGroupRepository(template));
-        super.setStyleRepository(new PgsqlStyleRepository(template));
+        PgsqlNamespaceRepository namespaces = new PgsqlNamespaceRepository(template);
+        PgsqlWorkspaceRepository workspaces = new PgsqlWorkspaceRepository(template);
+        PgsqlStyleRepository styles = new PgsqlStyleRepository(template);
+
+        PgsqlStoreRepository stores = new PgsqlStoreRepository(template);
+        PgsqlLayerRepository layers = new PgsqlLayerRepository(template, styles);
+        PgsqlResourceRepository resources = new PgsqlResourceRepository(template, layers);
+        PgsqlLayerGroupRepository layerGroups = new PgsqlLayerGroupRepository(template);
+
+        super.setNamespaceRepository(namespaces);
+        super.setWorkspaceRepository(workspaces);
+        super.setStoreRepository(stores);
+        super.setResourceRepository(resources);
+        super.setLayerRepository(layers);
+        super.setLayerGroupRepository(layerGroups);
+        super.setStyleRepository(styles);
+    }
+
+    @Override
+    public void setCatalog(Catalog catalog) {
+        super.setCatalog(catalog);
+        setOutboundResolver();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setOutboundResolver() {
+        UnaryOperator<CatalogInfo> resolvingFunction =
+                CatalogPropertyResolver.<CatalogInfo>of(this::getCatalog)
+                                .andThen(ResolvingProxyResolver.<CatalogInfo>of(catalog))
+                                .andThen(CollectionPropertiesInitializer.instance())
+                        ::apply;
+
+        super.repositories.all().stream()
+                .map(PgsqlCatalogInfoRepository.class::cast)
+                .forEach(repo -> repo.setOutboundResolver(resolvingFunction));
     }
 }

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgsqlLayerGroupRepository.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgsqlLayerGroupRepository.java
@@ -46,7 +46,7 @@ public class PgsqlLayerGroupRepository extends PgsqlCatalogInfoRepository<LayerG
                 FROM layergroupinfos
                 WHERE "workspace.id" IS NULL AND name = ?
                 """;
-        return findOne(sql, LayerGroupInfo.class, newRowMapper(), name);
+        return findOne(sql, name);
     }
 
     @Override
@@ -59,7 +59,7 @@ public class PgsqlLayerGroupRepository extends PgsqlCatalogInfoRepository<LayerG
                 FROM layergroupinfos
                 WHERE "workspace.id" = ? AND name = ?
                 """;
-        return findOne(sql, LayerGroupInfo.class, newRowMapper(), workspace.getId(), name);
+        return findOne(sql, workspace.getId(), name);
     }
 
     @Override
@@ -70,7 +70,7 @@ public class PgsqlLayerGroupRepository extends PgsqlCatalogInfoRepository<LayerG
                 FROM layergroupinfos
                 WHERE "workspace.id" IS NULL
                 """;
-        return template.queryForStream(sql, newRowMapper());
+        return super.queryForStream(sql);
     }
 
     @Override
@@ -81,7 +81,7 @@ public class PgsqlLayerGroupRepository extends PgsqlCatalogInfoRepository<LayerG
                 FROM layergroupinfos
                 WHERE "workspace.id" = ?
                 """;
-        return template.queryForStream(sql, newRowMapper(), workspace.getId());
+        return super.queryForStream(sql, workspace.getId());
     }
 
     @Override

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgsqlNamespaceRepository.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgsqlNamespaceRepository.java
@@ -74,11 +74,10 @@ public class PgsqlNamespaceRepository extends PgsqlCatalogInfoRepository<Namespa
 
     @Override
     public Stream<NamespaceInfo> findAllByURI(@NonNull String uri) {
-        return template.queryForStream(
+        return super.queryForStream(
                 """
                 SELECT namespace FROM namespaceinfos WHERE uri = ?
                 """,
-                newRowMapper(),
                 uri);
     }
 

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgsqlResourceRepository.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgsqlResourceRepository.java
@@ -26,12 +26,15 @@ public class PgsqlResourceRepository extends PgsqlCatalogInfoRepository<Resource
         implements ResourceRepository {
 
     private static final String AND_TYPE_INFOTYPE = " AND \"@type\" = ?::infotype";
+    private final PgsqlLayerRepository layerrepo;
 
     /**
      * @param template
      */
-    public PgsqlResourceRepository(@NonNull JdbcTemplate template) {
+    public PgsqlResourceRepository(
+            @NonNull JdbcTemplate template, @NonNull PgsqlLayerRepository layerrepo) {
         super(template);
+        this.layerrepo = layerrepo;
     }
 
     @Override
@@ -54,7 +57,6 @@ public class PgsqlResourceRepository extends PgsqlCatalogInfoRepository<Resource
 
     private void updateLayer(ResourceInfo oldResource, ResourceInfo patched) {
         if (!oldResource.getName().equals(patched.getName())) {
-            PgsqlLayerRepository layerrepo = new PgsqlLayerRepository(template);
             Optional<LayerInfo> layer = layerrepo.findOneByName(oldResource.prefixedName());
             layer.ifPresent(
                     // update the layer's json name which will update the layerinfo.name computed
@@ -111,11 +113,10 @@ public class PgsqlResourceRepository extends PgsqlCatalogInfoRepository<Resource
                 WHERE "namespace.id" = ?
                 """;
         if (ResourceInfo.class.equals(clazz)) {
-            return template.queryForStream(query, newRowMapper(), ns.getId()).map(clazz::cast);
+            return super.queryForStream(clazz, query, ns.getId());
         }
         query += AND_TYPE_INFOTYPE;
-        return template.queryForStream(query, newRowMapper(), ns.getId(), infoType(clazz))
-                .map(clazz::cast);
+        return super.queryForStream(clazz, query, ns.getId(), infoType(clazz));
     }
 
     @Override
@@ -144,11 +145,10 @@ public class PgsqlResourceRepository extends PgsqlCatalogInfoRepository<Resource
                 WHERE "store.id" = ?
                 """;
         if (ResourceInfo.class.equals(clazz)) {
-            return template.queryForStream(query, newRowMapper(), store.getId()).map(clazz::cast);
+            return super.queryForStream(clazz, query, store.getId());
         }
         query += AND_TYPE_INFOTYPE;
-        return template.queryForStream(query, newRowMapper(), store.getId(), infoType(clazz))
-                .map(clazz::cast);
+        return super.queryForStream(clazz, query, store.getId(), infoType(clazz));
     }
 
     @Override

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgsqlStyleRepository.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgsqlStyleRepository.java
@@ -46,7 +46,7 @@ public class PgsqlStyleRepository extends PgsqlCatalogInfoRepository<StyleInfo>
                 FROM styleinfos
                 WHERE "workspace.id" IS NULL
                 """;
-        return template.queryForStream(query, newRowMapper());
+        return super.queryForStream(query);
     }
 
     @Override
@@ -57,7 +57,7 @@ public class PgsqlStyleRepository extends PgsqlCatalogInfoRepository<StyleInfo>
                 FROM styleinfos
                 WHERE "workspace.id" = ?
                 """;
-        return template.queryForStream(query, newRowMapper(), ws.getId());
+        return super.queryForStream(query, ws.getId());
     }
 
     @Override
@@ -68,7 +68,7 @@ public class PgsqlStyleRepository extends PgsqlCatalogInfoRepository<StyleInfo>
                 FROM styleinfos
                 WHERE "workspace.id" IS NULL AND name = ?
                 """;
-        return findOne(query, StyleInfo.class, newRowMapper(), name);
+        return findOne(query, name);
     }
 
     @Override
@@ -81,7 +81,7 @@ public class PgsqlStyleRepository extends PgsqlCatalogInfoRepository<StyleInfo>
                 FROM styleinfos
                 WHERE "workspace.id" = ? AND name = ?
                 """;
-        return findOne(query, StyleInfo.class, newRowMapper(), workspace.getId(), name);
+        return findOne(query, workspace.getId(), name);
     }
 
     @Override

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgsqlWorkspaceRepository.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgsqlWorkspaceRepository.java
@@ -20,6 +20,11 @@ import java.util.Optional;
 public class PgsqlWorkspaceRepository extends PgsqlCatalogInfoRepository<WorkspaceInfo>
         implements WorkspaceRepository {
 
+    private static final String UNSET_DEFAULT_WORKSPACE =
+            """
+	UPDATE workspaceinfo SET default_workspace = FALSE WHERE default_workspace = TRUE
+	""";
+
     /**
      * @param template
      */
@@ -39,10 +44,7 @@ public class PgsqlWorkspaceRepository extends PgsqlCatalogInfoRepository<Workspa
 
     @Override
     public void unsetDefaultWorkspace() {
-        template.update(
-                """
-                UPDATE workspaceinfo SET default_workspace = FALSE WHERE default_workspace = TRUE
-                """);
+        template.update(UNSET_DEFAULT_WORKSPACE);
     }
 
     /** TODO: handle transactions and perform unset/set atomically */

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgconfig/PgsqlBackendAutoConfigurationTest.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgconfig/PgsqlBackendAutoConfigurationTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.geoserver.GeoServerConfigurationLock;
 import org.geoserver.catalog.plugin.CatalogPlugin;
-import org.geoserver.catalog.plugin.forwarding.ResolvingCatalogFacadeDecorator;
+import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
 import org.geoserver.cloud.backend.pgconfig.catalog.PgsqlCatalogFacade;
 import org.geoserver.cloud.backend.pgconfig.config.PgsqlConfigRepository;
 import org.geoserver.cloud.backend.pgconfig.config.PgsqlGeoServerFacade;
@@ -58,7 +58,7 @@ class PgsqlBackendAutoConfigurationTest {
                             .hasSingleBean(JdbcTemplate.class)
                             .hasSingleBean(GeoServerConfigurationLock.class)
                             .hasSingleBean(PgsqlUpdateSequence.class)
-                            .hasSingleBean(ResolvingCatalogFacadeDecorator.class)
+                            .hasSingleBean(PgsqlCatalogFacade.class)
                             .hasSingleBean(PgsqlGeoServerLoader.class)
                             .hasSingleBean(PgsqlConfigRepository.class)
                             .hasSingleBean(PgsqlGeoServerFacade.class)
@@ -66,9 +66,9 @@ class PgsqlBackendAutoConfigurationTest {
                             .hasSingleBean(PgsqlGeoServerResourceLoader.class)
                             .hasSingleBean(PgsqlLockProvider.class);
 
-                    ResolvingCatalogFacadeDecorator catalogFacade =
-                            context.getBean("catalogFacade", ResolvingCatalogFacadeDecorator.class);
-                    assertThat(catalogFacade.getFacade()).isInstanceOf(PgsqlCatalogFacade.class);
+                    ExtendedCatalogFacade catalogFacade =
+                            context.getBean("catalogFacade", ExtendedCatalogFacade.class);
+                    assertThat(catalogFacade).isInstanceOf(PgsqlCatalogFacade.class);
 
                     CatalogPlugin catalog = context.getBean("rawCatalog", CatalogPlugin.class);
                     assertThat(catalog.getRawFacade()).isSameAs(catalogFacade);

--- a/src/catalog/event-bus/src/main/java/org/geoserver/cloud/event/bus/InfoEventResolver.java
+++ b/src/catalog/event-bus/src/main/java/org/geoserver/cloud/event/bus/InfoEventResolver.java
@@ -40,7 +40,7 @@ public class InfoEventResolver {
 
     public InfoEventResolver(@NonNull Catalog rawCatalog, @NonNull GeoServer geoserverConfig) {
 
-        proxyUtils = new ProxyUtils(rawCatalog, Optional.of(geoserverConfig));
+        proxyUtils = new ProxyUtils(() -> rawCatalog, Optional.of(geoserverConfig));
 
         configInfoResolver =
                 CollectionPropertiesInitializer.<Info>instance()

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModuleTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModuleTest.java
@@ -128,7 +128,7 @@ public abstract class GeoServerCatalogModuleTest {
         geoserver = new GeoServerImpl();
         geoserver.setCatalog(catalog);
         data = CatalogTestData.initialized(() -> catalog, () -> geoserver).initialize();
-        proxyResolver = new ProxyUtils(catalog, Optional.of(geoserver));
+        proxyResolver = new ProxyUtils(() -> catalog, Optional.of(geoserver));
     }
 
     protected abstract ObjectMapper newObjectMapper();

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/PatchSerializationTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/PatchSerializationTest.java
@@ -130,7 +130,7 @@ public abstract class PatchSerializationTest {
         geoserver = new GeoServerImpl();
         geoserver.setCatalog(catalog);
         data = CatalogTestData.initialized(() -> catalog, () -> geoserver).initialize();
-        proxyResolver = new ProxyUtils(catalog, Optional.of(geoserver));
+        proxyResolver = new ProxyUtils(() -> catalog, Optional.of(geoserver));
     }
 
     protected abstract ObjectMapper newObjectMapper();

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/config/GeoServerConfigModuleTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/config/GeoServerConfigModuleTest.java
@@ -72,7 +72,7 @@ public abstract class GeoServerConfigModuleTest {
                 CatalogTestData.initialized(() -> catalog, () -> geoserver)
                         .initConfig(false)
                         .initialize();
-        proxyResolver = new ProxyUtils(catalog, Optional.of(geoserver));
+        proxyResolver = new ProxyUtils(() -> catalog, Optional.of(geoserver));
     }
 
     private <T extends Info> void roundtripTest(@NonNull final T orig)

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogInfoRepositoryHolderImpl.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogInfoRepositoryHolderImpl.java
@@ -22,6 +22,8 @@ import org.geoserver.catalog.plugin.CatalogInfoRepository.StoreRepository;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.StyleRepository;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.WorkspaceRepository;
 
+import java.util.List;
+
 public class CatalogInfoRepositoryHolderImpl implements CatalogInfoRepositoryHolder {
 
     protected NamespaceRepository namespaces;
@@ -46,6 +48,10 @@ public class CatalogInfoRepositoryHolderImpl implements CatalogInfoRepositoryHol
     @Override
     public <T extends CatalogInfo, R extends CatalogInfoRepository<T>> R repositoryFor(T info) {
         return (R) repos.forObject(info);
+    }
+
+    public List<CatalogInfoRepository<? extends CatalogInfo>> all() {
+        return repos.getAll();
     }
 
     @Override
@@ -134,5 +140,20 @@ public class CatalogInfoRepositoryHolderImpl implements CatalogInfoRepositoryHol
     @Override
     public MapRepository getMapRepository() {
         return maps;
+    }
+
+    public void dispose() {
+        dispose(stores);
+        dispose(resources);
+        dispose(namespaces);
+        dispose(workspaces);
+        dispose(layers);
+        dispose(layerGroups);
+        dispose(maps);
+        dispose(styles);
+    }
+
+    private void dispose(CatalogInfoRepository<?> repository) {
+        if (repository != null) repository.dispose();
     }
 }

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogInfoTypeRegistry.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogInfoTypeRegistry.java
@@ -58,6 +58,10 @@ public class CatalogInfoTypeRegistry<R> {
         return this;
     }
 
+    public List<R> getAll() {
+        return List.copyOf(mappings.values());
+    }
+
     @SuppressWarnings("unchecked")
     public <T extends CatalogInfo> CatalogInfoTypeRegistry<Consumer<T>> consume(
             Class<T> type, Consumer<T> with) {

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogPlugin.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogPlugin.java
@@ -141,12 +141,10 @@ public class CatalogPlugin extends CatalogImpl implements Catalog {
     private CatalogPlugin(CatalogPlugin catalog) {
         super(catalog); // sets dispatcher and resourcePool
         this.isolated = false;
-        super.resourcePool = catalog.resourcePool;
-        super.resourceLoader = catalog.resourceLoader;
-        validationSupport = new CatalogValidationRules(this);
-        // use setFacade to wrap it in a modificationproxy resolver if needed
-        // sets both rawFacade and facade
-        setFacade(catalog.getRawFacade());
+        this.validationSupport = new CatalogValidationRules(this);
+        super.resourceLoader = catalog.getResourceLoader();
+        super.rawFacade = catalog.getRawFacade();
+        super.facade = catalog.getFacade();
     }
 
     /**

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/DefaultMemoryCatalogFacade.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/DefaultMemoryCatalogFacade.java
@@ -41,7 +41,6 @@ import org.geoserver.ows.util.OwsUtils;
 import java.rmi.server.UID;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
@@ -63,7 +62,7 @@ public class DefaultMemoryCatalogFacade extends RepositoryCatalogFacadeImpl
         setWorkspaceRepository(new WorkspaceInfoLookup());
         setStoreRepository(new StoreInfoLookup());
         setLayerRepository(new LayerInfoLookup());
-        setResourceRepository(new ResourceInfoLookup((LayerInfoLookup) layers));
+        setResourceRepository(new ResourceInfoLookup((LayerInfoLookup) getLayerRepository()));
         setLayerGroupRepository(new LayerGroupInfoLookup());
         setMapRepository(new MapInfoLookup());
         setStyleRepository(new StyleInfoLookup());
@@ -71,30 +70,14 @@ public class DefaultMemoryCatalogFacade extends RepositoryCatalogFacadeImpl
 
     @Override
     public void resolve() {
-        // JD creation checks are done here b/c when xstream depersists
-        // some members may be left null
-        workspaces = resolve(workspaces, WorkspaceInfoLookup::new);
-        namespaces = resolve(namespaces, NamespaceInfoLookup::new);
-        stores = resolve(stores, StoreInfoLookup::new);
-        styles = resolve(styles, StyleInfoLookup::new);
-        layers = resolve(layers, LayerInfoLookup::new);
-        resources = resolve(resources, () -> new ResourceInfoLookup((LayerInfoLookup) layers));
-        layerGroups = resolve(layerGroups, LayerGroupInfoLookup::new);
-        maps = resolve(maps, MapInfoLookup::new);
-
-        workspaces.findAll().forEach(this::resolve);
-        namespaces.findAll().forEach(this::resolve);
-        stores.findAll().forEach(this::resolve);
-        styles.findAll().forEach(this::resolve);
-        resources.findAll().forEach(this::resolve);
-        layers.findAll().forEach(this::resolve);
-        layerGroups.findAll().forEach(this::resolve);
-        maps.findAll().forEach(this::resolve);
-    }
-
-    private <I extends CatalogInfo, R extends CatalogInfoRepository<I>> R resolve(
-            R current, Supplier<R> factory) {
-        return current == null ? factory.get() : current;
+        getWorkspaceRepository().findAll().forEach(this::resolve);
+        getNamespaceRepository().findAll().forEach(this::resolve);
+        getStoreRepository().findAll().forEach(this::resolve);
+        getStyleRepository().findAll().forEach(this::resolve);
+        getResourceRepository().findAll().forEach(this::resolve);
+        getLayerRepository().findAll().forEach(this::resolve);
+        getLayerGroupRepository().findAll().forEach(this::resolve);
+        getMapRepository().findAll().forEach(this::resolve);
     }
 
     protected void resolve(LayerInfo layer) {

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/ResolvingCatalogInfoRepository.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/ResolvingCatalogInfoRepository.java
@@ -1,0 +1,56 @@
+/*
+ * (c) 2023 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.catalog.plugin.resolving;
+
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.plugin.CatalogInfoRepository;
+
+import java.util.function.UnaryOperator;
+
+/**
+ * @since 1.4
+ */
+public abstract class ResolvingCatalogInfoRepository<T extends CatalogInfo>
+        implements ResolvingFacade<T>, CatalogInfoRepository<T> {
+
+    private final ResolvingFacadeSupport<T> resolver;
+
+    /**
+     * @param template
+     */
+    protected ResolvingCatalogInfoRepository() {
+        this.resolver = new ResolvingFacadeSupport<>();
+    }
+
+    @Override
+    public void setOutboundResolver(UnaryOperator<T> resolvingFunction) {
+        resolver.setOutboundResolver(resolvingFunction);
+    }
+
+    @Override
+    public UnaryOperator<T> getOutboundResolver() {
+        return resolver.getOutboundResolver();
+    }
+
+    @Override
+    public void setInboundResolver(UnaryOperator<T> resolvingFunction) {
+        resolver.setInboundResolver(resolvingFunction);
+    }
+
+    @Override
+    public UnaryOperator<T> getInboundResolver() {
+        return resolver.getInboundResolver();
+    }
+
+    @Override
+    public <C extends T> C resolveOutbound(C info) {
+        return resolver.resolveOutbound(info);
+    }
+
+    @Override
+    public <C extends T> C resolveInbound(C info) {
+        return resolver.resolveInbound(info);
+    }
+}

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/ResolvingFacadeSupport.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/ResolvingFacadeSupport.java
@@ -1,0 +1,66 @@
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.catalog.plugin.resolving;
+
+import com.google.common.collect.Lists;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.UnaryOperator;
+
+/** */
+public class ResolvingFacadeSupport<T> implements ResolvingFacade<T> {
+
+    private UnaryOperator<T> outboundResolver = UnaryOperator.identity();
+    private UnaryOperator<T> inboundResolver = UnaryOperator.identity();
+
+    @Override
+    public void setOutboundResolver(UnaryOperator<T> resolvingFunction) {
+        Objects.requireNonNull(resolvingFunction);
+        this.outboundResolver = resolvingFunction;
+    }
+
+    @Override
+    public UnaryOperator<T> getOutboundResolver() {
+        return this.outboundResolver;
+    }
+
+    @Override
+    public void setInboundResolver(UnaryOperator<T> resolvingFunction) {
+        Objects.requireNonNull(resolvingFunction);
+        this.inboundResolver = resolvingFunction;
+    }
+
+    @Override
+    public UnaryOperator<T> getInboundResolver() {
+        return this.inboundResolver;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <I extends T> UnaryOperator<I> outbound() {
+        return (UnaryOperator<I>) outboundResolver;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <I extends T> UnaryOperator<I> inbound() {
+        return (UnaryOperator<I>) inboundResolver;
+    }
+
+    @Override
+    public <C extends T> C resolveOutbound(C info) {
+        UnaryOperator<C> outboundResolve = outbound();
+        return outboundResolve.apply(info);
+    }
+
+    @Override
+    public <C extends T> C resolveInbound(C info) {
+        UnaryOperator<C> inboundResolve = inbound();
+        return inboundResolve.apply(info);
+    }
+
+    protected <C extends T> List<C> resolveOutbound(List<C> info) {
+        return Lists.transform(info, this::resolveOutbound);
+    }
+}


### PR DESCRIPTION
Some `Catalog` decorators like `AdvertisedCatalog`, and other beans like `DefaultResourceAccessManager` use
`org.geotools.filter.expression.InternalVolatileFunction` functions in the `Filter` passed to `Catalog` query methods. These functions are inherently non-translatable to SQL, and can do anything with the `CatalogInfo` they evaluate.

The `PgsqlCatalogFacade` resolves CatalogInfo relationships (`ResolvingProxy`) and other properties like the `Catalog` itself in its "outbound" function, but delegates the evaluation of `Filter`s to the
`PgsqlCatalogInfoRepository` for each `CatalogInfo` concrete type.

This in turn splits the provided `Filter` into supported (SQL translatable) and unsupported (evaluated in-process) parts.

Hence, at the time an `InternalVolatileFunction` is evaluated, either the `ResolvingProxy` relations or the `Catalog` property of a `CatalogInfo` may not yet be resolved, producing the `NullPointerException`.

A number of refactorings in this patch favor composition over inheritance to better use inbound/outbound resolvers, and moves the resolving bit from `PgsqlCatalogFacade` down to the `PgsqlCatalogInfoRepository` itself.