### PR TITLE
Workaround an issue where the JNDIInitializer would be called several times

### DIFF
--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/core/GeoServerBackendAutoConfiguration.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/core/GeoServerBackendAutoConfiguration.java
@@ -6,7 +6,7 @@ package org.geoserver.cloud.autoconfigure.catalog.backend.core;
 
 import org.geoserver.cloud.autoconfigure.geotools.GeoToolsHttpClientAutoConfiguration;
 import org.geoserver.cloud.config.catalog.backend.core.CoreBackendConfiguration;
-import org.geoserver.cloud.config.jndidatasource.JNDIDataSourceAutoConfiguration;
+import org.geoserver.cloud.config.jndi.JNDIDataSourceConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.context.annotation.Import;
@@ -23,6 +23,6 @@ import org.springframework.context.annotation.Import;
  * @see CoreBackendConfiguration
  */
 @AutoConfiguration(
-        after = {GeoToolsHttpClientAutoConfiguration.class, JNDIDataSourceAutoConfiguration.class})
+        after = {GeoToolsHttpClientAutoConfiguration.class, JNDIDataSourceConfiguration.class})
 @Import(CoreBackendConfiguration.class)
 public class GeoServerBackendAutoConfiguration {}

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgconfig/PgconfigDataSourceAutoConfiguration.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgconfig/PgconfigDataSourceAutoConfiguration.java
@@ -5,14 +5,14 @@
 package org.geoserver.cloud.autoconfigure.catalog.backend.pgconfig;
 
 import org.geoserver.cloud.config.catalog.backend.pgconfig.PconfigDataSourceConfiguration;
-import org.geoserver.cloud.config.jndidatasource.JNDIDataSourceAutoConfiguration;
+import org.geoserver.cloud.config.jndi.JNDIDataSourceConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Import;
 
 /**
  * @since 1.4
  */
-@AutoConfiguration(after = JNDIDataSourceAutoConfiguration.class)
+@AutoConfiguration(after = JNDIDataSourceConfiguration.class)
 @ConditionalOnPgconfigBackendEnabled
 @Import(PconfigDataSourceConfiguration.class)
 public class PgconfigDataSourceAutoConfiguration {}

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/config/catalog/backend/pgconfig/PconfigDataSourceConfiguration.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/config/catalog/backend/pgconfig/PconfigDataSourceConfiguration.java
@@ -46,9 +46,9 @@ public class PconfigDataSourceConfiguration {
     Object jndiInitializerFallback() {
         log.warn(
                 """
-                jndiInitializer is not provided, beware a JNDI datasource \
-                definition for the pgconfig catalog backend won't work.
-                """);
+                 jndiInitializer is not provided, beware a JNDI datasource \
+                 definition for the pgconfig catalog backend won't work.
+                 """);
         return new Object();
     }
 }

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/support/PgConfigTestContainer.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/support/PgConfigTestContainer.java
@@ -10,9 +10,9 @@ import com.zaxxer.hikari.HikariDataSource;
 import lombok.Getter;
 import lombok.SneakyThrows;
 
+import org.geoserver.cloud.autoconfigure.jndi.SimpleJNDIStaticContextInitializer;
 import org.geoserver.cloud.config.catalog.backend.pgconfig.PgconfigDatabaseMigrations;
-import org.geoserver.cloud.config.jndi.SimpleJNDIStaticContextInitializer;
-import org.geoserver.cloud.config.jndidatasource.JNDIDataSourceAutoConfiguration;
+import org.geoserver.cloud.config.jndi.JNDIDataSourceConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.AbstractApplicationContextRunner;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -94,8 +94,7 @@ public class PgConfigTestContainer<SELF extends PostgreSQLContainer<SELF>>
                 runner
                         // enable simplejndi
                         .withInitializer(new SimpleJNDIStaticContextInitializer())
-                        .withConfiguration(
-                                AutoConfigurations.of(JNDIDataSourceAutoConfiguration.class))
+                        .withConfiguration(AutoConfigurations.of(JNDIDataSourceConfiguration.class))
                         .withPropertyValues(
                                 "geoserver.backend.pgconfig.enabled: true", //
                                 // java:comp/env/jdbc/testdb config properties

--- a/src/library/spring-boot-simplejndi/pom.xml
+++ b/src/library/spring-boot-simplejndi/pom.xml
@@ -33,5 +33,10 @@
       <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/library/spring-boot-simplejndi/src/main/java/org/geoserver/cloud/autoconfigure/jndi/JNDIDataSourceAutoConfiguration.java
+++ b/src/library/spring-boot-simplejndi/src/main/java/org/geoserver/cloud/autoconfigure/jndi/JNDIDataSourceAutoConfiguration.java
@@ -1,0 +1,19 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.jndi;
+
+import org.geoserver.cloud.config.jndi.JNDIDataSourceConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureOrder;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.Ordered;
+
+/**
+ * @since 1.0
+ */
+@AutoConfiguration
+@AutoConfigureOrder(Ordered.HIGHEST_PRECEDENCE)
+@Import(JNDIDataSourceConfiguration.class)
+public class JNDIDataSourceAutoConfiguration {}

--- a/src/library/spring-boot-simplejndi/src/main/java/org/geoserver/cloud/autoconfigure/jndi/SimpleJNDIStaticContextInitializer.java
+++ b/src/library/spring-boot-simplejndi/src/main/java/org/geoserver/cloud/autoconfigure/jndi/SimpleJNDIStaticContextInitializer.java
@@ -2,7 +2,7 @@
  * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
  * GPL 2.0 license, available at the root application directory.
  */
-package org.geoserver.cloud.config.jndi;
+package org.geoserver.cloud.autoconfigure.jndi;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/library/spring-boot-simplejndi/src/main/java/org/geoserver/cloud/config/jndi/JNDIDataSourceConfiguration.java
+++ b/src/library/spring-boot-simplejndi/src/main/java/org/geoserver/cloud/config/jndi/JNDIDataSourceConfiguration.java
@@ -2,18 +2,18 @@
  * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
  * GPL 2.0 license, available at the root application directory.
  */
-package org.geoserver.cloud.config.jndidatasource;
+package org.geoserver.cloud.config.jndi;
 
-import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 /**
  * @since 1.0
  */
-@AutoConfiguration
+@Configuration
 @EnableConfigurationProperties(JNDIDataSourcesConfigurationProperties.class)
-public class JNDIDataSourceAutoConfiguration {
+public class JNDIDataSourceConfiguration {
     @Bean
     JNDIInitializer jndiInitializer(JNDIDataSourcesConfigurationProperties config) {
         return new JNDIInitializer(config);

--- a/src/library/spring-boot-simplejndi/src/main/java/org/geoserver/cloud/config/jndi/JNDIDataSourcesConfigurationProperties.java
+++ b/src/library/spring-boot-simplejndi/src/main/java/org/geoserver/cloud/config/jndi/JNDIDataSourcesConfigurationProperties.java
@@ -2,7 +2,7 @@
  * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
  * GPL 2.0 license, available at the root application directory.
  */
-package org.geoserver.cloud.config.jndidatasource;
+package org.geoserver.cloud.config.jndi;
 
 import lombok.Data;
 

--- a/src/library/spring-boot-simplejndi/src/main/java/org/geoserver/cloud/config/jndi/JNDIDatasourceConfig.java
+++ b/src/library/spring-boot-simplejndi/src/main/java/org/geoserver/cloud/config/jndi/JNDIDatasourceConfig.java
@@ -2,7 +2,7 @@
  * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
  * GPL 2.0 license, available at the root application directory.
  */
-package org.geoserver.cloud.config.jndidatasource;
+package org.geoserver.cloud.config.jndi;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;

--- a/src/library/spring-boot-simplejndi/src/main/resources/META-INF/spring.factories
+++ b/src/library/spring-boot-simplejndi/src/main/resources/META-INF/spring.factories
@@ -1,7 +1,7 @@
 # Initializers
 org.springframework.context.ApplicationContextInitializer=\
-org.geoserver.cloud.config.jndi.SimpleJNDIStaticContextInitializer
+org.geoserver.cloud.autoconfigure.jndi.SimpleJNDIStaticContextInitializer
 
 # Auto Configure
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.geoserver.cloud.config.jndidatasource.JNDIDataSourceAutoConfiguration
+org.geoserver.cloud.autoconfigure.jndi.JNDIDataSourceAutoConfiguration

--- a/src/library/spring-boot-simplejndi/src/test/java/org/geoserver/cloud/autoconfigure/jndi/JNDIDataSourceAutoConfigurationTest.java
+++ b/src/library/spring-boot-simplejndi/src/test/java/org/geoserver/cloud/autoconfigure/jndi/JNDIDataSourceAutoConfigurationTest.java
@@ -2,13 +2,13 @@
  * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
  * GPL 2.0 license, available at the root application directory.
  */
-package org.geoserver.cloud.config.jndidatasource;
+package org.geoserver.cloud.autoconfigure.jndi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.zaxxer.hikari.HikariDataSource;
 
-import org.geoserver.cloud.config.jndi.SimpleJNDIStaticContextInitializer;
+import org.geoserver.cloud.config.jndi.JNDIDataSourceConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -24,11 +24,10 @@ class JNDIDataSourceAutoConfigurationTest {
     private ApplicationContextRunner runner =
             new ApplicationContextRunner()
                     .withInitializer(new SimpleJNDIStaticContextInitializer())
-                    .withConfiguration(
-                            AutoConfigurations.of(JNDIDataSourceAutoConfiguration.class));
+                    .withConfiguration(AutoConfigurations.of(JNDIDataSourceConfiguration.class));
 
     @Test
-    void test() {
+    void testInitialContextLookup() {
 
         runner.withPropertyValues( //
                         "jndi.datasources.ds1.url: jdbc:h2:mem:ds1", //

--- a/src/library/spring-boot-simplejndi/src/test/java/org/geoserver/cloud/config/jndi/SimpleJNDIStaticContextInitializerTest.java
+++ b/src/library/spring-boot-simplejndi/src/test/java/org/geoserver/cloud/config/jndi/SimpleJNDIStaticContextInitializerTest.java
@@ -6,6 +6,7 @@ package org.geoserver.cloud.config.jndi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.geoserver.cloud.autoconfigure.jndi.SimpleJNDIStaticContextInitializer;
 import org.geoserver.cloud.jndi.SimpleNamingContext;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;


### PR DESCRIPTION
Workaround an issue where the JNDIInitializer would be called several times, making it wait for an unavailable JNDI data source multiple rounds instead of just one.

I can't figure out why JNDIDataSourceAutoConfiguration would be instantiated several times when JNDIInitializer fails, so added a static flag to JNDIInitializer to avoid waiting for unavailable databases again and again.

Also Refactor the simple JNDI configuration to auto and plain config classes