### PR TITLE
Make GeoServerHomePage.selectionMode system property default to TEXT

### DIFF
--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebUIContextInitializer.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebUIContextInitializer.java
@@ -1,0 +1,43 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.web.core;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.util.StringUtils;
+import org.springframework.web.context.support.GenericWebApplicationContext;
+
+/**
+ * @since 1.8.2
+ */
+@Slf4j
+public class WebUIContextInitializer
+        implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    @Override
+    public void initialize(ConfigurableApplicationContext applicationContext) {
+        // run once for the webapp context, ignore the actuator context
+        if (!(applicationContext instanceof GenericWebApplicationContext)) {
+            return;
+        }
+        setHomePageSelectionMode();
+    }
+
+    private void setHomePageSelectionMode() {
+
+        String systemProp = System.getProperty("GeoServerHomePage.selectionMode");
+        if (StringUtils.hasText(systemProp)) {
+            log.info(
+                    "GeoServerHomePage.selectionMode set to '{}' through system property",
+                    systemProp);
+        } else {
+            String selectionMode = "TEXT";
+            log.info("GeoServerHomePage.selectionMode set to '{}' as default value", selectionMode);
+            System.setProperty("GeoServerHomePage.selectionMode", selectionMode);
+        }
+    }
+}

--- a/src/apps/geoserver/webui/src/main/resources/META-INF/spring.factories
+++ b/src/apps/geoserver/webui/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,8 @@
+# Initializers
+org.springframework.context.ApplicationContextInitializer=\
+org.geoserver.cloud.autoconfigure.web.core.WebUIContextInitializer
+
+# Auto Configure
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.geoserver.cloud.autoconfigure.web.core.WebUIApplicationAutoConfiguration,\
 org.geoserver.cloud.autoconfigure.web.cloudnative.CloudNativeUIAutoConfiguration

--- a/src/apps/geoserver/webui/src/test/java/org/geoserver/cloud/web/app/WebUIApplicationTest.java
+++ b/src/apps/geoserver/webui/src/test/java/org/geoserver/cloud/web/app/WebUIApplicationTest.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.cloud.web.app;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -168,5 +169,13 @@ class WebUIApplicationTest {
                 "expected custom 'unused' css class to hide the %s form inputs in custom GlobalSettingsPage.html"
                         .formatted(id);
         assertEquals("unused", tag.getAttribute("class"), msg);
+    }
+
+    /**
+     * @see WebUIContextInitializer
+     */
+    @Test
+    void homePageSelectionModeDefaultsToTEXT() {
+        assertThat(System.getProperty("GeoServerHomePage.selectionMode")).isEqualTo("TEXT");
     }
 }


### PR DESCRIPTION
The GeoServer home page workspace and layer selectors can incur in a huge performance penalty with its default values.

Making it default to `TEXT` to prevent it.

See [Welcome page selectors](https://docs.geoserver.org/main/en/user/production/config.html#welcome-page-selectors) in the GeoServer user docs.