### PR TITLE
Cosign integration. Docker images signature and validation in github actions

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@v3.5.0
+
     - name: Login to Docker Hub
       uses: docker/login-action@v1
       with:
@@ -31,15 +34,13 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: recursive
+
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
         distribution: 'temurin'
         java-version: '21'
         cache: 'maven'
-
-    - name: Validate source code formatting
-      run: make lint
 
     - name: Build without tests
       run: |
@@ -57,3 +58,19 @@ jobs:
       run: |
         rm -rf ~/.m2/repository/org/geoserver
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}
+
+    - name: Sign images
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      env:
+        COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
+        COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+      run: |
+        make sign-image
+
+    - name: Verify image signatures
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      env:
+        COSIGN_PUB_KEY: ${{ secrets.COSIGN_PUB_KEY }}
+        COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+      run: |
+        make verify-image


### PR DESCRIPTION
Backport #491 to 1.8.x

Required to create these secrets in github actions setup:

![image](https://github.com/geoserver/geoserver-cloud/assets/207423/bc5e3db0-762c-4d3e-862e-e40c0e56fd5f)


Cosign_key is the private key
Cosign_pub_key the public one (for use in validation process)
Cosign_password is the password for the private key
Docker token and username for dockerhub repo.

You should create your keys with cosign generate-key-pair
You will be challenged for setting a password for the private key (that is going to be the value of your cosign_password secret)
Then you will get 2 files, cosign.key and cosign.pub.

Assign those values to the secrets, and make public the cosign.pub (adding to your repo in git, so people can access it for own validation).

Since cosign advices to avoid signing based on tags, then we are signing images based on digest.
Once pulled in repo, signing procedure is executed and cosign adds a .sig file into the dockerhub repo, which is used for validation. If the sig file for a digest is removed, then image wont be recognized as signed.

You can validate images in this way:
cosign verify --key cosign.pub jemacchi/geoserver-cloud-wms:1.9-SNAPSHOT

IMPORTANT Note: do not confuse use of Cosign with Docker Content Trust (reference: https://snyk.io/blog/signing-container-images/ ).