### PR TITLE
[backport 1.8.x] Upgrade to GeoServer 2.25.2

### DIFF
--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebCoreConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebCoreConfiguration.java
@@ -13,7 +13,6 @@ import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
-import org.vfny.geoserver.wfs.servlets.TestWfsPost;
 
 @Configuration(proxyBeanMethods = true)
 @ImportResource( //
@@ -32,23 +31,11 @@ public class WebCoreConfiguration {
         return new GeoServerWicketServlet();
     }
 
-    @Bean
-    TestWfsPost testWfsPostServlet() {
-        return new TestWfsPost();
-    }
-
     /** Register the {@link WicketServlet} */
     @Bean
     ServletRegistrationBean<GeoServerWicketServlet> geoServerWicketServletRegistration() {
         GeoServerWicketServlet servlet = geoServerWicketServlet();
         return new ServletRegistrationBean<>(servlet, "/web", "/web/*");
-    }
-
-    /** Register the {@link TestWfsPost servlet} */
-    @Bean
-    ServletRegistrationBean<TestWfsPost> wfsTestServletRegistration() {
-        TestWfsPost servlet = testWfsPostServlet();
-        return new ServletRegistrationBean<>(servlet, "/TestWfsPost");
     }
 
     @Bean

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/geotools/SpringEnvironmentAwareGeoToolsHttpClient.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/geotools/SpringEnvironmentAwareGeoToolsHttpClient.java
@@ -21,6 +21,7 @@ import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofSeconds;
 
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -30,6 +31,7 @@ import org.apache.http.StatusLine;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
@@ -39,6 +41,8 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
@@ -54,6 +58,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -66,18 +71,13 @@ import java.util.zip.GZIPInputStream;
  * extensibility, adding the ability to set up the Apache HTTPClient's proxy configuration from
  * Spring {@link PropertyResolver}'s properties.
  */
-class SpringEnvironmentAwareGeoToolsHttpClient
+@Slf4j
+class SpringEnvironmentAwareGeoToolsHttpClient extends org.geotools.http.AbstractHttpClient
         implements HTTPClient, HTTPConnectionPooling, HTTPProxy {
 
     private final PoolingHttpClientConnectionManager connectionManager;
 
     private HttpClient client;
-
-    private String user;
-
-    private String password;
-
-    private boolean tryGzip = true;
 
     private RequestConfig connectionConfig;
 
@@ -100,6 +100,18 @@ class SpringEnvironmentAwareGeoToolsHttpClient
                         .build();
         resetCredentials();
         client = builder().build();
+    }
+
+    @Override
+    public void setUser(String user) {
+        super.setUser(user);
+        resetCredentials();
+    }
+
+    @Override
+    public void setPassword(String password) {
+        super.setPassword(password);
+        resetCredentials();
     }
 
     private RequestConfig connectionConfig(URL url) {
@@ -172,6 +184,18 @@ class SpringEnvironmentAwareGeoToolsHttpClient
     public HttpMethodResponse post(
             final URL url, final InputStream postContent, final String postContentType)
             throws IOException {
+        return post(url, postContent, postContentType, null);
+    }
+
+    @Override
+    public HttpMethodResponse post(
+            URL url, InputStream postContent, String postContentType, Map<String, String> headers)
+            throws IOException {
+        if (headers == null) {
+            headers = Map.of();
+        } else {
+            headers = Map.copyOf(headers); // avoid parameter modification
+        }
 
         HttpPost postMethod = new HttpPost(url.toExternalForm());
         postMethod.setConfig(connectionConfig(url));
@@ -193,6 +217,8 @@ class SpringEnvironmentAwareGeoToolsHttpClient
         if (postContentType != null) {
             postMethod.setHeader("Content-type", postContentType);
         }
+
+        setHeadersOn(headers, postMethod);
 
         postMethod.setEntity(requestEntity);
 
@@ -217,6 +243,13 @@ class SpringEnvironmentAwareGeoToolsHttpClient
         HttpResponse resp;
         if (credsProvider != null) {
             localContext.setCredentialsProvider(credsProvider);
+            // see https://stackoverflow.com/a/21592593
+            AuthCache authCache = new BasicAuthCache();
+            URI target = method.getURI();
+            authCache.put(
+                    new HttpHost(target.getHost(), target.getPort(), target.getScheme()),
+                    new BasicScheme());
+            localContext.setAuthCache(authCache);
             resp = client.execute(method, localContext);
         } else {
             resp = client.execute(method);
@@ -232,6 +265,19 @@ class SpringEnvironmentAwareGeoToolsHttpClient
 
     @Override
     public HTTPResponse get(URL url, Map<String, String> headers) throws IOException {
+        if (isFile(url)) {
+            return createFileResponse(url);
+        }
+        if (headers == null) {
+            headers = Map.of();
+        } else {
+            headers = Map.copyOf(headers); // avoid parameter modification
+        }
+        Map<String, String> extraParams = getExtraParams();
+        if (!extraParams.isEmpty()) {
+            url = appendURL(url, extraParams);
+        }
+
         HttpGet getMethod = new HttpGet(url.toExternalForm());
         getMethod.setConfig(connectionConfig(url));
 
@@ -239,11 +285,7 @@ class SpringEnvironmentAwareGeoToolsHttpClient
             getMethod.setHeader("Accept-Encoding", "gzip");
         }
 
-        if (headers != null) {
-            for (Map.Entry<String, String> headerNameValue : headers.entrySet()) {
-                getMethod.setHeader(headerNameValue.getKey(), headerNameValue.getValue());
-            }
-        }
+        setHeadersOn(headers, getMethod);
 
         HttpMethodResponse response = executeMethod(getMethod);
 
@@ -256,26 +298,11 @@ class SpringEnvironmentAwareGeoToolsHttpClient
         return response;
     }
 
-    @Override
-    public String getUser() {
-        return user;
-    }
-
-    @Override
-    public void setUser(String user) {
-        this.user = user;
-        resetCredentials();
-    }
-
-    @Override
-    public String getPassword() {
-        return password;
-    }
-
-    @Override
-    public void setPassword(String password) {
-        this.password = password;
-        resetCredentials();
+    private void setHeadersOn(Map<String, String> headers, HttpRequestBase request) {
+        for (Map.Entry<String, String> header : headers.entrySet()) {
+            log.debug("Setting header {} = {}", header.getKey(), header.getValue());
+            request.setHeader(header.getKey(), header.getValue());
+        }
     }
 
     @Override
@@ -379,16 +406,6 @@ class SpringEnvironmentAwareGeoToolsHttpClient
             final Header encoding = methodResponse.getEntity().getContentEncoding();
             return encoding == null ? null : encoding.getValue();
         }
-    }
-
-    @Override
-    public void setTryGzip(boolean tryGZIP) {
-        this.tryGzip = tryGZIP;
-    }
-
-    @Override
-    public boolean isTryGzip() {
-        return tryGzip;
     }
 
     @Override

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/LoggingTemplate.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/LoggingTemplate.java
@@ -21,8 +21,8 @@ import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.RowCallbackHandler;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.lang.Nullable;
-import org.threeten.bp.Duration;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;

--- a/src/catalog/jackson-bindings/geoserver/pom.xml
+++ b/src/catalog/jackson-bindings/geoserver/pom.xml
@@ -33,7 +33,7 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver.community</groupId>
-      <artifactId>gs-cog</artifactId>
+      <artifactId>gs-cog-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/HTTPStore.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/HTTPStore.java
@@ -23,4 +23,15 @@ public abstract class HTTPStore extends Store {
     private int readTimeout;
     private int connectTimeout;
     private boolean useConnectionPooling;
+
+    /** Pulled up from {@link WMTSStore} to match the GeoServer 2.25.1 refactoring */
+    private String headerName;
+
+    /** Pulled up from {@link WMTSStore} to match the GeoServer 2.25.1 refactoring */
+    private String headerValue;
+
+    /**
+     * @since GeoServer 2.25.1
+     */
+    private String authKey;
 }

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/WMTSStore.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/WMTSStore.java
@@ -12,7 +12,4 @@ import lombok.EqualsAndHashCode;
 @Data
 @JsonTypeName("WMTSStoreInfo")
 @EqualsAndHashCode(callSuper = true)
-public class WMTSStore extends HTTPStore {
-    private String headerName;
-    private String headerValue;
-}
+public class WMTSStore extends HTTPStore {}

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigGwcInitializer.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigGwcInitializer.java
@@ -6,7 +6,6 @@ package org.geoserver.cloud.autoconfigure.gwc.backend;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.api.client.util.Objects;
 import com.google.common.base.Stopwatch;
 
 import lombok.NonNull;
@@ -36,6 +35,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -97,7 +97,7 @@ class PgconfigGwcInitializer implements GeoServerReinitializer {
                                     break;
                                 case MODIFIED:
                                     if (event.getOldName() != null
-                                            && !Objects.equal(
+                                            && !Objects.equals(
                                                     event.getOldName(), event.getName())) {
                                         log.info(
                                                 "TileLayer {} renamed to {}, notifying in-memory CacheProvider",

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -22,7 +22,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <spring-cloud.version>2021.0.8</spring-cloud.version>
     <spring-boot.version>2.7.18</spring-boot.version>
-    <jackson.version>2.15.3</jackson.version>
+    <jackson.version>2.17.1</jackson.version>
     <gs.version>2.25.2.0-CLOUD</gs.version>
     <gt.version>31-SNAPSHOT</gt.version>
     <acl.version>2.2.0</acl.version>
@@ -56,8 +56,6 @@
         <version>${logstash-logback-encoder.version}</version>
       </dependency>
       <dependency>
-        <!-- Upgrade to snakeyaml 2.0 to get rid of several CVE's from
-				the 1.30 version included with spring-boot -->
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
         <version>2.2</version>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1039,7 +1039,7 @@
           <dependency>
             <groupId>com.fasterxml.woodstox</groupId>
             <artifactId>woodstox-core</artifactId>
-            <version>6.5.1</version>
+            <version>6.6.2</version>
           </dependency>
           <dependency>
             <groupId>com.netflix.servo</groupId>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -28,7 +28,7 @@
     <acl.version>2.2.0</acl.version>
     <!-- Downgrade netty.version used by spring-boot to the one used by geoserver azure client
     (software.amazon.awssdk:netty-nio-client:jar:2.9.24) for COG and GWC Azure plugin -->
-    <netty.version>4.1.41.Final</netty.version>
+    <netty.version>4.1.46.Final</netty.version>
     <lombok.version>1.18.30</lombok.version>
     <mapstruct.version>1.6.0.Beta1</mapstruct.version>
     <flyway.version>10.10.0</flyway.version>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -23,9 +23,8 @@
     <spring-cloud.version>2021.0.8</spring-cloud.version>
     <spring-boot.version>2.7.18</spring-boot.version>
     <jackson.version>2.15.3</jackson.version>
-    <gs.version>2.25.0.4-CLOUD</gs.version>
-    <gs.community.version>2.25.0.4-CLOUD</gs.community.version>
-    <gt.version>31.0</gt.version>
+    <gs.version>2.25.2.0-CLOUD</gs.version>
+    <gt.version>31-SNAPSHOT</gt.version>
     <acl.version>2.2.0</acl.version>
     <!-- Downgrade netty.version used by spring-boot to the one used by geoserver azure client
     (software.amazon.awssdk:netty-nio-client:jar:2.9.24) for COG and GWC Azure plugin -->

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -20,7 +20,7 @@
   <properties>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <spring-cloud.version>2021.0.8</spring-cloud.version>
+    <spring-cloud.version>2021.0.9</spring-cloud.version>
     <spring-boot.version>2.7.18</spring-boot.version>
     <jackson.version>2.17.1</jackson.version>
     <gs.version>2.25.2.0-CLOUD</gs.version>
@@ -430,7 +430,7 @@
       <dependency>
         <groupId>org.geoserver.community</groupId>
         <artifactId>gs-jdbcconfig</artifactId>
-        <version>${gs.community.version}</version>
+        <version>${gs.version}</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -445,7 +445,7 @@
       <dependency>
         <groupId>org.geoserver.community</groupId>
         <artifactId>gs-jdbcstore</artifactId>
-        <version>${gs.community.version}</version>
+        <version>${gs.version}</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -548,7 +548,7 @@
       <dependency>
         <groupId>org.geoserver.community</groupId>
         <artifactId>gs-gwc-azure-blob</artifactId>
-        <version>${gs.community.version}</version>
+        <version>${gs.version}</version>
         <exclusions>
           <exclusion>
             <groupId>org.geoserver.web</groupId>
@@ -643,12 +643,56 @@
       <dependency>
         <groupId>org.geoserver.community</groupId>
         <artifactId>gs-pgraster</artifactId>
-        <version>${gs.community.version}</version>
+        <version>${gs.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geoserver.community</groupId>
-        <artifactId>gs-cog</artifactId>
-        <version>${gs.community.version}</version>
+        <artifactId>gs-cog-core</artifactId>
+        <version>${gs.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.geoserver.web</groupId>
+            <artifactId>gs-web-core</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.community</groupId>
+        <artifactId>gs-cog-http</artifactId>
+        <version>${gs.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.geoserver.web</groupId>
+            <artifactId>gs-web-core</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.community</groupId>
+        <artifactId>gs-cog-s3</artifactId>
+        <version>${gs.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.geoserver.web</groupId>
+            <artifactId>gs-web-core</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.community</groupId>
+        <artifactId>gs-cog-azure</artifactId>
+        <version>${gs.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.geoserver.web</groupId>
+            <artifactId>gs-web-core</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.community</groupId>
+        <artifactId>gs-cog-google</artifactId>
+        <version>${gs.version}</version>
         <exclusions>
           <exclusion>
             <groupId>org.geoserver.web</groupId>
@@ -677,7 +721,7 @@
       <dependency>
         <groupId>org.geoserver.community</groupId>
         <artifactId>gs-datadir-catalog-loader</artifactId>
-        <version>${gs.community.version}</version>
+        <version>${gs.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geotools</groupId>
@@ -955,6 +999,11 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>33.2.0-jre</version>
+          </dependency>
+          <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>failureaccess</artifactId>
+            <version>1.0.2</version>
           </dependency>
           <dependency>
             <groupId>commons-beanutils</groupId>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1129,7 +1129,7 @@
           <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.2</version>
+            <version>42.7.3</version>
           </dependency>
           <dependency>
             <groupId>com.jayway.jsonpath</groupId>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -954,7 +954,7 @@
           <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.1.1-jre</version>
+            <version>33.2.0-jre</version>
           </dependency>
           <dependency>
             <groupId>commons-beanutils</groupId>

--- a/src/starters/raster-formats/pom.xml
+++ b/src/starters/raster-formats/pom.xml
@@ -36,7 +36,23 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver.community</groupId>
-      <artifactId>gs-cog</artifactId>
+      <artifactId>gs-cog-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.community</groupId>
+      <artifactId>gs-cog-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.community</groupId>
+      <artifactId>gs-cog-s3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.community</groupId>
+      <artifactId>gs-cog-azure</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.community</groupId>
+      <artifactId>gs-cog-google</artifactId>
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>


### PR DESCRIPTION
f060a1294 Update config submodule with gateway removal of /TestWfsPost request
4cb0cacdb Upgrade netty.version to 4.1.46.Final, works with bot cog-s3 and azure-blobstore
d34d0ef82 Remove TestWfsPost servlet registration in web-ui service, it's gone upstream
f3b884478 Fix compile errors after gs depenency upgrade
6d5decfc4 Import splitted gs-cog-* jars
2bd77f8a8 upgrade woodstox to match transitive version from jackson-databind:2.17.1
73091fefc Base SpringEnvironmentAwareGeoToolsHttpClient on AbstractHttpClient
5ef094ce3 Dependency update: guava:32.1.1 -> 33.2.0, follow suit with geoserver 2.25.1
7f5d0cb3f Dependency upgrade: postgresql:42.7.2 -> 42.7.3
690d32375 Adatp JSON mappings to changes in WMSStoreInfo/WMTSStoreInfo
1c40e7f52 Dependency upgrade: jackson:2.15.2 -> 2.17.1
081716453 Upgrade to GeoServer 2.25.2.0-CLOUD
