### PR TITLE
Support IAU planetary CRSs and additional EPSG projections out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Only a curated list of the [vast amount](http://geoserver.org/release/stable/) o
 - cog
 - importer
 - imagepyramid
+- gt-iau-wkt ([https://docs.geotools.org/latest/userguide/library/referencing/iau.html](IAU planetary CRS Plugin)(
 
 Advanced ACL system is available through the project [GeoServer ACL](https://github.com/geoserver/geoserver-acl) which offers the same capacities as GeoFence.
 

--- a/src/apps/base-images/geoserver/Dockerfile
+++ b/src/apps/base-images/geoserver/Dockerfile
@@ -17,6 +17,9 @@ RUN java -Djarmode=layertools -jar application.jar extract
 ##########
 FROM $REPOSITORY/gs-cloud-base-spring-boot:$TAG
 
+ENV JAVA_TOOL_OPTIONS="${DEFAULT_JAVA_TOOL_OPTIONS} \
+-Duser.projections.file=/etc/geoserver/user_projections/epsg.properties"
+
 # init
 RUN apt update \
 && apt -y upgrade \

--- a/src/apps/geoserver/pom.xml
+++ b/src/apps/geoserver/pom.xml
@@ -74,6 +74,11 @@
       <artifactId>spring-boot-starter-aop</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-iau-wkt</artifactId>
+      <version>${gt.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>


### PR DESCRIPTION
* Add `gt-iau-wkt` dependency to support [IAU planetary CRSs](https://docs.geoserver.org/main/en/user/extensions/iau/index.html)
* Use additional "user projections" from /etc/geoserver/user_projections/epsg.properties

    Add `-Duser.projections.file=/etc/geoserver/user_projections/epsg.properties`
    to `JAVA_TOOL_OPTIONS` for the base geoserver application image to always
    load additional projections from the embedded config.

    This allows to always have the additional projections even when starting off
    and empty data directory/database.