### PR TITLE
Cosign integration. Docker images signing during CICD.

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -55,6 +55,7 @@ jobs:
         make build-image
 
     - name: Write signing key to disk (only needed for `cosign sign --key`)
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
       run: echo "${{ secrets.COSIGN_KEY }}" > cosign.key
 
     - name: Push images
@@ -62,15 +63,18 @@ jobs:
         make push-image
 
     - name: Sign images
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
       run: |
         make sign-image
       env:
         COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
 
     - name: Write pub key to disk (for verification)
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
       run: echo "${{ secrets.COSIGN_PUB_KEY }}" > cosign.pub
 
     - name: Verify images
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
       run: |
         make verify-image
       env:

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -22,6 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@v3.5.0
+
     - name: Login to Docker Hub
       uses: docker/login-action@v1
       with:
@@ -32,6 +35,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: recursive
+
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
@@ -50,9 +54,27 @@ jobs:
       run: |
         make build-image
 
+    - name: Write signing key to disk (only needed for `cosign sign --key`)
+      run: echo "${{ secrets.COSIGN_KEY }}" > cosign.key
+
     - name: Push images
       run: |
         make push-image
+
+    - name: Sign images
+      run: |
+        make sign-image
+      env:
+        COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+
+    - name: Write pub key to disk (for verification)
+      run: echo "${{ secrets.COSIGN_PUB_KEY }}" > cosign.pub
+
+    - name: Verify images
+      run: |
+        make verify-image
+      env:
+        COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
 
     - name: Remove project jars from cached repository
       run: |

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 all: install test build-image
 
 TAG=`mvn help:evaluate -Dexpression=project.version -q -DforceStdout`
+COSIGN_PASSWORD := $(COSIGN_PASSWORD)
 
 clean:
 	./mvnw clean
@@ -16,7 +17,6 @@ install:
 
 test:
 	./mvnw verify -ntp -T4
-
 
 build-base-images:
 	./mvnw clean package -f src/apps/base-images -DksipTests -T4 && \
@@ -47,3 +47,35 @@ push-image:
 	-f docker-build/infrastructure.yml \
 	-f docker-build/geoserver.yml \
 	push
+
+.PHONY: sign-image
+sign-image:
+	@bash -c '\
+	export COSIGN_PASSWORD=$(COSIGN_PASSWORD); \
+	images=$$(docker images --format "{{.Repository}}@{{.Digest}}" | grep "geoserver-cloud-"); \
+	for image in $$images; do \
+	  echo "Signing $$image"; \
+	  output=$$(cosign sign --yes --key cosign.key $$image 2>&1); \
+	  if [ $$? -ne 0 ]; then \
+	    echo "Error occurred: $$output"; \
+	    exit 1; \
+	  else \
+	    echo "Signing successful: $$output"; \
+	  fi; \
+	done'
+
+.PHONY: verify-image
+verify-image:
+	@bash -c '\
+	images=$$(docker images --format "{{.Repository}}@{{.Digest}}" | grep "geoserver-cloud-"); \
+	for image in $$images; do \
+	  echo "Verifying $$image"; \
+	  output=$$(cosign verify --key cosign.pub $$image 2>&1); \
+	  if [ $$? -ne 0 ]; then \
+	    echo "Error occurred: $$output"; \
+	    exit 1; \
+	  else \
+	    echo "Verification successful: $$output"; \
+	  fi; \
+	done'
+


### PR DESCRIPTION
Required to create these secrets in github actions setup:

![image](https://github.com/geoserver/geoserver-cloud/assets/1171099/7c056b04-7f37-4bb0-ba21-c68a9b92c89b)

Cosign_key is the private key
Cosign_pub_key the public one (for use in validation process)
Cosign_password is the password for the private key
Docker token and username for dockerhub repo.

You should create your keys with cosign generate-key-pair
You will be challenged for setting a password for the private key (that is going to be the value of your cosign_password secret)
Then you will get 2 files, cosign.key and cosign.pub.

Assign those values to the secrets, and make public the cosign.pub (adding to your repo in git, so people can access it for own validation).

Since cosign advices to avoid signing based on tags, then we are signing images based on digest.
Once pulled in repo, signing procedure is executed and cosign adds a .sig file into the dockerhub repo, which is used for validation. If the sig file for a digest is removed, then image wont be recognized as signed.

You can validate images in this way:
cosign verify --key cosign.pub jemacchi/geoserver-cloud-wms:1.9-SNAPSHOT

IMPORTANT Note: do not confuse use of Cosign with Docker Content Trust (reference: https://snyk.io/blog/signing-container-images/ ).