### PR TITLE
PgsqlResourceStore performance improvement

### DIFF
--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/resource/FileSystemResourceStoreCache.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/resource/FileSystemResourceStoreCache.java
@@ -143,8 +143,9 @@ public class FileSystemResourceStoreCache implements DisposableBean {
     @SneakyThrows
     public void moved(@NonNull PgsqlResource source, @NonNull PgsqlResource target) {
         Path sourcePath = toPath(source);
-        Path targetPath = toPath(target);
         if (Files.exists(sourcePath)) {
+            Path targetPath = toPath(target);
+            ensureDirectoryExists(targetPath.getParent());
             Files.move(sourcePath, targetPath, StandardCopyOption.REPLACE_EXISTING);
         }
     }

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/config/catalog/backend/pgconfig/PgsqlBackendConfiguration.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/config/catalog/backend/pgconfig/PgsqlBackendConfiguration.java
@@ -109,7 +109,7 @@ public class PgsqlBackendConfiguration extends GeoServerBackendConfigurer {
 
     @Bean
     @Override
-    protected PgsqlResourceStore resourceStoreImpl() {
+    protected ResourceStore resourceStoreImpl() {
         log.debug("Creating ResourceStore {}", PgsqlResourceStore.class.getSimpleName());
         FileSystemResourceStoreCache resourceStoreCache = pgsqlFileSystemResourceStoreCache();
         JdbcTemplate template = template();

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/config/catalog/backend/pgconfig/PgsqlDataSourceConfiguration.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/config/catalog/backend/pgconfig/PgsqlDataSourceConfiguration.java
@@ -8,13 +8,17 @@ import com.zaxxer.hikari.HikariDataSource;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.jdbc.datasource.lookup.JndiDataSourceLookup;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.util.StringUtils;
 
 import javax.sql.DataSource;
@@ -23,6 +27,7 @@ import javax.sql.DataSource;
  * @since 1.4
  */
 @Configuration
+@EnableTransactionManagement
 @EnableConfigurationProperties(PgsqlBackendProperties.class)
 @Slf4j
 public class PgsqlDataSourceConfiguration {
@@ -37,6 +42,12 @@ public class PgsqlDataSourceConfiguration {
             return new JndiDataSourceLookup().getDataSource(jndiName);
         }
         return config.initializeDataSourceBuilder().type(HikariDataSource.class).build();
+    }
+
+    @Bean
+    PlatformTransactionManager pgconfigTransactionManager(
+            @Qualifier("pgsqlConfigDatasource") DataSource dataSource) {
+        return new DataSourceTransactionManager(dataSource);
     }
 
     @Bean(name = "jndiInitializer")

--- a/src/catalog/backends/pgconfig/src/main/resources/db/pgsqlcatalog/migration/postgresql/V1_6__ResourceStore_NoCTE.sql
+++ b/src/catalog/backends/pgconfig/src/main/resources/db/pgsqlcatalog/migration/postgresql/V1_6__ResourceStore_NoCTE.sql
@@ -1,0 +1,47 @@
+/*
+ * Change the resourcestore table to hold the full path instead of just the name,
+ * so no recursive queries are required to query. And delete the resources view.
+ * The caveat being the ResourceStore implementation is hence in charge of 
+ * transactionally update the path of all children when a directory resource is
+ * renamed/moved, but the perfomance gain is huge.
+ * 
+ * @since 1.8 
+ */
+ALTER TABLE resourcestore ADD COLUMN tmp TEXT;
+UPDATE resourcestore SET tmp = v.path FROM resources v WHERE resourcestore.id = v.id;
+DROP VIEW resources;
+ALTER TABLE resourcestore RENAME COLUMN name TO path;
+UPDATE resourcestore SET path = tmp;
+ALTER TABLE resourcestore DROP COLUMN tmp;
+
+ALTER INDEX resourcestore_name_idx RENAME TO resourcestore_path_idx;
+ALTER INDEX resourcestore_parentid_name_key RENAME TO resourcestore_parentid_path_key;
+DROP INDEX resourcestore_parent_name_idx;
+
+-- change OLD.name to OLD.path
+CREATE OR REPLACE FUNCTION resourcestore_type_readonly() RETURNS trigger LANGUAGE plpgsql AS
+$$BEGIN
+  IF NEW."type" <> OLD."type" THEN
+    RAISE EXCEPTION 'resourcestore.type is read-only, trying to upate % to %s on % (%)', OLD."type", NEW."type", NEW.id, OLD.path;
+  END IF;
+  RETURN NEW;
+END;$$;
+
+-- change OLD.name to OLD.path and NEW.name to NEW.path
+CREATE OR REPLACE FUNCTION resourcestore_update_parent_mtime() RETURNS trigger LANGUAGE plpgsql AS
+$$BEGIN
+  RAISE DEBUG 'resourcestore_update_parent_mtime: %, %', OLD, NEW;
+  IF NEW IS NULL THEN -- delete
+    RAISE DEBUG 'updating mtime to % on parent (%) on delete of % (%)', OLD.mtime, OLD.parentid, OLD.id, OLD.path;
+    UPDATE resourcestore SET mtime = now() WHERE id = OLD.parentid;
+  ELSIF OLD IS NULL THEN -- insert
+    RAISE DEBUG 'updating mtime to % on parent (%) on insert of % (%)', NEW.mtime, NEW.parentid, NEW.id, NEW.path;
+    UPDATE resourcestore SET mtime = NEW.mtime WHERE id = NEW.parentid;
+  ELSIF OLD.parentid <> NEW.parentid THEN -- moved
+    RAISE DEBUG '% parent moved from % to %, updating mtime to % on both', NEW.id, NEW.mtime, OLD.parentid, NEW.parentid;
+	  UPDATE resourcestore SET mtime = NEW.mtime WHERE id = OLD.parentid OR parentid = NEW.parentid;
+	ELSIF OLD.mtime <> NEW.mtime THEN
+    RAISE DEBUG '% updated, parent %, does not trigger update of parent mtime', NEW.id, NEW.parentid;
+  END IF;
+  RETURN NEW;
+END;$$;

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgconfig/PgsqlBackendAutoConfigurationTest.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgconfig/PgsqlBackendAutoConfigurationTest.java
@@ -13,7 +13,6 @@ import org.geoserver.cloud.backend.pgconfig.config.PgsqlConfigRepository;
 import org.geoserver.cloud.backend.pgconfig.config.PgsqlGeoServerFacade;
 import org.geoserver.cloud.backend.pgconfig.config.PgsqlUpdateSequence;
 import org.geoserver.cloud.backend.pgconfig.resource.PgsqlLockProvider;
-import org.geoserver.cloud.backend.pgconfig.resource.PgsqlResourceStore;
 import org.geoserver.cloud.backend.pgconfig.support.PgConfigTestContainer;
 import org.geoserver.cloud.config.catalog.backend.pgconfig.PgsqlGeoServerLoader;
 import org.geoserver.cloud.config.catalog.backend.pgconfig.PgsqlGeoServerResourceLoader;
@@ -54,6 +53,7 @@ class PgsqlBackendAutoConfigurationTest {
                 context -> {
                     assertThat(context)
                             .hasNotFailed()
+                            .hasBean("pgconfigTransactionManager")
                             .hasSingleBean(JdbcTemplate.class)
                             .hasSingleBean(GeoServerConfigurationLock.class)
                             .hasSingleBean(PgsqlUpdateSequence.class)
@@ -61,7 +61,7 @@ class PgsqlBackendAutoConfigurationTest {
                             .hasSingleBean(PgsqlGeoServerLoader.class)
                             .hasSingleBean(PgsqlConfigRepository.class)
                             .hasSingleBean(PgsqlGeoServerFacade.class)
-                            .hasSingleBean(PgsqlResourceStore.class)
+                            .hasBean("resourceStoreImpl")
                             .hasSingleBean(PgsqlGeoServerResourceLoader.class)
                             .hasSingleBean(PgsqlLockProvider.class);
 

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgconfig/PgsqlMigrationAutoConfigurationTest.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgconfig/PgsqlMigrationAutoConfigurationTest.java
@@ -106,7 +106,6 @@ class PgsqlMigrationAutoConfigurationTest {
                         "styleinfos",
                         "settingsinfos",
                         "serviceinfos",
-                        "resources",
                         "publishedinfos",
                         "tilelayers");
         List<String> tables =


### PR DESCRIPTION
Change the resourcestore table to hold the full path instead of just the name, so no recursive queries are required to query. And delete the resources view. The caveat being the ResourceStore implementation is hence in charge of transactionally update the path of all children when a directory resource is renamed/moved, but the perfomance gain is huge.