### PR TITLE
[backport 1.8.x] Fix for GWC not storing tiles when using datadir or jdbcconfig catalog back-ends

### DIFF
--- a/src/gwc/autoconfigure/pom.xml
+++ b/src/gwc/autoconfigure/pom.xml
@@ -74,5 +74,10 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-lambda</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/DefaultTileLayerCatalogAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/DefaultTileLayerCatalogAutoConfiguration.java
@@ -19,10 +19,14 @@ import javax.annotation.PostConstruct;
 
 /**
  * {@link AutoConfiguration @AutoConfiguration} to set up the GeoServer {@link TileLayerCatalog}
- * using the default implementation based on the {@link ResourceStore}
+ * using the default implementation based on the {@link ResourceStore}.
+ *
+ * <p>This default configuration applies if there's no other {@link GeoServerTileLayerConfiguration}
+ * provided.
  *
  * @see DefaultTileLayerCatalogConfiguration
  * @see ConditionalOnGeoWebCacheEnabled
+ * @see PgconfigTileLayerCatalogAutoConfiguration
  * @since 1.0
  */
 @AutoConfiguration(after = PgconfigTileLayerCatalogAutoConfiguration.class)

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigGwcInitializer.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigGwcInitializer.java
@@ -4,39 +4,22 @@
  */
 package org.geoserver.cloud.autoconfigure.gwc.backend;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import com.google.common.base.Stopwatch;
-
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.geoserver.cloud.gwc.backend.pgconfig.PgconfigTileLayerCatalog;
+import org.geoserver.cloud.gwc.config.core.AbstractGwcInitializer;
 import org.geoserver.cloud.gwc.event.TileLayerEvent;
 import org.geoserver.cloud.gwc.repository.GeoServerTileLayerConfiguration;
-import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerReinitializer;
 import org.geoserver.gwc.ConfigurableBlobStore;
-import org.geoserver.gwc.config.GWCConfig;
 import org.geoserver.gwc.config.GWCConfigPersister;
 import org.geoserver.gwc.config.GWCInitializer;
-import org.geoserver.gwc.layer.GeoServerTileLayer;
 import org.geoserver.gwc.layer.TileLayerCatalog;
 import org.geowebcache.config.TileLayerConfiguration;
-import org.geowebcache.layer.TileLayer;
 import org.geowebcache.layer.TileLayerDispatcher;
-import org.geowebcache.storage.blobstore.memory.CacheConfiguration;
 import org.geowebcache.storage.blobstore.memory.CacheProvider;
-import org.geowebcache.storage.blobstore.memory.guava.GuavaCacheProvider;
-import org.springframework.context.event.EventListener;
-
-import java.io.IOException;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import org.slf4j.Logger;
 
 /**
  * Replacement for {@link GWCInitializer} when using the "pgconfig" storage.
@@ -57,151 +40,18 @@ import java.util.Optional;
  *
  * @since 1.8
  */
-@RequiredArgsConstructor
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.backend")
-class PgconfigGwcInitializer implements GeoServerReinitializer {
+class PgconfigGwcInitializer extends AbstractGwcInitializer {
 
-    private final @NonNull GWCConfigPersister configPersister;
-    private final @NonNull ConfigurableBlobStore blobStore;
-    private final @NonNull GeoServerTileLayerConfiguration geoseverTileLayers;
+    public PgconfigGwcInitializer(
+            @NonNull GWCConfigPersister configPersister,
+            @NonNull ConfigurableBlobStore blobStore,
+            @NonNull GeoServerTileLayerConfiguration geoseverTileLayers) {
+        super(configPersister, blobStore, geoseverTileLayers);
+    }
 
-    /**
-     * @see org.geoserver.config.GeoServerInitializer#initialize(org.geoserver.config.GeoServer)
-     */
     @Override
-    public void initialize(final GeoServer geoServer) throws Exception {
-        log.info("Initializing GeoServer specific GWC configuration from gwc-gs.xml");
-
-        final GWCConfig gwcConfig = configPersister.getConfig();
-        checkNotNull(gwcConfig);
-
-        configureInMemoryCacheProvider(gwcConfig);
-
-        final boolean initialization = true;
-        blobStore.setChanged(gwcConfig, initialization);
-
-        setUpNonMemoryCacheableLayers();
-    }
-
-    @EventListener(TileLayerEvent.class)
-    void onTileLayerEvent(TileLayerEvent event) {
-        cacheProvider()
-                .ifPresent(
-                        cache -> {
-                            switch (event.getEventType()) {
-                                case DELETED:
-                                    log.debug(
-                                            "TileLayer {} deleted, notifying in-memory CacheProvider",
-                                            event.getName());
-                                    cache.removeUncachedLayer(event.getName());
-                                    break;
-                                case MODIFIED:
-                                    if (event.getOldName() != null
-                                            && !Objects.equals(
-                                                    event.getOldName(), event.getName())) {
-                                        log.info(
-                                                "TileLayer {} renamed to {}, notifying in-memory CacheProvider",
-                                                event.getOldName(),
-                                                event.getName());
-                                        cache.removeUncachedLayer(event.getOldName());
-                                    }
-                                    setInMemoryLayerCaching(event.getName());
-                                    break;
-                                default:
-                                    setInMemoryLayerCaching(event.getName());
-                                    break;
-                            }
-                        });
-    }
-
-    private void configureInMemoryCacheProvider(final GWCConfig gwcConfig) throws IOException {
-        // Setting default CacheProvider class if not present
-        if (gwcConfig.getCacheProviderClass() == null
-                || gwcConfig.getCacheProviderClass().isEmpty()) {
-            gwcConfig.setCacheProviderClass(GuavaCacheProvider.class.toString());
-            configPersister.save(gwcConfig);
-        }
-
-        // Setting default Cache Configuration
-        if (gwcConfig.getCacheConfigurations() == null) {
-            log.debug("Setting default CacheConfiguration");
-            Map<String, CacheConfiguration> map = new HashMap<>();
-            map.put(GuavaCacheProvider.class.toString(), new CacheConfiguration());
-            gwcConfig.setCacheConfigurations(map);
-            configPersister.save(gwcConfig);
-        } else {
-            log.debug("CacheConfiguration loaded");
-        }
-
-        // Change ConfigurableBlobStore behavior
-        String cacheProviderClass = gwcConfig.getCacheProviderClass();
-        Map<String, CacheProvider> cacheProviders = blobStore.getCacheProviders();
-        if (!cacheProviders.containsKey(cacheProviderClass)) {
-            gwcConfig.setCacheProviderClass(GuavaCacheProvider.class.toString());
-            configPersister.save(gwcConfig);
-            log.debug("Unable to find: {}, used default configuration", cacheProviderClass);
-        }
-    }
-
-    private void setInMemoryLayerCaching(@NonNull String layerName) {
-
-        layer(layerName)
-                .ifPresentOrElse(this::addUncachedLayer, () -> removeCachedLayer(layerName));
-    }
-
-    private void removeCachedLayer(String layerName) {
-        cacheProvider()
-                .ifPresent(
-                        cache -> {
-                            log.debug(
-                                    "TileLayer {} does not exist, notifying CacheProvider",
-                                    layerName);
-                            cache.removeLayer(layerName);
-                            cache.removeUncachedLayer(layerName);
-                        });
-    }
-
-    private void addUncachedLayer(GeoServerTileLayer tl) {
-        if (!tl.getInfo().isInMemoryCached()) {
-            log.debug(
-                    "TileLayer {} is not to be memory cached, notifying CacheProvider",
-                    tl.getName());
-            cacheProvider().ifPresent(cache -> cache.addUncachedLayer(tl.getName()));
-        }
-    }
-
-    private Optional<GeoServerTileLayer> layer(String layerName) {
-        return geoseverTileLayers
-                .getLayer(layerName)
-                .filter(GeoServerTileLayer.class::isInstance)
-                .map(GeoServerTileLayer.class::cast);
-    }
-
-    /**
-     * Private method for adding all the Layer that must not be cached to the {@link CacheProvider}
-     * instance.
-     */
-    private void setUpNonMemoryCacheableLayers() {
-        cacheProvider()
-                .ifPresent(
-                        cache -> {
-                            // Add all the various Layers to avoid caching
-                            log.info("Adding Layers to avoid In Memory Caching");
-                            // it is ok to use the ForkJoinPool.commonPool() here, there's no I/O
-                            // involved
-                            Stopwatch sw = Stopwatch.createStarted();
-                            Collection<? extends TileLayer> layers = geoseverTileLayers.getLayers();
-                            log.info("Queried {} tile layers in {}", layers.size(), sw.stop());
-                            layers.stream()
-                                    .filter(GeoServerTileLayer.class::isInstance)
-                                    .map(GeoServerTileLayer.class::cast)
-                                    .filter(l -> l.isEnabled() && !l.getInfo().isInMemoryCached())
-                                    .map(GeoServerTileLayer::getName)
-                                    .forEach(cache::addUncachedLayer);
-                        });
-    }
-
-    private Optional<CacheProvider> cacheProvider() {
-        return Optional.ofNullable(blobStore.getCache());
+    protected Logger logger() {
+        return log;
     }
 }

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigTileLayerCatalogAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigTileLayerCatalogAutoConfiguration.java
@@ -44,6 +44,7 @@ import javax.sql.DataSource;
  * GeoServer Catalog in the Postgres database;
  *
  * @since 1.7
+ * @see ConditionalOnPgconfigBackendEnabled
  */
 @AutoConfiguration(after = PgconfigDataSourceAutoConfiguration.class)
 @ConditionalOnClass(PgconfigTileLayerCatalog.class)

--- a/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/core/GwcCoreAutoConfigurationTest.java
+++ b/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/core/GwcCoreAutoConfigurationTest.java
@@ -17,7 +17,7 @@ import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheContextRunner;
 import org.geoserver.cloud.gwc.repository.CloudDefaultStorageFinder;
 import org.geoserver.cloud.gwc.repository.CloudGwcXmlConfiguration;
 import org.geoserver.cloud.gwc.repository.CloudXMLResourceProvider;
-import org.geoserver.gwc.config.GwcGeoserverConfigurationInitializer;
+import org.geoserver.gwc.config.DefaultGwcInitializer;
 import org.geoserver.platform.GeoServerExtensionsHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -72,11 +72,9 @@ class GwcCoreAutoConfigurationTest {
                     GeoServerExtensionsHelper.init(context);
                     assertThat(context)
                             .hasNotFailed()
-                            .hasBean("gwcGeoserverConfigurationInitializer")
-                            .getBean(
-                                    "gwcGeoserverConfigurationInitializer",
-                                    GwcGeoserverConfigurationInitializer.class)
-                            .isInstanceOf(GwcGeoserverConfigurationInitializer.class);
+                            .hasBean("gwcInitializer")
+                            .getBean("gwcInitializer")
+                            .isInstanceOf(DefaultGwcInitializer.class);
 
                     assertThat(context.isTypeMatch("gwcXmlConfig", CloudGwcXmlConfiguration.class))
                             .isTrue();

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/AbstractGwcInitializer.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/AbstractGwcInitializer.java
@@ -1,0 +1,210 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.gwc.config.core;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Stopwatch;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import org.geoserver.cloud.gwc.event.TileLayerEvent;
+import org.geoserver.cloud.gwc.repository.GeoServerTileLayerConfiguration;
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.GeoServerReinitializer;
+import org.geoserver.gwc.ConfigurableBlobStore;
+import org.geoserver.gwc.config.GWCConfig;
+import org.geoserver.gwc.config.GWCConfigPersister;
+import org.geoserver.gwc.config.GWCInitializer;
+import org.geoserver.gwc.layer.GeoServerTileLayer;
+import org.geoserver.gwc.layer.TileLayerCatalog;
+import org.geowebcache.layer.TileLayer;
+import org.geowebcache.storage.blobstore.memory.CacheConfiguration;
+import org.geowebcache.storage.blobstore.memory.CacheProvider;
+import org.geowebcache.storage.blobstore.memory.guava.GuavaCacheProvider;
+import org.slf4j.Logger;
+import org.springframework.context.event.EventListener;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Base class for replacements of {@link GWCInitializer}.
+ *
+ * <p>This is required because GeoServer Cloud may not set up a {@link TileLayerCatalog}, which
+ * {@link GWCInitializer} requires.
+ *
+ * <p>This {@link GeoServerReinitializer} is hence in charge of notifying {@link
+ * ConfigurableBlobStore#setChanged(org.geoserver.gwc.config.GWCConfig, boolean)}
+ *
+ * <p>This bean also listens to {@link TileLayerEvent}s and notifies the {@link CacheProvider} to
+ * either {@link CacheProvider#removeLayer(String) removeLayer} or {@link
+ * CacheProvider#removeUncachedLayer(String) removeUncachedLayer} on changes and deletions as
+ * appropriate, or to {@link CacheProvider#addUncachedLayer(String) addUncachedLayer} when a layer
+ * is created to changed to not be memory cached.
+ *
+ * @since 1.8
+ */
+@RequiredArgsConstructor
+public abstract class AbstractGwcInitializer implements GeoServerReinitializer {
+
+    protected final @NonNull GWCConfigPersister configPersister;
+    protected final @NonNull ConfigurableBlobStore blobStore;
+    protected final @NonNull GeoServerTileLayerConfiguration geoseverTileLayers;
+
+    protected abstract Logger logger();
+
+    /**
+     * @see org.geoserver.config.GeoServerInitializer#initialize(org.geoserver.config.GeoServer)
+     */
+    @Override
+    public void initialize(final GeoServer geoServer) throws Exception {
+        logger().info("Initializing GeoServer specific GWC configuration from gwc-gs.xml");
+
+        final GWCConfig gwcConfig = configPersister.getConfig();
+        checkNotNull(gwcConfig);
+
+        configureInMemoryCacheProvider(gwcConfig);
+
+        final boolean initialization = true;
+        blobStore.setChanged(gwcConfig, initialization);
+
+        setUpNonMemoryCacheableLayers();
+    }
+
+    @EventListener(TileLayerEvent.class)
+    void onTileLayerEvent(TileLayerEvent event) {
+        cacheProvider().ifPresent(cache -> onTileLayerEvent(event, cache));
+    }
+
+    private void onTileLayerEvent(TileLayerEvent event, CacheProvider cache) {
+        @NonNull String layerName = event.getName();
+
+        switch (event.getEventType()) {
+            case DELETED:
+                logger().debug(
+                                "TileLayer {} deleted, notifying in-memory CacheProvider",
+                                layerName);
+                cache.removeUncachedLayer(layerName);
+                break;
+            case MODIFIED:
+                if (isRename(event)) {
+                    String oldName = event.getOldName();
+                    logger().info(
+                                    "TileLayer {} renamed to {}, notifying in-memory CacheProvider",
+                                    oldName,
+                                    layerName);
+                    cache.removeUncachedLayer(oldName);
+                }
+                setInMemoryLayerCaching(layerName);
+                break;
+            default:
+                setInMemoryLayerCaching(layerName);
+                break;
+        }
+    }
+
+    private boolean isRename(TileLayerEvent event) {
+        String layerName = event.getName();
+        String oldName = event.getOldName();
+        return oldName != null && !Objects.equals(oldName, layerName);
+    }
+
+    private void configureInMemoryCacheProvider(final GWCConfig gwcConfig) throws IOException {
+        // Setting default CacheProvider class if not present
+        if (!StringUtils.hasText(gwcConfig.getCacheProviderClass())) {
+            gwcConfig.setCacheProviderClass(GuavaCacheProvider.class.toString());
+            configPersister.save(gwcConfig);
+        }
+
+        // Setting default Cache Configuration
+        if (gwcConfig.getCacheConfigurations() == null) {
+            logger().debug("Setting default CacheConfiguration");
+            Map<String, CacheConfiguration> map = new HashMap<>();
+            map.put(GuavaCacheProvider.class.toString(), new CacheConfiguration());
+            gwcConfig.setCacheConfigurations(map);
+            configPersister.save(gwcConfig);
+        } else {
+            logger().debug("CacheConfiguration loaded");
+        }
+
+        // Change ConfigurableBlobStore behavior
+        String cacheProviderClass = gwcConfig.getCacheProviderClass();
+        Map<String, CacheProvider> cacheProviders = blobStore.getCacheProviders();
+        if (!cacheProviders.containsKey(cacheProviderClass)) {
+            gwcConfig.setCacheProviderClass(GuavaCacheProvider.class.toString());
+            configPersister.save(gwcConfig);
+            logger().debug("Unable to find: {}, used default configuration", cacheProviderClass);
+        }
+    }
+
+    private void setInMemoryLayerCaching(@NonNull String layerName) {
+
+        layer(layerName)
+                .ifPresentOrElse(this::addUncachedLayer, () -> removeCachedLayer(layerName));
+    }
+
+    private void removeCachedLayer(String layerName) {
+        cacheProvider()
+                .ifPresent(
+                        cache -> {
+                            logger().debug(
+                                            "TileLayer {} does not exist, notifying CacheProvider",
+                                            layerName);
+                            cache.removeLayer(layerName);
+                            cache.removeUncachedLayer(layerName);
+                        });
+    }
+
+    private void addUncachedLayer(GeoServerTileLayer tl) {
+        if (!tl.getInfo().isInMemoryCached()) {
+            logger().debug(
+                            "TileLayer {} is not to be memory cached, notifying CacheProvider",
+                            tl.getName());
+            cacheProvider().ifPresent(cache -> cache.addUncachedLayer(tl.getName()));
+        }
+    }
+
+    private Optional<GeoServerTileLayer> layer(String layerName) {
+        return geoseverTileLayers
+                .getLayer(layerName)
+                .filter(GeoServerTileLayer.class::isInstance)
+                .map(GeoServerTileLayer.class::cast);
+    }
+
+    /**
+     * Private method for adding all the Layer that must not be cached to the {@link CacheProvider}
+     * instance.
+     */
+    private void setUpNonMemoryCacheableLayers() {
+        cacheProvider()
+                .ifPresent(
+                        cache -> {
+                            // Add all the various Layers to avoid caching
+                            logger().info("Adding Layers to avoid In Memory Caching");
+                            // it is ok to use the ForkJoinPool.commonPool() here, there's no I/O
+                            // involved
+                            Stopwatch sw = Stopwatch.createStarted();
+                            Collection<? extends TileLayer> layers = geoseverTileLayers.getLayers();
+                            logger().info("Queried {} tile layers in {}", layers.size(), sw.stop());
+                            layers.stream()
+                                    .filter(GeoServerTileLayer.class::isInstance)
+                                    .map(GeoServerTileLayer.class::cast)
+                                    .filter(l -> l.isEnabled() && !l.getInfo().isInMemoryCached())
+                                    .map(GeoServerTileLayer::getName)
+                                    .forEach(cache::addUncachedLayer);
+                        });
+    }
+
+    private Optional<CacheProvider> cacheProvider() {
+        return Optional.ofNullable(blobStore.getCache());
+    }
+}

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/DefaultTileLayerCatalogConfiguration.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/DefaultTileLayerCatalogConfiguration.java
@@ -4,12 +4,18 @@
  */
 package org.geoserver.cloud.gwc.config.core;
 
+import org.geoserver.GeoServerConfigurationLock;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.cloud.gwc.event.TileLayerEvent;
 import org.geoserver.cloud.gwc.repository.CachingTileLayerCatalog;
 import org.geoserver.cloud.gwc.repository.CloudCatalogConfiguration;
 import org.geoserver.cloud.gwc.repository.GeoServerTileLayerConfiguration;
 import org.geoserver.cloud.gwc.repository.ResourceStoreTileLayerCatalog;
+import org.geoserver.gwc.ConfigurableBlobStore;
+import org.geoserver.gwc.config.DefaultGwcInitializer;
+import org.geoserver.gwc.config.GWCConfigPersister;
+import org.geoserver.gwc.config.GWCInitializer;
+import org.geoserver.gwc.layer.CatalogConfiguration;
 import org.geoserver.gwc.layer.TileLayerCatalog;
 import org.geoserver.platform.resource.ResourceStore;
 import org.geowebcache.grid.GridSetBroker;
@@ -30,6 +36,26 @@ import java.util.function.Consumer;
  */
 @Configuration(proxyBeanMethods = false)
 public class DefaultTileLayerCatalogConfiguration {
+
+    /**
+     * Replaces {@link GWCInitializer}
+     *
+     * <p>
+     *
+     * <ul>
+     *   <li>We don't need to upgrade from very old configuration settings
+     *   <li>{@code GWCInitializer} depends on {@link TileLayerCatalog}, assuming {@link
+     *       CatalogConfiguration} is the only tile layer storage backend for geoserver tile layers,
+     *       and it's not the case for GS cloud
+     */
+    @Bean
+    DefaultGwcInitializer gwcInitializer(
+            GWCConfigPersister configPersister,
+            ConfigurableBlobStore blobStore,
+            GeoServerTileLayerConfiguration geoseverTileLayers,
+            GeoServerConfigurationLock lock) {
+        return new DefaultGwcInitializer(configPersister, blobStore, geoseverTileLayers, lock);
+    }
 
     @SuppressWarnings("java:S6830")
     @Bean(name = "gwcCatalogConfiguration")

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/GeoServerIntegrationConfiguration.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/GeoServerIntegrationConfiguration.java
@@ -4,17 +4,9 @@
  */
 package org.geoserver.cloud.gwc.config.core;
 
-import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
-import org.geoserver.GeoServerConfigurationLock;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
-import org.geoserver.gwc.config.GWCConfigPersister;
-import org.geoserver.gwc.config.GWCInitializer;
-import org.geoserver.gwc.config.GwcGeoserverConfigurationInitializer;
-import org.geoserver.gwc.layer.CatalogConfiguration;
-import org.geoserver.gwc.layer.TileLayerCatalog;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
@@ -22,6 +14,7 @@ import javax.annotation.PostConstruct;
 
 /**
  * @since 1.0
+ * @see DefaultTileLayerCatalogConfiguration
  */
 @Configuration(proxyBeanMethods = true)
 @ImportResource(
@@ -47,28 +40,6 @@ public class GeoServerIntegrationConfiguration {
 
     @PostConstruct
     public void log() {
-
         log.info("GeoWebCache core GeoServer integration enabled");
-    }
-
-    /**
-     * Replaces {@link GWCInitializer}
-     *
-     * <p>
-     *
-     * <ul>
-     *   <li>We don't need to upgrade from very old configuration settings
-     *   <li>{@code GWCInitializer} depends on {@link TileLayerCatalog}, assuming {@link
-     *       CatalogConfiguration} is the only tile layer storage backend for geoserver tile layers,
-     *       and it's not the case for GS cloud
-     *
-     * @param configPersister
-     * @param lock
-     */
-    @Bean
-    GwcGeoserverConfigurationInitializer gwcGeoserverConfigurationInitializer(
-            GWCConfigPersister configPersister, @NonNull GeoServerConfigurationLock lock) {
-
-        return new GwcGeoserverConfigurationInitializer(configPersister, lock);
     }
 }

--- a/src/gwc/core/src/main/java/org/geoserver/gwc/config/DefaultGwcInitializer.java
+++ b/src/gwc/core/src/main/java/org/geoserver/gwc/config/DefaultGwcInitializer.java
@@ -5,22 +5,27 @@
 package org.geoserver.gwc.config;
 
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.geoserver.GeoServerConfigurationLock;
 import org.geoserver.GeoServerConfigurationLock.LockType;
+import org.geoserver.cloud.gwc.config.core.AbstractGwcInitializer;
+import org.geoserver.cloud.gwc.repository.GeoServerTileLayerConfiguration;
+import org.geoserver.gwc.ConfigurableBlobStore;
 import org.geoserver.gwc.layer.CatalogConfiguration;
 import org.geoserver.gwc.layer.TileLayerCatalog;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.platform.resource.Resources;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.InitializingBean;
 
 import java.io.IOException;
 
-import javax.annotation.PostConstruct;
-
 /**
  * Replaces {@link GWCInitializer}
+ *
+ * <p>Using package {@code org.geoserver.gwc.config} to be able of accessing the package-private
+ * method {@link GWCConfigPersister#findConfigFile()}
  *
  * <p>
  *
@@ -31,27 +36,46 @@ import javax.annotation.PostConstruct;
  *       it's not the case for GS cloud
  * </ul>
  */
-@Slf4j
-@RequiredArgsConstructor
-public class GwcGeoserverConfigurationInitializer {
+@Slf4j(topic = "org.geoserver.cloud.gwc.config.core")
+public class DefaultGwcInitializer extends AbstractGwcInitializer implements InitializingBean {
 
-    @NonNull private final GWCConfigPersister configPersister;
     @NonNull private final GeoServerConfigurationLock configLock;
 
-    @PostConstruct
-    void initialize() throws IOException {
+    public DefaultGwcInitializer(
+            @NonNull GWCConfigPersister configPersister,
+            @NonNull ConfigurableBlobStore blobStore,
+            @NonNull GeoServerTileLayerConfiguration geoseverTileLayers,
+            @NonNull GeoServerConfigurationLock configLock) {
+
+        super(configPersister, blobStore, geoseverTileLayers);
+        this.configLock = configLock;
+    }
+
+    @Override
+    protected Logger logger() {
+        return log;
+    }
+
+    /**
+     * Initialize the datadir/gs-gwc.xml file before {@link
+     * #initialize(org.geoserver.config.GeoServer) super.initialize(GeoServer)}
+     */
+    @Override
+    public void afterPropertiesSet() throws Exception {
         initializeGeoServerIntegrationConfigFile();
     }
 
     private void initializeGeoServerIntegrationConfigFile() throws IOException {
-        if (configExists()) {
+        if (configFileExists()) {
             return;
         }
         final boolean lockAcquired = configLock.tryLock(LockType.WRITE);
         if (lockAcquired) {
             try {
-                if (!configExists()) {
-                    log.info("Initializing GeoServer specific GWC configuration");
+                if (!configFileExists()) {
+                    log.info(
+                            "Initializing GeoServer specific GWC configuration {}",
+                            configPersister.findConfigFile());
                     GWCConfig defaults = new GWCConfig();
                     defaults.setVersion("1.1.0");
                     configPersister.save(defaults);
@@ -62,7 +86,7 @@ public class GwcGeoserverConfigurationInitializer {
         }
     }
 
-    private boolean configExists() throws IOException {
+    private boolean configFileExists() throws IOException {
         Resource configFile = configPersister.findConfigFile();
         return Resources.exists(configFile);
     }

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -856,6 +856,12 @@
         <version>3.8.0</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>com.github.stefanbirkner</groupId>
+        <artifactId>system-lambda</artifactId>
+        <version>1.2.1</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>


### PR DESCRIPTION
backport #511 to 1.8.x

---

Abstract out the `PgconfigGwcInitializer` as `AbstractGwcInitializer` and refactor the default configuration classes to include the initializer.

Tiles weren't being stored when using the `datadir` or `jdbcconfig` catalog backends because `ConfigurableBlobStore.setChanged()` wouldn't be called at startup and it would hence bypass the storage, as its internal `configured` flag was not set.