### PR TITLE
[Backport 1.8.x] Implement eventual consistency enforcement for the datadir catalog backend

### DIFF
--- a/compose/infra.yml
+++ b/compose/infra.yml
@@ -34,7 +34,7 @@ services:
       resources:
         limits:
           cpus: '4.0'
-          memory: 1G
+          memory: 2G
     restart: unless-stopped
     healthcheck:
       test: rabbitmq-diagnostics is_running

--- a/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/datadir/RemoteEventDataDirectoryAutoConfiguration.java
+++ b/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/datadir/RemoteEventDataDirectoryAutoConfiguration.java
@@ -4,23 +4,32 @@
  */
 package org.geoserver.cloud.autoconfigure.catalog.backend.datadir;
 
-import org.geoserver.catalog.plugin.CatalogPlugin;
 import org.geoserver.cloud.autoconfigure.catalog.event.ConditionalOnCatalogEvents;
-import org.geoserver.cloud.event.remote.datadir.RemoteEventDataDirectoryProcessor;
-import org.geoserver.config.plugin.RepositoryGeoServerFacade;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.geoserver.cloud.catalog.backend.datadir.EventualConsistencyEnforcer;
+import org.geoserver.cloud.event.remote.datadir.RemoteEventDataDirectoryConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 
+/**
+ * {@link AutoConfiguration @AutoConfiguration} to contribute beans related to handling remotely
+ * produced catalog and config events
+ *
+ * @see RemoteEventDataDirectoryConfiguration
+ */
 @AutoConfiguration
 @ConditionalOnDataDirectoryEnabled
 @ConditionalOnCatalogEvents
+@Import(RemoteEventDataDirectoryConfiguration.class)
 public class RemoteEventDataDirectoryAutoConfiguration {
 
     @Bean
-    RemoteEventDataDirectoryProcessor dataDirectoryRemoteEventProcessor(
-            @Qualifier("geoserverFacade") RepositoryGeoServerFacade configFacade,
-            @Qualifier("rawCatalog") CatalogPlugin rawCatalog) {
-        return new RemoteEventDataDirectoryProcessor(configFacade, rawCatalog);
+    @ConditionalOnProperty(
+            name = "geoserver.backend.data-directory.eventual-consistency.enabled",
+            havingValue = "true",
+            matchIfMissing = true)
+    EventualConsistencyEnforcer eventualConsistencyEnforcer() {
+        return new EventualConsistencyEnforcer();
     }
 }

--- a/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/catalog/backend/datadir/EventualConsistencyEnforcer.java
+++ b/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/catalog/backend/datadir/EventualConsistencyEnforcer.java
@@ -1,0 +1,611 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.catalog.backend.datadir;
+
+import com.google.common.collect.Sets;
+
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.catalog.impl.ResolvingProxy;
+import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
+import org.geoserver.catalog.plugin.Patch;
+import org.geoserver.catalog.plugin.resolving.ProxyUtils;
+import org.geoserver.catalog.plugin.resolving.ResolvingProxyResolver;
+import org.geoserver.cloud.event.info.ConfigInfoType;
+import org.geoserver.config.impl.GeoServerLifecycleHandler;
+import org.springframework.lang.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Aids {@link EventuallyConsistentCatalogFacade} in ensuring the catalog stays consistent and
+ * eventually converges while remote events may arrive out of order and {@link CatalogInfo}s
+ * reference objects not yet added to the local catalog.
+ *
+ * <p>
+ *
+ * <ul>
+ *   <li>All {@code add()} methods check if the {@link CatalogInfo} being added have unresolved
+ *       ({@link ResolvingProxy}) references
+ *   <li>If so, the object is put in a pending list and not added
+ *   <li>Conversely, if during {@code add()}, there's a pending add waiting for this new object, the
+ *       {@code add()} proceeds and then the pending object is added
+ * </ul>
+ *
+ * @since 1.9
+ */
+@Slf4j(topic = "org.geoserver.cloud.catalog.backend.datadir")
+public class EventualConsistencyEnforcer implements GeoServerLifecycleHandler {
+
+    private final Map<String, List<ConsistencyOp<?>>> pendingOperations = new HashMap<>();
+
+    @Setter private ExtendedCatalogFacade rawFacade;
+
+    private final ReentrantLock lock = new ReentrantLock();
+
+    public EventualConsistencyEnforcer() {
+        log.debug("raw catalog facade to be set using setter injection");
+    }
+
+    EventualConsistencyEnforcer(@NonNull ExtendedCatalogFacade rawFacade) {
+        this.rawFacade = rawFacade;
+    }
+
+    @Override
+    public void onDispose() {
+        lock.lock();
+        try {
+            pendingOperations.clear();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void beforeReload() {
+        onDispose();
+    }
+
+    @Override
+    public void onReset() {
+        // no-op
+    }
+
+    @Override
+    public void onReload() {
+        // no-op
+    }
+
+    boolean isConverged() {
+        lock.lock();
+        try {
+            return pendingOperations.isEmpty();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void forceResolve() {
+        lock.lock();
+        try {
+            resolvePending();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void resolvePending() {
+        if (pendingOperations.size() > 0) {
+            for (String missingRef : Set.copyOf(pendingOperations.keySet())) {
+                tryResolvePending(missingRef);
+            }
+        }
+    }
+
+    private void tryResolvePending(String missingRef) {
+        var pending = pendingOperations.get(missingRef);
+        if (pending != null && pending.isEmpty()) {
+            pendingOperations.remove(missingRef);
+            return;
+        }
+        Optional<CatalogInfo> found = rawFacade.get(missingRef);
+        if (found.isPresent()) {
+            log.debug(
+                    "previously missing ref {} found, resolving pending operations waiting for it",
+                    missingRef);
+            tryResolvePending(found.orElseThrow());
+        } else {
+            log.debug(
+                    "missing ref {} still not found, the follwing operations wait for it: {}",
+                    missingRef,
+                    pendingOperations.get(missingRef));
+        }
+    }
+
+    private void tryResolvePending(CatalogInfo resolved) {
+        var pending = List.copyOf(pendingOperations.getOrDefault(resolved.getId(), List.of()));
+        for (var op : pending) {
+            log.debug("converging operation for resolved {}: {}", resolved.getId(), op);
+            execute(op);
+        }
+    }
+
+    private <T> T execute(ConsistencyOp<T> op) {
+        lock.lock();
+        try {
+            T ret = op.call();
+            if (!op.completedSuccessfully() && log.isDebugEnabled()) {
+                log.debug("operation not converged {}, misses {}", op, op.getMissingRefs());
+            }
+            return ret;
+        } catch (Exception e) {
+            log.error("Error executing {}", op, e);
+            throw e;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @NonNull
+    public <T extends CatalogInfo> T add(@NonNull T info) {
+        return execute(new AddOp<>(info));
+    }
+
+    public void remove(@NonNull CatalogInfo info) {
+        execute(new RemoveOp(info));
+    }
+
+    @NonNull
+    public <I extends CatalogInfo> I update(I info, Patch patch) {
+        return execute(new UpdateOp<>(info, patch));
+    }
+
+    public void setDefaultWorkspace(@Nullable WorkspaceInfo workspace) {
+        execute(new SetDefaultWorkspace(workspace));
+    }
+
+    public void setDefaultNamespace(@Nullable NamespaceInfo namespace) {
+        execute(new SetDefaultNamespace(namespace));
+    }
+
+    public void setDefaultDataStore(
+            @NonNull WorkspaceInfo workspace, @Nullable DataStoreInfo store) {
+        execute(new SetDefaultDataStore(workspace, store));
+    }
+
+    private abstract class ConsistencyOp<T> implements Callable<T> {
+
+        private final UUID operationId = UUID.randomUUID();
+
+        protected boolean success;
+
+        @Override
+        public final boolean equals(Object o) {
+            return o instanceof ConsistencyOp<?> op && operationId.equals(op.operationId);
+        }
+
+        @Override
+        public final int hashCode() {
+            return operationId.hashCode();
+        }
+
+        @NonNull
+        abstract Set<String> getMissingRefs();
+
+        @Override
+        public final T call() {
+            Set<String> pre = Set.copyOf(getMissingRefs());
+            if (!pre.isEmpty()) log.debug("{} is missing refs {}", this, pre);
+            T result = resolve();
+            if (completedSuccessfully()) {
+                if (pre.isEmpty()) {
+                    purge(this);
+                } else {
+                    pre.forEach(ref -> unsetPending(ref, this));
+                }
+                afterSuccess();
+                return result;
+            }
+
+            Set<String> resolved;
+            Set<String> unresolved = getMissingRefs();
+            if (unresolved.isEmpty()) {
+                resolved = pre;
+            } else {
+                resolved = Sets.difference(pre, unresolved);
+            }
+            resolved.forEach(ref -> unsetPending(ref, this));
+            unresolved.forEach(ref -> setPending(ref, this));
+            return result;
+        }
+
+        protected void afterSuccess() {
+            // override as needed
+        }
+
+        protected abstract T resolve();
+
+        protected boolean completedSuccessfully() {
+            return success;
+        }
+
+        private void setPending(String missingRef, ConsistencyOp<?> deferredOp) {
+            log.debug("missing ref {}, deferring execution of {}", missingRef, deferredOp);
+            pendingOperations.computeIfAbsent(missingRef, ref -> new ArrayList<>()).add(deferredOp);
+        }
+
+        private void unsetPending(String resolvedRef, ConsistencyOp<?> completedOp) {
+            log.debug("missing ref {} resolved, completed {}", resolvedRef, completedOp);
+            remove(resolvedRef, completedOp);
+        }
+
+        protected void discard(ConsistencyOp<?> op) {
+            for (String ref : Set.copyOf(pendingOperations.keySet())) {
+                List<ConsistencyOp<?>> pending = pendingOperations.get(ref);
+                boolean removed = pending.remove(op);
+                if (removed) {
+                    log.debug("discarded op waiting for ref {}: {}", ref, op);
+                }
+                if (pending.isEmpty()) {
+                    pendingOperations.remove(ref);
+                }
+            }
+        }
+
+        protected void purge(ConsistencyOp<?> op) {
+            Set<String> removedFromRefs = new HashSet<>();
+            for (String ref : Set.copyOf(pendingOperations.keySet())) {
+                List<ConsistencyOp<?>> pending = pendingOperations.get(ref);
+                boolean removed = pending.remove(op);
+                if (removed) {
+                    removedFromRefs.add(ref);
+                }
+                if (pending.isEmpty()) {
+                    pendingOperations.remove(ref);
+                }
+            }
+            if (!removedFromRefs.isEmpty()) {
+                log.debug("purged op {} from pending refs {}", op, removedFromRefs);
+            }
+        }
+
+        private void remove(String resolvedRef, ConsistencyOp<?> completedOp) {
+            List<ConsistencyOp<?>> pendingForRef = pendingOperations.get(resolvedRef);
+            if (null != pendingForRef) {
+                pendingForRef.remove(completedOp);
+                if (pendingForRef.isEmpty()) {
+                    log.debug("there are no more consistency ops waiting for {}", resolvedRef);
+                    pendingOperations.remove(resolvedRef);
+                }
+            }
+        }
+    }
+
+    @RequiredArgsConstructor
+    private class AddOp<T extends CatalogInfo> extends ConsistencyOp<T> {
+
+        private @NonNull T info;
+
+        @Override
+        Set<String> getMissingRefs() {
+            if (completedSuccessfully()) {
+                return Set.of();
+            }
+            return findMissingRefs(info);
+        }
+
+        private <I extends CatalogInfo> Set<String> findMissingRefs(I info) {
+            final Set<String> missing = new HashSet<>();
+            var lookup = ResolvingProxyResolver.<CatalogInfo>of(rawFacade.getCatalog());
+            lookup.onNotFound((proxied, proxy) -> missing.add(proxy.getRef()));
+            lookup.apply(info);
+            return missing;
+        }
+
+        @Override
+        protected T resolve() {
+            var missing = getMissingRefs();
+            if (missing.isEmpty()) {
+                // check if the object already exists, may happen on a node that started while the
+                // events are being sent
+                Class<T> type = ConfigInfoType.valueOf(info).type();
+                rawFacade
+                        .get(info.getId(), type)
+                        .ifPresentOrElse(
+                                existing ->
+                                        log.info("Ignoring add, object exists {}", info.getId()),
+                                () -> {
+                                    T added = rawFacade.add(info);
+                                    this.info = added;
+                                    success = true;
+                                });
+            }
+            // return info to comply with the catalog facade add() contract
+            // but delay insertion of info as it has unresolved references
+            return info;
+        }
+
+        // resolve any pending ops waiting for the object just inserted
+        @Override
+        protected void afterSuccess() {
+            tryResolvePending(this.info);
+        }
+
+        @Override
+        public String toString() {
+            return "%s(%s)".formatted(getClass().getSimpleName(), info.getId());
+        }
+    }
+
+    @RequiredArgsConstructor
+    private class UpdateOp<T extends CatalogInfo> extends ConsistencyOp<T> {
+        /** Object to update, may be a ResolvingProxy itself */
+        private @NonNull T toUpdate;
+
+        /** Patch to apply, may contain ResolvingProxy properties */
+        private @NonNull Patch patch;
+
+        @Override
+        public String toString() {
+            return "%s(%s, patch: %s)"
+                    .formatted(
+                            getClass().getSimpleName(), toUpdate.getId(), patch.getPropertyNames());
+        }
+
+        @Override
+        @NonNull
+        Set<String> getMissingRefs() {
+            if (completedSuccessfully()) return Set.of();
+            var missing = new HashSet<String>();
+            if (ProxyUtils.isResolvingProxy(toUpdate)) {
+                missing.add(toUpdate.getId());
+            }
+            patch = resolvePatch(patch, missing);
+            return missing;
+        }
+
+        @Override
+        protected T resolve() {
+            Optional<T> found = objectToUpdate();
+            if (found.isPresent()) {
+                this.toUpdate = found.orElseThrow();
+                Set<String> missing = new HashSet<>();
+                this.patch = resolvePatch(patch, missing);
+                if (missing.isEmpty()) {
+                    success = true;
+                    return rawFacade.update(toUpdate, patch);
+                }
+            }
+            return toUpdate;
+        }
+
+        @SuppressWarnings("unchecked")
+        private Optional<T> objectToUpdate() {
+            return rawFacade.get(toUpdate.getId()).map(found -> (T) found);
+        }
+
+        private Patch resolvePatch(Patch patch, Set<String> target) {
+            var lookup = ResolvingProxyResolver.<CatalogInfo>of(rawFacade.getCatalog());
+            lookup.onNotFound((proxied, proxy) -> target.add(proxy.getRef()));
+            return lookup.resolve(patch);
+        }
+    }
+
+    @RequiredArgsConstructor
+    private class RemoveOp extends ConsistencyOp<Void> {
+        /**
+         * Object to remove, may be a {@link ResolvingProxy} itself, in which case the operation is
+         * deferred until the object is found. When executed, any pending operation waiting for this
+         * object is discarded
+         */
+        private @NonNull CatalogInfo info;
+
+        @Override
+        public String toString() {
+            return "%s(%s)".formatted(getClass().getSimpleName(), info.getId());
+        }
+
+        @Override
+        Set<String> getMissingRefs() {
+            if (ProxyUtils.isResolvingProxy(info)) {
+                return Set.of(info.getId());
+            }
+            return Set.of();
+        }
+
+        private List<ConsistencyOp<?>> clearDependants() {
+            List<ConsistencyOp<?>> dependants = pendingOperations.remove(info.getId());
+            return dependants == null ? List.of() : List.copyOf(dependants);
+        }
+
+        @Override
+        protected Void resolve() {
+            if (ProxyUtils.isResolvingProxy(info)) {
+                final String id = info.getId();
+                Optional<CatalogInfo> found = rawFacade.get(id);
+                if (found.isPresent()) {
+                    this.info = found.orElseThrow();
+                } else {
+                    // this.info is still a ResolvingProxy, defer operation
+                    return null;
+                }
+            }
+
+            // complete or discard any pending op waiting for this object
+            var waitingForThis = clearDependants();
+            for (var dependant : waitingForThis) {
+                completeOrDiscard(dependant);
+            }
+
+            rawFacade.remove(ModificationProxy.unwrap(info));
+            success = true;
+            return null;
+        }
+
+        private void completeOrDiscard(ConsistencyOp<?> dependant) {
+            final String id = info.getId();
+            execute(dependant);
+            if (dependant.completedSuccessfully()) {
+                log.debug(
+                        "successfully executed {} depending on {} before removing it",
+                        dependant,
+                        id);
+            } else {
+                log.warn(
+                        "operation dependant on {} didn't complete successfully before removing it. It will be discarded: {}",
+                        id,
+                        dependant);
+                // discard the op in case its waiting for some other ref besides the object removed
+                // by this op
+                discard(dependant);
+            }
+        }
+    }
+
+    @RequiredArgsConstructor
+    private class SetDefaultWorkspace extends ConsistencyOp<Void> {
+        @Nullable private final WorkspaceInfo workspace;
+
+        @Override
+        Set<String> getMissingRefs() {
+            if (ProxyUtils.isResolvingProxy(workspace)) {
+                return Set.of(workspace.getId());
+            }
+            return Set.of();
+        }
+
+        @Override
+        protected Void resolve() {
+            if (null == workspace) {
+                success = true;
+                rawFacade.setDefaultWorkspace(null);
+            } else {
+                String id = workspace.getId();
+                Optional<WorkspaceInfo> found = rawFacade.get(id, WorkspaceInfo.class);
+                if (found.isPresent()) {
+                    success = true;
+                    rawFacade.setDefaultWorkspace(found.orElseThrow());
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public String toString() {
+            return "%s(workspace: %s)"
+                    .formatted(
+                            getClass().getSimpleName(),
+                            (workspace == null ? null : workspace.getId()));
+        }
+    }
+
+    @RequiredArgsConstructor
+    private class SetDefaultNamespace extends ConsistencyOp<Void> {
+        @Nullable private final NamespaceInfo namespace;
+
+        @Override
+        Set<String> getMissingRefs() {
+            if (ProxyUtils.isResolvingProxy(namespace)) {
+                return Set.of(namespace.getId());
+            }
+            return Set.of();
+        }
+
+        @Override
+        protected Void resolve() {
+            if (null == namespace) {
+                success = true;
+                rawFacade.setDefaultNamespace(null);
+            } else {
+                String id = namespace.getId();
+                Optional<NamespaceInfo> found = rawFacade.get(id, NamespaceInfo.class);
+                if (found.isPresent()) {
+                    success = true;
+                    rawFacade.setDefaultNamespace(found.orElseThrow());
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public String toString() {
+            return "%s(namespace: %s)"
+                    .formatted(
+                            getClass().getSimpleName(),
+                            (namespace == null ? null : namespace.getId()));
+        }
+    }
+
+    @AllArgsConstructor
+    private class SetDefaultDataStore extends ConsistencyOp<Void> {
+        @NonNull private WorkspaceInfo workspace;
+        @Nullable private DataStoreInfo store;
+
+        @Override
+        Set<String> getMissingRefs() {
+            if (completedSuccessfully()) {
+                return Set.of();
+            }
+            var missing = new HashSet<String>();
+            if (ProxyUtils.isResolvingProxy(workspace)) {
+                missing.add(workspace.getId());
+            }
+            if (ProxyUtils.isResolvingProxy(store)) {
+                missing.add(store.getId());
+            }
+            return missing;
+        }
+
+        @Override
+        protected Void resolve() {
+            WorkspaceInfo ws = rawFacade.getWorkspace(workspace.getId());
+            if (null == ws) {
+                return null;
+            }
+            this.workspace = ws;
+            if (null == store) {
+                success = true;
+                rawFacade.setDefaultDataStore(ws, null);
+            } else {
+                String storeId = store.getId();
+                Optional<DataStoreInfo> found = rawFacade.get(storeId, DataStoreInfo.class);
+                if (found.isPresent()) {
+                    success = true;
+                    this.store = found.orElseThrow();
+                    rawFacade.setDefaultDataStore(ws, store);
+                }
+            }
+
+            return null;
+        }
+
+        @Override
+        public String toString() {
+            return "%s(workspace: %s, store: %s)"
+                    .formatted(
+                            getClass().getSimpleName(),
+                            workspace.getId(),
+                            (store == null ? null : store.getId()));
+        }
+    }
+}

--- a/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/catalog/backend/datadir/EventuallyConsistentCatalogFacade.java
+++ b/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/catalog/backend/datadir/EventuallyConsistentCatalogFacade.java
@@ -1,0 +1,362 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.catalog.backend.datadir;
+
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.MapInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.PublishedInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StoreInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.ResolvingProxy;
+import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
+import org.geoserver.catalog.plugin.Patch;
+import org.geoserver.catalog.plugin.forwarding.ForwardingExtendedCatalogFacade;
+import org.geoserver.ows.util.OwsUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+/**
+ *
+ *
+ * <ul>
+ *   <li>All {@code add(@NonNull )} methods check if the {@link CatalogInfo} being added have
+ *       unresolved ({@link ResolvingProxy}) references
+ *   <li>If so, the object is put in a pending list and not added
+ *   <li>Conversely, if during {@code add(@NonNull )}, there's a pending add waiting for this new
+ *       object, the {@code add(@NonNull )} proceeds and then the pending object is added
+ * </ul>
+ *
+ * @since 1.9
+ * @see EventualConsistencyEnforcer
+ * @see RemoteEventDataDirectoryProcessor
+ */
+@Slf4j(topic = "org.geoserver.cloud.catalog.backend.datadir")
+public class EventuallyConsistentCatalogFacade extends ForwardingExtendedCatalogFacade {
+
+    private final EventualConsistencyEnforcer enforcer;
+
+    /**
+     * number of retry attemps and milliseconds to wait between retries
+     *
+     * @see #retry
+     */
+    private final @NonNull int[] retryAttemptMillis;
+
+    public EventuallyConsistentCatalogFacade(
+            @NonNull ExtendedCatalogFacade facade,
+            @NonNull EventualConsistencyEnforcer tracker,
+            @NonNull int[] retryAttemptMillis) {
+        super(facade);
+        this.retryAttemptMillis = retryAttemptMillis;
+        this.enforcer = tracker;
+    }
+
+    @Override
+    public <T extends CatalogInfo> T add(@NonNull T info) {
+        return enforcer.add(info);
+    }
+
+    @Override
+    public WorkspaceInfo add(@NonNull WorkspaceInfo info) {
+        return enforcer.add(info);
+    }
+
+    @Override
+    public NamespaceInfo add(@NonNull NamespaceInfo info) {
+        return enforcer.add(info);
+    }
+
+    @Override
+    public LayerGroupInfo add(@NonNull LayerGroupInfo info) {
+        return enforcer.add(info);
+    }
+
+    @Override
+    public LayerInfo add(@NonNull LayerInfo info) {
+        return enforcer.add(info);
+    }
+
+    @Override
+    public ResourceInfo add(@NonNull ResourceInfo info) {
+        return enforcer.add(info);
+    }
+
+    @Override
+    public StoreInfo add(@NonNull StoreInfo info) {
+        return enforcer.add(info);
+    }
+
+    @Override
+    public StyleInfo add(@NonNull StyleInfo info) {
+        return enforcer.add(info);
+    }
+
+    @Override
+    public <I extends CatalogInfo> I update(@NonNull I info, @NonNull Patch patch) {
+        return enforcer.update(info, patch);
+    }
+
+    @Override
+    public void remove(@NonNull CatalogInfo info) {
+        enforcer.remove(info);
+    }
+
+    @Override
+    public void remove(@NonNull WorkspaceInfo info) {
+        enforcer.remove(info);
+    }
+
+    @Override
+    public void remove(@NonNull NamespaceInfo info) {
+        enforcer.remove(info);
+    }
+
+    @Override
+    public void remove(@NonNull StoreInfo info) {
+        enforcer.remove(info);
+    }
+
+    @Override
+    public void remove(@NonNull ResourceInfo info) {
+        enforcer.remove(info);
+    }
+
+    @Override
+    public void remove(@NonNull LayerInfo info) {
+        enforcer.remove(info);
+    }
+
+    @Override
+    public void remove(@NonNull LayerGroupInfo info) {
+        enforcer.remove(info);
+    }
+
+    @Override
+    public void remove(@NonNull StyleInfo info) {
+        enforcer.remove(info);
+    }
+
+    @Override
+    public void remove(@NonNull MapInfo info) {
+        enforcer.remove(info);
+    }
+
+    @Override
+    public void setDefaultWorkspace(WorkspaceInfo workspace) {
+        enforcer.setDefaultWorkspace(workspace);
+    }
+
+    @Override
+    public void setDefaultNamespace(NamespaceInfo defaultNamespace) {
+        enforcer.setDefaultNamespace(defaultNamespace);
+    }
+
+    @Override
+    public void setDefaultDataStore(WorkspaceInfo workspace, DataStoreInfo store) {
+        enforcer.setDefaultDataStore(workspace, store);
+    }
+
+    ///////// point queries, apply retry if
+
+    @Override
+    public <T extends StoreInfo> T getStore(String id, Class<T> clazz) {
+        return retryOnNull(
+                () -> super.getStore(id, clazz), //
+                () -> "getStore(%s, %s)".formatted(id, clazz.getSimpleName()));
+    }
+
+    @Override
+    public <T extends StoreInfo> T getStoreByName(
+            WorkspaceInfo workspace, String name, Class<T> clazz) {
+        return retryOnNull(
+                () -> super.getStoreByName(workspace, name, clazz), //
+                () ->
+                        "getStoreByName(%s, %s, %s)"
+                                .formatted(nameof(workspace), name, clazz.getSimpleName()));
+    }
+
+    @Override
+    public <T extends ResourceInfo> T getResource(String id, Class<T> clazz) {
+        return retryOnNull(
+                () -> super.getResource(id, clazz), //
+                () -> "getResource(%s, %s)".formatted(id, clazz.getSimpleName()));
+    }
+
+    @Override
+    public <T extends ResourceInfo> T getResourceByName(
+            NamespaceInfo namespace, String name, Class<T> clazz) {
+        return retryOnNull(
+                () -> super.getResourceByName(namespace, name, clazz), //
+                () ->
+                        "getResourceByName(%s, %s, %s)"
+                                .formatted(nameof(namespace), name, clazz.getSimpleName()));
+    }
+
+    @Override
+    public <T extends ResourceInfo> T getResourceByStore(
+            StoreInfo store, String name, Class<T> clazz) {
+        return retryOnNull(
+                () -> super.getResourceByStore(store, name, clazz), //
+                () ->
+                        "getResourceByStore(%s, %s, %s)"
+                                .formatted(nameof(store), name, clazz.getSimpleName()));
+    }
+
+    @Override
+    public LayerInfo getLayer(String id) {
+        return retryOnNull(
+                () -> super.getLayer(id), //
+                () -> "getLayer(%s)".formatted(id));
+    }
+
+    @Override
+    public LayerInfo getLayerByName(String name) {
+        return retryOnNull(
+                () -> super.getLayerByName(name), //
+                () -> "getLayerByName(%s)".formatted(name));
+    }
+
+    @Override
+    public LayerGroupInfo getLayerGroup(String id) {
+        return retryOnNull(
+                () -> super.getLayerGroup(id), //
+                () -> "getLayerGroup(%s)".formatted(id));
+    }
+
+    @Override
+    public LayerGroupInfo getLayerGroupByName(String name) {
+        return retryOnNull(
+                () -> super.getLayerGroupByName(name), //
+                () -> "getLayerGroupByName(%s)".formatted(name));
+    }
+
+    @Override
+    public LayerGroupInfo getLayerGroupByName(WorkspaceInfo workspace, String name) {
+        return retryOnNull(
+                () -> super.getLayerGroupByName(workspace, name), //
+                () -> "getLayerGroupByName(%s,%s)".formatted(nameof(workspace), name));
+    }
+
+    @Override
+    public NamespaceInfo getNamespace(String id) {
+        return retryOnNull(
+                () -> super.getNamespace(id), //
+                () -> "getNamespace(%s)".formatted(id));
+    }
+
+    @Override
+    public NamespaceInfo getNamespaceByPrefix(String prefix) {
+        // hack, CatalogImpl.getResourceByName(String ns, String name, Class<T> clazz)
+        // wil try uri and prefix, if it looks like a uri don't bother retrying
+        boolean maybeUri = prefix != null && prefix.indexOf(':') > -1;
+        if (maybeUri) return super.getNamespace(prefix);
+        return retryOnNull(
+                () -> super.getNamespaceByPrefix(prefix), //
+                () -> "getNamespaceByPrefix(%s)".formatted(prefix));
+    }
+
+    @Override
+    public NamespaceInfo getNamespaceByURI(String uri) {
+        return retryOnNull(
+                () -> super.getNamespaceByURI(uri), //
+                () -> "getNamespaceByURI(%s)".formatted(uri));
+    }
+
+    @Override
+    public WorkspaceInfo getWorkspace(String id) {
+        return retryOnNull(
+                () -> super.getWorkspace(id), //
+                () -> "getWorkspace(%s)".formatted(id));
+    }
+
+    @Override
+    public WorkspaceInfo getWorkspaceByName(String name) {
+        return retryOnNull(
+                () -> super.getWorkspaceByName(name), //
+                () -> "getWorkspaceByName(%s)".formatted(name));
+    }
+
+    @Override
+    public StyleInfo getStyle(String id) {
+        return retryOnNull(
+                () -> super.getStyle(id), //
+                () -> "getStyle(%s)".formatted(id));
+    }
+
+    @Override
+    public StyleInfo getStyleByName(String name) {
+        return retryOnNull(
+                () -> super.getStyleByName(name), //
+                () -> "getStyleByName(%s)".formatted(name));
+    }
+
+    @Override
+    public StyleInfo getStyleByName(WorkspaceInfo workspace, String name) {
+        return retryOnNull(
+                () -> super.getStyleByName(workspace, name), //
+                () -> "getStyleByName(%s, %s)".formatted(nameof(workspace), name));
+    }
+
+    private <T> T retryOnNull(Supplier<T> supplier, Supplier<String> op) {
+        return retry(supplier, Objects::nonNull, op);
+    }
+
+    private <T> T retry(Supplier<T> supplier, Predicate<T> predicate, Supplier<String> op) {
+        T ret = supplier.get();
+        if (predicate.test(ret)) return ret;
+        if (!isWebRequest()) return ret;
+        // poor man's Retry implementation
+        final int maxAttempts = retryAttemptMillis.length;
+        final String opDesc = op.get();
+        log.debug("{} not found, retrying up to {} times", opDesc, maxAttempts);
+        for (int i = 0; i < maxAttempts; i++) {
+            int waitMillis = retryAttemptMillis[i];
+            waitBeforeRetry(waitMillis);
+            enforcer.forceResolve();
+
+            int attempt = i + 1;
+            ret = supplier.get();
+            if (predicate.test(ret)) {
+                log.debug("retry #{} after {}ms found, call: {}", attempt, opDesc);
+                return ret;
+            } else {
+                log.debug("retry #{} after {}ms not found, call: {}", attempt, waitMillis, opDesc);
+            }
+        }
+        log.debug("failing out after retry #{}, call: {}", maxAttempts, opDesc);
+        return ret;
+    }
+
+    private boolean isWebRequest() {
+        return null != RequestContextHolder.getRequestAttributes();
+    }
+
+    @SneakyThrows(InterruptedException.class)
+    private void waitBeforeRetry(int waitMillis) {
+        TimeUnit.MILLISECONDS.sleep(waitMillis);
+    }
+
+    private String nameof(CatalogInfo info) {
+        if (null == info) return null;
+        if (info instanceof StoreInfo s)
+            return "%s:%s".formatted(s.getWorkspace().getName(), s.getName());
+        if (info instanceof PublishedInfo p) return p.prefixedName();
+        return (String) OwsUtils.get(info, "name");
+    }
+}

--- a/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/config/catalog/backend/datadirectory/DataDirectoryProperties.java
+++ b/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/config/catalog/backend/datadirectory/DataDirectoryProperties.java
@@ -11,6 +11,7 @@ import org.geoserver.cloud.config.catalog.backend.core.GeoServerBackendConfigure
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.nio.file.Path;
+import java.util.List;
 
 /**
  * Configuration properties to use GeoServer's traditional, file-system based data-directory as the
@@ -24,4 +25,24 @@ public class DataDirectoryProperties {
     private boolean enabled;
     private Path location;
     private boolean parallelLoader = true;
+    private DataDirectoryProperties.EventualConsistencyConfig eventualConsistency =
+            new EventualConsistencyConfig();
+
+    /**
+     * Eventual consistency enfocement configuration. Bus events may come out of order under stress
+     */
+    @Data
+    public static class EventualConsistencyConfig {
+        /**
+         * If enabled, the data directory catalog will be resilient to bus events coming out of
+         * order
+         */
+        private boolean enabled = true;
+
+        /**
+         * milliseconds to wait before retrying Catalog.getXXX point queries returning null. The
+         * list size determines the number of retries. The values the milliseconds to wait
+         */
+        private List<Integer> retries = List.of(25, 25, 50);
+    }
 }

--- a/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/event/remote/datadir/RemoteEventDataDirectoryConfiguration.java
+++ b/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/event/remote/datadir/RemoteEventDataDirectoryConfiguration.java
@@ -1,0 +1,25 @@
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.event.remote.datadir;
+
+import org.geoserver.catalog.plugin.CatalogPlugin;
+import org.geoserver.config.plugin.RepositoryGeoServerFacade;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration to contribute beans related to handling remotely produced catalog and config events
+ */
+@Configuration(proxyBeanMethods = false)
+public class RemoteEventDataDirectoryConfiguration {
+
+    @Bean
+    RemoteEventDataDirectoryProcessor dataDirectoryRemoteEventProcessor(
+            @Qualifier("geoserverFacade") RepositoryGeoServerFacade configFacade,
+            @Qualifier("rawCatalog") CatalogPlugin rawCatalog) {
+        return new RemoteEventDataDirectoryProcessor(configFacade, rawCatalog);
+    }
+}

--- a/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/event/remote/datadir/RemoteEventDataDirectoryProcessor.java
+++ b/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/event/remote/datadir/RemoteEventDataDirectoryProcessor.java
@@ -43,7 +43,7 @@ import java.util.function.Function;
  */
 @Slf4j(topic = "org.geoserver.cloud.event.remote.datadir")
 @RequiredArgsConstructor
-public class RemoteEventDataDirectoryProcessor {
+class RemoteEventDataDirectoryProcessor {
 
     private final @NonNull RepositoryGeoServerFacade configFacade;
     private final @NonNull CatalogPlugin rawCatalog;

--- a/src/catalog/backends/datadir/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/datadir/DataDirectoryAutoConfigurationTest.java
+++ b/src/catalog/backends/datadir/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/datadir/DataDirectoryAutoConfigurationTest.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import org.geoserver.GeoServerConfigurationLock;
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.plugin.CatalogPlugin;
-import org.geoserver.catalog.plugin.DefaultMemoryCatalogFacade;
 import org.geoserver.catalog.plugin.locking.LockProviderGeoServerConfigurationLock;
 import org.geoserver.catalog.plugin.locking.LockingCatalog;
 import org.geoserver.catalog.plugin.locking.LockingGeoServer;
@@ -102,16 +101,6 @@ class DataDirectoryAutoConfigurationTest {
                             context.getBean("catalogFacade", CatalogFacade.class);
                     CatalogPlugin rawCatalog = context.getBean("rawCatalog", CatalogPlugin.class);
                     assertSame(rawCatalogFacade, rawCatalog.getRawFacade());
-                });
-    }
-
-    @Test
-    void testCatalogFacade() {
-        runner.run(
-                context -> {
-                    assertThat(context)
-                            .getBean("catalogFacade")
-                            .isInstanceOf(DefaultMemoryCatalogFacade.class);
                 });
     }
 

--- a/src/catalog/backends/datadir/src/test/java/org/geoserver/cloud/catalog/backend/datadir/EventuallyConsistentCatalogFacadeTest.java
+++ b/src/catalog/backends/datadir/src/test/java/org/geoserver/cloud/catalog/backend/datadir/EventuallyConsistentCatalogFacadeTest.java
@@ -1,0 +1,238 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.catalog.backend.datadir;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.CoverageInfo;
+import org.geoserver.catalog.CoverageStoreInfo;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.MapInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StoreInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WMSLayerInfo;
+import org.geoserver.catalog.WMSStoreInfo;
+import org.geoserver.catalog.WMTSLayerInfo;
+import org.geoserver.catalog.WMTSStoreInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
+import org.geoserver.catalog.plugin.Patch;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Consumer;
+
+class EventuallyConsistentCatalogFacadeTest {
+
+    EventualConsistencyEnforcer tracker;
+    EventuallyConsistentCatalogFacade facade;
+
+    @BeforeEach
+    void setUp() {
+        ExtendedCatalogFacade subject = mock(ExtendedCatalogFacade.class);
+        tracker = mock(EventualConsistencyEnforcer.class);
+        facade = new EventuallyConsistentCatalogFacade(subject, tracker, new int[] {10, 25, 50});
+    }
+
+    @Test
+    void testEventuallyConsistentCatalogFacade() {
+        assertThrows(NullPointerException.class, () -> new EventualConsistencyEnforcer(null));
+    }
+
+    @Test
+    void testAddStoreInfo() {
+        testAdd(mock(StoreInfo.class), facade::add);
+    }
+
+    @Test
+    void testRemoveStoreInfo() {
+        testRemove(mock(StoreInfo.class), facade::remove);
+    }
+
+    @Test
+    void testSetDefaultDataStore() {
+        WorkspaceInfo ws = mock(WorkspaceInfo.class);
+
+        facade.setDefaultDataStore(ws, null);
+        verify(tracker, times(1)).setDefaultDataStore(ws, null);
+        verifyNoMoreInteractions(tracker);
+        clearInvocations(tracker);
+
+        DataStoreInfo store = mock(DataStoreInfo.class);
+        facade.setDefaultDataStore(ws, store);
+        verify(tracker, times(1)).setDefaultDataStore(ws, store);
+        verifyNoMoreInteractions(tracker);
+        clearInvocations(tracker);
+    }
+
+    @Test
+    void testAddResourceInfo() {
+        testAdd(mock(ResourceInfo.class), facade::add);
+    }
+
+    @Test
+    void testRemoveResourceInfo() {
+        testRemove(mock(ResourceInfo.class), facade::remove);
+    }
+
+    @Test
+    void testAddLayerInfo() {
+        testAdd(mock(LayerInfo.class), facade::add);
+    }
+
+    @Test
+    void testRemoveLayerInfo() {
+        testRemove(mock(LayerInfo.class), facade::remove);
+    }
+
+    @Test
+    void testAddLayerGroupInfo() {
+        testAdd(mock(LayerGroupInfo.class), facade::add);
+    }
+
+    @Test
+    void testRemoveLayerGroupInfo() {
+        testRemove(mock(LayerGroupInfo.class), facade::remove);
+    }
+
+    @Test
+    void testAddNamespaceInfo() {
+        testAdd(mock(NamespaceInfo.class), facade::add);
+    }
+
+    @Test
+    void testRemoveNamespaceInfo() {
+        testRemove(mock(NamespaceInfo.class), facade::remove);
+    }
+
+    @Test
+    void testSetDefaultNamespace() {
+        NamespaceInfo ns = mock(NamespaceInfo.class);
+        facade.setDefaultNamespace(ns);
+        verify(tracker, times(1)).setDefaultNamespace(ns);
+        verifyNoMoreInteractions(tracker);
+        clearInvocations(tracker);
+        facade.setDefaultNamespace(null);
+        verify(tracker, times(1)).setDefaultNamespace(null);
+        verifyNoMoreInteractions(tracker);
+    }
+
+    @Test
+    void testAddWorkspaceInfo() {
+        testAdd(mock(WorkspaceInfo.class), facade::add);
+    }
+
+    @Test
+    void testRemoveWorkspaceInfo() {
+        testRemove(mock(WorkspaceInfo.class), facade::remove);
+    }
+
+    @Test
+    void testSetDefaultWorkspace() {
+        WorkspaceInfo ws = mock(WorkspaceInfo.class);
+        facade.setDefaultWorkspace(ws);
+        verify(tracker, times(1)).setDefaultWorkspace(ws);
+        verifyNoMoreInteractions(tracker);
+        clearInvocations(tracker);
+        facade.setDefaultWorkspace(null);
+        verify(tracker, times(1)).setDefaultWorkspace(null);
+        verifyNoMoreInteractions(tracker);
+    }
+
+    @Test
+    void testAddStyleInfo() {
+        testAdd(mock(StyleInfo.class), facade::add);
+    }
+
+    @Test
+    void testRemoveStyleInfo() {
+        testRemove(mock(StyleInfo.class), facade::remove);
+    }
+
+    @Test
+    void testUpdate() {
+        CatalogInfo info = mock(LayerInfo.class);
+        Patch patch = mock(Patch.class);
+
+        assertThrows(NullPointerException.class, () -> facade.update(null, patch));
+        assertThrows(NullPointerException.class, () -> facade.update(info, null));
+
+        facade.update(info, patch);
+        verify(tracker, times(1)).update(info, patch);
+    }
+
+    @Test
+    void testAddT() {
+        testAddCatalogInfo(mock(WorkspaceInfo.class));
+        testAddCatalogInfo(mock(NamespaceInfo.class));
+        testAddCatalogInfo(mock(DataStoreInfo.class));
+        testAddCatalogInfo(mock(CoverageStoreInfo.class));
+        testAddCatalogInfo(mock(WMSStoreInfo.class));
+        testAddCatalogInfo(mock(WMTSStoreInfo.class));
+        testAddCatalogInfo(mock(FeatureTypeInfo.class));
+        testAddCatalogInfo(mock(CoverageInfo.class));
+        testAddCatalogInfo(mock(WMSLayerInfo.class));
+        testAddCatalogInfo(mock(WMTSLayerInfo.class));
+        testAddCatalogInfo(mock(LayerInfo.class));
+        testAddCatalogInfo(mock(LayerGroupInfo.class));
+        testAddCatalogInfo(mock(StyleInfo.class));
+        testAddCatalogInfo(mock(MapInfo.class));
+    }
+
+    private void testAddCatalogInfo(CatalogInfo mock) {
+        testAdd(mock, facade::add);
+    }
+
+    @Test
+    void testRemoveCatalogInfo() {
+        testRemoveCatalogInfo(mock(WorkspaceInfo.class));
+        testRemoveCatalogInfo(mock(NamespaceInfo.class));
+        testRemoveCatalogInfo(mock(DataStoreInfo.class));
+        testRemoveCatalogInfo(mock(CoverageStoreInfo.class));
+        testRemoveCatalogInfo(mock(WMSStoreInfo.class));
+        testRemoveCatalogInfo(mock(WMTSStoreInfo.class));
+        testRemoveCatalogInfo(mock(FeatureTypeInfo.class));
+        testRemoveCatalogInfo(mock(CoverageInfo.class));
+        testRemoveCatalogInfo(mock(WMSLayerInfo.class));
+        testRemoveCatalogInfo(mock(WMTSLayerInfo.class));
+        testRemoveCatalogInfo(mock(LayerInfo.class));
+        testRemoveCatalogInfo(mock(LayerGroupInfo.class));
+        testRemoveCatalogInfo(mock(StyleInfo.class));
+        testRemoveCatalogInfo(mock(MapInfo.class));
+    }
+
+    private void testRemoveCatalogInfo(CatalogInfo mock) {
+        testRemove(mock, facade::remove);
+    }
+
+    private <T extends CatalogInfo> void testAdd(T info, Consumer<T> addop) {
+        assertThrows(NullPointerException.class, () -> addop.accept(null));
+
+        addop.accept(info);
+        verify(tracker, times(1)).add(info);
+        verifyNoMoreInteractions(tracker);
+    }
+
+    private <T extends CatalogInfo> void testRemove(T info, Consumer<T> removeop) {
+
+        assertThrows(NullPointerException.class, () -> removeop.accept(null));
+
+        removeop.accept(info);
+        verify(tracker, times(1)).remove(info);
+        verifyNoMoreInteractions(tracker);
+        clearInvocations(tracker);
+    }
+}

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/info/ConfigInfoType.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/info/ConfigInfoType.java
@@ -62,6 +62,15 @@ public enum ConfigInfoType {
 
     private final @Getter @NonNull Class<? extends Info> type;
 
+    public static boolean isPersistable(Info nested) {
+        return nested instanceof WorkspaceInfo
+                || nested instanceof NamespaceInfo
+                || nested instanceof StoreInfo
+                || nested instanceof ResourceInfo
+                || nested instanceof PublishedInfo
+                || nested instanceof StyleInfo;
+    }
+
     public boolean isInstance(Info object) {
         return object != null && getType().isInstance(object);
     }

--- a/src/catalog/plugin/src/test/java/org/geoserver/catalog/plugin/CatalogConformanceTest.java
+++ b/src/catalog/plugin/src/test/java/org/geoserver/catalog/plugin/CatalogConformanceTest.java
@@ -2042,7 +2042,7 @@ public abstract class CatalogConformanceTest {
     }
 
     @Test
-    void testModifyStyleChangeWorkspace() throws IOException {
+    protected void testModifyStyleChangeWorkspace() throws IOException {
         WorkspaceInfo ws1 = addWorkspace(data.workspaceA);
         WorkspaceInfo ws2 = addWorkspace(data.workspaceB);
 


### PR DESCRIPTION
Backport #484 to release/1.8.x

When performing several catalog updates, for example through the REST API, and especially if the rabbitmq event bus is under stress, catalog events may arrive out of order.

This is troublesome for the datadir catalog backend, as the add/modify event for a given CatalogInfo may arrive before the event for one of its dependencies. For example, the WorkspaceInfo for a StoreInfo does not yet exist in the local catalog.

The `EventuallyConsistentCatalogFacade` will delay such changes with missing dependencies until they're resolved. This is usually a matter of a few milliseconds.

Also, when a web request is in progress, and an object is not found, the catalog facade will retry the operation for a configurable number of times and milliseconds, giving the eventual consistency enforcer a chance to having resolved a pending update.

The default configuration properties are as follow:

```
geoserver:
  backend:
    data-directory:
      eventual-consistency:
        # eventual consistency enfocement. Bus events may come out of order under stress
        enabled: true
        # milliseconds to wait before retries. The list size determines the number of retries. The values the milliseconds to wait
        retries: 25, 25, 50
```