### PR TITLE
Upgrade GeoServer to 2.25.2.1-CLOUD

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -25,7 +25,7 @@
     <spring.version>5.3.37</spring.version>
     <spring.security.version>5.7.12</spring.security.version>
     <jackson.version>2.17.1</jackson.version>
-    <gs.version>2.25.2.0-CLOUD</gs.version>
+    <gs.version>2.25.2.1-CLOUD</gs.version>
     <gt.version>31-SNAPSHOT</gt.version>
     <acl.version>2.2.0</acl.version>
     <!-- Downgrade netty.version used by spring-boot to the one used by geoserver azure client


### PR DESCRIPTION
Incorporates the fix for
[GEOS-11469] Datadir catalog loader does not decrypt HTTPStoreInfo passwords