### PR TITLE
Avoid exceptions when gateway-shared-auth is disabled after being enabled

### DIFF
--- a/compose/.env
+++ b/compose/.env
@@ -3,6 +3,7 @@ COMPOSE_PROJECT_NAME=gscloud_dev
 TAG=1.9-SNAPSHOT
 ACL_TAG=2.3-SNAPSHOT
 GS_USER="1000:1000"
+GATEWAY_SHARED_AUTH=false
 
 # geoserver entry point for the gateway
 GEOSERVER_BASE_PATH=/geoserver/cloud

--- a/compose/compose.yml
+++ b/compose/compose.yml
@@ -104,6 +104,7 @@ services:
       # eat our own dogfood and set a base path
       GEOSERVER_BASE_PATH: ${GEOSERVER_BASE_PATH}
       SPRING_PROFILES_ACTIVE: "${GATEWAY_DEFAULT_PROFILES}"
+      GATEWAY_SHARED_AUTH: "${GATEWAY_SHARED_AUTH}" #same as in gstemplate
     ports:
       - 9090:8080
     deploy:

--- a/compose/templates.yml
+++ b/compose/templates.yml
@@ -6,6 +6,7 @@ services:
       # enable the postgis jndi datasource. This is just an example used for development
       JNDI_POSTGIS_ENABLED: true
       GEOWEBCACHE_CACHE_DIR: /data/geowebcache
+      GATEWAY_SHARED_AUTH: "${GATEWAY_SHARED_AUTH}"
     volumes:
       - geowebcache_data:/data/geowebcache
     deploy:

--- a/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/ConditionalOnGatewaySharedAuthDisabled.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/ConditionalOnGatewaySharedAuthDisabled.java
@@ -1,0 +1,25 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.authzn;
+
+import org.geoserver.cloud.autoconfigure.security.ConditionalOnGeoServerSecurityEnabled;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Conditional to check if gateway/webui shared authentication is disabled. */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Documented
+@ConditionalOnGeoServerSecurityEnabled
+@ConditionalOnProperty(
+        name = GatewaySharedAuthConfigProperties.ENABLED_PROP,
+        havingValue = "false",
+        matchIfMissing = true)
+public @interface ConditionalOnGatewaySharedAuthDisabled {}

--- a/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/ConditionalOnGatewaySharedAuthEnabled.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/ConditionalOnGatewaySharedAuthEnabled.java
@@ -1,0 +1,29 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.authzn;
+
+import org.geoserver.cloud.autoconfigure.security.ConditionalOnGeoServerSecurityEnabled;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Conditional to enable gateway/webui shared authentication mechanism. It must also be enabled in
+ * the gateway with the same config property {@code
+ * geoserver.security.gateway-shared-auth.enabled=true}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Documented
+@ConditionalOnGeoServerSecurityEnabled
+@ConditionalOnProperty(
+        name = GatewaySharedAuthConfigProperties.ENABLED_PROP,
+        havingValue = "true",
+        matchIfMissing = false)
+public @interface ConditionalOnGatewaySharedAuthEnabled {}

--- a/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/GatewaySharedAuthConfigProperties.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/GatewaySharedAuthConfigProperties.java
@@ -24,7 +24,10 @@ public class GatewaySharedAuthConfigProperties {
     static final String AUTO_PROP = PREFIX + ".auto";
     static final String SERVER_PROP = PREFIX + ".server";
 
-    /** Whether the gateway-shared-auth webui authentication conveyor protocol is enabled */
+    /**
+     * Whether the gateway-shared-auth webui authentication conveyor protocol is enabled. Note the
+     * same configuration must be applied to the gateway-service.
+     */
     private boolean enabled = true;
 
     /**

--- a/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/ClientConfiguration.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/ClientConfiguration.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.Configuration;
  * Contributes a {@link GatewaySharedAuthenticationProvider} in client mode.
  *
  * @see ServerConfiguration
+ * @see DisabledConfiguration
  * @since 1.9
  */
 @Configuration

--- a/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/DisabledConfiguration.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/DisabledConfiguration.java
@@ -1,0 +1,29 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.security.gateway.sharedauth;
+
+import static org.geoserver.cloud.security.gateway.sharedauth.GatewaySharedAuthenticationProvider.Mode.DISABLED;
+
+import org.geoserver.security.filter.AbstractFilterProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Contributes a {@link GatewaySharedAuthenticationProvider} in disabled mode, essentially a no-op
+ * {@link AbstractFilterProvider} to avoid starup failure when the gateway shared auth was enabled,
+ * then disabled, and geoserver restarted.
+ *
+ * @see ClientConfiguration
+ * @see ServerConfiguration
+ * @since 1.9
+ */
+@Configuration
+public class DisabledConfiguration {
+
+    @Bean
+    GatewaySharedAuthenticationProvider gatewaySharedAuthenticationProvider() {
+        return new GatewaySharedAuthenticationProvider(DISABLED);
+    }
+}

--- a/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/GatewaySharedAuthenticationProvider.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/GatewaySharedAuthenticationProvider.java
@@ -28,7 +28,8 @@ public class GatewaySharedAuthenticationProvider extends AbstractFilterProvider 
      */
     public enum Mode {
         SERVER,
-        CLIENT
+        CLIENT,
+        DISABLED
     }
 
     private final @NonNull Mode mode;
@@ -51,9 +52,11 @@ public class GatewaySharedAuthenticationProvider extends AbstractFilterProvider 
 
     @Override
     public GeoServerSecurityFilter createFilter(SecurityNamedServiceConfig config) {
-        if (Mode.SERVER == mode) {
-            return GatewaySharedAuthenticationFilter.server();
-        }
-        return GatewaySharedAuthenticationFilter.client();
+        return switch (mode) {
+            case SERVER -> GatewaySharedAuthenticationFilter.server();
+            case CLIENT -> GatewaySharedAuthenticationFilter.client();
+            case DISABLED -> GatewaySharedAuthenticationFilter.disabled();
+            default -> throw new IllegalArgumentException("Unexpected value: " + mode);
+        };
     }
 }

--- a/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/ServerConfiguration.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/ServerConfiguration.java
@@ -16,6 +16,7 @@ import org.springframework.context.annotation.Configuration;
  * Contributes a {@link GatewaySharedAuthenticationProvider} in server mode.
  *
  * @see ClientConfiguration
+ * @see DisabledConfiguration
  * @since 1.9
  */
 @Configuration


### PR DESCRIPTION
If the `gateway-shared-auth` geoserver authentication filter was enabled, and it was automatically added to the filter chains, when disabled and the applications restart, would produce an error message and the webui Authentication configuration page would be broken.

This patch adds a no-op filter when `gateway-shared-auth` is disabled by externalized configuration.