### PR TITLE
Fix error saving layers/groups with pgconfig and gwc enabled.

### DIFF
--- a/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgsqlTileLayerCatalog.java
+++ b/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgsqlTileLayerCatalog.java
@@ -11,6 +11,8 @@ import lombok.NonNull;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.LayerGroupInfoImpl;
+import org.geoserver.catalog.impl.LayerInfoImpl;
 import org.geoserver.catalog.plugin.resolving.ModificationProxyDecorator;
 import org.geoserver.cloud.backend.pgconfig.catalog.PgsqlCatalogFacade;
 import org.geoserver.gwc.layer.GeoServerTileLayer;
@@ -229,7 +231,11 @@ public class PgsqlTileLayerCatalog implements TileLayerConfiguration {
 
     GeoServerTileLayer toLayer(TileLayerInfo pgTileLayerInfo) {
         PublishedInfo published = pgTileLayerInfo.getPublished();
-        published = publishedResolver.apply(published);
+        // resolve only if its a plain layer/group. Otherwise it can be Secured* or other wrapper,
+        // meaning it's already resolved
+        if (published instanceof LayerInfoImpl || published instanceof LayerGroupInfoImpl) {
+            published = publishedResolver.apply(published);
+        }
 
         GeoServerTileLayerInfo info = infoMapper.map(pgTileLayerInfo);
         return new GeoServerTileLayer(published, this.gridsetBroker, info);


### PR DESCRIPTION
`PgsqlTileLayerCatalog.toLayer(TileLayerInfo):GeoServerTileLayer` needs to resolve the `PublishedInfo` as it may have danling references or may not be a modification proxy, only if it's a "plain" `Layer(Group)InfoImpl`, otherwise it's already resolved and the `ModificationProxyDecorator` will throw an error.