### PR TITLE
Include application, http, and geoserver ows request properties in the logging MDC

### DIFF
--- a/src/starters/observability/pom.xml
+++ b/src/starters/observability/pom.xml
@@ -8,11 +8,43 @@
   </parent>
   <artifactId>gs-cloud-starter-observability</artifactId>
   <packaging>jar</packaging>
-  <description>Spring boot starter for application observability (logging, metrics, tracing)</description>
+  <description>Spring boot starter for application observability (logging,
+		metrics, tracing)</description>
   <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.f4b6a3</groupId>
+      <artifactId>ulid-creator</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
     <dependency>
       <groupId>net.logstash.logback</groupId>
       <artifactId>logstash-logback-encoder</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-main</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-webmvc</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 </project>

--- a/src/starters/observability/src/main/java/org/geoserver/cloud/autoconfigure/observability/GeoServerDispatcherMDCConfiguration.java
+++ b/src/starters/observability/src/main/java/org/geoserver/cloud/autoconfigure/observability/GeoServerDispatcherMDCConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.observability;
+
+import org.geoserver.cloud.observability.logging.config.MDCConfigProperties;
+import org.geoserver.cloud.observability.logging.ows.MDCDispatcherCallback;
+import org.geoserver.ows.Dispatcher;
+import org.geoserver.ows.DispatcherCallback;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@link AutoConfiguration @AutoConfiguration} to enable logging MDC (Mapped Diagnostic Context)
+ * for the GeoSever {@link Dispatcher} events using a {@link DispatcherCallback}
+ *
+ * @see MDCDispatcherCallback
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass({
+    Dispatcher.class,
+    // from spring-webmvc, required by Dispatcher.class
+    org.springframework.web.servlet.mvc.AbstractController.class
+})
+@ConditionalOnWebApplication(type = Type.SERVLET)
+class GeoServerDispatcherMDCConfiguration {
+
+    @Bean
+    MDCDispatcherCallback mdcDispatcherCallback(MDCConfigProperties config) {
+        return new MDCDispatcherCallback(config);
+    }
+}

--- a/src/starters/observability/src/main/java/org/geoserver/cloud/autoconfigure/observability/LoggingMDCAutoConfiguration.java
+++ b/src/starters/observability/src/main/java/org/geoserver/cloud/autoconfigure/observability/LoggingMDCAutoConfiguration.java
@@ -1,0 +1,95 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.observability;
+
+import org.geoserver.cloud.observability.logging.config.MDCConfigProperties;
+import org.geoserver.cloud.observability.logging.servlet.HttpRequestMdcConfigProperties;
+import org.geoserver.cloud.observability.logging.servlet.HttpRequestMdcFilter;
+import org.geoserver.cloud.observability.logging.servlet.MDCAuthenticationFilter;
+import org.geoserver.cloud.observability.logging.servlet.MDCCleaningFilter;
+import org.geoserver.cloud.observability.logging.servlet.SpringEnvironmentMdcConfigProperties;
+import org.geoserver.cloud.observability.logging.servlet.SpringEnvironmentMdcFilter;
+import org.geoserver.security.GeoServerSecurityFilterChainProxy;
+import org.slf4j.MDC;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.env.Environment;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+
+import java.util.Optional;
+
+/**
+ * {@link AutoConfiguration @AutoConfiguration} to enable logging MDC (Mapped Diagnostic Context)
+ * contributions during the request life cycle
+ *
+ * @see GeoServerDispatcherMDCConfiguration
+ */
+@AutoConfiguration
+@EnableConfigurationProperties({
+    MDCConfigProperties.class,
+    HttpRequestMdcConfigProperties.class,
+    SpringEnvironmentMdcConfigProperties.class
+})
+@Import(GeoServerDispatcherMDCConfiguration.class)
+@ConditionalOnWebApplication(type = Type.SERVLET)
+public class LoggingMDCAutoConfiguration {
+
+    /**
+     * @return servlet filter to {@link MDC#clear() clear} the MDC after the servlet request is
+     *     executed
+     */
+    @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    HttpRequestMdcFilter httpMdcFilter(HttpRequestMdcConfigProperties config) {
+        return new HttpRequestMdcFilter(config);
+    }
+
+    @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    MDCCleaningFilter mdcCleaningServletFilter() {
+        return new MDCCleaningFilter();
+    }
+
+    @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    SpringEnvironmentMdcFilter springEnvironmentMdcFilter(
+            Environment env,
+            SpringEnvironmentMdcConfigProperties config,
+            Optional<BuildProperties> buildProperties) {
+        return new SpringEnvironmentMdcFilter(env, buildProperties, config);
+    }
+
+    /**
+     * A servlet registration for {@link MDCAuthenticationFilter}, with {@link
+     * FilterRegistrationBean#setMatchAfter setMatchAfter(true)} to ensure it runs after {@link
+     * GeoServerSecurityFilterChainProxy} and hence the {@link SecurityContext} already has the
+     * {@link Authentication} object.
+     */
+    @Bean
+    @ConditionalOnClass(name = "org.springframework.security.core.Authentication")
+    FilterRegistrationBean<MDCAuthenticationFilter> mdcAuthenticationPropertiesServletFilter(
+            MDCConfigProperties config) {
+        FilterRegistrationBean<MDCAuthenticationFilter> registration =
+                new FilterRegistrationBean<>();
+
+        var filter = new MDCAuthenticationFilter(config);
+        registration.setMatchAfter(true);
+
+        registration.addUrlPatterns("/*");
+        registration.setOrder(Ordered.LOWEST_PRECEDENCE);
+        registration.setFilter(filter);
+        return registration;
+    }
+}

--- a/src/starters/observability/src/main/java/org/geoserver/cloud/observability/logging/config/MDCConfigProperties.java
+++ b/src/starters/observability/src/main/java/org/geoserver/cloud/observability/logging/config/MDCConfigProperties.java
@@ -1,0 +1,18 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.observability.logging.config;
+
+import lombok.Data;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties(prefix = "logging.mdc.include")
+public class MDCConfigProperties {
+
+    private boolean user = true;
+    private boolean roles = true;
+    private boolean ows = true;
+}

--- a/src/starters/observability/src/main/java/org/geoserver/cloud/observability/logging/ows/MDCDispatcherCallback.java
+++ b/src/starters/observability/src/main/java/org/geoserver/cloud/observability/logging/ows/MDCDispatcherCallback.java
@@ -1,0 +1,43 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.observability.logging.ows;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import org.geoserver.cloud.observability.logging.config.MDCConfigProperties;
+import org.geoserver.ows.AbstractDispatcherCallback;
+import org.geoserver.ows.DispatcherCallback;
+import org.geoserver.ows.Request;
+import org.geoserver.platform.Operation;
+import org.geoserver.platform.Service;
+import org.slf4j.MDC;
+
+@RequiredArgsConstructor
+public class MDCDispatcherCallback extends AbstractDispatcherCallback
+        implements DispatcherCallback {
+
+    private final @NonNull MDCConfigProperties config;
+
+    @Override
+    public Service serviceDispatched(Request request, Service service) {
+        if (config.isOws()) {
+            MDC.put("gs.ows.service.name", service.getId());
+            MDC.put("gs.ows.service.version", String.valueOf(service.getVersion()));
+            if (null != request.getOutputFormat()) {
+                MDC.put("gs.ows.service.format", request.getOutputFormat());
+            }
+        }
+        return super.serviceDispatched(request, service);
+    }
+
+    @Override
+    public Operation operationDispatched(Request request, Operation operation) {
+        if (config.isOws()) {
+            MDC.put("gs.ows.service.operation", operation.getId());
+        }
+        return super.operationDispatched(request, operation);
+    }
+}

--- a/src/starters/observability/src/main/java/org/geoserver/cloud/observability/logging/servlet/HttpRequestMdcConfigProperties.java
+++ b/src/starters/observability/src/main/java/org/geoserver/cloud/observability/logging/servlet/HttpRequestMdcConfigProperties.java
@@ -1,0 +1,43 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.observability.logging.servlet;
+
+import lombok.Data;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.regex.Pattern;
+
+@Data
+@ConfigurationProperties(prefix = "logging.mdc.include.http")
+public class HttpRequestMdcConfigProperties {
+
+    private boolean id = true;
+
+    /**
+     * The Internet Protocol (IP) address of the client or last proxy that sent the request. For
+     * HTTP servlets, same as the value of the CGI variable REMOTE_ADDR.
+     */
+    private boolean remoteAddr = true;
+
+    /**
+     * The fully qualified name of the client or the last proxy that sent the request. If the engine
+     * cannot or chooses not to resolve the hostname (to improve performance), this method returns
+     * the dotted-string form of the IP address. For HTTP servlets, same as the value of the CGI
+     * variable REMOTE_HOST. Defaults to false to avoid the possible overhead in reverse DNS
+     * lookups. remoteAddress should be enough in most cases.
+     */
+    private boolean remoteHost = true;
+
+    private boolean method = true;
+    private boolean url = true;
+    private boolean parameters = true;
+    private boolean queryString = true;
+    private boolean sessionId = true;
+
+    private boolean cookies = true;
+    private boolean headers = true;
+    private Pattern headersPattern = Pattern.compile(".*");
+}

--- a/src/starters/observability/src/main/java/org/geoserver/cloud/observability/logging/servlet/HttpRequestMdcFilter.java
+++ b/src/starters/observability/src/main/java/org/geoserver/cloud/observability/logging/servlet/HttpRequestMdcFilter.java
@@ -1,0 +1,152 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.observability.logging.servlet;
+
+import com.github.f4b6a3.ulid.UlidCreator;
+import com.google.common.collect.Streams;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import org.slf4j.MDC;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+@RequiredArgsConstructor
+public class HttpRequestMdcFilter extends OncePerRequestFilter {
+
+    private final @NonNull HttpRequestMdcConfigProperties config;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        try {
+            if (request instanceof HttpServletRequest req) addRequestMdcProperties(req);
+        } finally {
+            chain.doFilter(request, response);
+        }
+    }
+
+    private void addRequestMdcProperties(HttpServletRequest req) {
+        HttpSession session = req.getSession(false);
+
+        put("http.request.id", config::isId, () -> requestId(req));
+        put("http.request.remote-addr", config::isRemoteAddr, req::getRemoteAddr);
+        put("http.request.remote-host", config::isRemoteHost, req::getRemoteHost);
+
+        put("http.request.method", config::isMethod, req::getMethod);
+        put("http.request.url", config::isUrl, req::getRequestURL);
+        putRequestParams(req);
+        put("http.request.query-string", config::isQueryString, req::getQueryString);
+        put(
+                "http.request.session.id",
+                config::isSessionId,
+                () -> session == null ? null : session.getId());
+        put(
+                "http.request.session.started",
+                config::isSessionId,
+                () -> session == null ? null : !session.isNew());
+        addHeaders(req);
+        addCookies(req);
+    }
+
+    private void putRequestParams(HttpServletRequest req) {
+        if (config.isParameters()) {
+            Streams.stream(req.getParameterNames().asIterator())
+                    .forEach(
+                            name ->
+                                    put(
+                                            "http.request.parameter.%s".formatted(name),
+                                            requestParam(name, req)));
+        }
+    }
+
+    private String requestParam(String name, HttpServletRequest req) {
+        String[] values = req.getParameterValues(name);
+        if (null == values) return null;
+        if (values.length == 1) return values[0];
+        return null;
+    }
+
+    private void addHeaders(HttpServletRequest req) {
+        if (config.isHeaders()) {
+            Streams.stream(req.getHeaderNames().asIterator())
+                    .filter(h -> !"cookie".equalsIgnoreCase(h))
+                    .filter(this::includeHeader)
+                    .forEach(name -> putHeader(name, req));
+        }
+    }
+
+    private void putHeader(String name, HttpServletRequest req) {
+        put("http.request.header.%s".formatted(name), () -> getHeader(name, req));
+    }
+
+    private String getHeader(String name, HttpServletRequest req) {
+        return Streams.stream(req.getHeaders(name).asIterator()).collect(Collectors.joining(","));
+    }
+
+    private boolean includeHeader(String headerName) {
+        return config.getHeadersPattern().matcher(headerName).matches();
+    }
+
+    private void addCookies(HttpServletRequest req) {
+        if (config.isCookies()) {
+            Cookie[] cookies = req.getCookies();
+            if (null != cookies) {
+                Stream.of(cookies).forEach(this::put);
+            }
+        }
+    }
+
+    private void put(Cookie c) {
+        String key = "http.request.cookie.%s".formatted(c.getName());
+        String value = MDC.get(key);
+        if (value == null) {
+            value = c.getValue();
+        } else {
+            value = "%s;%s".formatted(value, c.getValue());
+        }
+        MDC.put(key, value);
+    }
+
+    private void put(String key, BooleanSupplier enabled, Supplier<Object> value) {
+        if (enabled.getAsBoolean()) {
+            put(key, value);
+        }
+    }
+
+    private void put(String key, Supplier<Object> value) {
+        Object val = value.get();
+        String svalue = val == null ? null : String.valueOf(val);
+        put(key, svalue);
+    }
+
+    private void put(@NonNull String key, String value) {
+        MDC.put(key, value);
+    }
+
+    /**
+     * @return the id provided by the {@code http.request.id} header, or a new monotonically
+     *     increating UID if no such header is present
+     */
+    private String requestId(HttpServletRequest req) {
+        return Optional.ofNullable(req.getHeader("http.request.id"))
+                .orElseGet(() -> UlidCreator.getMonotonicUlid().toLowerCase());
+    }
+}

--- a/src/starters/observability/src/main/java/org/geoserver/cloud/observability/logging/servlet/MDCAuthenticationFilter.java
+++ b/src/starters/observability/src/main/java/org/geoserver/cloud/observability/logging/servlet/MDCAuthenticationFilter.java
@@ -1,0 +1,65 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.observability.logging.servlet;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import org.geoserver.cloud.observability.logging.config.MDCConfigProperties;
+import org.slf4j.MDC;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.io.IOException;
+import java.util.stream.Collectors;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+/**
+ * Appends the {@code enduser.id} and {@code enduser.role} MDC properties depending on whether
+ * {@link MDCConfigProperties#isUser() user} and {@link MDCConfigProperties#isRoles() roles} config
+ * properties are enabled, respectivelly.
+ *
+ * <p>Note the appended MDC properties follow the <a href=
+ * "https://opentelemetry.io/docs/specs/semconv/general/attributes/#general-identity-attributes">OpenTelemetry
+ * identity attributes</a> convention, so we can replace this component if OTel would automatically
+ * add them to the logs.
+ */
+@RequiredArgsConstructor
+public class MDCAuthenticationFilter implements Filter {
+
+    private final @NonNull MDCConfigProperties config;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        try {
+            addEnduserMdcProperties();
+        } finally {
+            chain.doFilter(request, response);
+        }
+    }
+
+    void addEnduserMdcProperties() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        boolean authenticated = auth != null && auth.isAuthenticated();
+        MDC.put("enduser.authenticated", String.valueOf(authenticated));
+        if (authenticated) {
+            if (config.isUser()) MDC.put("enduser.id", auth.getName());
+            if (config.isRoles()) MDC.put("enduser.role", roles(auth));
+        }
+    }
+
+    private String roles(Authentication auth) {
+        return auth.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+    }
+}

--- a/src/starters/observability/src/main/java/org/geoserver/cloud/observability/logging/servlet/MDCCleaningFilter.java
+++ b/src/starters/observability/src/main/java/org/geoserver/cloud/observability/logging/servlet/MDCCleaningFilter.java
@@ -1,0 +1,29 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.observability.logging.servlet;
+
+import org.slf4j.MDC;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class MDCCleaningFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            MDC.clear();
+        }
+    }
+}

--- a/src/starters/observability/src/main/java/org/geoserver/cloud/observability/logging/servlet/SpringEnvironmentMdcConfigProperties.java
+++ b/src/starters/observability/src/main/java/org/geoserver/cloud/observability/logging/servlet/SpringEnvironmentMdcConfigProperties.java
@@ -1,0 +1,19 @@
+package org.geoserver.cloud.observability.logging.servlet;
+
+import lombok.Data;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@Data
+@ConfigurationProperties(prefix = "logging.mdc.include.application")
+public class SpringEnvironmentMdcConfigProperties {
+
+    private boolean name = true;
+    private boolean version = true;
+    private boolean instanceId = true;
+    private List<String> instanceIdProperties =
+            List.of("info.instance-id", "spring.application.instance_id");
+    private boolean activeProfiles = true;
+}

--- a/src/starters/observability/src/main/java/org/geoserver/cloud/observability/logging/servlet/SpringEnvironmentMdcFilter.java
+++ b/src/starters/observability/src/main/java/org/geoserver/cloud/observability/logging/servlet/SpringEnvironmentMdcFilter.java
@@ -1,0 +1,76 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.observability.logging.servlet;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import org.slf4j.MDC;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@RequiredArgsConstructor
+public class SpringEnvironmentMdcFilter extends OncePerRequestFilter {
+
+    private final @NonNull Environment env;
+    private final @NonNull Optional<BuildProperties> buildProperties;
+    private final @NonNull SpringEnvironmentMdcConfigProperties config;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        try {
+            addEnvironmentProperties();
+        } finally {
+            chain.doFilter(request, response);
+        }
+    }
+
+    private void addEnvironmentProperties() {
+        if (config.isName())
+            MDC.put("application.name", env.getProperty("spring.application.name"));
+
+        putVersion();
+        putInstanceId();
+
+        if (config.isActiveProfiles())
+            MDC.put(
+                    "spring.profiles.active",
+                    Stream.of(env.getActiveProfiles()).collect(Collectors.joining(",")));
+    }
+
+    private void putVersion() {
+        if (config.isVersion()) {
+            buildProperties
+                    .map(BuildProperties::getVersion)
+                    .ifPresent(v -> MDC.put("application.version", v));
+        }
+    }
+
+    private void putInstanceId() {
+        if (!config.isInstanceId() || null == config.getInstanceIdProperties()) return;
+
+        for (String prop : config.getInstanceIdProperties()) {
+            String value = env.getProperty(prop);
+            if (StringUtils.hasText(value)) {
+                MDC.put("application.instance.id", value);
+                return;
+            }
+        }
+    }
+}

--- a/src/starters/observability/src/main/resources/META-INF/spring.factories
+++ b/src/starters/observability/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.geoserver.cloud.autoconfigure.observability.LoggingMDCAutoConfiguration

--- a/src/starters/observability/src/test/java/org/geoserver/cloud/autoconfigure/observability/LoggingMDCAutoConfigurationTest.java
+++ b/src/starters/observability/src/test/java/org/geoserver/cloud/autoconfigure/observability/LoggingMDCAutoConfigurationTest.java
@@ -1,0 +1,93 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.observability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.geoserver.cloud.observability.logging.config.MDCConfigProperties;
+import org.geoserver.cloud.observability.logging.ows.MDCDispatcherCallback;
+import org.geoserver.cloud.observability.logging.servlet.HttpRequestMdcFilter;
+import org.geoserver.cloud.observability.logging.servlet.MDCCleaningFilter;
+import org.geoserver.cloud.observability.logging.servlet.SpringEnvironmentMdcFilter;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.security.core.Authentication;
+
+class LoggingMDCAutoConfigurationTest {
+
+    private WebApplicationContextRunner runner =
+            new WebApplicationContextRunner()
+                    .withConfiguration(AutoConfigurations.of(LoggingMDCAutoConfiguration.class));
+
+    @Test
+    void testDefaultBeans() {
+        runner.run(
+                context ->
+                        assertThat(context)
+                                .hasNotFailed()
+                                .hasSingleBean(MDCConfigProperties.class)
+                                .hasSingleBean(MDCDispatcherCallback.class)
+                                .hasSingleBean(MDCCleaningFilter.class)
+                                .hasSingleBean(HttpRequestMdcFilter.class)
+                                .hasSingleBean(SpringEnvironmentMdcFilter.class)
+                                .hasBean("mdcAuthenticationPropertiesServletFilter"));
+    }
+
+    @Test
+    void testMDCConfigProperties() {
+        MDCConfigProperties defaults = new MDCConfigProperties();
+
+        runner.withPropertyValues(
+                        "logging.mdc.include.user=%s".formatted(!defaults.isUser()),
+                        "logging.mdc.include.roles=%s".formatted(!defaults.isRoles()),
+                        "logging.mdc.include.ows=%s".formatted(!defaults.isOws()))
+                .run(
+                        context ->
+                                assertThat(context)
+                                        .getBean(MDCConfigProperties.class)
+                                        .hasFieldOrPropertyWithValue("user", !defaults.isUser())
+                                        .hasFieldOrPropertyWithValue("roles", !defaults.isRoles())
+                                        .hasFieldOrPropertyWithValue("ows", !defaults.isOws()));
+    }
+
+    @Test
+    void conditionalOnGeoServerDispatcher() {
+        runner.withClassLoader(new FilteredClassLoader(org.geoserver.ows.Dispatcher.class))
+                .run(
+                        context ->
+                                assertThat(context)
+                                        .hasNotFailed()
+                                        .doesNotHaveBean(MDCDispatcherCallback.class));
+    }
+
+    @Test
+    void conditionalOnServletWebApplication() {
+        ReactiveWebApplicationContextRunner reactiveAppRunner =
+                new ReactiveWebApplicationContextRunner()
+                        .withConfiguration(
+                                AutoConfigurations.of(LoggingMDCAutoConfiguration.class));
+        reactiveAppRunner.run(
+                context ->
+                        assertThat(context)
+                                .hasNotFailed()
+                                .doesNotHaveBean(MDCConfigProperties.class)
+                                .doesNotHaveBean(MDCDispatcherCallback.class)
+                                .doesNotHaveBean("mdcCleaningServletFilter"));
+    }
+
+    @Test
+    void authenticationFilterConditionalOnAuthenticationClass() {
+        runner.withClassLoader(new FilteredClassLoader(Authentication.class))
+                .run(
+                        context ->
+                                assertThat(context)
+                                        .hasNotFailed()
+                                        .doesNotHaveBean(
+                                                "mdcAuthenticationPropertiesServletFilter"));
+    }
+}

--- a/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/GatewaySharedAuthenticationFilter.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/GatewaySharedAuthenticationFilter.java
@@ -145,6 +145,7 @@ class GatewaySharedAuthenticationFilter extends GeoServerSecurityFilter
 
         private String getHeaders(HttpServletRequest req) {
             return Streams.stream(req.getHeaderNames().asIterator())
+                    .filter(h -> h.toLowerCase().startsWith("x-gsc"))
                     .map(name -> "\t%s: %s".formatted(name, req.getHeader(name)))
                     .collect(Collectors.joining("\n"));
         }


### PR DESCRIPTION
Enable adding application, http request, and geoserver OWS request properties to the logging 

## Externalized configuration properties:

Which properties to include in the MDC can be controlled through the following externalized configuration properties:

### logging.mdc.include.application
**Class:** `org.geoserver.cloud.observability.logging.servlet.SpringEnvironmentMdcConfigProperties`

|Key|Type|Description|Default value|Environment variable |
|---|----|-----------|-------------|----------------------|
| active-profiles| java.lang.Boolean| | true|  `LOGGING_MDC_INCLUDE_APPLICATION_ACTIVEPROFILES`|
| instance-id| java.lang.Boolean| | true|  `LOGGING_MDC_INCLUDE_APPLICATION_INSTANCEID`|
| name| java.lang.Boolean| | true|  `LOGGING_MDC_INCLUDE_APPLICATION_NAME`|
| version| java.lang.Boolean| | true|  `LOGGING_MDC_INCLUDE_APPLICATION_VERSION`|
### logging.mdc.include
**Class:** `org.geoserver.cloud.observability.logging.config.MDCConfigProperties`

|Key|Type|Description|Default value|Environment variable |
|---|----|-----------|-------------|----------------------|
| ows| java.lang.Boolean| | true|  `LOGGING_MDC_INCLUDE_OWS`|
| roles| java.lang.Boolean| | true|  `LOGGING_MDC_INCLUDE_ROLES`|
| user| java.lang.Boolean| | true|  `LOGGING_MDC_INCLUDE_USER`|
### logging.mdc.include.http
**Class:** `org.geoserver.cloud.observability.logging.servlet.HttpRequestMdcConfigProperties`

|Key|Type|Description|Default value|Environment variable |
|---|----|-----------|-------------|----------------------|
| cookies| java.lang.Boolean| | true|  `LOGGING_MDC_INCLUDE_HTTP_COOKIES`|
| headers| java.lang.Boolean| | true|  `LOGGING_MDC_INCLUDE_HTTP_HEADERS`|
| headers-pattern| java.util.regex.Pattern| | .*|  `LOGGING_MDC_INCLUDE_HTTP_HEADERSPATTERN`|
| id| java.lang.Boolean| | true|  `LOGGING_MDC_INCLUDE_HTTP_ID`|
| method| java.lang.Boolean| | true|  `LOGGING_MDC_INCLUDE_HTTP_METHOD`|
| parameters| java.lang.Boolean| | true|  `LOGGING_MDC_INCLUDE_HTTP_PARAMETERS`|
| query-string| java.lang.Boolean| | true|  `LOGGING_MDC_INCLUDE_HTTP_QUERYSTRING`|
| remote-addr| java.lang.Boolean| The Internet Protocol (IP) address of the client or last proxy that sent the request. For HTTP servlets, same as the value of the CGI variable REMOTE_ADDR.| true|  `LOGGING_MDC_INCLUDE_HTTP_REMOTEADDR`|
| remote-host| java.lang.Boolean| The fully qualified name of the client or the last proxy that sent the request. If the engine cannot or chooses not to resolve the hostname (to improve performance), this method returns the dotted-string form of the IP address. For HTTP servlets, same as the value of the CGI variable REMOTE_HOST. Defaults to false to avoid the possible overhead in reverse DNS lookups. remoteAddress should be enough in most cases.| true|  `LOGGING_MDC_INCLUDE_HTTP_REMOTEHOST`|
| session-id| java.lang.Boolean| | true|  `LOGGING_MDC_INCLUDE_HTTP_SESSIONID`|
| url| java.lang.Boolean| | true|  `LOGGING_MDC_INCLUDE_HTTP_URL`|


Here's an example of a complete log entry with all the settings enabled:

```json
{
  "@timestamp": "2024-08-29T12:24:38.615Z",
  "@version": "1",
  "message": "\nRequest: getMap\n\tAngle = 0.0\n\tBaseUrl = http://127.0.0.1:9090/geoserver/cloud/\n\tBbox = SRSEnvelope[-269.976562734375 : 269.976562734375, -134.976562734375 : 134.976562734375]\n\tBgColor = java.awt.Color[r=255,g=255,b=255]\n\tBuffer = 0\n\tClip = null\n\tCQLFilter = null\n\tCrs = GEOGCS[\"WGS 84\", \n  DATUM[\"World Geodetic System 1984\", \n    SPHEROID[\"WGS 84\", 6378137.0, 298.257223563, AUTHORITY[\"EPSG\",\"7030\"]], \n    AUTHORITY[\"EPSG\",\"6326\"]], \n  PRIMEM[\"Greenwich\", 0.0, AUTHORITY[\"EPSG\",\"8901\"]], \n  UNIT[\"degree\", 0.017453292519943295], \n  AXIS[\"Geodetic longitude\", EAST], \n  AXIS[\"Geodetic latitude\", NORTH], \n  AUTHORITY[\"EPSG\",\"4326\"]]\n\tElevation = []\n\tEnv = {}\n\tExceptions = application/vnd.ogc.se_inimage\n\tFeatureId = null\n\tFeatureVersion = null\n\tFilter = null\n\tFormat = image/jpeg\n\tFormatOptions = {}\n\tGet = true\n\tHeight = 384\n\tInterpolations = []\n\tLayers = [org.geoserver.wms.MapLayerInfo@c353bf8d, org.geoserver.wms.MapLayerInfo@5e6faffa, org.geoserver.wms.MapLayerInfo@ef7d2b8, org.geoserver.wms.MapLayerInfo@de280657, org.geoserver.wms.MapLayerInfo@5ef2c670]\n\tMaxFeatures = null\n\tPalette = null\n\tRawKvp = {EXCEPTIONS=application/vnd.ogc.se_inimage, REQUEST=GetMap, FORMAT=image/jpeg, SRS=EPSG:4326, BBOX=-269.976562734375,-134.976562734375,269.976562734375,134.976562734375, VERSION=1.1.1, STYLES=, SERVICE=WMS, WIDTH=768, HEIGHT=384, TRANSPARENT=true, LAYERS=ne:world2}\n\tRemoteOwsType = null\n\tRemoteOwsURL = null\n\tRequest = GetMap\n\tRequestCharset = UTF-8\n\tScaleMethod = null\n\tSld = null\n\tSldBody = null\n\tSldVersion = null\n\tSortBy = null\n\tSortByArrays = null\n\tSRS = EPSG:4326\n\tStartIndex = null\n\tStyleBody = null\n\tStyleFormat = sld\n\tStyles = [StyleImpl[ name=ne:countries], StyleImpl[ name=ne:disputed], StyleImpl[ name=ne:coastline], StyleImpl[ name=ne:boundary_lines], StyleImpl[ name=ne:populated_places]]\n\tStyleUrl = null\n\tStyleVersion = null\n\tTiled = false\n\tTilesOrigin = null\n\tTime = []\n\tTransparent = true\n\tValidateSchema = false\n\tVersion = 1.1.1\n\tViewParams = null\n\tWidth = 768",
  "logger_name": "org.geoserver.wms",
  "thread_name": "http-nio-8080-exec-5",
  "level": "INFO",
  "level_value": 20000,
  "gs.ows.service.version": "1.1.1",
  "gs.ows.service.name": "wms",
  "gs.ows.service.operation": "GetMap",
  "application.name": "wms-service",
  "application.instance.id": "wms-service:172.22.0.2:8080",
  "application.version": "1.9-SNAPSHOT",
  "enduser.authenticated": "true",
  "enduser.id": "admin",
  "enduser.role": "ADMIN,ROLE_ADMINISTRATOR,ROLE_AUTHENTICATED",
  "spring.profiles.active": "wms_service,json-logs,acl,datadir",
  "http.request.id": "01j6f1gjafgh5kfjcxye2nr9kd",
  "http.request.method": "GET",
  "http.request.url": "http://127.0.0.1:9090/geoserver/cloud/ne/wms",
  "http.request.query-string": "SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&FORMAT=image%2Fjpeg&TRANSPARENT=true&STYLES&LAYERS=ne%3Aworld2&EXCEPTIONS=application%2Fvnd.ogc.se_inimage&SRS=EPSG%3A4326&WIDTH=768&HEIGHT=384&BBOX=-269.976562734375%2C-134.976562734375%2C269.976562734375%2C134.976562734375",
  "http.request.remote-addr": "172.22.0.1",
  "http.request.remote-host": "172.22.0.1",

  "http.request.parameter.SERVICE": "WMS",
  "http.request.parameter.BBOX": "-269.976562734375,-134.976562734375,269.976562734375,134.976562734375",
  "http.request.parameter.LAYERS": "ne:world2",
  "http.request.parameter.SRS": "EPSG:4326",
  "http.request.parameter.STYLES": "",
  "http.request.parameter.REQUEST": "GetMap",
  "http.request.parameter.TRANSPARENT": "true",
  "http.request.parameter.HEIGHT": "384",
  "http.request.parameter.VERSION": "1.1.1",
  "http.request.parameter.EXCEPTIONS": "application/vnd.ogc.se_inimage",
  "http.request.parameter.FORMAT": "image/jpeg",
  "http.request.parameter.WIDTH": "768",

  "http.request.header.sec-fetch-site": "same-origin",
  "http.request.header.host": "172.22.0.2:8080",
  "http.request.header.content-length": "0",
  "http.request.header.x-gsc-roles": "ADMIN,ROLE_ADMINISTRATOR,ROLE_AUTHENTICATED",
  "http.request.header.x-gsc-username": "admin",
  "http.request.header.accept-encoding": "gzip, deflate, br, zstd",
  "http.request.header.user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
  "http.request.header.pragma": "no-cache",
  "http.request.header.sec-fetch-mode": "no-cors",
  "http.request.header.sec-fetch-dest": "image",
  "http.request.header.cache-control": "no-cache",
  "http.request.header.referer": "http://127.0.0.1:9090/geoserver/cloud/ne/wms?service=WMS&version=1.1.0&request=GetMap&layers=ne%3Aworld2&bbox=-180.0%2C-90.0%2C180.0%2C90.0&width=768&height=384&srs=EPSG%3A4326&styles=&format=application/openlayers",
  "http.request.header.accept-language": "en-US,en;q=0.9",
  "http.request.header.accept": "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8",
  "http.request.header.sec-ch-ua-mobile": "?0",
  "http.request.header.sec-ch-ua-platform": "\"Linux\"",
  "http.request.header.sec-ch-ua": "\"Not/A)Brand\";v=\"8\", \"Chromium\";v=\"126\", \"Google Chrome\";v=\"126\"",
  "http.request.cookie.JSESSIONID": "node072b2f91765ps3457b31800r10.node0",
  "http.request.cookie.JSESSIONID_web-ui": "BCB13A606CF4FF54EC3BC1CEA1DA76CC",
  "http.request.cookie.SESSION": "cf1dc214-bc60-4f7c-b943-1f5722913b6f",
  "http.request.cookie.mp_d7f79c10b89f9fa3026f2fb08d3cf36d_mixpanel": "%7B%22distinct_id%22%3A%20%22%24device%3A191757bb12b49-0de177dd0f0d11-11462c6f-510000-191757bb12b49%22%2C%22%24device_id%22%3A%20%22191757bb12b49-0de177dd0f0d11-11462c6f-510000-191757bb12b49%22%2C%22%24initial_referrer%22%3A%20%22%24direct%22%2C%22%24initial_referring_domain%22%3A%20%22%24direct%22%7D"
}

```