### PR TITLE
ExtendedCatalogFacade improvements for handling generic CatalogInfos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ docker-compose_datadir*
 
 # Yourkit Java Profiler docker compose env file with private token
 .env.yjp
+
+hs_err_pid*.log

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/event/remote/resourcepool/RemoteEventResourcePoolProcessor.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/event/remote/resourcepool/RemoteEventResourcePoolProcessor.java
@@ -21,6 +21,8 @@ import org.geoserver.cloud.event.catalog.CatalogInfoRemoved;
 import org.geoserver.cloud.event.info.ConfigInfoType;
 import org.geoserver.cloud.event.info.InfoEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 
 import java.util.Optional;
 
@@ -53,6 +55,7 @@ public class RemoteEventResourcePoolProcessor {
     }
 
     @EventListener(CatalogInfoRemoved.class)
+    @Order(Ordered.HIGHEST_PRECEDENCE)
     public void onCatalogRemoteRemoveEvent(CatalogInfoRemoved event) {
         event.remote()
                 .ifPresentOrElse(
@@ -61,6 +64,7 @@ public class RemoteEventResourcePoolProcessor {
     }
 
     @EventListener(CatalogInfoModified.class)
+    @Order(Ordered.HIGHEST_PRECEDENCE)
     public void onCatalogRemoteModifyEvent(CatalogInfoModified event) {
         event.remote()
                 .ifPresentOrElse(
@@ -86,11 +90,11 @@ public class RemoteEventResourcePoolProcessor {
 
         info.ifPresentOrElse(
                 object -> {
-                    log.info(
+                    log.debug(
                             "Evicting ResourcePool cache entry for {}({}) upon {}",
                             infoType,
                             id,
-                            event);
+                            event.toShortString());
                     ResourcePool resourcePool = rawCatalog.getResourcePool();
                     CacheClearingListener cleaner = new CacheClearingListener(resourcePool);
                     object.accept(cleaner);

--- a/src/catalog/backends/datadir/pom.xml
+++ b/src/catalog/backends/datadir/pom.xml
@@ -43,5 +43,17 @@
       <artifactId>spring-boot-autoconfigure-processor</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-main</artifactId>
+      <version>${gs.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/datadir/RemoteEventDataDirectoryAutoConfiguration.java
+++ b/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/datadir/RemoteEventDataDirectoryAutoConfiguration.java
@@ -4,7 +4,7 @@
  */
 package org.geoserver.cloud.autoconfigure.catalog.backend.datadir;
 
-import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
+import org.geoserver.catalog.plugin.CatalogPlugin;
 import org.geoserver.cloud.autoconfigure.catalog.event.ConditionalOnCatalogEvents;
 import org.geoserver.cloud.event.remote.datadir.RemoteEventDataDirectoryProcessor;
 import org.geoserver.config.plugin.RepositoryGeoServerFacade;
@@ -20,7 +20,7 @@ public class RemoteEventDataDirectoryAutoConfiguration {
     @Bean
     RemoteEventDataDirectoryProcessor dataDirectoryRemoteEventProcessor(
             @Qualifier("geoserverFacade") RepositoryGeoServerFacade configFacade,
-            @Qualifier("catalogFacade") ExtendedCatalogFacade catalogFacade) {
-        return new RemoteEventDataDirectoryProcessor(configFacade, catalogFacade);
+            @Qualifier("rawCatalog") CatalogPlugin rawCatalog) {
+        return new RemoteEventDataDirectoryProcessor(configFacade, rawCatalog);
     }
 }

--- a/src/catalog/backends/datadir/src/test/java/org/geoserver/cloud/event/remote/datadir/RemoteEventDataDirectoryProcessorTest.java
+++ b/src/catalog/backends/datadir/src/test/java/org/geoserver/cloud/event/remote/datadir/RemoteEventDataDirectoryProcessorTest.java
@@ -1,0 +1,310 @@
+/*
+ * (c) 2023 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.event.remote.datadir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.catalog.impl.NamespaceInfoImpl;
+import org.geoserver.catalog.impl.ResolvingProxy;
+import org.geoserver.catalog.impl.WorkspaceInfoImpl;
+import org.geoserver.catalog.plugin.CatalogPlugin;
+import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
+import org.geoserver.catalog.plugin.Patch;
+import org.geoserver.catalog.plugin.PropertyDiff;
+import org.geoserver.cloud.event.UpdateSequenceEvent;
+import org.geoserver.cloud.event.catalog.CatalogInfoAdded;
+import org.geoserver.cloud.event.catalog.CatalogInfoModified;
+import org.geoserver.cloud.event.catalog.CatalogInfoRemoved;
+import org.geoserver.cloud.event.catalog.DefaultDataStoreSet;
+import org.geoserver.cloud.event.catalog.DefaultNamespaceSet;
+import org.geoserver.cloud.event.catalog.DefaultWorkspaceSet;
+import org.geoserver.cloud.event.config.ConfigInfoModified;
+import org.geoserver.cloud.event.config.GeoServerInfoModified;
+import org.geoserver.cloud.event.config.ServiceAdded;
+import org.geoserver.cloud.event.config.ServiceRemoved;
+import org.geoserver.cloud.event.config.SettingsAdded;
+import org.geoserver.cloud.event.config.SettingsRemoved;
+import org.geoserver.cloud.event.info.InfoModified;
+import org.geoserver.config.GeoServerInfo;
+import org.geoserver.config.ServiceInfo;
+import org.geoserver.config.SettingsInfo;
+import org.geoserver.config.impl.GeoServerInfoImpl;
+import org.geoserver.config.impl.ServiceInfoImpl;
+import org.geoserver.config.impl.SettingsInfoImpl;
+import org.geoserver.config.plugin.RepositoryGeoServerFacade;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+class RemoteEventDataDirectoryProcessorTest {
+
+    ExtendedCatalogFacade mockFacade;
+    RepositoryGeoServerFacade mockGeoServerFacade;
+    RemoteEventDataDirectoryProcessor processor;
+
+    GeoServerInfo global;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mockFacade = mock(ExtendedCatalogFacade.class);
+        var catalog = mock(CatalogPlugin.class);
+        when(catalog.getFacade()).thenReturn(mockFacade);
+        mockGeoServerFacade = mock(RepositoryGeoServerFacade.class);
+        global = new GeoServerInfoImpl();
+        when(mockGeoServerFacade.getGlobal()).thenReturn(global);
+        processor = new RemoteEventDataDirectoryProcessor(mockGeoServerFacade, catalog);
+    }
+
+    @Test
+    void testRemoteEventDataDirectoryProcessor() {
+        RepositoryGeoServerFacade configFacade = mock(RepositoryGeoServerFacade.class);
+        CatalogPlugin rawCatalog = mock(CatalogPlugin.class);
+
+        assertThrows(
+                NullPointerException.class,
+                () -> new RemoteEventDataDirectoryProcessor(null, rawCatalog));
+
+        assertThrows(
+                NullPointerException.class,
+                () -> new RemoteEventDataDirectoryProcessor(configFacade, null));
+
+        var catalogFacade = mock(ExtendedCatalogFacade.class);
+        when(rawCatalog.getFacade()).thenReturn(catalogFacade);
+        var processor = new RemoteEventDataDirectoryProcessor(configFacade, rawCatalog);
+        assertSame(catalogFacade, processor.catalogFacade());
+    }
+
+    @Test
+    void testOnRemoteUpdateSequenceEvent() {
+        global.setUpdateSequence(1);
+        UpdateSequenceEvent event = UpdateSequenceEvent.createLocal(10);
+
+        event.setRemote(false);
+        processor.onRemoteUpdateSequenceEvent(event);
+        verify(mockGeoServerFacade, never()).getGlobal();
+
+        event.setRemote(true);
+        processor.onRemoteUpdateSequenceEvent(event);
+        assertThat(global.getUpdateSequence()).isEqualTo(10);
+
+        clearInvocations(mockGeoServerFacade);
+        event = UpdateSequenceEvent.createLocal(global.getUpdateSequence() - 1);
+        event.setRemote(true);
+        processor.onRemoteUpdateSequenceEvent(event);
+        verify(mockGeoServerFacade, times(1)).getGlobal();
+        assertThat(global.getUpdateSequence()).isEqualTo(10);
+    }
+
+    @Test
+    void testOnRemoteRemoveEvent_CatalogInfo() {
+        CatalogInfoRemoved event =
+                CatalogInfoRemoved.createLocal(
+                        101, ResolvingProxy.create("ws1", WorkspaceInfo.class));
+
+        processor.onRemoteRemoveEvent(event);
+        verifyNoMoreInteractions(mockFacade);
+
+        WorkspaceInfo info = new WorkspaceInfoImpl();
+        ((WorkspaceInfoImpl) info).setId("ws1");
+        ((WorkspaceInfoImpl) info).setName("workspace1");
+        Optional<WorkspaceInfo> found = Optional.of(info);
+        when(mockFacade.get("ws1", WorkspaceInfo.class)).thenReturn(found);
+
+        clearInvocations(mockFacade);
+        event.setRemote(true);
+        processor.onRemoteRemoveEvent(event);
+        // cast cause it'll call the generic remove method
+        verify(mockFacade).remove((CatalogInfo) info);
+
+        clearInvocations(mockFacade);
+        when(mockFacade.get("ws1", WorkspaceInfo.class)).thenReturn(Optional.empty());
+        processor.onRemoteRemoveEvent(event);
+        verify(mockFacade, times(1)).get("ws1", WorkspaceInfo.class);
+        verifyNoMoreInteractions(mockFacade);
+    }
+
+    @Test
+    void testOnRemoteRemoveEvent_ConfigInfo() {
+        ServiceInfoImpl service = new ServiceInfoImpl();
+        service.setId("wms1");
+        SettingsInfoImpl settings = new SettingsInfoImpl();
+        settings.setId("settings1");
+        settings.setWorkspace(new WorkspaceInfoImpl());
+        ((WorkspaceInfoImpl) settings.getWorkspace()).setId("ws-id");
+
+        when(mockGeoServerFacade.getService(service.getId(), ServiceInfo.class))
+                .thenReturn(service);
+        when(mockGeoServerFacade.getSettings(settings.getId())).thenReturn(settings);
+
+        ServiceRemoved serviceEvent = ServiceRemoved.createLocal(101, service);
+        SettingsRemoved settingsEvent = SettingsRemoved.createLocal(102, settings);
+
+        processor.onRemoteRemoveEvent(serviceEvent);
+        verifyNoMoreInteractions(mockGeoServerFacade);
+        clearInvocations(mockGeoServerFacade);
+
+        processor.onRemoteRemoveEvent(settingsEvent);
+        verifyNoMoreInteractions(mockGeoServerFacade);
+        clearInvocations(mockGeoServerFacade);
+
+        serviceEvent.setRemote(true);
+        settingsEvent.setRemote(true);
+
+        clearInvocations(mockGeoServerFacade);
+        processor.onRemoteRemoveEvent(serviceEvent);
+        verify(mockGeoServerFacade, times(1)).getService(service.getId(), ServiceInfo.class);
+        verify(mockGeoServerFacade, times(1)).remove(service);
+        verifyNoMoreInteractions(mockGeoServerFacade);
+
+        clearInvocations(mockGeoServerFacade);
+        processor.onRemoteRemoveEvent(settingsEvent);
+        verify(mockGeoServerFacade, times(1)).getSettings(settings.getId());
+        verify(mockGeoServerFacade, times(1)).remove(settings);
+        verifyNoMoreInteractions(mockGeoServerFacade);
+    }
+
+    @Test
+    void testOnRemoteAddEvent_CatalogInfo() {
+        NamespaceInfoImpl info = new NamespaceInfoImpl();
+        info.setId("ns1");
+        info.setPrefix("ns");
+        info.setURI("ns");
+        CatalogInfoAdded event = CatalogInfoAdded.createLocal(10, info);
+
+        event.setRemote(false);
+        processor.onRemoteAddEvent(event);
+        verifyNoMoreInteractions(mockFacade);
+
+        event.setRemote(true);
+        processor.onRemoteAddEvent(event);
+        verify(mockFacade, times(1)).add((CatalogInfo) info);
+    }
+
+    @Test
+    void testOnRemoteAddEvent_ServiceInfo() {
+        ServiceInfoImpl service = new ServiceInfoImpl();
+        service.setId("s1");
+        ServiceAdded event = ServiceAdded.createLocal(0, service);
+        event.setRemote(true);
+        processor.onRemoteAddEvent(event);
+        verify(mockGeoServerFacade, times(1)).add(service);
+    }
+
+    @Test
+    void testOnRemoteAddEvent_SettingsInfo() {
+        SettingsInfoImpl settings = new SettingsInfoImpl();
+        settings.setId("settings1");
+        SettingsAdded event = SettingsAdded.createLocal(0, settings);
+        event.setRemote(true);
+        processor.onRemoteAddEvent(event);
+        verify(mockGeoServerFacade, times(1)).add(settings);
+    }
+
+    @Test
+    void testOnRemoteModifyEvent_CatalogInfo() {
+        WorkspaceInfo info = new WorkspaceInfoImpl();
+        ((WorkspaceInfoImpl) info).setId("id");
+        ((WorkspaceInfoImpl) info).setName("oldName");
+        Patch patch = simplePatch("name", "oldName", "newName");
+
+        InfoModified event = CatalogInfoModified.createLocal(1, info, patch);
+        event.setRemote(false);
+        processor.onRemoteModifyEvent(event);
+        verifyNoMoreInteractions(mockFacade);
+
+        when(mockFacade.get(info.getId(), WorkspaceInfo.class)).thenReturn(Optional.of(info));
+        event.setRemote(true);
+        processor.onRemoteModifyEvent(event);
+        verify(mockFacade, times(1)).update(info, patch);
+    }
+
+    private Patch simplePatch(String property, Object oldValue, Object newValue) {
+        return PropertyDiff.valueOf(List.of(property), List.of(oldValue), List.of(newValue))
+                .toPatch();
+    }
+
+    @Test
+    void testOnRemoteModifyEvent_IgnoresSetDefaultEvents() {
+        processor.onRemoteModifyEvent(mock(DefaultWorkspaceSet.class));
+        processor.onRemoteModifyEvent(mock(DefaultNamespaceSet.class));
+        processor.onRemoteModifyEvent(mock(DefaultDataStoreSet.class));
+        verifyNoMoreInteractions(mockFacade);
+        verifyNoMoreInteractions(mockGeoServerFacade);
+    }
+
+    @Test
+    void testOnRemoteModifyEvent_GeoServerInfo() {
+        GeoServerInfo global = this.global;
+
+        when(mockGeoServerFacade.getGlobal())
+                .thenReturn(ModificationProxy.create(global, GeoServerInfo.class));
+
+        global.setFeatureTypeCacheSize(1);
+        var proxied = mockGeoServerFacade.getGlobal();
+        proxied.setFeatureTypeCacheSize(1000);
+        Patch patch = PropertyDiff.valueOf(ModificationProxy.handler(proxied)).toPatch();
+
+        ConfigInfoModified event = ConfigInfoModified.createLocal(1, global, patch);
+        event.setRemote(true);
+
+        processor.onRemoteModifyEvent(event);
+        assertThat(global.getFeatureTypeCacheSize()).isEqualTo(1_000);
+    }
+
+    @Test
+    void testOnRemoteModifyEvent_SettingsInfo() {
+        SettingsInfoImpl settings = new SettingsInfoImpl();
+        settings.setId("set1");
+        settings.setWorkspace(new WorkspaceInfoImpl());
+        ((WorkspaceInfoImpl) settings.getWorkspace()).setId("ws1");
+
+        when(mockGeoServerFacade.getSettings(settings.getId()))
+                .thenReturn(ModificationProxy.create(settings, SettingsInfo.class));
+
+        settings.setCharset("ISO-8859-1");
+        var proxied = mockGeoServerFacade.getSettings(settings.getId());
+        proxied.setCharset("UTF-8");
+        Patch patch = PropertyDiff.valueOf(ModificationProxy.handler(proxied)).toPatch();
+
+        ConfigInfoModified event = GeoServerInfoModified.createLocal(1, settings, patch);
+        event.setRemote(true);
+
+        processor.onRemoteModifyEvent(event);
+        assertThat(settings.getCharset()).isEqualTo("UTF-8");
+    }
+
+    @Test
+    void testOnRemoteModifyEvent_ServiceInfo() {
+        ServiceInfoImpl service = new ServiceInfoImpl();
+        service.setId("serv1");
+
+        when(mockGeoServerFacade.getService(service.getId(), ServiceInfo.class))
+                .thenReturn(ModificationProxy.create(service, ServiceInfo.class));
+
+        service.setTitle("old title");
+        var proxied = mockGeoServerFacade.getService(service.getId(), ServiceInfo.class);
+        proxied.setTitle("new title");
+        Patch patch = PropertyDiff.valueOf(ModificationProxy.handler(proxied)).toPatch();
+
+        InfoModified event = GeoServerInfoModified.createLocal(1, service, patch);
+        event.setRemote(true);
+
+        processor.onRemoteModifyEvent(event);
+        assertThat(service.getTitle()).isEqualTo("new title");
+    }
+}

--- a/src/catalog/cache/src/main/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeImpl.java
+++ b/src/catalog/cache/src/main/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeImpl.java
@@ -74,6 +74,18 @@ class CachingCatalogFacadeImpl extends ForwardingExtendedCatalogFacade
         return idCache.evictIfPresent(key);
     }
 
+    @Override
+    @CachePut(key = "new org.geoserver.cloud.catalog.cache.CatalogInfoKey(#p0)")
+    public <T extends CatalogInfo> T add(@NonNull T info) {
+        return super.add(info);
+    }
+
+    @Override
+    @CacheEvict(key = "new org.geoserver.cloud.catalog.cache.CatalogInfoKey(#p0)")
+    public void remove(@NonNull CatalogInfo info) {
+        super.remove(info);
+    }
+
     @CachePut(key = "new org.geoserver.cloud.catalog.cache.CatalogInfoKey(#p0)")
     @Override
     public StoreInfo add(StoreInfo store) {

--- a/src/catalog/event-bus/pom.xml
+++ b/src/catalog/event-bus/pom.xml
@@ -64,6 +64,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>

--- a/src/catalog/event-bus/src/main/java/org/geoserver/cloud/autoconfigure/event/bus/GeoServerBusIntegrationAutoConfiguration.java
+++ b/src/catalog/event-bus/src/main/java/org/geoserver/cloud/autoconfigure/event/bus/GeoServerBusIntegrationAutoConfiguration.java
@@ -6,10 +6,11 @@ package org.geoserver.cloud.autoconfigure.event.bus;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.geoserver.cloud.autoconfigure.catalog.event.ConditionalOnCatalogEvents;
+import org.geoserver.cloud.event.bus.RemoteGeoServerEventsConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.cloud.bus.BusAutoConfiguration;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 import javax.annotation.PostConstruct;
@@ -23,16 +24,18 @@ import javax.annotation.PostConstruct;
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.bus")
 public class GeoServerBusIntegrationAutoConfiguration {
 
-    @Configuration(proxyBeanMethods = false)
-    @ConditionalOnGeoServerRemoteEventsEnabled
+    @AutoConfiguration
     @AutoConfigureAfter(BusAutoConfiguration.class)
+    @ConditionalOnCatalogEvents
+    @ConditionalOnGeoServerRemoteEventsEnabled
+    @Import(RemoteGeoServerEventsConfiguration.class)
     static class Enabled {
         public @PostConstruct void logBusDisabled() {
             log.info("GeoServer event-bus integration is enabled");
         }
     }
 
-    @Configuration(proxyBeanMethods = false)
+    @AutoConfiguration
     @ConditionalOnGeoServerRemoteEventsDisabled
     static class Disabled {
         public @PostConstruct void logBusDisabled() {

--- a/src/catalog/event-bus/src/main/java/org/geoserver/cloud/event/bus/RemoteGeoServerEvent.java
+++ b/src/catalog/event-bus/src/main/java/org/geoserver/cloud/event/bus/RemoteGeoServerEvent.java
@@ -19,6 +19,7 @@ public class RemoteGeoServerEvent extends RemoteApplicationEvent {
     @Getter @NonNull private GeoServerEvent event;
 
     /** Deserialization-time constructor, {@link #getSource()} will be {@code null} */
+    @SuppressWarnings("java:S2637") // final fields initialized by deserialization
     protected RemoteGeoServerEvent() {
         // default constructor, needed for deserialization
     }
@@ -42,5 +43,9 @@ public class RemoteGeoServerEvent extends RemoteApplicationEvent {
                 getOriginService(),
                 getDestinationService(),
                 getEvent());
+    }
+
+    public String toShortString() {
+        return getEvent().toShortString();
     }
 }

--- a/src/catalog/event-bus/src/main/resources/META-INF/spring.factories
+++ b/src/catalog/event-bus/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,2 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.geoserver.cloud.autoconfigure.event.bus.GeoServerBusIntegrationAutoConfiguration,\
-org.geoserver.cloud.autoconfigure.event.bus.RemoteGeoServerEventsAutoConfiguration
+org.geoserver.cloud.autoconfigure.event.bus.GeoServerBusIntegrationAutoConfiguration

--- a/src/catalog/event-bus/src/test/java/org/geoserver/cloud/autoconfigure/event/bus/GeoServerBusIntegrationAutoConfigurationTest.java
+++ b/src/catalog/event-bus/src/test/java/org/geoserver/cloud/autoconfigure/event/bus/GeoServerBusIntegrationAutoConfigurationTest.java
@@ -1,0 +1,89 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.event.bus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.geoserver.catalog.Catalog;
+import org.geoserver.cloud.event.bus.RemoteGeoServerEventBridge;
+import org.geoserver.config.GeoServer;
+import org.geoserver.jackson.databind.catalog.GeoServerCatalogModule;
+import org.geoserver.jackson.databind.config.GeoServerConfigModule;
+import org.geoserver.platform.config.UpdateSequence;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.bus.BusAutoConfiguration;
+import org.springframework.cloud.bus.BusBridge;
+import org.springframework.cloud.bus.ServiceMatcher;
+
+/**
+ * @since 1.0
+ */
+class GeoServerBusIntegrationAutoConfigurationTest {
+
+    private final ServiceMatcher mockServiceMatcher = mock(ServiceMatcher.class);
+    private final BusBridge mockBusBridge = mock(BusBridge.class);
+    private final Catalog mockCatalog = mock(Catalog.class);
+    private final GeoServer mockGeoserver = mock(GeoServer.class);
+    private final UpdateSequence updateSequence = mock(UpdateSequence.class);
+
+    private ApplicationContextRunner runner =
+            new ApplicationContextRunner()
+                    .withBean(ServiceMatcher.class, () -> mockServiceMatcher)
+                    .withBean(BusBridge.class, () -> mockBusBridge)
+                    .withBean(UpdateSequence.class, () -> updateSequence)
+                    .withBean("rawCatalog", Catalog.class, () -> mockCatalog)
+                    .withBean("Geoserver", GeoServer.class, () -> mockGeoserver)
+                    .withConfiguration(
+                            AutoConfigurations.of(
+                                    BusAutoConfiguration.class,
+                                    GeoServerBusIntegrationAutoConfiguration.class));
+
+    @Test
+    void enabledByDefault() {
+        assertEnabled(runner);
+    }
+
+    @Test
+    void conditionalOnGeoServerRemoteEventsEnabled() {
+        assertDisabled(runner.withPropertyValues("geoserver.bus.enabled: false"));
+    }
+
+    @Test
+    void conditionalOnBusEnabled() {
+        assertDisabled(runner.withPropertyValues("spring.cloud.bus.enabled: false"));
+    }
+
+    @Test
+    void conditionalOnCatalogEvents() {
+        assertDisabled(runner.withPropertyValues("geoserver.catalog.events.enabled: false"));
+    }
+
+    private void assertEnabled(ApplicationContextRunner runner) {
+
+        runner.run(
+                context -> {
+                    assertThat(context)
+                            .hasNotFailed()
+                            .hasSingleBean(GeoServerCatalogModule.class)
+                            .hasSingleBean(GeoServerConfigModule.class)
+                            .hasSingleBean(RemoteGeoServerEventBridge.class);
+                });
+    }
+
+    private void assertDisabled(ApplicationContextRunner runner) {
+
+        runner.run(
+                context -> {
+                    assertThat(context)
+                            .hasNotFailed()
+                            .doesNotHaveBean(GeoServerCatalogModule.class)
+                            .doesNotHaveBean(GeoServerConfigModule.class)
+                            .doesNotHaveBean(RemoteGeoServerEventBridge.class);
+                });
+    }
+}

--- a/src/catalog/event-bus/src/test/java/org/geoserver/cloud/event/bus/BusEventCollector.java
+++ b/src/catalog/event-bus/src/test/java/org/geoserver/cloud/event/bus/BusEventCollector.java
@@ -80,7 +80,7 @@ public class BusEventCollector {
             Class<T> payloadType, Predicate<T> filter) {
 
         List<RemoteGeoServerEvent> matches =
-                await().atMost(Duration.ofSeconds(5)) //
+                await().atMost(Duration.ofSeconds(500)) //
                         .until(() -> allOf(payloadType, filter), not(List::isEmpty));
 
         Supplier<String> message =
@@ -126,12 +126,12 @@ public class BusEventCollector {
     public void stop() {
         log.debug("bus id {}: stopped", busId);
         capturing = false;
-        bridge.enabled(false);
+        bridge.disable();
     }
 
     public void start() {
         log.debug("bus id {}: ready to capture {} events", busId, eventType.getSimpleName());
         capturing = true;
-        bridge.enabled(true);
+        bridge.enable();
     }
 }

--- a/src/catalog/event-bus/src/test/java/org/geoserver/cloud/event/bus/CatalogRemoteApplicationEventsIT.java
+++ b/src/catalog/event-bus/src/test/java/org/geoserver/cloud/event/bus/CatalogRemoteApplicationEventsIT.java
@@ -198,7 +198,7 @@ class CatalogRemoteApplicationEventsIT extends BusAmqpIntegrationTests {
         catalog.add(testData.workspaceA);
         catalog.add(testData.namespaceA);
         catalog.add(testData.dataStoreA);
-        testRemoteCatalogInfoAddEvent(testData.featureTypeA, catalog::add);
+        testRemoteCatalogInfoAddEvent(testData.featureTypeA);
     }
 
     @Test
@@ -208,7 +208,7 @@ class CatalogRemoteApplicationEventsIT extends BusAmqpIntegrationTests {
         catalog.add(testData.dataStoreA);
         catalog.add(testData.featureTypeA);
         catalog.add(testData.style1);
-        testRemoteCatalogInfoAddEvent(testData.layerFeatureTypeA, catalog::add);
+        testRemoteCatalogInfoAddEvent(testData.layerFeatureTypeA);
     }
 
     @Test

--- a/src/catalog/event-bus/src/test/java/org/geoserver/cloud/event/bus/RemoteGeoServerEventsConfigurationTest.java
+++ b/src/catalog/event-bus/src/test/java/org/geoserver/cloud/event/bus/RemoteGeoServerEventsConfigurationTest.java
@@ -2,20 +2,19 @@
  * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
  * GPL 2.0 license, available at the root application directory.
  */
-package org.geoserver.cloud.autoconfigure.event.bus;
+package org.geoserver.cloud.event.bus;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import org.geoserver.catalog.Catalog;
-import org.geoserver.cloud.event.bus.InfoEventResolver;
-import org.geoserver.cloud.event.bus.RemoteGeoServerEventBridge;
-import org.geoserver.cloud.event.bus.RemoteGeoServerEventMapper;
 import org.geoserver.config.GeoServer;
 import org.geoserver.jackson.databind.catalog.GeoServerCatalogModule;
 import org.geoserver.jackson.databind.config.GeoServerConfigModule;
+import org.geoserver.platform.config.UpdateSequence;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.context.annotation.UserConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.bus.BusAutoConfiguration;
 import org.springframework.cloud.bus.BusBridge;
@@ -24,46 +23,27 @@ import org.springframework.cloud.bus.ServiceMatcher;
 /**
  * @since 1.0
  */
-class RemoteGeoServerEventsAutoConfigurationTest {
+class RemoteGeoServerEventsConfigurationTest {
 
     private final ServiceMatcher mockServiceMatcher = mock(ServiceMatcher.class);
     private final BusBridge mockBusBridge = mock(BusBridge.class);
     private final Catalog mockCatalog = mock(Catalog.class);
     private final GeoServer mockGeoserver = mock(GeoServer.class);
+    private final UpdateSequence updateSequence = mock(UpdateSequence.class);
 
     private ApplicationContextRunner runner =
             new ApplicationContextRunner()
                     .withBean(ServiceMatcher.class, () -> mockServiceMatcher)
                     .withBean(BusBridge.class, () -> mockBusBridge)
+                    .withBean(UpdateSequence.class, () -> updateSequence)
                     .withBean("rawCatalog", Catalog.class, () -> mockCatalog)
                     .withBean("Geoserver", GeoServer.class, () -> mockGeoserver)
+                    .withConfiguration(AutoConfigurations.of(BusAutoConfiguration.class))
                     .withConfiguration(
-                            AutoConfigurations.of(
-                                    BusAutoConfiguration.class,
-                                    RemoteGeoServerEventsAutoConfiguration.class));
+                            UserConfigurations.of(RemoteGeoServerEventsConfiguration.class));
 
     @Test
     void enabledByDefault() {
-        assertEnabled(runner);
-    }
-
-    @Test
-    void conditionalOnGeoServerRemoteEventsEnabled() {
-        assertDisabled(runner.withPropertyValues("geoserver.bus.enabled: false"));
-    }
-
-    @Test
-    void conditionalOnBusEnabled() {
-        assertDisabled(runner.withPropertyValues("spring.cloud.bus.enabled: false"));
-    }
-
-    @Test
-    void conditionalOnCatalogEvents() {
-        assertDisabled(runner.withPropertyValues("geoserver.catalog.events.enabled: false"));
-    }
-
-    private void assertEnabled(ApplicationContextRunner runner) {
-
         runner.run(
                 context -> {
                     assertThat(context).hasSingleBean(GeoServerCatalogModule.class);
@@ -71,18 +51,6 @@ class RemoteGeoServerEventsAutoConfigurationTest {
                     assertThat(context).hasSingleBean(InfoEventResolver.class);
                     assertThat(context).hasSingleBean(RemoteGeoServerEventMapper.class);
                     assertThat(context).hasSingleBean(RemoteGeoServerEventBridge.class);
-                });
-    }
-
-    private void assertDisabled(ApplicationContextRunner runner) {
-
-        runner.run(
-                context -> {
-                    assertThat(context).doesNotHaveBean(GeoServerCatalogModule.class);
-                    assertThat(context).doesNotHaveBean(GeoServerConfigModule.class);
-                    assertThat(context).doesNotHaveBean(InfoEventResolver.class);
-                    assertThat(context).doesNotHaveBean(RemoteGeoServerEventMapper.class);
-                    assertThat(context).doesNotHaveBean(RemoteGeoServerEventBridge.class);
                 });
     }
 }

--- a/src/catalog/event-bus/src/test/resources/application.yml
+++ b/src/catalog/event-bus/src/test/resources/application.yml
@@ -14,5 +14,5 @@ logging:
     root: WARN
     org.springframework: error
     org.geoserver.platform: error
-    org.geoserver.cloud: info
-    org.geoserver.cloud.bus: info
+    org.geoserver.cloud: debug
+    org.geoserver.cloud.bus: debug

--- a/src/catalog/event-bus/src/test/resources/logback-test.xml
+++ b/src/catalog/event-bus/src/test/resources/logback-test.xml
@@ -11,4 +11,7 @@
 
     <logger name="org.springframework" level="WARN"/>
     <logger name="org.testcontainers" level="INFO"/>
+    <logger name="org.geoserver.cloud.event" level="DEBUG"/>
+    <logger name="org.geoserver.cloud.event.bus" level="DEBUG"/>
+    
 </configuration>

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/GeoServerEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/GeoServerEvent.java
@@ -68,6 +68,8 @@ public abstract class GeoServerEvent implements Serializable {
         return toStringBuilder().toString();
     }
 
+    public abstract String toShortString();
+
     protected ToStringCreator toStringBuilder() {
         return new ToStringCreator(this)
                 .append("id", getId())

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/UpdateSequenceEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/UpdateSequenceEvent.java
@@ -24,7 +24,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 })
 @JsonTypeName("UpdateSequence")
 @SuppressWarnings("serial")
-public class UpdateSequenceEvent extends GeoServerEvent {
+public class UpdateSequenceEvent extends GeoServerEvent implements Comparable<UpdateSequenceEvent> {
     /**
      * The provided {@link GeoServerInfo}'s {@link GeoServerInfo#getUpdateSequence() update
      * sequence}. Being the most frequently updated property, it's readily available for remote
@@ -50,5 +50,18 @@ public class UpdateSequenceEvent extends GeoServerEvent {
 
     public static UpdateSequenceEvent createLocal(long value) {
         return new UpdateSequenceEvent(value);
+    }
+
+    @Override
+    public int compareTo(UpdateSequenceEvent o) {
+        return Long.compare(getUpdateSequence(), o.getUpdateSequence());
+    }
+
+    @Override
+    public String toShortString() {
+        String originService = getOrigin();
+        String type = getClass().getSimpleName();
+        return "%s[origin: %s, updateSequence: %s]"
+                .formatted(type, originService, getUpdateSequence());
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/CatalogInfoAdded.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/catalog/CatalogInfoAdded.java
@@ -34,6 +34,10 @@ public class CatalogInfoAdded extends InfoAdded<CatalogInfo> {
 
     public static CatalogInfoAdded createLocal(
             long updateSequence, @NonNull CatalogAddEvent event) {
-        return new CatalogInfoAdded(updateSequence, event.getSource());
+        return createLocal(updateSequence, event.getSource());
+    }
+
+    public static CatalogInfoAdded createLocal(long updateSequence, @NonNull CatalogInfo info) {
+        return new CatalogInfoAdded(updateSequence, info);
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/info/ConfigInfoType.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/info/ConfigInfoType.java
@@ -58,6 +58,15 @@ public enum ConfigInfoType {
         return object != null && getType().isInstance(object);
     }
 
+    public static boolean isPersistable(@NonNull Info info) {
+        for (ConfigInfoType enumVal : ConfigInfoType.values()) {
+            if (enumVal.isInstance(info)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static ConfigInfoType valueOf(@NonNull Info object) {
         for (ConfigInfoType enumVal : ConfigInfoType.values()) {
             if (enumVal.isInstance(object)) {
@@ -69,5 +78,10 @@ public enum ConfigInfoType {
 
     public boolean isA(Class<? extends Info> type) {
         return type.isAssignableFrom(getType());
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> Class<T> type() {
+        return (Class<T>) type;
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/info/InfoEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/info/InfoEvent.java
@@ -61,6 +61,15 @@ public abstract class InfoEvent extends UpdateSequenceEvent {
      */
     private static final String LOGGING_ID = "logging";
 
+    @Override
+    public String toShortString() {
+        String originService = getOrigin();
+        String type = getClass().getSimpleName();
+        return "%s[origin: %s, updateSequence: %s, object: %s(%s)]"
+                .formatted(
+                        type, originService, getUpdateSequence(), getObjectType(), getObjectId());
+    }
+
     public static String resolveId(Info object) {
         if (null == object) return null;
         String id = object.getId();

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/security/SecurityConfigChanged.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/security/SecurityConfigChanged.java
@@ -39,4 +39,12 @@ public class SecurityConfigChanged extends UpdateSequenceEvent {
     public static SecurityConfigChanged createLocal(long updateSequence, @NonNull String reason) {
         return new SecurityConfigChanged(updateSequence, reason);
     }
+
+    @Override
+    public String toShortString() {
+        String originService = getOrigin();
+        String type = getClass().getSimpleName();
+        return "%s[origin: %s, updateSequence: %s, reason: %s]"
+                .formatted(type, originService, getUpdateSequence(), getReason());
+    }
 }

--- a/src/catalog/plugin/pom.xml
+++ b/src/catalog/plugin/pom.xml
@@ -116,6 +116,10 @@
       <groupId>org.geotools</groupId>
       <artifactId>gt-process-feature</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.github.f4b6a3</groupId>
+      <artifactId>ulid-creator</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/ExtendedCatalogFacade.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/ExtendedCatalogFacade.java
@@ -4,23 +4,30 @@
  */
 package org.geoserver.catalog.plugin;
 
+import lombok.NonNull;
+
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.MapInfo;
 import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.ClassMappings;
 import org.geoserver.catalog.util.CloseableIterator;
 import org.geoserver.catalog.util.CloseableIteratorAdapter;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.sort.SortBy;
 
 import java.io.Closeable;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
@@ -32,6 +39,105 @@ import javax.annotation.Nullable;
  * directly to {@link CatalogFacade}
  */
 public interface ExtendedCatalogFacade extends CatalogFacade {
+
+    default <T extends CatalogInfo> void forEach(Consumer<? super CatalogInfo> consumer) {
+        List<Class<? extends CatalogInfo>> types =
+                List.of(
+                        WorkspaceInfo.class,
+                        NamespaceInfo.class,
+                        StoreInfo.class,
+                        ResourceInfo.class,
+                        StyleInfo.class,
+                        LayerInfo.class,
+                        LayerGroupInfo.class);
+
+        for (var type : types) {
+            try (var stream = query(Query.valueOf(type, Filter.INCLUDE))) {
+                stream.forEach(consumer);
+            }
+        }
+    }
+
+    default Optional<CatalogInfo> get(@NonNull String id) {
+        CatalogInfo found = getWorkspace(id);
+        if (null == found) found = getNamespace(id);
+        if (null == found) found = getStore(id, StoreInfo.class);
+        if (null == found) found = getResource(id, ResourceInfo.class);
+        if (null == found) found = getPublished(id);
+        if (null == found) found = getStyle(id);
+        if (null == found) found = getMap(id);
+        return Optional.ofNullable(found);
+    }
+
+    default <T extends CatalogInfo> Optional<T> get(@NonNull String id, @NonNull Class<T> type) {
+        if (!type.isInterface()) {
+            throw new IllegalArgumentException("Expected an interface type, got " + type);
+        }
+        if (CatalogInfo.class.equals(type)) {
+            return get(id).map(type::cast);
+        }
+
+        ClassMappings cm = ClassMappings.fromInterface(type);
+        CatalogInfo found =
+                switch (cm) {
+                    case WORKSPACE -> getWorkspace(id);
+                    case NAMESPACE -> getNamespace(id);
+
+                    case DATASTORE, COVERAGESTORE, WMSSTORE, WMTSSTORE, STORE -> getStore(
+                            id, StoreInfo.class);
+
+                    case FEATURETYPE, COVERAGE, WMSLAYER, WMTSLAYER, RESOURCE -> getResource(
+                            id, ResourceInfo.class);
+
+                    case LAYER -> getLayer(id);
+                    case LAYERGROUP -> getLayerGroup(id);
+                    case PUBLISHED -> getPublished(id);
+
+                    case STYLE -> getStyle(id);
+                    case MAP -> getMap(id);
+                    default -> throw new IllegalArgumentException(
+                            "Unknown CatalogInfo type " + type);
+                };
+
+        return Optional.ofNullable(found).filter(type::isInstance).map(type::cast);
+    }
+
+    default PublishedInfo getPublished(@NonNull String id) {
+        return get(id, LayerInfo.class)
+                .map(PublishedInfo.class::cast)
+                .or(() -> get(id, LayerGroupInfo.class))
+                .orElse(null);
+    }
+
+    @SuppressWarnings("unchecked")
+    default <T extends CatalogInfo> T add(@NonNull T info) {
+        return switch (info) {
+            case WorkspaceInfo ws -> (T) add(ws);
+            case NamespaceInfo ns -> (T) add(ns);
+            case StoreInfo st -> (T) add(st);
+            case ResourceInfo r -> (T) add(r);
+            case LayerInfo l -> (T) add(l);
+            case LayerGroupInfo lg -> (T) add(lg);
+            case StyleInfo s -> (T) add(s);
+            case MapInfo m -> (T) add(m);
+            default -> throw new IllegalArgumentException("Unexpected value: %s".formatted(info));
+        };
+    }
+
+    default void remove(@NonNull CatalogInfo info) {
+        switch (info) {
+            case WorkspaceInfo ws -> remove(ws);
+            case NamespaceInfo ns -> remove(ns);
+            case StoreInfo st -> remove(st);
+            case ResourceInfo r -> remove(r);
+            case LayerInfo l -> remove(l);
+            case LayerGroupInfo lg -> remove(lg);
+            case StyleInfo s -> remove(s);
+            case MapInfo m -> remove(m);
+            default -> throw new IllegalArgumentException("Unexpected value: %s".formatted(info));
+        }
+        ;
+    }
 
     <I extends CatalogInfo> I update(I info, Patch patch);
 

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/RepositoryCatalogFacadeImpl.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/RepositoryCatalogFacadeImpl.java
@@ -179,6 +179,7 @@ public class RepositoryCatalogFacadeImpl
     @Override
     public <T extends ResourceInfo> T getResourceByName(
             NamespaceInfo namespace, String name, Class<T> clazz) {
+        if (namespace == null) return null;
         Optional<T> result;
         if (namespace == ANY_NAMESPACE) {
             result = getResourceRepository().findFirstByName(name, clazz);

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingCatalogFacade.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingCatalogFacade.java
@@ -4,8 +4,6 @@
  */
 package org.geoserver.catalog.plugin.forwarding;
 
-import lombok.Getter;
-
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogCapabilities;
 import org.geoserver.catalog.CatalogFacade;
@@ -37,7 +35,7 @@ import javax.annotation.Nullable;
 public class ForwardingCatalogFacade implements CatalogFacade {
 
     // wrapped catalog facade
-    @Getter protected final CatalogFacade facade;
+    protected final CatalogFacade facade;
 
     public ForwardingCatalogFacade(CatalogFacade facade) {
         this.facade = facade;

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingExtendedCatalogFacade.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingExtendedCatalogFacade.java
@@ -4,6 +4,8 @@
  */
 package org.geoserver.catalog.plugin.forwarding;
 
+import lombok.NonNull;
+
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
@@ -32,5 +34,15 @@ public class ForwardingExtendedCatalogFacade extends ForwardingCatalogFacade
 
     protected ExtendedCatalogFacade asExtendedFacade() {
         return (ExtendedCatalogFacade) super.facade;
+    }
+
+    @Override
+    public <T extends CatalogInfo> T add(@NonNull T info) {
+        return asExtendedFacade().add(info);
+    }
+
+    @Override
+    public void remove(@NonNull CatalogInfo info) {
+        asExtendedFacade().remove(info);
     }
 }

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ResolvingCatalogFacadeDecorator.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ResolvingCatalogFacadeDecorator.java
@@ -31,6 +31,7 @@ import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.sort.SortBy;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
@@ -327,6 +328,11 @@ public class ResolvingCatalogFacadeDecorator extends ForwardingExtendedCatalogFa
     }
 
     @Override
+    public void setDefaultDataStore(WorkspaceInfo workspace, DataStoreInfo store) {
+        super.setDefaultDataStore(resolveInbound(workspace), resolveInbound(store));
+    }
+
+    @Override
     public WorkspaceInfo getWorkspace(String id) {
         return resolveOutbound(super.getWorkspace(id));
     }
@@ -506,6 +512,6 @@ public class ResolvingCatalogFacadeDecorator extends ForwardingExtendedCatalogFa
 
     @Override
     public <T extends CatalogInfo> Stream<T> query(Query<T> query) {
-        return super.query(query).map(this::resolveOutbound).filter(i -> i != null);
+        return super.query(query).map(this::resolveOutbound).filter(Objects::nonNull);
     }
 }

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/locking/LockingCatalog.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/locking/LockingCatalog.java
@@ -21,7 +21,6 @@ import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.CatalogPlugin;
 
-import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
 /**
@@ -120,9 +119,9 @@ public class LockingCatalog extends CatalogPlugin {
     }
 
     /** {@inheritDoc} */
-    protected @Override <T extends CatalogInfo> void doRemove(T info, Consumer<T> remover) {
+    protected @Override <T extends CatalogInfo> void doRemove(T info, Class<T> type) {
         locking.runInWriteLock(
-                () -> super.doRemove(info, remover),
+                () -> super.doRemove(info, type),
                 format("remove(%s[%s])", typeOf(info), nameOf(info)));
     }
 

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/ProxyUtils.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/ProxyUtils.java
@@ -48,7 +48,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /** */
-@Slf4j
+@Slf4j(topic = "org.geoserver.catalog.plugin.resolving")
 @RequiredArgsConstructor
 public class ProxyUtils {
     /**

--- a/src/catalog/plugin/src/test/java/org/geoserver/catalog/faker/CatalogFaker.java
+++ b/src/catalog/plugin/src/test/java/org/geoserver/catalog/faker/CatalogFaker.java
@@ -594,7 +594,7 @@ public class CatalogFaker {
         return s;
     }
 
-    public AttributionInfo attributionInfo() throws Exception {
+    public AttributionInfo attributionInfo() {
         AttributionInfoImpl attinfo = new AttributionInfoImpl();
         attinfo.setId(faker.idNumber().valid());
         attinfo.setHref(faker.company().url());

--- a/src/catalog/plugin/src/test/java/org/geoserver/catalog/plugin/CatalogConformanceTest.java
+++ b/src/catalog/plugin/src/test/java/org/geoserver/catalog/plugin/CatalogConformanceTest.java
@@ -1145,7 +1145,8 @@ public abstract class CatalogConformanceTest {
         catalog.remove(data.dataStoreA);
 
         assertEquals(1, l.removed.size());
-        assertEquals(data.dataStoreA, l.removed.get(0).getSource());
+        // comparing id, DataStoreInfoImpl.equals() is screwed up
+        assertEquals(data.dataStoreA.getId(), l.removed.get(0).getSource().getId());
     }
 
     @Test

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -113,6 +113,11 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>com.github.f4b6a3</groupId>
+        <artifactId>ulid-creator</artifactId>
+        <version>5.2.3</version>
+      </dependency>
+      <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-platform</artifactId>
         <version>${gs.version}</version>


### PR DESCRIPTION
* Add methods to ExtendedCatalogFacade to handle add/remove operations for CatalogInfos in a generic way.

* Improve BusAmqpIntegrationTests to check incoming remote objects are fully resolved
* Refactor remote events configuration separating autoconfiguration from configuration