### PR TITLE
Upgrade to GeoServer 2.25.2

### DIFF
--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebCoreConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebCoreConfiguration.java
@@ -13,7 +13,6 @@ import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
-import org.vfny.geoserver.wfs.servlets.TestWfsPost;
 
 @Configuration(proxyBeanMethods = true)
 @ImportResource( //
@@ -32,23 +31,11 @@ public class WebCoreConfiguration {
         return new GeoServerWicketServlet();
     }
 
-    @Bean
-    TestWfsPost testWfsPostServlet() {
-        return new TestWfsPost();
-    }
-
     /** Register the {@link WicketServlet} */
     @Bean
     ServletRegistrationBean<GeoServerWicketServlet> geoServerWicketServletRegistration() {
         GeoServerWicketServlet servlet = geoServerWicketServlet();
         return new ServletRegistrationBean<>(servlet, "/web", "/web/*");
-    }
-
-    /** Register the {@link TestWfsPost servlet} */
-    @Bean
-    ServletRegistrationBean<TestWfsPost> wfsTestServletRegistration() {
-        TestWfsPost servlet = testWfsPostServlet();
-        return new ServletRegistrationBean<>(servlet, "/TestWfsPost");
     }
 
     @Bean

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/LoggingTemplate.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/LoggingTemplate.java
@@ -21,8 +21,8 @@ import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.RowCallbackHandler;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.lang.Nullable;
-import org.threeten.bp.Duration;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;

--- a/src/catalog/jackson-bindings/geoserver/pom.xml
+++ b/src/catalog/jackson-bindings/geoserver/pom.xml
@@ -33,7 +33,7 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver.community</groupId>
-      <artifactId>gs-cog</artifactId>
+      <artifactId>gs-cog-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/HTTPStore.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/HTTPStore.java
@@ -23,4 +23,15 @@ public abstract class HTTPStore extends Store {
     private int readTimeout;
     private int connectTimeout;
     private boolean useConnectionPooling;
+
+    /** Pulled up from {@link WMTSStore} to match the GeoServer 2.25.1 refactoring */
+    private String headerName;
+
+    /** Pulled up from {@link WMTSStore} to match the GeoServer 2.25.1 refactoring */
+    private String headerValue;
+
+    /**
+     * @since GeoServer 2.25.1
+     */
+    private String authKey;
 }

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/WMTSStore.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/WMTSStore.java
@@ -12,7 +12,4 @@ import lombok.EqualsAndHashCode;
 @Data
 @JsonTypeName("WMTSStoreInfo")
 @EqualsAndHashCode(callSuper = true)
-public class WMTSStore extends HTTPStore {
-    private String headerName;
-    private String headerValue;
-}
+public class WMTSStore extends HTTPStore {}

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigGwcInitializer.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigGwcInitializer.java
@@ -6,7 +6,6 @@ package org.geoserver.cloud.autoconfigure.gwc.backend;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.api.client.util.Objects;
 import com.google.common.base.Stopwatch;
 
 import lombok.NonNull;
@@ -36,6 +35,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -97,7 +97,7 @@ class PgconfigGwcInitializer implements GeoServerReinitializer {
                                     break;
                                 case MODIFIED:
                                     if (event.getOldName() != null
-                                            && !Objects.equal(
+                                            && !Objects.equals(
                                                     event.getOldName(), event.getName())) {
                                         log.info(
                                                 "TileLayer {} renamed to {}, notifying in-memory CacheProvider",

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1039,7 +1039,7 @@
           <dependency>
             <groupId>com.fasterxml.woodstox</groupId>
             <artifactId>woodstox-core</artifactId>
-            <version>6.5.1</version>
+            <version>6.6.2</version>
           </dependency>
           <dependency>
             <groupId>com.netflix.servo</groupId>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -28,7 +28,7 @@
     <acl.version>2.2.0</acl.version>
     <!-- Downgrade netty.version used by spring-boot to the one used by geoserver azure client
     (software.amazon.awssdk:netty-nio-client:jar:2.9.24) for COG and GWC Azure plugin -->
-    <netty.version>4.1.41.Final</netty.version>
+    <netty.version>4.1.46.Final</netty.version>
     <lombok.version>1.18.30</lombok.version>
     <mapstruct.version>1.6.0.Beta1</mapstruct.version>
     <flyway.version>10.10.0</flyway.version>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1129,7 +1129,7 @@
           <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.2</version>
+            <version>42.7.3</version>
           </dependency>
           <dependency>
             <groupId>com.jayway.jsonpath</groupId>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -954,7 +954,7 @@
           <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.1.1-jre</version>
+            <version>33.2.0-jre</version>
           </dependency>
           <dependency>
             <groupId>commons-beanutils</groupId>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -23,8 +23,8 @@
     <spring-cloud.version>2021.0.9</spring-cloud.version>
     <spring-boot.version>2.7.18</spring-boot.version>
     <jackson.version>2.15.3</jackson.version>
-    <gs.version>2.25.0.4-CLOUD</gs.version>
-    <gt.version>31.0</gt.version>
+    <gs.version>2.25.2.0-CLOUD</gs.version>
+    <gt.version>31-SNAPSHOT</gt.version>
     <acl.version>2.2.0</acl.version>
     <!-- Downgrade netty.version used by spring-boot to the one used by geoserver azure client
     (software.amazon.awssdk:netty-nio-client:jar:2.9.24) for COG and GWC Azure plugin -->

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -647,7 +647,51 @@
       </dependency>
       <dependency>
         <groupId>org.geoserver.community</groupId>
-        <artifactId>gs-cog</artifactId>
+        <artifactId>gs-cog-core</artifactId>
+        <version>${gs.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.geoserver.web</groupId>
+            <artifactId>gs-web-core</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.community</groupId>
+        <artifactId>gs-cog-http</artifactId>
+        <version>${gs.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.geoserver.web</groupId>
+            <artifactId>gs-web-core</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.community</groupId>
+        <artifactId>gs-cog-s3</artifactId>
+        <version>${gs.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.geoserver.web</groupId>
+            <artifactId>gs-web-core</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.community</groupId>
+        <artifactId>gs-cog-azure</artifactId>
+        <version>${gs.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.geoserver.web</groupId>
+            <artifactId>gs-web-core</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.community</groupId>
+        <artifactId>gs-cog-google</artifactId>
         <version>${gs.version}</version>
         <exclusions>
           <exclusion>
@@ -955,6 +999,11 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>33.2.0-jre</version>
+          </dependency>
+          <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>failureaccess</artifactId>
+            <version>1.0.2</version>
           </dependency>
           <dependency>
             <groupId>commons-beanutils</groupId>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -22,7 +22,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <spring-cloud.version>2021.0.9</spring-cloud.version>
     <spring-boot.version>2.7.18</spring-boot.version>
-    <jackson.version>2.15.3</jackson.version>
+    <jackson.version>2.17.1</jackson.version>
     <gs.version>2.25.2.0-CLOUD</gs.version>
     <gt.version>31-SNAPSHOT</gt.version>
     <acl.version>2.2.0</acl.version>
@@ -56,8 +56,6 @@
         <version>${logstash-logback-encoder.version}</version>
       </dependency>
       <dependency>
-        <!-- Upgrade to snakeyaml 2.0 to get rid of several CVE's from
-				the 1.30 version included with spring-boot -->
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
         <version>2.2</version>

--- a/src/starters/raster-formats/pom.xml
+++ b/src/starters/raster-formats/pom.xml
@@ -36,7 +36,23 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver.community</groupId>
-      <artifactId>gs-cog</artifactId>
+      <artifactId>gs-cog-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.community</groupId>
+      <artifactId>gs-cog-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.community</groupId>
+      <artifactId>gs-cog-s3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.community</groupId>
+      <artifactId>gs-cog-azure</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.community</groupId>
+      <artifactId>gs-cog-google</artifactId>
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>


### PR DESCRIPTION
850a81bac Update config submodule with gateway removal of /TestWfsPost request
25fd4405e Upgrade netty.version to 4.1.46.Final, works with bot cog-s3 and azure-blobstore
e74fa39c8 Remove TestWfsPost servlet registration in web-ui service, it's gone upstream
ace72d79b Fix compile errors after gs depenency upgrade
ee301ddeb Import splitted gs-cog-* jars
57f3fcc41 upgrade woodstox to match transitive version from jackson-databind:2.17.1
51e163586 Base SpringEnvironmentAwareGeoToolsHttpClient on AbstractHttpClient
c5b903725 Dependency update: guava:32.1.1 -> 33.2.0, follow suit with geoserver 2.25.1
0e98c8c1c Dependency upgrade: postgresql:42.7.2 -> 42.7.3
f996fba2d Adatp JSON mappings to changes in WMSStoreInfo/WMTSStoreInfo
f3a4624f8 Dependency upgrade: jackson:2.15.2 -> 2.17.1
dbb832145 Upgrade to GeoServer 2.25.2.0-CLOUD