### PR TITLE
Enable logstash-formatted JSON logging to the console

### DIFF
--- a/compose/.env
+++ b/compose/.env
@@ -4,24 +4,30 @@ TAG=1.9-SNAPSHOT
 ACL_TAG=2.3-SNAPSHOT
 GS_USER="1000:1000"
 
-BASE_PATH=/geoserver/cloud
+# geoserver entry point for the gateway
+GEOSERVER_BASE_PATH=/geoserver/cloud
 
-GEOSERVER_DEFAULT_PROFILES="default,acl"
+# logging profile, either "default" or "json-logs"
+LOGGING_PROFILE=json-logs
 
-JDBCCONFIG_DBNAME=geoserver_config
-JDBCCONFIG_URL=jdbc:postgresql://database:5432/${JDBCCONFIG_DBNAME}
-JDBCCONFIG_USERNAME=geoserver
-JDBCCONFIG_PASSWORD=geo5erver
+GEOSERVER_DEFAULT_PROFILES="${LOGGING_PROFILE},acl"
+GATEWAY_DEFAULT_PROFILES=${LOGGING_PROFILE}
+DISCOVERY_SERVER_DEFAULT_PROFILES=${LOGGING_PROFILE}
 
-# Remember to use docker-compose --compatibility 
+# Either 'git' or 'native' active profile must be set. Use the default sample git repository to download the services configuration from
+# If 'git', BEWARE config server will look for a branch called "master", and github changed the default branch name to "main"
+# For more information, see https://cloud.spring.io/spring-cloud-config/multi/multi__spring_cloud_config_server.html#_git_backend
+CONFIG_SERVER_DEFAULT_PROFILES=${LOGGING_PROFILE},native,standalone
 
-JAVA_OPTS_DEFAULT=-XX:MaxRAMPercentage=80 -XshowSettings:system -Djndi.postgis.enabled=true
 
-JAVA_OPTS_GEOSERVER=$JAVA_OPTS_DEFAULT
+JAVA_OPTS_DEFAULT=-XX:MaxRAMPercentage=80 -XshowSettings:system -Dlogging.config=file:/etc/geoserver/logback-spring.xml
 
 JAVA_OPTS_DISCOVERY=$JAVA_OPTS_DEFAULT
 JAVA_OPTS_CONFIG=$JAVA_OPTS_DEFAULT
 JAVA_OPTS_GATEWAY=$JAVA_OPTS_DEFAULT
+
+JAVA_OPTS_GEOSERVER=$JAVA_OPTS_DEFAULT -Djndi.postgis.enabled=true
+
 JAVA_OPTS_WFS=$JAVA_OPTS_GEOSERVER
 JAVA_OPTS_WMS=$JAVA_OPTS_GEOSERVER
 JAVA_OPTS_WCS=$JAVA_OPTS_GEOSERVER
@@ -29,3 +35,8 @@ JAVA_OPTS_WPS=$JAVA_OPTS_GEOSERVER
 JAVA_OPTS_REST=$JAVA_OPTS_GEOSERVER
 JAVA_OPTS_WEBUI=$JAVA_OPTS_GEOSERVER
 JAVA_OPTS_GWC=$JAVA_OPTS_GEOSERVER
+
+JDBCCONFIG_DBNAME=geoserver_config
+JDBCCONFIG_URL=jdbc:postgresql://database:5432/${JDBCCONFIG_DBNAME}
+JDBCCONFIG_USERNAME=geoserver
+JDBCCONFIG_PASSWORD=geo5erver

--- a/compose/compose.yml
+++ b/compose/compose.yml
@@ -54,10 +54,7 @@ services:
     user: ${GS_USER}
     environment:
       JAVA_OPTS: "${JAVA_OPTS_CONFIG}"
-      # Either 'git' or 'native'. Use the default sample git repository to download the services configuration from
-      # If 'git', BEWARE config server will look for a branch called "master", and github changed the default branch name to "main"
-      # For more information, see https://cloud.spring.io/spring-cloud-config/multi/multi__spring_cloud_config_server.html#_git_backend
-      SPRING_PROFILES_ACTIVE: native,standalone
+      SPRING_PROFILES_ACTIVE: "${CONFIG_SERVER_DEFAULT_PROFILES}"
       # 'git' profile config
       CONFIG_GIT_URI: https://github.com/geoserver/geoserver-cloud-config
       CONFIG_GIT_BASEDIR: /tmp/git_config
@@ -82,6 +79,7 @@ services:
     user: ${GS_USER}
     environment:
       JAVA_OPTS: "${JAVA_OPTS_DISCOVERY}"
+      SPRING_PROFILES_ACTIVE: "${DISCOVERY_SERVER_DEFAULT_PROFILES}"
     ports:
       - 8761:8761 # for development, so services can be run from localhost and find the discovery service running on docker
     restart: unless-stopped
@@ -103,9 +101,9 @@ services:
         condition: service_healthy
     environment:
       JAVA_OPTS: "${JAVA_OPTS_GATEWAY}"
-      SPRING_PROFILES_ACTIVE: dev #exposes the catalog and config API at /api/v1/**
       # eat our own dogfood and set a base path
-      GEOSERVER_BASE_PATH: ${BASE_PATH}
+      GEOSERVER_BASE_PATH: ${GEOSERVER_BASE_PATH}
+      SPRING_PROFILES_ACTIVE: "${GATEWAY_DEFAULT_PROFILES}"
     ports:
       - 9090:8080
     deploy:

--- a/compose/infra.yml
+++ b/compose/infra.yml
@@ -25,7 +25,8 @@ services:
     user: ${GS_USER}
     tmpfs:
       - /var/lib/rabbitmq
-    #volumes:
+    volumes:
+      - $PWD/../config/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
     #  - rabbitmq_data:/var/lib/rabbitmq
     ports:
       - "5672:5672"

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,11 @@
         <version>${project.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.geoserver.cloud</groupId>
+        <artifactId>gs-cloud-starter-observability</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.geoserver.cloud.catalog</groupId>
         <artifactId>gs-cloud-catalog-plugin</artifactId>
         <version>${project.version}</version>

--- a/src/apps/base-images/spring-boot/pom.xml
+++ b/src/apps/base-images/spring-boot/pom.xml
@@ -14,6 +14,11 @@
       <artifactId>gs-cloud-spring-boot-starter</artifactId>
     </dependency>
     <dependency>
+      <!-- include the observability libraries in the base spring boot image -->
+      <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-starter-observability</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.geoserver.cloud.apps</groupId>
       <artifactId>gs-cloud-base-jre</artifactId>
       <version>${project.version}</version>

--- a/src/apps/geoserver/pom.xml
+++ b/src/apps/geoserver/pom.xml
@@ -46,6 +46,10 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-starter-observability</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-cloud-starter-geonode</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/src/apps/geoserver/wms/src/main/resources/bootstrap.yml
+++ b/src/apps/geoserver/wms/src/main/resources/bootstrap.yml
@@ -48,7 +48,8 @@ spring:
 # override default of true, this service does not use the registry (when eureka client is enabled)
 eureka.client.fetch-registry: false
 
-logging.level:
+logging:
+  level:
     '[org.springframework.retry]': debug
 ---
 # local profile, used for development only. Other settings like config and eureka urls in gs_cloud_bootstrap_profiles.yml

--- a/src/apps/infrastructure/pom.xml
+++ b/src/apps/infrastructure/pom.xml
@@ -25,6 +25,10 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-starter-observability</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -44,10 +44,17 @@
     -->
     <aws.version>2.20.117</aws.version>
     <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+    <!-- logstash-logback-encoder:7.4+ requires logback 1.3+ and slf4j 2.0+, only available on spring-boot 3.0+ -->
+    <logstash-logback-encoder.version>7.3</logstash-logback-encoder.version>
   </properties>
   <dependencyManagement>
     <!-- Note dependencies added purely to satisfy the dependencyConvergence maven-enforcer-plugin rule are in the dependencyConvergence maven profile -->
     <dependencies>
+      <dependency>
+        <groupId>net.logstash.logback</groupId>
+        <artifactId>logstash-logback-encoder</artifactId>
+        <version>${logstash-logback-encoder.version}</version>
+      </dependency>
       <dependency>
         <!-- Upgrade to snakeyaml 2.0 to get rid of several CVE's from
 				the 1.30 version included with spring-boot -->

--- a/src/starters/observability/README.md
+++ b/src/starters/observability/README.md
@@ -1,0 +1,21 @@
+# Observability starter
+
+Spring-Boot starter project to treat application observability (logging, metrics, tracing) as a cross-cutting concern.
+
+## Dependency
+
+Add dependency
+
+```xml
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-starter-observability</artifactId>
+      <version>${project.verison}</version>
+    </dependency>
+```
+
+## Logstash formatted JSON Logging
+
+The `net.logstash.logback:logstash-logback-encoder` dependency allows to write logging entries as JSON-formatted objects in Logstash scheme.
+
+The application must be run with the `json-logs` Spring profile, as defined in [logback-spring.xml](src/main/resources/logback-spring.xml).

--- a/src/starters/observability/pom.xml
+++ b/src/starters/observability/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.geoserver.cloud</groupId>
+    <artifactId>gs-cloud-starters</artifactId>
+    <version>${revision}</version>
+  </parent>
+  <artifactId>gs-cloud-starter-observability</artifactId>
+  <packaging>jar</packaging>
+  <description>Spring boot starter for application observability (logging, metrics, tracing)</description>
+  <dependencies>
+    <dependency>
+      <groupId>net.logstash.logback</groupId>
+      <artifactId>logstash-logback-encoder</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/starters/observability/src/main/resources/logback-spring.xml
+++ b/src/starters/observability/src/main/resources/logback-spring.xml
@@ -1,0 +1,17 @@
+<configuration>
+
+  <springProfile name="default">
+    <include resource="org/springframework/boot/logging/logback/base.xml" />
+  </springProfile>
+
+  <springProfile name="json-logs">
+    <appender name="jsonConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+      <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+    </appender>
+
+    <root level="INFO">
+      <appender-ref ref="jsonConsoleAppender" />
+    </root>
+  </springProfile>
+
+</configuration>

--- a/src/starters/pom.xml
+++ b/src/starters/pom.xml
@@ -19,6 +19,7 @@
     <module>wms-extensions</module>
     <module>security</module>
     <module>geonode</module>
+    <module>observability</module>
   </modules>
   <dependencies>
     <dependency>


### PR DESCRIPTION
To enable JSON logging, the applications must be run with the `json-logs` Spring profile.

The default configuration in the Docker images at `/etc/geoserver/` include logback and rabbitmq config files for JSON logging:

* `logback-spring.xml` defines a logstash compatible JSON console   appender for spring boot apps. This default file is identical to the one included in the applications classpath already. In order to use this one, for example, may it require some tunning, the application must be run with `-Dlogging.config=file:/etc/geoserver/logback-spring.xml`,  or any other location where the xml config file is placed.
* A sample `rabbitmq.conf` file declaring console json logging output  for rabbitmq. Must be mounted at `/etc/rabbitmq/rabbitmq.conf`, or use it as a guideline to enhance rabbitmq's configuration.