### PR TITLE
Add Geopackage and DXF output format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Only a curated list of the [vast amount](http://geoserver.org/release/stable/) o
 - vectortiles
 - flatgeobuf
 - dxf
+- geopkg-output
 - cog
 - importer
 - imagepyramid

--- a/compose/compose.yml
+++ b/compose/compose.yml
@@ -7,7 +7,7 @@ volumes:
     driver_opts:
       type: none
       o: bind
-      device: $PWD/../config
+      device: C:\\temp\\config
     driver: local
 
 x-gs-dependencies: &gs-dependencies

--- a/src/apps/geoserver/webui/pom.xml
+++ b/src/apps/geoserver/webui/pom.xml
@@ -121,6 +121,20 @@
       <artifactId>gs-dxf-wps</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-geopkg-output</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.geoserver</groupId>
+          <artifactId>gs-wms</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.geoserver</groupId>
+          <artifactId>gs-gwc</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wms</artifactId>
     </dependency>

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/wfs/WfsConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/wfs/WfsConfiguration.java
@@ -15,7 +15,8 @@ import org.springframework.context.annotation.ImportResource;
             "jar:gs-web-wfs-.*!/applicationContext.xml", //
             "jar:gs-wfs-.*!/applicationContext.xml",
             "jar:gs-flatgeobuf-.*!/applicationContext.xml#name=.*",
-            "jar:gs-dxf-core-.*!/applicationContext.xml#name=.*"
+            "jar:gs-dxf-core-.*!/applicationContext.xml#name=.*",
+            "jar:gs-geopkg-output-.*!/applicationContext.xml#name=.*"
         } //
         )
 public class WfsConfiguration {}

--- a/src/apps/geoserver/wfs/pom.xml
+++ b/src/apps/geoserver/wfs/pom.xml
@@ -35,6 +35,20 @@
       <artifactId>gs-dxf-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-geopkg-output</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.geoserver</groupId>
+          <artifactId>gs-wms</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.geoserver</groupId>
+          <artifactId>gs-gwc</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/src/apps/geoserver/wfs/src/main/java/org/geoserver/cloud/wfs/config/WfsAutoConfiguration.java
+++ b/src/apps/geoserver/wfs/src/main/java/org/geoserver/cloud/wfs/config/WfsAutoConfiguration.java
@@ -19,7 +19,8 @@ import org.springframework.context.annotation.ImportResource;
         locations = {
             "jar:gs-wfs-.*!/applicationContext.xml#name=.*",
             "jar:gs-flatgeobuf-.*!/applicationContext.xml#name=.*",
-            "jar:gs-dxf-core-.*!/applicationContext.xml#name=.*"
+            "jar:gs-dxf-core-.*!/applicationContext.xml#name=.*",
+            "jar:gs-geopkg-output-.*!/applicationContext.xml#name=.*"
         } //
         )
 public class WfsAutoConfiguration {

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -599,6 +599,11 @@
       </dependency>
       <dependency>
         <groupId>org.geoserver.extension</groupId>
+        <artifactId>gs-geopkg-output</artifactId>
+        <version>${gs.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.extension</groupId>
         <artifactId>gs-web-resource</artifactId>
         <version>${gs.version}</version>
       </dependency>

--- a/src/starters/wms-extensions/pom.xml
+++ b/src/starters/wms-extensions/pom.xml
@@ -34,6 +34,16 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-geopkg-output</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.geoserver</groupId>
+          <artifactId>gs-wfs</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-vectortiles</artifactId>
     </dependency>
     <dependency>

--- a/src/starters/wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/extensions/GeoPkgOutputConfiguration.java
+++ b/src/starters/wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/extensions/GeoPkgOutputConfiguration.java
@@ -1,0 +1,36 @@
+/*
+ * (c) 2021 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.wms.extensions;
+
+import org.geoserver.cloud.autoconfigure.wms.extensions.WmsExtensionsConfigProperties.Wms.WmsOutputFormatsConfigProperties.VectorTilesConfigProperties;
+import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportResource;
+
+/**
+ * @since 1.0
+ */
+@Configuration
+@EnableConfigurationProperties(WmsExtensionsConfigProperties.class)
+@ImportResource( //
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = {"jar:gs-geopkg-output-.*!/applicationContext.xml"})
+class GeoPkgOutputConfiguration {
+
+    @ConditionalOnProperty(
+            name = "geoserver.wms.output-formats.geopkg.enabled",
+            havingValue = "true",
+            matchIfMissing = true)
+    @ImportResource( //
+            reader = FilteringXmlBeanDefinitionReader.class, //
+            locations = {
+                "jar:gs-geopkg-output-.*!/applicationContext.xml"
+            })
+    static class Enabled {}
+}

--- a/src/starters/wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/extensions/WmsExtensionsAutoConfiguration.java
+++ b/src/starters/wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/extensions/WmsExtensionsAutoConfiguration.java
@@ -22,7 +22,8 @@ import javax.annotation.PostConstruct;
         value = {
             CssStylingConfiguration.class,
             MapBoxStylingConfiguration.class,
-            VectorTilesConfiguration.class
+            VectorTilesConfiguration.class,
+            GeoPkgOutputConfiguration.class
         })
 public class WmsExtensionsAutoConfiguration {
     public @PostConstruct void log() {

--- a/src/starters/wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/extensions/WmsExtensionsConfigProperties.java
+++ b/src/starters/wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/extensions/WmsExtensionsConfigProperties.java
@@ -22,6 +22,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *     mapbox.enabled: true
  *   wms:
  *     outputFormats:
+ *       geopkg.enabled: true
  *       vectorTiles:
  *         mapbox.enabled: true
  *         geojson.enabled: true
@@ -50,6 +51,9 @@ public @Data class WmsExtensionsConfigProperties {
                 new WmsOutputFormatsConfigProperties();
 
         public static @Data class WmsOutputFormatsConfigProperties {
+
+            private EnabledProperty geopkg = new EnabledProperty();
+
             private VectorTilesConfigProperties vectorTiles = new VectorTilesConfigProperties();
 
             public static @Data class VectorTilesConfigProperties {


### PR DESCRIPTION
As discusses in issue #531, there was no reason to include support for geopackage and dxf except that it wasn't implemented yet.

Hereby the implementation that (as far as I can see and test) works. It implements the extensions in a way identical to for instance the flatgeobuf extension, which is a community extension of the regular Geoserver. As I am not familiair enough with the WPS modules in Geoserver Cloud, I did not incorporate the WPS modules in this PR for both formats.