### PR TITLE
Install system CA certificates in base Docker image

### DIFF
--- a/src/apps/base-images/jre/Dockerfile
+++ b/src/apps/base-images/jre/Dockerfile
@@ -4,3 +4,6 @@ LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
 
 ENV JAVA_TOOL_OPTIONS=
 ENV JAVA_OPTS=
+
+# Install the system CA certificates for the JVM :wqnow that we're root
+RUN USE_SYSTEM_CA_CERTS=true /__cacert_entrypoint.sh


### PR DESCRIPTION
- Install the `ca-certificates` package to include trusted system CA certificates.
- Ensures secure SSL/TLS communication with external services over HTTPS.
- Allows the Dockerized application to verify certificates against a trusted set of certificate authorities.
- Supports integration with APIs, databases, and other secure services.

This change improves the container's ability to connect to external resources securely, making it compatible with environments that require certificate validation.