### PR TITLE
Update ACL to 2.1.0

### DIFF
--- a/compose/.env
+++ b/compose/.env
@@ -1,7 +1,7 @@
 # docker-compose default environment variable values
 COMPOSE_PROJECT_NAME=gscloud_dev
 TAG=1.8-SNAPSHOT
-ACL_TAG=2.0.1
+ACL_TAG=2.1.0
 GS_USER="1000:1000"
 
 BASE_PATH=/geoserver/cloud

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -26,7 +26,7 @@
     <gs.version>2.25.0-CLOUD</gs.version>
     <gs.community.version>2.25.0-CLOUD</gs.community.version>
     <gt.version>31.0</gt.version>
-    <acl.version>2.0.1</acl.version>
+    <acl.version>2.1.0</acl.version>
     <!-- Downgrade netty.version used by spring-boot to the one used by geoserver azure client
     (software.amazon.awssdk:netty-nio-client:jar:2.9.24) for COG and GWC Azure plugin -->
     <netty.version>4.1.41.Final</netty.version>


### PR DESCRIPTION
Fixes swagger-ui behind reverse proxy and exposes
it under the gateway's `${geoserver.base-path}/acl` route instead of `/acl`.