### PR TITLE
share webui authentication with the other services through the gateway

### DIFF
--- a/src/apps/infrastructure/gateway/src/main/java/org/geoserver/cloud/gateway/GatewayApplication.java
+++ b/src/apps/infrastructure/gateway/src/main/java/org/geoserver/cloud/gateway/GatewayApplication.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.cloud.gateway;
 
+import org.geoserver.cloud.gateway.filter.GatewaySharedAuhenticationGlobalFilter;
 import org.geoserver.cloud.gateway.filter.RouteProfileGatewayFilterFactory;
 import org.geoserver.cloud.gateway.filter.StripBasePathGatewayFilterFactory;
 import org.geoserver.cloud.gateway.predicate.RegExpQueryRoutePredicateFactory;
@@ -46,5 +47,10 @@ public class GatewayApplication {
     @Bean
     StripBasePathGatewayFilterFactory stripBasePathGatewayFilterFactory() {
         return new StripBasePathGatewayFilterFactory();
+    }
+
+    @Bean
+    GatewaySharedAuhenticationGlobalFilter gatewaySharedAuhenticationGlobalFilter() {
+        return new GatewaySharedAuhenticationGlobalFilter();
     }
 }

--- a/src/apps/infrastructure/gateway/src/main/java/org/geoserver/cloud/gateway/filter/GatewaySharedAuhenticationGlobalFilter.java
+++ b/src/apps/infrastructure/gateway/src/main/java/org/geoserver/cloud/gateway/filter/GatewaySharedAuhenticationGlobalFilter.java
@@ -1,0 +1,163 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.gateway.filter;
+
+import org.springframework.boot.web.servlet.server.Session;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebSession;
+
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * {@link GlobalFilter} to enable sharing the webui form-based authentication object with the other
+ * services.
+ *
+ * <p>When a user is logged in through the regular web ui's authentication form, the {@link
+ * Authentication} object is held in the web ui's {@link Session}. Hence, further requests to
+ * stateless services, as they're on separate containers, don't share the webui session, and hence
+ * are executed as anonymous.
+ *
+ * <p>This {@link GlobalFilter} enables a mechanism by which the authenticated user name and roles
+ * can be shared with the stateless services through request and response headrers, using the
+ * geoserver cloud gateway as the man in the middle.
+ *
+ * <p>The webui container will send a couple response headers with the authenticated user name and
+ * roles. The gateway will store them in its own session, and forward them to all services as
+ * request headers. The stateless services will intercept these request headers and impersonate the
+ * authenticated user as a {@link PreAuthenticatedAuthenticationToken}.
+ *
+ * <p>At the same time, the gateway will take care of removing the webui response headers from the
+ * responses sent to the clients, and from incoming client requests.
+ *
+ * @since 1.9
+ */
+public class GatewaySharedAuhenticationGlobalFilter implements GlobalFilter {
+
+    static final String X_GSCLOUD_USERNAME = "x-gsc-username";
+    static final String X_GSCLOUD_ROLES = "x-gsc-roles";
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        // first, remove any incoming header to prevent impersonation
+        exchange = removeRequestHeaders(exchange);
+
+        return addHeadersFromSession(exchange)
+                .flatMap(mutatedExchange -> proceed(mutatedExchange, chain))
+                .flatMap(this::saveHeadersInSession)
+                .flatMap(this::removeResponseHeaders);
+    }
+
+    private Mono<ServerWebExchange> proceed(ServerWebExchange exchange, GatewayFilterChain chain) {
+        return chain.filter(exchange).thenReturn(exchange);
+    }
+
+    /**
+     * After the filter chain's run, if the proxied service replied with the user and roles headers,
+     * save them in the session.
+     *
+     * <p>
+     *
+     * <ul>
+     *   <li>A missing request header does not change the session
+     *   <li>An empty username header clears out the values in the session (i.e. it's a logout)
+     * </ul>
+     */
+    private Mono<ServerWebExchange> saveHeadersInSession(ServerWebExchange exchange) {
+
+        HttpHeaders responseHeaders = exchange.getResponse().getHeaders();
+        if (responseHeaders.containsKey(X_GSCLOUD_USERNAME)) {
+            return exchange.getSession()
+                    .flatMap(session -> save(responseHeaders, session))
+                    .thenReturn(exchange);
+        }
+
+        return Mono.just(exchange);
+    }
+
+    private Mono<Void> save(HttpHeaders responseHeaders, WebSession session) {
+        assert responseHeaders.containsKey(X_GSCLOUD_USERNAME);
+
+        Optional<String> userame =
+                responseHeaders.getOrDefault(X_GSCLOUD_USERNAME, List.of()).stream()
+                        .filter(StringUtils::hasText)
+                        .findFirst();
+
+        var roles = responseHeaders.getOrDefault(X_GSCLOUD_ROLES, List.of());
+
+        return Mono.fromRunnable(
+                () ->
+                        userame.ifPresentOrElse(
+                                user -> {
+                                    var attributes = session.getAttributes();
+                                    attributes.put(X_GSCLOUD_USERNAME, user);
+                                    attributes.put(X_GSCLOUD_ROLES, roles);
+                                },
+                                () -> {
+                                    var attributes = session.getAttributes();
+                                    attributes.remove(X_GSCLOUD_USERNAME);
+                                    attributes.remove(X_GSCLOUD_ROLES);
+                                }));
+    }
+
+    /**
+     * Before proceeding with the filter chain, if the username and roles are stored in the session,
+     * apply the request headers for the proxied service
+     */
+    private Mono<ServerWebExchange> addHeadersFromSession(ServerWebExchange exchange) {
+        return exchange.getSession().map(session -> addHeadersFromSession(session, exchange));
+    }
+
+    private ServerWebExchange addHeadersFromSession(
+            WebSession session, ServerWebExchange exchange) {
+
+        String username = session.getAttributeOrDefault(X_GSCLOUD_USERNAME, "");
+        if (StringUtils.hasText(username)) {
+            String[] roles =
+                    session.getAttributeOrDefault(X_GSCLOUD_ROLES, List.of())
+                            .toArray(String[]::new);
+            var request =
+                    exchange.getRequest()
+                            .mutate()
+                            .header(X_GSCLOUD_USERNAME, username)
+                            .header(X_GSCLOUD_ROLES, roles)
+                            .build();
+            exchange = exchange.mutate().request(request).build();
+        }
+        return exchange;
+    }
+
+    private ServerWebExchange removeRequestHeaders(ServerWebExchange exchange) {
+        if (impersonating(exchange)) {
+            var request = exchange.getRequest().mutate().headers(this::removeHeaders).build();
+            exchange = exchange.mutate().request(request).build();
+        }
+        return exchange;
+    }
+
+    private Mono<Void> removeResponseHeaders(ServerWebExchange exchange) {
+        return Mono.fromRunnable(
+                () -> {
+                    HttpHeaders responseHeaders = exchange.getResponse().getHeaders();
+                    removeHeaders(responseHeaders);
+                });
+    }
+
+    private void removeHeaders(HttpHeaders httpHeaders) {
+        httpHeaders.remove(X_GSCLOUD_USERNAME);
+        httpHeaders.remove(X_GSCLOUD_ROLES);
+    }
+
+    private boolean impersonating(ServerWebExchange exchange) {
+        HttpHeaders headers = exchange.getRequest().getHeaders();
+        return headers.containsKey(X_GSCLOUD_USERNAME) || headers.containsKey(X_GSCLOUD_ROLES);
+    }
+}

--- a/src/apps/infrastructure/gateway/src/main/resources/bootstrap.yml
+++ b/src/apps/infrastructure/gateway/src/main/resources/bootstrap.yml
@@ -33,5 +33,5 @@ eureka.client:
 ---
 # local profile, used for development only. Other settings like config and eureka urls in gs_cloud_bootstrap_profiles.yml
 spring.config.activate.on-profile: local
-server.port: 9000
-management.server.port: 9000
+server.port: 9090
+management.server.port: 9090

--- a/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/GatewayPreAuthenticationAutoConfiguration.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/GatewayPreAuthenticationAutoConfiguration.java
@@ -5,68 +5,28 @@
 package org.geoserver.cloud.autoconfigure.authzn;
 
 import org.geoserver.cloud.autoconfigure.security.ConditionalOnGeoServerSecurityEnabled;
-import org.geoserver.cloud.security.gateway.GatewayPreAuthenticationFilter;
-import org.geoserver.cloud.security.gateway.GatewayPreAuthenticationProvider;
-import org.geoserver.platform.ExtensionPriority;
-import org.geoserver.security.config.RequestHeaderAuthenticationFilterConfig;
+import org.geoserver.cloud.autoconfigure.security.GeoServerSecurityAutoConfiguration;
+import org.geoserver.cloud.security.gateway.GatewayPreAuthenticationConfiguration;
+import org.geoserver.cloud.security.gateway.GatewayPreAuthenticationConfigurationWebUI;
 import org.geoserver.security.web.auth.AuthenticationFilterPanelInfo;
-import org.geoserver.security.web.auth.HeaderAuthFilterPanel;
-import org.geoserver.security.web.auth.HeaderAuthFilterPanelInfo;
-import org.geoserver.web.LoginFormInfo;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-@AutoConfiguration
-@Import(GatewayPreAuthenticationAutoConfiguration.GatewayPreAuthWebConfiguration.class)
+// run before GeoServerSecurityAutoConfiguration so the provider is available when
+// GeoServerSecurityManager calls GeoServerExtensions.extensions(GeoServerSecurityProvider.class)
+@AutoConfiguration(before = GeoServerSecurityAutoConfiguration.class)
+@Import({
+    GatewayPreAuthenticationConfiguration.class,
+    GatewayPreAuthenticationAutoConfiguration.WebUi.class
+})
 @ConditionalOnGeoServerSecurityEnabled
+@SuppressWarnings("java:S1118")
 public class GatewayPreAuthenticationAutoConfiguration {
 
-    @Bean
-    GatewayPreAuthenticationProvider gatewayPreAuthenticationProvider() {
-        return new GatewayPreAuthenticationProvider();
-    }
-
     @Configuration
+    @Import(GatewayPreAuthenticationConfigurationWebUI.class)
     @ConditionalOnClass(AuthenticationFilterPanelInfo.class)
-    static class GatewayPreAuthWebConfiguration {
-        @Bean
-        HeaderAuthFilterPanelInfo gatewayAuthPanelInfo() {
-            HeaderAuthFilterPanelInfo panelInfo = new HeaderAuthFilterPanelInfo();
-            panelInfo.setId("security.gatewayPreAuthFilter");
-            panelInfo.setShortTitleKey("GatewayPreAuthFilterPanel.short");
-            panelInfo.setTitleKey("GatewayPreAuthFilterPanel.title");
-            panelInfo.setDescriptionKey("GatewayPreAuthFilterPanel.description");
-
-            panelInfo.setComponentClass(HeaderAuthFilterPanel.class);
-            panelInfo.setServiceClass(GatewayPreAuthenticationFilter.class);
-            panelInfo.setServiceConfigClass(RequestHeaderAuthenticationFilterConfig.class);
-
-            return panelInfo;
-        }
-
-        @SuppressWarnings("unchecked")
-        @Bean
-        LoginFormInfo gatewayLoginFormInfo() {
-            PrioritizableLoginFormInfo lif = new PrioritizableLoginFormInfo();
-            lif.setPriority(ExtensionPriority.LOWEST + 1);
-            lif.setId("gatewayLoginFormInfo");
-            lif.setName("gateway");
-            lif.setLoginPath("/login");
-
-            @SuppressWarnings("rawtypes")
-            Class componentClass = GatewayPreAuthenticationAutoConfiguration.class;
-            lif.setComponentClass(componentClass);
-            lif.setIcon("oidc.png");
-
-            lif.setTitleKey("GatewayLoginFormInfo.title");
-            lif.setDescriptionKey("GatewayLoginFormInfo.description");
-            @SuppressWarnings("rawtypes")
-            Class class1 = GatewayPreAuthenticationFilter.class;
-            lif.setFilterClass(class1);
-            return lif;
-        }
-    }
+    static class WebUi {}
 }

--- a/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/GatewaySharedAuthConfigProperties.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/GatewaySharedAuthConfigProperties.java
@@ -1,0 +1,38 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.authzn;
+
+import lombok.Data;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties to control enablement of the GeoServer Cloud specific "gateway shared
+ * authentication" mechanism, by which the authentication in the webui service is conveyed to the
+ * other serices using the GeoServer Cloud gateway as intermediary.
+ *
+ * @since 1.9
+ */
+@ConfigurationProperties(value = GatewaySharedAuthConfigProperties.PREFIX)
+@Data
+public class GatewaySharedAuthConfigProperties {
+
+    static final String PREFIX = "geoserver.security.gateway-shared-auth";
+    static final String ENABLED_PROP = PREFIX + ".enabled";
+    static final String AUTO_PROP = PREFIX + ".auto";
+    static final String SERVER_PROP = PREFIX + ".server";
+
+    /** Whether the gateway-shared-auth webui authentication conveyor protocol is enabled */
+    private boolean enabled = true;
+
+    /**
+     * Whether to automatically create the gateway-shared-auth authentication filter and append it
+     * to the filter chains when enabled
+     */
+    private boolean auto = true;
+
+    /** true to act as server (i.e. to be set in the webui service) or client (default) */
+    private boolean server = false;
+}

--- a/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/GatewaySharedAuthenticationAutoConfiguration.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/GatewaySharedAuthenticationAutoConfiguration.java
@@ -1,0 +1,104 @@
+/*
+ * (c) 2023 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.authzn;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.geoserver.cloud.autoconfigure.security.ConditionalOnGeoServerSecurityEnabled;
+import org.geoserver.cloud.autoconfigure.security.GeoServerSecurityAutoConfiguration;
+import org.geoserver.cloud.security.gateway.sharedauth.ClientConfiguration;
+import org.geoserver.cloud.security.gateway.sharedauth.GatewaySharedAuthenticationInitializer;
+import org.geoserver.cloud.security.gateway.sharedauth.ServerConfiguration;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.server.Session;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * {@link AutoConfiguration @AutoConfiguration} to enable sharing the webui form-based
+ * authentication object with the other services.
+ *
+ * <p>When a user is logged in through the regular web ui's authentication form, the {@link
+ * Authentication} object is held in the web ui's {@link Session}. Hence, further requests to
+ * stateless services, as they're on separate containers, don't share the webui session, and hence
+ * are executed as anonymous.
+ *
+ * <p>This {@link AutoConfiguration} enables a mechanism by which the authenticated user name and
+ * roles can be shared with the stateless services through request and response headrers, using the
+ * geoserver cloud gateway as the man in the middle.
+ *
+ * <p>The webui container will send a couple response headers with the authenticated user name and
+ * roles. The gateway will store them in its own session, and forward them to all services as
+ * request headers. The stateless services will intercept these request headers and impersonate the
+ * authenticated user as a {@link PreAuthenticatedAuthenticationToken}.
+ *
+ * <p>At the same time, the gateway will take care of removing the webui response headers from the
+ * responses sent to the clients, and from incoming client requests.
+ *
+ * @see ServerConfiguration
+ * @see ClientConfiguration
+ * @since 1.9
+ */
+// run before GeoServerSecurityAutoConfiguration so the provider is available when
+// GeoServerSecurityManager calls GeoServerExtensions.extensions(GeoServerSecurityProvider.class)
+@AutoConfiguration(before = GeoServerSecurityAutoConfiguration.class)
+@EnableConfigurationProperties(GatewaySharedAuthConfigProperties.class)
+@ConditionalOnGeoServerSecurityEnabled
+@ConditionalOnProperty(
+        name = GatewaySharedAuthConfigProperties.ENABLED_PROP,
+        havingValue = "true",
+        matchIfMissing = false)
+@Import({
+    GatewaySharedAuthenticationAutoConfiguration.Server.class,
+    GatewaySharedAuthenticationAutoConfiguration.Client.class
+})
+@SuppressWarnings("java:S1118")
+@Slf4j(topic = "org.geoserver.cloud.autoconfigure.authzn")
+public class GatewaySharedAuthenticationAutoConfiguration {
+
+    @Bean
+    @ConditionalOnProperty(
+            name = GatewaySharedAuthConfigProperties.AUTO_PROP,
+            havingValue = "true",
+            matchIfMissing = false)
+    GatewaySharedAuthenticationInitializer gatewaySharedAuthenticationInitializer(
+            GeoServerSecurityManager secManager) {
+        return new GatewaySharedAuthenticationInitializer(secManager);
+    }
+
+    @Configuration
+    @ConditionalOnProperty(
+            name = GatewaySharedAuthConfigProperties.SERVER_PROP,
+            havingValue = "true",
+            matchIfMissing = false)
+    @Import(ServerConfiguration.class)
+    static class Server {
+        @PostConstruct
+        void log() {
+            log.info("Gateway shared authentication method available in server mode");
+        }
+    }
+
+    @Configuration
+    @ConditionalOnProperty(
+            name = GatewaySharedAuthConfigProperties.SERVER_PROP,
+            havingValue = "false",
+            matchIfMissing = true)
+    @Import(ClientConfiguration.class)
+    static class Client {
+        @PostConstruct
+        void log() {
+            log.info("Gateway shared authentication method available in client mode");
+        }
+    }
+}

--- a/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/GatewayPreAuthenticationConfiguration.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/GatewayPreAuthenticationConfiguration.java
@@ -1,0 +1,17 @@
+/*
+ * (c) 2023 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.security.gateway;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GatewayPreAuthenticationConfiguration {
+
+    @Bean
+    GatewayPreAuthenticationProvider gatewayPreAuthenticationProvider() {
+        return new GatewayPreAuthenticationProvider();
+    }
+}

--- a/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/GatewayPreAuthenticationConfigurationWebUI.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/GatewayPreAuthenticationConfigurationWebUI.java
@@ -1,0 +1,51 @@
+package org.geoserver.cloud.security.gateway;
+
+import org.geoserver.cloud.autoconfigure.authzn.PrioritizableLoginFormInfo;
+import org.geoserver.platform.ExtensionPriority;
+import org.geoserver.security.config.RequestHeaderAuthenticationFilterConfig;
+import org.geoserver.security.web.auth.HeaderAuthFilterPanel;
+import org.geoserver.security.web.auth.HeaderAuthFilterPanelInfo;
+import org.geoserver.web.LoginFormInfo;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GatewayPreAuthenticationConfigurationWebUI {
+
+    @Bean
+    HeaderAuthFilterPanelInfo gatewayPreAuthPanelInfo() {
+        HeaderAuthFilterPanelInfo panelInfo = new HeaderAuthFilterPanelInfo();
+        panelInfo.setId("security.gatewayPreAuthFilter");
+        panelInfo.setShortTitleKey("GatewayPreAuthFilterPanel.short");
+        panelInfo.setTitleKey("GatewayPreAuthFilterPanel.title");
+        panelInfo.setDescriptionKey("GatewayPreAuthFilterPanel.description");
+
+        panelInfo.setComponentClass(HeaderAuthFilterPanel.class);
+        panelInfo.setServiceClass(GatewayPreAuthenticationFilter.class);
+        panelInfo.setServiceConfigClass(RequestHeaderAuthenticationFilterConfig.class);
+
+        return panelInfo;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Bean
+    LoginFormInfo gatewayPreAuthLoginFormInfo() {
+        PrioritizableLoginFormInfo lif = new PrioritizableLoginFormInfo();
+        lif.setPriority(ExtensionPriority.LOWEST + 1);
+        lif.setId("gatewayLoginFormInfo");
+        lif.setName("gateway");
+        lif.setLoginPath("/login");
+
+        @SuppressWarnings("rawtypes")
+        Class componentClass = GatewayPreAuthenticationConfiguration.class;
+        lif.setComponentClass(componentClass);
+        lif.setIcon("oidc.png");
+
+        lif.setTitleKey("GatewayLoginFormInfo.title");
+        lif.setDescriptionKey("GatewayLoginFormInfo.description");
+        @SuppressWarnings("rawtypes")
+        Class class1 = GatewayPreAuthenticationFilter.class;
+        lif.setFilterClass(class1);
+        return lif;
+    }
+}

--- a/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/GatewayPreAuthenticationFilter.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/GatewayPreAuthenticationFilter.java
@@ -25,7 +25,7 @@ import javax.servlet.http.HttpServletResponse;
  * @since 1.2
  */
 @Slf4j
-public class GatewayPreAuthenticationFilter extends GeoServerRequestHeaderAuthenticationFilter {
+class GatewayPreAuthenticationFilter extends GeoServerRequestHeaderAuthenticationFilter {
 
     /** Try to authenticate if there is no authenticated principal */
     @Override

--- a/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/ClientConfiguration.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/ClientConfiguration.java
@@ -1,0 +1,25 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.security.gateway.sharedauth;
+
+import static org.geoserver.cloud.security.gateway.sharedauth.GatewaySharedAuthenticationProvider.Mode.CLIENT;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Contributes a {@link GatewaySharedAuthenticationProvider} in client mode.
+ *
+ * @see ServerConfiguration
+ * @since 1.9
+ */
+@Configuration
+public class ClientConfiguration {
+
+    @Bean
+    GatewaySharedAuthenticationProvider gatewaySharedAuthenticationProvider() {
+        return new GatewaySharedAuthenticationProvider(CLIENT);
+    }
+}

--- a/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/GatewaySharedAuthenticationFilter.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/GatewaySharedAuthenticationFilter.java
@@ -1,0 +1,160 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.security.gateway.sharedauth;
+
+import static com.google.common.collect.Streams.stream;
+
+import lombok.AccessLevel;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+
+import org.geoserver.security.GeoServerRoleConverter;
+import org.geoserver.security.config.PreAuthenticatedUserNameFilterConfig.PreAuthenticatedUserNameRoleSource;
+import org.geoserver.security.config.SecurityAuthFilterConfig;
+import org.geoserver.security.config.SecurityFilterConfig;
+import org.geoserver.security.filter.GeoServerAuthenticationFilter;
+import org.geoserver.security.filter.GeoServerRequestHeaderAuthenticationFilter;
+import org.geoserver.security.filter.GeoServerSecurityFilter;
+import org.geoserver.security.impl.GeoServerRole;
+import org.geoserver.security.impl.GeoServerRoleConverterImpl;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @since 1.9
+ */
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+class GatewaySharedAuthenticationFilter extends GeoServerSecurityFilter
+        implements GeoServerAuthenticationFilter {
+
+    static final String X_GSCLOUD_USERNAME = "x-gsc-username";
+    static final String X_GSCLOUD_ROLES = "x-gsc-roles";
+
+    @SuppressWarnings("serial")
+    public static class Config extends SecurityFilterConfig implements SecurityAuthFilterConfig {
+        public Config() {
+            super.setClassName(GatewaySharedAuthenticationFilter.class.getCanonicalName());
+            super.setName("gateway-shared-auth");
+        }
+    }
+
+    private final @NonNull GeoServerSecurityFilter delegate;
+
+    /**
+     * @return a {@link GatewaySharedAuthenticationFilter} proxy filter with a {@link ServerFilter}
+     *     delegate
+     */
+    public static GeoServerSecurityFilter server() {
+        return new GatewaySharedAuthenticationFilter(new ServerFilter());
+    }
+
+    /**
+     * @return a {@link GatewaySharedAuthenticationFilter} proxy filter with a {@link ClientFilter}
+     *     delegate
+     */
+    public static GeoServerSecurityFilter client() {
+        return new GatewaySharedAuthenticationFilter(new ClientFilter());
+    }
+
+    @Override
+    public boolean applicableForHtml() {
+        return true;
+    }
+
+    @Override
+    public boolean applicableForServices() {
+        return true;
+    }
+
+    @Override
+    @SneakyThrows({ServletException.class, IOException.class})
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) {
+
+        delegate.doFilter(request, response, chain);
+    }
+
+    @SuppressWarnings("java:S110")
+    static class ClientFilter extends GeoServerRequestHeaderAuthenticationFilter {
+
+        ClientFilter() {
+            super.setRoleSource(PreAuthenticatedUserNameRoleSource.Header);
+            super.setConverter(new GeoServerRoleConverterImpl());
+            super.setPrincipalHeaderAttribute(X_GSCLOUD_USERNAME);
+            super.setRolesHeaderAttribute(X_GSCLOUD_ROLES);
+            super.setRoleConverterName("");
+        }
+
+        /**
+         * Override to handle muilti-valued roles header, the superclass assumes a single-valued
+         * header with a delimiter to handle mutliple values
+         */
+        @Override
+        protected Collection<GeoServerRole> getRolesFromHttpAttribute(
+                HttpServletRequest request, String principal) {
+
+            GeoServerRoleConverter roleConverter = super.getConverter();
+
+            var rolesHeader = getRolesHeaderAttribute();
+            var rolesEnum = request.getHeaders(rolesHeader);
+            return stream(rolesEnum.asIterator())
+                    .filter(StringUtils::hasText)
+                    .map(role -> roleConverter.convertRoleFromString(role, principal))
+                    .toList();
+        }
+    }
+
+    static class ServerFilter extends GeoServerSecurityFilter {
+
+        @Override
+        @SneakyThrows({ServletException.class, IOException.class})
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) {
+
+            // if the user is authenticated by some method, set the response headers for the
+            // Gateway to act as the middle man and send the user and roles to the other services
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth == null || auth instanceof AnonymousAuthenticationToken) {
+                removeGatewayResponseHeaders((HttpServletResponse) response);
+            } else {
+                setGatewayResponseHeaders(auth, (HttpServletResponse) response);
+            }
+
+            chain.doFilter(request, response);
+        }
+
+        /**
+         * Sets the {@link #X_GSCLOUD_USERNAME} request header to the empty string, the gateway
+         * requires for it to be explicitly set to clear it out from its session, just removing the
+         * header wouldn't work.
+         */
+        private void removeGatewayResponseHeaders(HttpServletResponse response) {
+            response.setHeader(X_GSCLOUD_USERNAME, "");
+        }
+
+        private void setGatewayResponseHeaders(
+                Authentication preAuth, HttpServletResponse response) {
+            final String name = null == preAuth ? null : preAuth.getName();
+            response.setHeader(X_GSCLOUD_USERNAME, name);
+            if (null != name) {
+                preAuth.getAuthorities().stream()
+                        .map(GrantedAuthority::getAuthority)
+                        .forEach(role -> response.addHeader(X_GSCLOUD_ROLES, role));
+            }
+        }
+    }
+}

--- a/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/GatewaySharedAuthenticationInitializer.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/GatewaySharedAuthenticationInitializer.java
@@ -1,0 +1,147 @@
+/*
+ * (c) 2023 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.security.gateway.sharedauth;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.geoserver.cloud.security.gateway.sharedauth.GatewaySharedAuthenticationFilter.Config;
+import org.geoserver.platform.ContextLoadedEvent;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.Resource.Lock;
+import org.geoserver.security.GeoServerSecurityFilterChain;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.RequestFilterChain;
+import org.geoserver.security.config.SecurityManagerConfig;
+import org.geoserver.security.validation.SecurityConfigException;
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.Ordered;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Upon a GeoServer {@link ContextLoadedEvent}, creates the {@link
+ * GatewaySharedAuthenticationFilter} filter in the {@link GeoServerSecurityManager} configuration,
+ * and appends the filter to the {@link SecurityManagerConfig#getFilterChain() filter chain}.
+ *
+ * @since 1.9
+ */
+@Slf4j(topic = "org.geoserver.cloud.security.gateway.sharedauth")
+@RequiredArgsConstructor
+public class GatewaySharedAuthenticationInitializer
+        implements ApplicationListener<ContextLoadedEvent>, Ordered {
+
+    @NonNull private final GeoServerSecurityManager securityManager;
+
+    @Override
+    public void onApplicationEvent(ContextLoadedEvent event) {
+        if (!filterIsMissing()) {
+            log.info(
+                    "{} config is present.",
+                    GatewaySharedAuthenticationFilter.class.getSimpleName());
+            return;
+        }
+        log.info(
+                "{} config is missing, acquiring security lock",
+                GatewaySharedAuthenticationFilter.class.getSimpleName());
+        final Resource security = securityManager.security();
+        final Lock securityLock = security.lock();
+        try {
+            if (filterIsMissing()) {
+                Config filterConfig = createFilter();
+                addToFilterChains(filterConfig);
+            } else {
+                log.info(
+                        "{} config already present after acquiring security lock",
+                        GatewaySharedAuthenticationFilter.class.getSimpleName());
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        } finally {
+            securityLock.release();
+        }
+    }
+
+    private void addToFilterChains(Config filterConfig) throws Exception {
+        final String filterName = filterConfig.getName();
+        SecurityManagerConfig config = securityManager.getSecurityConfig();
+        GeoServerSecurityFilterChain filterChain = config.getFilterChain();
+
+        final Set<String> applyTo = Set.of("web", "rest", "gwc", "default");
+
+        filterChain
+                .getRequestChains()
+                .forEach(
+                        requestFiltersChain -> {
+                            String chainName = requestFiltersChain.getName();
+                            if (applyTo.contains(chainName)) {
+                                addToFilterChain(requestFiltersChain, filterName);
+                            }
+                        });
+
+        securityManager.saveSecurityConfig(config);
+        log.info("SecurityManagerConfig saved");
+    }
+
+    private void addToFilterChain(RequestFilterChain requestFiltersChain, String filterName) {
+        List<String> filterNames = new ArrayList<>(requestFiltersChain.getFilterNames());
+        if (filterNames.contains(filterName)) {
+            log.info(
+                    "Filter chain {} already contains {} -> {}",
+                    requestFiltersChain.getName(),
+                    filterName,
+                    requestFiltersChain.getFilterNames().stream()
+                            .collect(Collectors.joining(", ")));
+        } else {
+            if (filterNames.contains("anonymous")) {
+                // anonymous must always be the last one if present
+                int index = filterNames.indexOf("anonymous");
+                filterNames.add(index, filterName);
+            } else {
+                filterNames.add(filterName);
+            }
+
+            requestFiltersChain.setFilterNames(filterNames);
+            log.info(
+                    "Applied filter {} to filter chain {} -> {}",
+                    filterName,
+                    requestFiltersChain.getName(),
+                    requestFiltersChain.getFilterNames().stream()
+                            .collect(Collectors.joining(", ")));
+        }
+    }
+
+    private boolean filterIsMissing() {
+        try {
+            return securityManager.listFilters(GatewaySharedAuthenticationFilter.class).isEmpty();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private Config createFilter() throws SecurityConfigException, IOException {
+        var config = new GatewaySharedAuthenticationFilter.Config();
+        securityManager.saveFilter(config);
+        log.info("Created {}", GatewaySharedAuthenticationFilter.class.getSimpleName());
+        return config;
+    }
+
+    /**
+     * @return {@link Ordered#LOWEST_PRECEDENCE} to make sure it runs after {@link
+     *     GeoServerSecurityManager#onApplicationEvent}
+     */
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
+    }
+}

--- a/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/GatewaySharedAuthenticationProvider.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/GatewaySharedAuthenticationProvider.java
@@ -1,0 +1,59 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.security.gateway.sharedauth;
+
+import com.thoughtworks.xstream.XStream;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import org.geoserver.config.util.XStreamPersister;
+import org.geoserver.security.config.SecurityNamedServiceConfig;
+import org.geoserver.security.filter.AbstractFilterProvider;
+import org.geoserver.security.filter.GeoServerSecurityFilter;
+
+/**
+ * @since 1.9
+ */
+@RequiredArgsConstructor
+public class GatewaySharedAuthenticationProvider extends AbstractFilterProvider {
+
+    /**
+     * Used to indicate whether the auth provider shall act in server or client mode
+     *
+     * @see GatewaySharedAuthenticationFilter#server()
+     * @see GatewaySharedAuthenticationFilter#client()
+     */
+    public enum Mode {
+        SERVER,
+        CLIENT
+    }
+
+    private final @NonNull Mode mode;
+
+    @Override
+    public void configure(XStreamPersister xp) {
+        super.configure(xp);
+        XStream xStream = xp.getXStream();
+        xStream.allowTypes(new Class[] {GatewaySharedAuthenticationFilter.Config.class});
+        xStream.alias("gatewaySharedAuthentication", GatewaySharedAuthenticationProvider.class);
+        xStream.alias(
+                "gatewaySharedAuthenticationFilter",
+                GatewaySharedAuthenticationFilter.Config.class);
+    }
+
+    @Override
+    public Class<GatewaySharedAuthenticationFilter> getFilterClass() {
+        return GatewaySharedAuthenticationFilter.class;
+    }
+
+    @Override
+    public GeoServerSecurityFilter createFilter(SecurityNamedServiceConfig config) {
+        if (Mode.SERVER == mode) {
+            return GatewaySharedAuthenticationFilter.server();
+        }
+        return GatewaySharedAuthenticationFilter.client();
+    }
+}

--- a/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/ServerConfiguration.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/ServerConfiguration.java
@@ -1,0 +1,65 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.security.gateway.sharedauth;
+
+import static org.geoserver.cloud.security.gateway.sharedauth.GatewaySharedAuthenticationProvider.Mode.SERVER;
+
+import org.apache.wicket.model.IModel;
+import org.geoserver.security.web.auth.AuthenticationFilterPanel;
+import org.geoserver.security.web.auth.AuthenticationFilterPanelInfo;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Contributes a {@link GatewaySharedAuthenticationProvider} in server mode.
+ *
+ * @see ClientConfiguration
+ * @since 1.9
+ */
+@Configuration
+public class ServerConfiguration {
+
+    @Bean
+    GatewaySharedAuthenticationProvider gatewaySharedAuthenticationProvider() {
+        return new GatewaySharedAuthenticationProvider(SERVER);
+    }
+
+    @Bean
+    GatewaySharedAuthFilterPanelInfo gatewaySharedAuthPanelInfo() {
+        var panelInfo = new GatewaySharedAuthFilterPanelInfo();
+        panelInfo.setId("security.gatewaySharedAuthFilter");
+        panelInfo.setShortTitleKey("GatewaySharedAuthFilterPanel.short");
+        panelInfo.setTitleKey("GatewaySharedAuthFilterPanel.title");
+        panelInfo.setDescriptionKey("GatewaySharedAuthFilterPanel.description");
+
+        panelInfo.setComponentClass(GatewaySharedAuthAuthFilterPanel.class);
+        panelInfo.setServiceClass(GatewaySharedAuthenticationFilter.class);
+        panelInfo.setServiceConfigClass(GatewaySharedAuthenticationFilter.Config.class);
+
+        return panelInfo;
+    }
+
+    @SuppressWarnings("serial")
+    public static class GatewaySharedAuthFilterPanelInfo
+            extends AuthenticationFilterPanelInfo<
+                    GatewaySharedAuthenticationFilter.Config, GatewaySharedAuthAuthFilterPanel> {
+
+        public GatewaySharedAuthFilterPanelInfo() {
+            setServiceClass(GatewaySharedAuthenticationFilter.class);
+            setServiceConfigClass(GatewaySharedAuthenticationFilter.Config.class);
+            setComponentClass(GatewaySharedAuthAuthFilterPanel.class);
+        }
+    }
+
+    @SuppressWarnings({"serial", "java:S110"})
+    public static class GatewaySharedAuthAuthFilterPanel
+            extends AuthenticationFilterPanel<GatewaySharedAuthenticationFilter.Config> {
+
+        public GatewaySharedAuthAuthFilterPanel(
+                String id, IModel<GatewaySharedAuthenticationFilter.Config> model) {
+            super(id, model);
+        }
+    }
+}

--- a/src/starters/security/src/main/resources/GeoServerApplication.properties
+++ b/src/starters/security/src/main/resources/GeoServerApplication.properties
@@ -4,3 +4,9 @@ GatewayPreAuthFilterPanel.title=Authentication headers provided by the Gateway
 GatewayPreAuthFilterPanel.description=The Gateway application is in charge of performing authentication and pass credentials as request headers
 GatewayLoginFormInfo.title=OAuth2/OIDC
 GatewayLoginFormInfo.description=Log in with OAuth2 / OpenId Connect
+
+org.geoserver.cloud.security.gateway.sharedauth.GatewaySharedAuthenticationFilter.title=GeoServer Cloud shared webui auth
+GatewaySharedAuthFilterPanel.short=GeoServer Cloud shared Authentication
+GatewaySharedAuthFilterPanel.title=GeoServer Cloud shared WebUI
+GatewaySharedAuthFilterPanel.description=When authenticated through the WebUI, the GeoServer Cloud Gateway keeps the authenticated user in synch with the other microservices.\
+When applied to a filter chain, this filter must always be the latest one except for the anonymous filter, to give precedence to other authentication methods, like basic or form.

--- a/src/starters/security/src/main/resources/META-INF/spring.factories
+++ b/src/starters/security/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,4 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.geoserver.cloud.autoconfigure.authzn.AuthKeyAutoConfiguration,\
-org.geoserver.cloud.autoconfigure.authzn.GatewayPreAuthenticationAutoConfiguration
+org.geoserver.cloud.autoconfigure.authzn.GatewayPreAuthenticationAutoConfiguration,\
+org.geoserver.cloud.autoconfigure.authzn.GatewaySharedAuthenticationAutoConfiguration


### PR DESCRIPTION
Introduce a `GatewaySharedAuthenticationFilter`, where the web-ui service acts as service, returning the authenticated user name and roles as response headers, the other services act as client, receiving the user name and roles as request headers, and the gateway acts as intermediary to convey the auth returned by the webui and sending it to the other services.

The functionality is enabled by default, and automatically creates the required authentication filter and injects it to the filter chains.

This behavior can be controlled through the following configuration properties:

```
  geoserver:
    security:
      gateway-shared-auth:
         enabled: true
         auto: true
         server: false (true for webui)
```