### PR TITLE
[backport] Fix GWC not storing tiles on disk when using pgconfig catalog backend

### DIFF
--- a/compose/.env
+++ b/compose/.env
@@ -15,7 +15,7 @@ JDBCCONFIG_PASSWORD=geo5erver
 
 # Remember to use docker-compose --compatibility 
 
-JAVA_OPTS_DEFAULT=-XX:MaxRAMPercentage=80 -XshowSettings:system
+JAVA_OPTS_DEFAULT=-XX:MaxRAMPercentage=80 -XshowSettings:system -Djndi.postgis.enabled=true
 
 JAVA_OPTS_GEOSERVER=$JAVA_OPTS_DEFAULT
 

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgsqlGwcInitializer.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgsqlGwcInitializer.java
@@ -1,0 +1,205 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.gwc.backend;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.api.client.util.Objects;
+import com.google.common.base.Stopwatch;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.geoserver.cloud.gwc.backend.pgconfig.PgsqlTileLayerCatalog;
+import org.geoserver.cloud.gwc.event.TileLayerEvent;
+import org.geoserver.cloud.gwc.repository.GeoServerTileLayerConfiguration;
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.GeoServerReinitializer;
+import org.geoserver.gwc.ConfigurableBlobStore;
+import org.geoserver.gwc.config.GWCConfig;
+import org.geoserver.gwc.config.GWCConfigPersister;
+import org.geoserver.gwc.config.GWCInitializer;
+import org.geoserver.gwc.layer.GeoServerTileLayer;
+import org.geoserver.gwc.layer.TileLayerCatalog;
+import org.geowebcache.config.TileLayerConfiguration;
+import org.geowebcache.layer.TileLayer;
+import org.geowebcache.layer.TileLayerDispatcher;
+import org.geowebcache.storage.blobstore.memory.CacheConfiguration;
+import org.geowebcache.storage.blobstore.memory.CacheProvider;
+import org.geowebcache.storage.blobstore.memory.guava.GuavaCacheProvider;
+import org.springframework.context.event.EventListener;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Replacement for {@link GWCInitializer} when using the "pgconfig" storage.
+ *
+ * <p>This is required because {@link PgsqlTileLayerCatalogAutoConfiguration} does not set up a
+ * {@link TileLayerCatalog}, which {@link GWCInitializer} requires, but a {@link
+ * PgsqlTileLayerCatalog} instead, which directly implements {@link TileLayerConfiguration} to be
+ * contributed to {@link TileLayerDispatcher}.
+ *
+ * <p>This {@link GeoServerReinitializer} is hence in charge of notifying {@link
+ * ConfigurableBlobStore#setChanged(org.geoserver.gwc.config.GWCConfig, boolean)}
+ *
+ * <p>This bean also listens to {@link TileLayerEvent}s and notifies the {@link CacheProvider} to
+ * either {@link CacheProvider#removeLayer(String) removeLayer} or {@link
+ * CacheProvider#removeUncachedLayer(String) removeUncachedLayer} on changes and deletions as
+ * appropriate, or to {@link CacheProvider#addUncachedLayer(String) addUncachedLayer} when a layer
+ * is created to changed to not be memory cached.
+ *
+ * @since 1.8
+ */
+@RequiredArgsConstructor
+@Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.backend")
+class PgsqlGwcInitializer implements GeoServerReinitializer {
+
+    private final @NonNull GWCConfigPersister configPersister;
+    private final @NonNull ConfigurableBlobStore blobStore;
+    private final @NonNull GeoServerTileLayerConfiguration geoseverTileLayers;
+
+    /**
+     * @see org.geoserver.config.GeoServerInitializer#initialize(org.geoserver.config.GeoServer)
+     */
+    @Override
+    public void initialize(final GeoServer geoServer) throws Exception {
+        log.info("Initializing GeoServer specific GWC configuration from gwc-gs.xml");
+
+        final GWCConfig gwcConfig = configPersister.getConfig();
+        checkNotNull(gwcConfig);
+
+        configureInMemoryCacheProvider(gwcConfig);
+
+        final boolean initialization = true;
+        blobStore.setChanged(gwcConfig, initialization);
+
+        setUpNonMemoryCacheableLayers();
+    }
+
+    @EventListener(TileLayerEvent.class)
+    void onTileLayerEvent(TileLayerEvent event) {
+        cacheProvider()
+                .ifPresent(
+                        cache -> {
+                            switch (event.getEventType()) {
+                                case DELETED:
+                                    log.debug(
+                                            "TileLayer {} deleted, notifying in-memory CacheProvider",
+                                            event.getName());
+                                    cache.removeUncachedLayer(event.getName());
+                                    break;
+                                case MODIFIED:
+                                    if (!Objects.equal(event.getOldName(), event.getName())) {
+                                        log.info(
+                                                "TileLayer {} renamed to {}, notifying in-memory CacheProvider",
+                                                event.getOldName(),
+                                                event.getName());
+                                        cache.removeUncachedLayer(event.getOldName());
+                                    }
+                                    setInMemoryLayerCaching(event.getName());
+                                    break;
+                                default:
+                                    setInMemoryLayerCaching(event.getName());
+                                    break;
+                            }
+                        });
+    }
+
+    private void configureInMemoryCacheProvider(final GWCConfig gwcConfig) throws IOException {
+        // Setting default CacheProvider class if not present
+        if (gwcConfig.getCacheProviderClass() == null
+                || gwcConfig.getCacheProviderClass().isEmpty()) {
+            gwcConfig.setCacheProviderClass(GuavaCacheProvider.class.toString());
+            configPersister.save(gwcConfig);
+        }
+
+        // Setting default Cache Configuration
+        if (gwcConfig.getCacheConfigurations() == null) {
+            log.debug("Setting default CacheConfiguration");
+            Map<String, CacheConfiguration> map = new HashMap<>();
+            map.put(GuavaCacheProvider.class.toString(), new CacheConfiguration());
+            gwcConfig.setCacheConfigurations(map);
+            configPersister.save(gwcConfig);
+        } else {
+            log.debug("CacheConfiguration loaded");
+        }
+
+        // Change ConfigurableBlobStore behavior
+        String cacheProviderClass = gwcConfig.getCacheProviderClass();
+        Map<String, CacheProvider> cacheProviders = blobStore.getCacheProviders();
+        if (!cacheProviders.containsKey(cacheProviderClass)) {
+            gwcConfig.setCacheProviderClass(GuavaCacheProvider.class.toString());
+            configPersister.save(gwcConfig);
+            log.debug("Unable to find: {}, used default configuration", cacheProviderClass);
+        }
+    }
+
+    private void setInMemoryLayerCaching(@NonNull String layerName) {
+
+        layer(layerName)
+                .ifPresentOrElse(this::addUncachedLayer, () -> removeCachedLayer(layerName));
+    }
+
+    private void removeCachedLayer(String layerName) {
+        cacheProvider()
+                .ifPresent(
+                        cache -> {
+                            log.debug(
+                                    "TileLayer {} does not exist, notifying CacheProvider",
+                                    layerName);
+                            cache.removeLayer(layerName);
+                            cache.removeUncachedLayer(layerName);
+                        });
+    }
+
+    private void addUncachedLayer(GeoServerTileLayer tl) {
+        if (!tl.getInfo().isInMemoryCached()) {
+            log.debug(
+                    "TileLayer {} is not to be memory cached, notifying CacheProvider",
+                    tl.getName());
+            cacheProvider().ifPresent(cache -> cache.addUncachedLayer(tl.getName()));
+        }
+    }
+
+    private Optional<GeoServerTileLayer> layer(String layerName) {
+        return geoseverTileLayers
+                .getLayer(layerName)
+                .filter(GeoServerTileLayer.class::isInstance)
+                .map(GeoServerTileLayer.class::cast);
+    }
+
+    /**
+     * Private method for adding all the Layer that must not be cached to the {@link CacheProvider}
+     * instance.
+     */
+    private void setUpNonMemoryCacheableLayers() {
+        cacheProvider()
+                .ifPresent(
+                        cache -> {
+                            // Add all the various Layers to avoid caching
+                            log.info("Adding Layers to avoid In Memory Caching");
+                            // it is ok to use the ForkJoinPool.commonPool() here, there's no I/O
+                            // involved
+                            Stopwatch sw = Stopwatch.createStarted();
+                            Collection<? extends TileLayer> layers = geoseverTileLayers.getLayers();
+                            log.info("Queried {} tile layers in {}", layers.size(), sw.stop());
+                            layers.stream()
+                                    .filter(GeoServerTileLayer.class::isInstance)
+                                    .map(GeoServerTileLayer.class::cast)
+                                    .filter(l -> l.isEnabled() && !l.getInfo().isInMemoryCached())
+                                    .map(GeoServerTileLayer::getName)
+                                    .forEach(cache::addUncachedLayer);
+                        });
+    }
+
+    private Optional<CacheProvider> cacheProvider() {
+        return Optional.ofNullable(blobStore.getCache());
+    }
+}

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgsqlTileLayerCatalogAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgsqlTileLayerCatalogAutoConfiguration.java
@@ -16,6 +16,9 @@ import org.geoserver.cloud.gwc.backend.pgconfig.PgsqlTileLayerInfoRepository;
 import org.geoserver.cloud.gwc.backend.pgconfig.TileLayerInfoRepository;
 import org.geoserver.cloud.gwc.event.TileLayerEvent;
 import org.geoserver.cloud.gwc.repository.GeoServerTileLayerConfiguration;
+import org.geoserver.gwc.ConfigurableBlobStore;
+import org.geoserver.gwc.config.GWCConfigPersister;
+import org.geoserver.gwc.config.GWCInitializer;
 import org.geoserver.gwc.layer.TileLayerCatalog;
 import org.geowebcache.grid.GridSetBroker;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -51,6 +54,15 @@ public class PgsqlTileLayerCatalogAutoConfiguration {
     @PostConstruct
     void log() {
         log.info("GeoWebCache TileLayerCatalog using PostgreSQL config backend");
+    }
+
+    /** Replacement for {@link GWCInitializer} when using {@link GeoServerTileLayerConfiguration} */
+    @Bean
+    PgsqlGwcInitializer gwcInitializer(
+            GWCConfigPersister configPersister,
+            ConfigurableBlobStore blobStore,
+            GeoServerTileLayerConfiguration tileLayerCatalog) {
+        return new PgsqlGwcInitializer(configPersister, blobStore, tileLayerCatalog);
     }
 
     @Bean(name = "gwcCatalogConfiguration")

--- a/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgsqlTileLayerCatalogAutoConfigurationTest.java
+++ b/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgsqlTileLayerCatalogAutoConfigurationTest.java
@@ -83,7 +83,9 @@ class PgsqlTileLayerCatalogAutoConfigurationTest {
     void testPgsqlTileLayerCatalogReplacesDefaultTileLayerCatalogAutoConfiguration() {
         runner.run(
                 context -> {
-                    assertThat(context).doesNotHaveBean(GWCInitializer.class);
+                    assertThat(context)
+                            .doesNotHaveBean(GWCInitializer.class)
+                            .hasSingleBean(PgsqlGwcInitializer.class);
 
                     assertThat(context)
                             .hasNotFailed()

--- a/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/CachingTileLayerInfoRepository.java
+++ b/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/CachingTileLayerInfoRepository.java
@@ -21,7 +21,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 @RequiredArgsConstructor
-@Slf4j(topic = "org.geoserver.cloud.gwc.backend.pgconfig")
+@Slf4j(topic = "org.geoserver.cloud.gwc.backend.pgconfig.caching")
 public class CachingTileLayerInfoRepository implements TileLayerInfoRepository {
 
     public static final String CACHE_NAME = "gwc-tilelayerinfo";

--- a/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgsqlTileLayerCatalog.java
+++ b/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgsqlTileLayerCatalog.java
@@ -118,6 +118,10 @@ public class PgsqlTileLayerCatalog implements TileLayerConfiguration {
         }
     }
 
+    public Stream<GeoServerTileLayer> streamLayers() {
+        return repository.findAll().map(this::toLayer);
+    }
+
     @Override
     public Optional<TileLayer> getLayer(@NonNull String layerName) {
 

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/GeoWebCacheCoreConfiguration.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/GeoWebCacheCoreConfiguration.java
@@ -4,6 +4,8 @@
  */
 package org.geoserver.cloud.gwc.config.core;
 
+import static org.geoserver.cloud.gwc.config.core.GeoWebCacheConfigurationProperties.CACHE_DIRECTORY;
+import static org.geoserver.cloud.gwc.config.core.GeoWebCacheConfigurationProperties.CONFIG_DIRECTORY;
 import static org.geowebcache.storage.DefaultStorageFinder.GWC_CACHE_DIR;
 
 import lombok.extern.slf4j.Slf4j;
@@ -87,20 +89,20 @@ public class GeoWebCacheCoreConfiguration {
      */
     @Bean
     Path gwcDefaultCacheDirectory(GeoWebCacheConfigurationProperties config) {
-        log.debug(
-                "resolving default cache directory from configuration property {}",
-                GeoWebCacheConfigurationProperties.CACHE_DIRECTORY);
-
         final Path directory = config.getCacheDirectory();
-        final String propName = GeoWebCacheConfigurationProperties.CACHE_DIRECTORY;
+        log.debug(
+                "resolving default cache directory from configuration property {}={}",
+                CACHE_DIRECTORY,
+                directory);
+
         if (null == directory) {
             throw new InvalidPropertyException(
                     GeoWebCacheConfigurationProperties.class,
                     "cacheDirectory",
                     "%s is not set. The default cache directory MUST be provided."
-                            .formatted(propName));
+                            .formatted(CACHE_DIRECTORY));
         }
-        validateDirectory(directory, propName);
+        validateDirectory(directory, CACHE_DIRECTORY);
 
         String path = directory.toAbsolutePath().toString();
         log.info("forcing System Property {}={}", GWC_CACHE_DIR, path);
@@ -129,11 +131,12 @@ public class GeoWebCacheCoreConfiguration {
             throws FatalBeanException {
 
         final Path directory = config.getConfigDirectory();
-        final String propName = GeoWebCacheConfigurationProperties.CONFIG_DIRECTORY;
+        final String propName = CONFIG_DIRECTORY;
         final Supplier<Resource> resource;
         if (null == directory) {
             log.debug(
-                    "no {} config property found, geowebcache.xml will be loaded from the resource store's gwc/ directory");
+                    "no {} config property found, geowebcache.xml will be loaded from the resource store's gwc/ directory",
+                    propName);
             resource = () -> resourceStore.get("gwc");
         } else {
             log.debug(


### PR DESCRIPTION
When using the `pgconfig` catalog backend, it replaces the default GWC tile layer catalog with a specialized one to store the tile layers config directly on the database instead of going through the resource store.

To do so, it has to exclude the `GWCInitializer` bean, as it depends on a `TileLayerCatalog`.

By doing so, we missed the call to
`ConfigurableBlobStore.setChanged(...)`, resulting in the `ConfigurableBlobStore` decorator never having its `configured` flag set to true, and hence never calling the actual `BlobStore`'s `put(TileObject)` method.

This patch introduces `PgsqlGwcInitializer` as a replacement for the default `GWCInitializer`, which takes care of that and also listens to `TileEvents` to maintain the non-memory-cacheable list of layers in sync at `org.geowebcache.storage.blobstore.memory.CacheProvider`.