### PR TITLE
pgconfig: save resource store temporary or auxiliary folders only on disk

### DIFF
--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/resource/FileSystemResourceStoreCache.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/resource/FileSystemResourceStoreCache.java
@@ -2,10 +2,12 @@ package org.geoserver.cloud.backend.pgconfig.resource;
 
 import com.google.common.base.Preconditions;
 
+import lombok.Getter;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
+import org.geoserver.platform.resource.FileSystemResourceStore;
 import org.geoserver.platform.resource.Resource;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.util.FileSystemUtils;
@@ -25,6 +27,7 @@ public class FileSystemResourceStoreCache implements DisposableBean {
 
     private final Path base;
     private boolean disposable;
+    private @Getter FileSystemResourceStore localOnlyStore;
 
     private FileSystemResourceStoreCache(@NonNull Path cacheDirectory, boolean disposable) {
         this.disposable = disposable;
@@ -37,6 +40,7 @@ public class FileSystemResourceStoreCache implements DisposableBean {
                 "Cache directory is not writable: %s",
                 cacheDirectory.toAbsolutePath());
         this.base = cacheDirectory;
+        this.localOnlyStore = new FileSystemResourceStore(new File(this.base.toUri()));
     }
 
     @SneakyThrows

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/resource/PgsqlResource.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/resource/PgsqlResource.java
@@ -23,10 +23,6 @@ import java.util.List;
  */
 @EqualsAndHashCode(exclude = {"store"})
 class PgsqlResource implements Resource {
-
-    static final long ROOT_ID = 0L;
-    static final long UNDEFINED_ID = -1L;
-
     @Getter long id;
     @Getter long parentId;
     Resource.Type type;
@@ -49,14 +45,15 @@ class PgsqlResource implements Resource {
         this.lastmodified = lastmodified;
     }
 
-    /** Undefined type constructor */
-    PgsqlResource(@NonNull PgsqlResourceStore store, @NonNull String path) {
-        this.store = store;
-        this.id = UNDEFINED_ID;
-        this.parentId = UNDEFINED_ID;
-        this.type = Type.UNDEFINED;
-        this.path = path;
-        this.lastmodified = 0L;
+    /** Undefined type factory method */
+    static PgsqlResource undefined(@NonNull PgsqlResourceStore store, @NonNull String path) {
+        return new PgsqlResource(
+                store,
+                PgsqlResourceStore.UNDEFINED_ID,
+                PgsqlResourceStore.UNDEFINED_ID,
+                Type.UNDEFINED,
+                path,
+                0L);
     }
 
     void copy(PgsqlResource other) {
@@ -110,8 +107,7 @@ class PgsqlResource implements Resource {
 
     @Override
     public PgsqlResource parent() {
-        if (ROOT_ID == id) return null;
-        return (PgsqlResource) store.get(parentPath());
+        return store.getParent(this);
     }
 
     @Override
@@ -163,12 +159,11 @@ class PgsqlResource implements Resource {
     }
 
     public PgsqlResource mkdirs() {
-        store.mkdirs(this);
-        return this;
+        return store.mkdirs(this);
     }
 
     public boolean exists() {
-        return id != UNDEFINED_ID;
+        return id != PgsqlResourceStore.UNDEFINED_ID;
     }
 
     public boolean isFile() {

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/resource/PgsqlResourceRowMapper.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/resource/PgsqlResourceRowMapper.java
@@ -43,6 +43,6 @@ public class PgsqlResourceRowMapper implements RowMapper<PgsqlResource> {
     }
 
     public PgsqlResource undefined(String path) {
-        return new PgsqlResource(store, path);
+        return PgsqlResource.undefined(store, path);
     }
 }

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/config/catalog/backend/pgconfig/PgsqlBackendConfiguration.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/config/catalog/backend/pgconfig/PgsqlBackendConfiguration.java
@@ -33,6 +33,8 @@ import org.springframework.integration.support.locks.LockRegistry;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.util.StringUtils;
 
+import java.util.function.Predicate;
+
 import javax.sql.DataSource;
 
 /**
@@ -114,7 +116,8 @@ public class PgsqlBackendConfiguration extends GeoServerBackendConfigurer {
         FileSystemResourceStoreCache resourceStoreCache = pgsqlFileSystemResourceStoreCache();
         JdbcTemplate template = template();
         PgsqlLockProvider lockProvider = pgsqlLockProvider();
-        return new PgsqlResourceStore(resourceStoreCache, template, lockProvider);
+        Predicate<String> ignoreDirs = PgsqlResourceStore.defaultIgnoredDirs();
+        return new PgsqlResourceStore(resourceStoreCache, template, lockProvider, ignoreDirs);
     }
 
     @Bean


### PR DESCRIPTION
The following folders are served only from the filesystem, skipping the database: `temp`, `tmp`, `legendsamples`, `data`, `logs`.