### PR TITLE
pgconfig: encode null values in JSON for Postgres jsonb_populate_record() to update automatic columns

### DIFF
--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/CatalogInfoRowMapper.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/CatalogInfoRowMapper.java
@@ -21,7 +21,6 @@ import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.ClassMappings;
 import org.geoserver.catalog.impl.LayerInfoImpl;
 import org.geoserver.catalog.impl.ModificationProxy;
-import org.geotools.jackson.databind.util.ObjectMapperUtil;
 import org.springframework.jdbc.core.RowMapper;
 
 import java.io.UncheckedIOException;
@@ -39,7 +38,7 @@ import java.util.function.Function;
  */
 public final class CatalogInfoRowMapper {
 
-    protected static final ObjectMapper objectMapper = ObjectMapperUtil.newObjectMapper();
+    protected static final ObjectMapper objectMapper = PgsqlObjectMapper.newObjectMapper();
 
     // TODO: limit the amount of cached objects
     private Map<String, CatalogInfo> cache = new HashMap<>();

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgsqlCatalogInfoRepository.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgsqlCatalogInfoRepository.java
@@ -21,7 +21,6 @@ import org.geoserver.cloud.backend.pgconfig.catalog.filter.PgsqlQueryBuilder;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.sort.SortBy;
 import org.geotools.api.filter.sort.SortOrder;
-import org.geotools.jackson.databind.util.ObjectMapperUtil;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
@@ -50,7 +49,7 @@ public abstract class PgsqlCatalogInfoRepository<T extends CatalogInfo>
 
     protected final @NonNull JdbcTemplate template;
 
-    protected static final ObjectMapper infoMapper = ObjectMapperUtil.newObjectMapper();
+    protected static final ObjectMapper infoMapper = PgsqlObjectMapper.newObjectMapper();
 
     private Set<String> sortableProperties;
 

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgsqlObjectMapper.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgsqlObjectMapper.java
@@ -1,0 +1,43 @@
+/*
+ * (c) 2023 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.backend.pgconfig.catalog.repository;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.experimental.UtilityClass;
+
+import org.geotools.jackson.databind.util.ObjectMapperUtil;
+
+@UtilityClass
+public class PgsqlObjectMapper {
+
+    /**
+     * Creates a Jackson {@link ObjectMapper} configured for the PostgreSQL JSONB encoding of
+     * catalog and config info objects. In particular, null values must be encoded as {@code null}
+     * in JSON, for the Postgres triggers calling {@code populate_table_columns_from_jsonb()} to
+     * correctly unset columns used for joining when values in the JSON representation change to
+     * {@code null}.
+     *
+     * <p>For example, if a layer group is moved from one workspace to no-workspace, the {@code
+     * layergroupinfo.workspace} table column must be automatically set to null by {@code
+     * populate_table_columns_from_jsonb()}, which won't happen if the new JSON object does not have
+     * the {@code "workspace": null} property, as when the {@link ObjectMapper} has default property
+     * inclusion {@link Include#NON_EMPTY}.
+     *
+     * @return a Jackson {@link ObjectMapper} configured for the PostgreSQL JSONB encoding of
+     *     catalog and config info objects.
+     * @see ObjectMapperUtil#newObjectMapper()
+     * @see {@code populate_table_columns_from_jsonb()} in {@literal
+     *     src/main/resources/db/pgsqlcatalog/migration/postgresql/V1_0__Catalog_Tables.sql}
+     */
+    public static ObjectMapper newObjectMapper() {
+        ObjectMapper mapper = ObjectMapperUtil.newObjectMapper();
+        // encode nulls as nulls, default from ObjectMapperUtil.newObjectMapper() is
+        // Include.NON_EMPTY
+        mapper.setDefaultPropertyInclusion(Include.ALWAYS);
+        return mapper;
+    }
+}

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/config/PgsqlConfigRepository.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/config/PgsqlConfigRepository.java
@@ -15,12 +15,12 @@ import org.geoserver.catalog.Info;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.ClassMappings;
 import org.geoserver.catalog.plugin.Patch;
+import org.geoserver.cloud.backend.pgconfig.catalog.repository.PgsqlObjectMapper;
 import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.LoggingInfo;
 import org.geoserver.config.ServiceInfo;
 import org.geoserver.config.SettingsInfo;
 import org.geoserver.config.plugin.ConfigRepository;
-import org.geotools.jackson.databind.util.ObjectMapperUtil;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
@@ -38,7 +38,7 @@ import java.util.stream.Stream;
 public class PgsqlConfigRepository implements ConfigRepository {
 
     private final @NonNull JdbcTemplate template;
-    protected static final ObjectMapper infoMapper = ObjectMapperUtil.newObjectMapper();
+    protected static final ObjectMapper infoMapper = PgsqlObjectMapper.newObjectMapper();
 
     private static final RowMapper<GeoServerInfo> GeoServerInfoRowMapper =
             (rs, rn) -> decode(rs.getString("info"), GeoServerInfo.class);

--- a/src/catalog/plugin/src/test/java/org/geoserver/catalog/plugin/CatalogConformanceTest.java
+++ b/src/catalog/plugin/src/test/java/org/geoserver/catalog/plugin/CatalogConformanceTest.java
@@ -2703,6 +2703,43 @@ public abstract class CatalogConformanceTest {
         catalog.remove(data.layerGroup1);
     }
 
+    @Test
+    void testGetLayerGroupModifyToAndFromWorkspace() {
+        { // set a different default workspace, we don't want the catalog to default look up on
+            // data.workspaceA
+            WorkspaceInfo defws = addWorkspace("defws");
+            catalog.setDefaultWorkspace(defws);
+        }
+        addLayer();
+        CatalogFactory factory = catalog.getFactory();
+        LayerGroupInfo lg = factory.createLayerGroup();
+
+        lg.setName("testlg");
+        lg.setWorkspace(null);
+        lg.getLayers().add(data.layerFeatureTypeA);
+        lg.getStyles().add(data.style1);
+        catalog.add(lg);
+
+        final String lgName = lg.getName();
+        final WorkspaceInfo ws = data.workspaceA;
+        final String wsname = ws.getName();
+
+        assertNull(catalog.getLayerGroupByName(wsname, lgName));
+        LayerGroupInfo actual = catalog.getLayerGroupByName(lgName);
+        assertEquals(lg, actual);
+
+        actual.setWorkspace(ws);
+        catalog.save(actual);
+
+        assertNull(catalog.getLayerGroupByName(lgName));
+        assertNotNull(catalog.getLayerGroupByName(wsname, lgName));
+
+        actual.setWorkspace(null);
+        catalog.save(actual);
+        assertNotNull(catalog.getLayerGroupByName(lgName));
+        assertNull(catalog.getLayerGroupByName(wsname, lgName));
+    }
+
     protected static class TestListener implements CatalogListener {
         public List<CatalogAddEvent> added = new CopyOnWriteArrayList<>();
         public List<CatalogModifyEvent> modified = new CopyOnWriteArrayList<>();


### PR DESCRIPTION
Use a Jackson `ObjectMapper` configured for the PostgreSQL JSONB encoding of catalog and config info objects. In particular, null values must be encoded as `null` in JSON, for the Postgres triggers calling `populate_table_columns_from_jsonb()` to correctly unset columns used for joining when values in the JSON representation change to `null`.

For example, if a layer group is moved from one workspace to no-workspace, the `layergroupinfo.workspace` table column must be automatically set to `null` by `populate_table_columns_from_jsonb()`, which won't happen if the new JSON object does not have the `"workspace": null` property, as when the `ObjectMapper has default property inclusion `Include#NON_EMPTY`.