### PR TITLE
Fix SpringEnvironmentAwareGeoToolsHttpClientFactory registration

### DIFF
--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/geotools/GeoToolsStaticContextInitializer.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/geotools/GeoToolsStaticContextInitializer.java
@@ -30,17 +30,15 @@ public class GeoToolsStaticContextInitializer
         }
         System.setProperty("org.geotools.referencing.forceXY", "true");
 
-        Boolean useEnvAwareHttpClient =
+        boolean useEnvAwareHttpClient =
                 applicationContext
                         .getEnvironment()
                         .getProperty(
                                 "geotools.httpclient.proxy.enabled", Boolean.class, Boolean.TRUE);
         if (useEnvAwareHttpClient) {
-            // factoryName matches the one in
-            // src/main/resources/META-INF/services/org.geotools.http.HTTPClientFactory
-            String factoryName =
-                    SpringEnvironmentAwareGeoToolsHttpClientFactory.class.getCanonicalName();
-            Hints.putSystemDefault(Hints.HTTP_CLIENT_FACTORY, factoryName);
+            Hints.putSystemDefault(
+                    Hints.HTTP_CLIENT_FACTORY,
+                    SpringEnvironmentAwareGeoToolsHttpClientFactory.class);
         }
     }
 }

--- a/src/catalog/backends/common/src/test/java/org/geoserver/cloud/autoconfigure/geotools/GeoToolsHttpClientAutoConfigurationTest.java
+++ b/src/catalog/backends/common/src/test/java/org/geoserver/cloud/autoconfigure/geotools/GeoToolsHttpClientAutoConfigurationTest.java
@@ -7,6 +7,8 @@ package org.geoserver.cloud.autoconfigure.geotools;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import org.geotools.http.HTTPClient;
+import org.geotools.http.HTTPClientFinder;
 import org.geotools.util.factory.Hints;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,6 +46,16 @@ class GeoToolsHttpClientAutoConfigurationTest {
                                     context.getBean(
                                             GeoToolsHttpClientProxyConfigurationProperties.class))
                             .hasFieldOrPropertyWithValue("enabled", true);
+
+                    HTTPClient client = HTTPClientFinder.createClient();
+                    assertThat(client)
+                            .as(
+                                    """
+                            		Expected SpringEnvironmentAwareGeoToolsHttpClient \
+                            		after GeoToolsStaticContextInitializer sets \
+                            		SpringEnvironmentAwareGeoToolsHttpClientFactory as the default factory
+                            		""")
+                            .isInstanceOf(SpringEnvironmentAwareGeoToolsHttpClient.class);
                 });
     }
 
@@ -56,8 +68,7 @@ class GeoToolsHttpClientAutoConfigurationTest {
 
     @Test
     void testInitializerSetsHttpClientFactorySystemProperty() {
-        final String expected =
-                SpringEnvironmentAwareGeoToolsHttpClientFactory.class.getCanonicalName();
+        final var expected = SpringEnvironmentAwareGeoToolsHttpClientFactory.class;
 
         assertNull(Hints.getSystemDefault(Hints.HTTP_CLIENT_FACTORY));
         runner.run(


### PR DESCRIPTION
Fix `SpringEnvironmentAwareGeoToolsHttpClientFactory` registration as the default `HTTPClient` factory using the `Class` object as value instead of the qualified class name when doing
`Hints.putSystemDefault( Hints.HTTP_CLIENT_FACTORY, <factory>)` in `GeoToolsStaticContextInitializer`.

It doesn't work with the class name after changes upstream.

Fixes #460