### PR TITLE
Distributed event notification of GWC config changes

### DIFF
--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigGwcInitializer.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigGwcInitializer.java
@@ -7,12 +7,13 @@ package org.geoserver.cloud.autoconfigure.gwc.backend;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
+import org.geoserver.GeoServerConfigurationLock;
 import org.geoserver.cloud.gwc.backend.pgconfig.PgconfigTileLayerCatalog;
-import org.geoserver.cloud.gwc.config.core.AbstractGwcInitializer;
 import org.geoserver.cloud.gwc.event.TileLayerEvent;
 import org.geoserver.cloud.gwc.repository.GeoServerTileLayerConfiguration;
 import org.geoserver.config.GeoServerReinitializer;
 import org.geoserver.gwc.ConfigurableBlobStore;
+import org.geoserver.gwc.config.AbstractGwcInitializer;
 import org.geoserver.gwc.config.GWCConfigPersister;
 import org.geoserver.gwc.config.GWCInitializer;
 import org.geoserver.gwc.layer.TileLayerCatalog;
@@ -46,8 +47,9 @@ class PgconfigGwcInitializer extends AbstractGwcInitializer {
     public PgconfigGwcInitializer(
             @NonNull GWCConfigPersister configPersister,
             @NonNull ConfigurableBlobStore blobStore,
-            @NonNull GeoServerTileLayerConfiguration geoseverTileLayers) {
-        super(configPersister, blobStore, geoseverTileLayers);
+            @NonNull GeoServerTileLayerConfiguration geoseverTileLayers,
+            @NonNull GeoServerConfigurationLock configLock) {
+        super(configPersister, blobStore, geoseverTileLayers, configLock);
     }
 
     @Override

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigTileLayerCatalogAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigTileLayerCatalogAutoConfiguration.java
@@ -7,6 +7,7 @@ package org.geoserver.cloud.autoconfigure.gwc.backend;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
+import org.geoserver.GeoServerConfigurationLock;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.cloud.autoconfigure.catalog.backend.pgconfig.ConditionalOnPgconfigBackendEnabled;
 import org.geoserver.cloud.autoconfigure.catalog.backend.pgconfig.PgconfigDataSourceAutoConfiguration;
@@ -58,13 +59,18 @@ public class PgconfigTileLayerCatalogAutoConfiguration {
         log.info("GeoWebCache TileLayerCatalog using PostgreSQL config backend");
     }
 
-    /** Replacement for {@link GWCInitializer} when using {@link GeoServerTileLayerConfiguration} */
+    /**
+     * Replacement for {@link GWCInitializer} when using {@link GeoServerTileLayerConfiguration}
+     *
+     * @param configLock
+     */
     @Bean
     PgconfigGwcInitializer gwcInitializer(
             GWCConfigPersister configPersister,
             ConfigurableBlobStore blobStore,
-            GeoServerTileLayerConfiguration tileLayerCatalog) {
-        return new PgconfigGwcInitializer(configPersister, blobStore, tileLayerCatalog);
+            GeoServerTileLayerConfiguration tileLayerCatalog,
+            GeoServerConfigurationLock configLock) {
+        return new PgconfigGwcInitializer(configPersister, blobStore, tileLayerCatalog, configLock);
     }
 
     @Bean(name = "gwcCatalogConfiguration")

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/GeoWebCacheCoreConfiguration.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/GeoWebCacheCoreConfiguration.java
@@ -59,7 +59,7 @@ import javax.servlet.http.HttpServletRequestWrapper;
 @ImportResource(
         reader = FilteringXmlBeanDefinitionReader.class, //
         locations = {
-            "jar:gs-gwc-[0-9]+.*!/geowebcache-core-context.xml#name=^(?!gwcXmlConfig|gwcDefaultStorageFinder|gwcGeoServervConfigPersister|metastoreRemover).*$"
+            "jar:gs-gwc-[0-9]+.*!/geowebcache-core-context.xml#name=^(?!gwcXmlConfig|gwcDefaultStorageFinder|metastoreRemover).*$"
         })
 @Slf4j(topic = "org.geoserver.cloud.gwc.config.core")
 public class GeoWebCacheCoreConfiguration {

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/event/ConfigChangeEvent.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/event/ConfigChangeEvent.java
@@ -1,0 +1,16 @@
+package org.geoserver.cloud.gwc.event;
+
+@SuppressWarnings("serial")
+public class ConfigChangeEvent extends GeoWebCacheEvent {
+
+    public static final String OBJECT_ID = "gwcConfig";
+
+    public ConfigChangeEvent(Object source) {
+        super(source, Type.MODIFIED);
+    }
+
+    @Override
+    protected String getObjectId() {
+        return OBJECT_ID;
+    }
+}

--- a/src/gwc/core/src/main/java/org/geoserver/gwc/config/CloudGwcConfigPersister.java
+++ b/src/gwc/core/src/main/java/org/geoserver/gwc/config/CloudGwcConfigPersister.java
@@ -1,0 +1,120 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.gwc.config;
+
+import com.thoughtworks.xstream.XStream;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.geoserver.cloud.gwc.event.ConfigChangeEvent;
+import org.geoserver.config.util.XStreamPersister;
+import org.geoserver.config.util.XStreamPersisterFactory;
+import org.geoserver.gwc.ConfigurableBlobStore;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.platform.GeoServerResourceLoader;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.Resource.Type;
+import org.geoserver.util.DimensionWarning;
+import org.geowebcache.storage.blobstore.memory.CacheConfiguration;
+import org.springframework.context.event.EventListener;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * extends {@link GWCConfigPersister} to send {@link ConfigChangeEvent}s upon {@link
+ * #save(org.geoserver.gwc.config.GWCConfig)}
+ */
+@Slf4j
+public class CloudGwcConfigPersister extends GWCConfigPersister {
+
+    private Consumer<ConfigChangeEvent> eventPublisher;
+    private XStreamPersisterFactory xspf;
+    private GWCConfig configuration;
+
+    public CloudGwcConfigPersister(
+            XStreamPersisterFactory xspf,
+            GeoServerResourceLoader resourceLoader,
+            Consumer<ConfigChangeEvent> eventPublisher) {
+        super(xspf, resourceLoader);
+        this.xspf = xspf;
+        this.eventPublisher = eventPublisher;
+    }
+
+    /**
+     * Override to get a hold to the config and be able of re-loading it upon {@link
+     * ConfigChangeEvent}, since super.config is private
+     */
+    @Override
+    public GWCConfig getConfig() {
+        if (null == configuration) {
+            configuration = super.getConfig();
+        }
+        return configuration;
+    }
+
+    /**
+     * Override to publish a {@link ConfigChangeEvent}
+     *
+     * @see #reloadOnRemoteConfigChangeEvent(ConfigChangeEvent)
+     */
+    @Override
+    public void save(final GWCConfig config) throws IOException {
+        super.save(config);
+        this.configuration = config;
+        eventPublisher.accept(new ConfigChangeEvent(this));
+    }
+
+    @EventListener(ConfigChangeEvent.class)
+    public void reloadOnRemoteConfigChangeEvent(ConfigChangeEvent event) throws IOException {
+        final boolean isRemote = event.getSource() != this;
+        if (isRemote) {
+            log.info("Reloading gwc configuration upon remote config change event");
+            GWCConfig config = reload();
+            this.configuration = config;
+
+            // Update ConfigurableBlobStore
+            ConfigurableBlobStore blobstore = GeoServerExtensions.bean(ConfigurableBlobStore.class);
+            if (blobstore != null) {
+                blobstore.setChanged(config, false);
+            }
+        }
+    }
+
+    // super.loadConfig() is private
+    private synchronized GWCConfig reload() throws IOException {
+        Resource configFile = findConfigFile();
+        if (configFile == null || configFile.getType() == Type.UNDEFINED) {
+            throw new IllegalStateException(
+                    "gwc config resource does not exist: %s".formatted(GWC_CONFIG_FILE));
+        }
+
+        XStreamPersister xmlPersister = this.xspf.createXMLPersister();
+        configure(xmlPersister.getXStream());
+        try (InputStream in = configFile.in()) {
+            return xmlPersister.load(in, GWCConfig.class);
+        }
+    }
+
+    // super.configureXstream() is private
+    private void configure(XStream xs) {
+        xs.alias("GeoServerGWCConfig", GWCConfig.class);
+        xs.alias("defaultCachingGridSetIds", HashSet.class);
+        xs.alias("defaultCoverageCacheFormats", HashSet.class);
+        xs.alias("defaultVectorCacheFormats", HashSet.class);
+        xs.alias("defaultOtherCacheFormats", HashSet.class);
+        xs.alias("InnerCacheConfiguration", CacheConfiguration.class);
+        xs.alias("warning", DimensionWarning.WarningType.class);
+        xs.allowTypes(
+                new Class[] {
+                    GWCConfig.class, CacheConfiguration.class, DimensionWarning.WarningType.class
+                });
+        xs.addDefaultImplementation(LinkedHashSet.class, Set.class);
+    }
+}

--- a/src/gwc/core/src/main/java/org/geoserver/gwc/config/DefaultGwcInitializer.java
+++ b/src/gwc/core/src/main/java/org/geoserver/gwc/config/DefaultGwcInitializer.java
@@ -8,18 +8,11 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 import org.geoserver.GeoServerConfigurationLock;
-import org.geoserver.GeoServerConfigurationLock.LockType;
-import org.geoserver.cloud.gwc.config.core.AbstractGwcInitializer;
 import org.geoserver.cloud.gwc.repository.GeoServerTileLayerConfiguration;
 import org.geoserver.gwc.ConfigurableBlobStore;
 import org.geoserver.gwc.layer.CatalogConfiguration;
 import org.geoserver.gwc.layer.TileLayerCatalog;
-import org.geoserver.platform.resource.Resource;
-import org.geoserver.platform.resource.Resources;
 import org.slf4j.Logger;
-import org.springframework.beans.factory.InitializingBean;
-
-import java.io.IOException;
 
 /**
  * Replaces {@link GWCInitializer}
@@ -37,9 +30,7 @@ import java.io.IOException;
  * </ul>
  */
 @Slf4j(topic = "org.geoserver.cloud.gwc.config.core")
-public class DefaultGwcInitializer extends AbstractGwcInitializer implements InitializingBean {
-
-    @NonNull private final GeoServerConfigurationLock configLock;
+public class DefaultGwcInitializer extends AbstractGwcInitializer {
 
     public DefaultGwcInitializer(
             @NonNull GWCConfigPersister configPersister,
@@ -47,47 +38,11 @@ public class DefaultGwcInitializer extends AbstractGwcInitializer implements Ini
             @NonNull GeoServerTileLayerConfiguration geoseverTileLayers,
             @NonNull GeoServerConfigurationLock configLock) {
 
-        super(configPersister, blobStore, geoseverTileLayers);
-        this.configLock = configLock;
+        super(configPersister, blobStore, geoseverTileLayers, configLock);
     }
 
     @Override
     protected Logger logger() {
         return log;
-    }
-
-    /**
-     * Initialize the datadir/gs-gwc.xml file before {@link
-     * #initialize(org.geoserver.config.GeoServer) super.initialize(GeoServer)}
-     */
-    @Override
-    public void afterPropertiesSet() throws Exception {
-        initializeGeoServerIntegrationConfigFile();
-    }
-
-    private void initializeGeoServerIntegrationConfigFile() throws IOException {
-        if (configFileExists()) {
-            return;
-        }
-        final boolean lockAcquired = configLock.tryLock(LockType.WRITE);
-        if (lockAcquired) {
-            try {
-                if (!configFileExists()) {
-                    log.info(
-                            "Initializing GeoServer specific GWC configuration {}",
-                            configPersister.findConfigFile());
-                    GWCConfig defaults = new GWCConfig();
-                    defaults.setVersion("1.1.0");
-                    configPersister.save(defaults);
-                }
-            } finally {
-                configLock.unlock();
-            }
-        }
-    }
-
-    private boolean configFileExists() throws IOException {
-        Resource configFile = configPersister.findConfigFile();
-        return Resources.exists(configFile);
     }
 }

--- a/src/gwc/integration-bus/src/main/java/org/geoserver/cloud/gwc/bus/GeoWebCacheRemoteEventsBroker.java
+++ b/src/gwc/integration-bus/src/main/java/org/geoserver/cloud/gwc/bus/GeoWebCacheRemoteEventsBroker.java
@@ -24,7 +24,7 @@ import java.util.function.Supplier;
  * to the cluster as {@link RemoteGeoWebCacheEvent} on the event bus, and vice-versa.
  */
 @RequiredArgsConstructor
-@Slf4j(topic = "org.geoserver.cloud.bus.outgoing.gwc")
+@Slf4j(topic = "org.geoserver.cloud.gwc.bus")
 public class GeoWebCacheRemoteEventsBroker {
 
     /**

--- a/src/gwc/integration-bus/src/main/java/org/geoserver/cloud/gwc/bus/RemoteConfigChangeEvent.java
+++ b/src/gwc/integration-bus/src/main/java/org/geoserver/cloud/gwc/bus/RemoteConfigChangeEvent.java
@@ -1,0 +1,28 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.gwc.bus;
+
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+import org.geoserver.cloud.gwc.event.ConfigChangeEvent;
+
+/**
+ * @since 1.9
+ */
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@SuppressWarnings("serial")
+public class RemoteConfigChangeEvent extends RemoteGeoWebCacheEvent {
+
+    public RemoteConfigChangeEvent(Object source, @NonNull String originService) {
+        super(source, originService);
+    }
+
+    protected @Override String getObjectId() {
+        return ConfigChangeEvent.OBJECT_ID;
+    }
+}

--- a/src/gwc/integration-bus/src/main/java/org/geoserver/cloud/gwc/bus/RemoteEventMapper.java
+++ b/src/gwc/integration-bus/src/main/java/org/geoserver/cloud/gwc/bus/RemoteEventMapper.java
@@ -8,6 +8,7 @@ import lombok.Generated;
 import lombok.NonNull;
 
 import org.geoserver.cloud.gwc.event.BlobStoreEvent;
+import org.geoserver.cloud.gwc.event.ConfigChangeEvent;
 import org.geoserver.cloud.gwc.event.GeoWebCacheEvent;
 import org.geoserver.cloud.gwc.event.GridsetEvent;
 import org.geoserver.cloud.gwc.event.TileLayerEvent;
@@ -33,6 +34,7 @@ interface RemoteEventMapper {
             case TileLayerEvent tle -> toRemote(tle, source, originService);
             case GridsetEvent gse -> toRemote(gse, source, originService);
             case BlobStoreEvent bse -> toRemote(bse, source, originService);
+            case ConfigChangeEvent ce -> toRemote(ce, source, originService);
             default -> throw new IllegalArgumentException(
                     "unknown GeoWebCacheEvent type: " + local);
         };
@@ -44,6 +46,7 @@ interface RemoteEventMapper {
             case RemoteTileLayerEvent tle -> toLocal(tle, source);
             case RemoteGridsetEvent gse -> toLocal(gse, source);
             case RemoteBlobStoreEvent bse -> toLocal(bse, source);
+            case RemoteConfigChangeEvent ce -> toLocal(ce, source);
             default -> throw new IllegalArgumentException(
                     "unknown RemoteGeoWebCacheEvent type: " + remote);
         };
@@ -64,10 +67,25 @@ interface RemoteEventMapper {
     RemoteBlobStoreEvent toRemote(
             BlobStoreEvent local, @Context Object source, @Context String originService);
 
+    ConfigChangeEvent toLocal(RemoteConfigChangeEvent remote, @Context Object source);
+
+    RemoteConfigChangeEvent toRemote(
+            ConfigChangeEvent local, @Context Object source, @Context String originService);
+
+    @ObjectFactory
+    default TileLayerEvent newTileEvent(@Context Object source) {
+        return new TileLayerEvent(source);
+    }
+
     @ObjectFactory
     default RemoteTileLayerEvent newRemoteTileEvent(
             @Context Object source, @Context String originService) {
         return new RemoteTileLayerEvent(source, originService);
+    }
+
+    @ObjectFactory
+    default GridsetEvent newGridsetEvent(@Context Object source) {
+        return new GridsetEvent(source);
     }
 
     @ObjectFactory
@@ -77,23 +95,24 @@ interface RemoteEventMapper {
     }
 
     @ObjectFactory
+    default BlobStoreEvent newBlobStoreEvent(@Context Object source) {
+        return new BlobStoreEvent(source);
+    }
+
+    @ObjectFactory
     default RemoteBlobStoreEvent newRemoteBlobStoreEvent(
             @Context Object source, @Context String originService) {
         return new RemoteBlobStoreEvent(source, originService);
     }
 
     @ObjectFactory
-    default TileLayerEvent newTileEvent(@Context Object source) {
-        return new TileLayerEvent(source);
+    default ConfigChangeEvent newConfigChangeEvent(@Context Object source) {
+        return new ConfigChangeEvent(source);
     }
 
     @ObjectFactory
-    default GridsetEvent newGridsetEvent(@Context Object source) {
-        return new GridsetEvent(source);
-    }
-
-    @ObjectFactory
-    default BlobStoreEvent newBlobStoreEvent(@Context Object source) {
-        return new BlobStoreEvent(source);
+    default RemoteConfigChangeEvent newConfigChangeEvent(
+            @Context Object source, @Context String originService) {
+        return new RemoteConfigChangeEvent(source, originService);
     }
 }


### PR DESCRIPTION
* Add missing `gs-gwc.xml` initialization for `pgconfig`
* Configure GWC lock provider with the cluster-aware geoserver lock provider
* Distributed event notification of GWC config changes
    
    Send a distributed event upon GWC config change and react accordingly
    on the receiving end by forcing a reload of the `GWCConfig` and applying
    the change to the `ConfigurableBlobStore`, as done in
    `GWCSettingsPage.save()`.
---
Fixes #411