### PR TITLE
Configure ACL service to use rabbitmq and client to do caching

### DIFF
--- a/compose/.env
+++ b/compose/.env
@@ -1,7 +1,7 @@
 # docker-compose default environment variable values
 COMPOSE_PROJECT_NAME=gscloud_dev
 TAG=1.7-SNAPSHOT
-ACL_TAG=2.0-M2
+ACL_TAG=2.0-SNAPSHOT
 GS_USER="1000:1000"
 
 BASE_PATH=/geoserver/cloud

--- a/compose/compose.yml
+++ b/compose/compose.yml
@@ -16,6 +16,7 @@ services:
   acl:
     image: geoservercloud/geoserver-acl:${ACL_TAG}
     environment:
+      # Override default values in the container's /etc/geoserver/acl-service.yml 
       - PG_HOST=acldb
       - PG_PORT=5432
       - PG_DB=acl
@@ -24,11 +25,22 @@ services:
       - PG_PASSWORD=acls3cr3t
       - 'ACL_USERS_ADMIN_PASSWORD={noop}s3cr3t'
       - 'ACL_USERS_GEOSERVER_PASSWORD={noop}s3cr3t'
+      - GEOSERVER_BUS_ENABLED=true
+      - RABBITMQ_HOST=rabbitmq
+      - RABBITMQ_PORT=5672
+      - RABBITMQ_USER=guest
+      - RABBITMQ_PASSWORD=guest
+      #- RABBITMQ_VHOST=""
     depends_on:
       acldb:
         condition: service_healthy
+        required: true
+      rabbitmq:
+        condition: service_healthy
+        required: true
     ports:
       - 9000:8080
+      - 9001:8081
     deploy:
       resources:
         limits:

--- a/src/apps/geoserver/webui/src/test/java/org/geoserver/cloud/web/app/AclIntegrationTest.java
+++ b/src/apps/geoserver/webui/src/test/java/org/geoserver/cloud/web/app/AclIntegrationTest.java
@@ -30,6 +30,7 @@ import java.util.Locale;
         properties = {
             "geoserver.acl.enabled: true",
             "geoserver.acl.client.basePath: http://localhost:9000/api",
+            "geoserver.acl.client.startupCheck: false",
             "geoserver.acl.client.username: acluser",
             "geoserver.acl.client.password: s3cr3t",
             "geoserver.web-ui.acl.enabled: true",

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -26,7 +26,7 @@
     <gs.version>2.25.0-SNAPSHOT</gs.version>
     <gs.community.version>2.25.0-SNAPSHOT</gs.community.version>
     <gt.version>31-SNAPSHOT</gt.version>
-    <acl.version>2.0-M2</acl.version>
+    <acl.version>2.0-SNAPSHOT</acl.version>
     <!-- Downgrade netty.version used by spring-boot to the one used by geoserver azure client
     (software.amazon.awssdk:netty-nio-client:jar:2.9.24) for COG and GWC Azure plugin -->
     <netty.version>4.1.41.Final</netty.version>

--- a/src/starters/security/pom.xml
+++ b/src/starters/security/pom.xml
@@ -19,6 +19,16 @@
       <artifactId>gs-acl-client-plugin</artifactId>
     </dependency>
     <dependency>
+      <!-- Use a CachingAuthorizationService decorator for the API client AuthorizationServiceClientAdaptor -->
+      <groupId>org.geoserver.acl.integration</groupId>
+      <artifactId>gs-acl-cache</artifactId>
+    </dependency>
+    <dependency>
+      <!-- Integrate with spring-cloud-bus to evict cached authorizations upon incoming rule and adminrule events -->
+      <groupId>org.geoserver.acl.integration</groupId>
+      <artifactId>gs-acl-spring-cloud-bus</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-authkey</artifactId>
       <exclusions>

--- a/src/starters/spring-boot/src/main/resources/gs_cloud_bootstrap_profiles.yml
+++ b/src/starters/spring-boot/src/main/resources/gs_cloud_bootstrap_profiles.yml
@@ -11,7 +11,7 @@ config.server.url: http://config:8080
 eureka.server.url: http://discovery:8761/eureka
 
 info:
-  component: Web Map Service
+  component: ${spring.application.name}
   instance-id: ${spring.application.name}:${vcap.application.instance_id:${spring.application.instance_id:${spring.cloud.client.ip-address}}:${server.port}}
 
 geoserver:


### PR DESCRIPTION
The ACL service must now integrate with the spring-cloud-bus, for the clients to receive remote rule events and perform cache eviction appropriately, evicting the authorization responses affected by the changed rules.