### PR TITLE
Add JDBC and LDAP security plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ Only a curated list of the [vast amount](http://geoserver.org/release/stable/) o
 - cog
 - importer
 - imagepyramid
-- gt-iau-wkt ([https://docs.geotools.org/latest/userguide/library/referencing/iau.html](IAU planetary CRS Plugin)(
+- [IAU planetary CRS Plugin](https://docs.geotools.org/latest/userguide/library/referencing/iau.html)
+- JDBC Security
+- LDAP Security
 
 Advanced ACL system is available through the project [GeoServer ACL](https://github.com/geoserver/geoserver-acl) which offers the same capacities as GeoFence.
 

--- a/src/apps/geoserver/gwc/src/main/resources/bootstrap.yml
+++ b/src/apps/geoserver/gwc/src/main/resources/bootstrap.yml
@@ -63,6 +63,7 @@ spring:
       - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
       - org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
       - org.springframework.boot.autoconfigure.freemarker.FreeMarkerAutoConfiguration
+      - org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration
 
 # override default of true, this service does not use the registry (when eureka client is enabled)
 eureka.client.fetch-registry: false

--- a/src/apps/geoserver/restconfig/src/main/resources/bootstrap.yml
+++ b/src/apps/geoserver/restconfig/src/main/resources/bootstrap.yml
@@ -36,6 +36,7 @@ spring:
       - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
       - org.springframework.boot.autoconfigure.freemarker.FreeMarkerAutoConfiguration
       - org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
+      - org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration
       
 
 # override default of true, this service does not use the registry (when eureka client is enabled)

--- a/src/apps/geoserver/wcs/src/main/resources/bootstrap.yml
+++ b/src/apps/geoserver/wcs/src/main/resources/bootstrap.yml
@@ -36,6 +36,7 @@ spring:
       - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
       - org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
       - org.springframework.boot.autoconfigure.freemarker.FreeMarkerAutoConfiguration
+      - org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration
 
 # override default of true, this service does not use the registry (when eureka client is enabled)
 eureka.client.fetch-registry: false

--- a/src/apps/geoserver/webui/pom.xml
+++ b/src/apps/geoserver/webui/pom.xml
@@ -31,6 +31,14 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver.web</groupId>
+      <artifactId>gs-web-sec-jdbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.web</groupId>
+      <artifactId>gs-web-sec-ldap</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-wms</artifactId>
     </dependency>
     <dependency>

--- a/src/apps/geoserver/wfs/src/main/resources/bootstrap.yml
+++ b/src/apps/geoserver/wfs/src/main/resources/bootstrap.yml
@@ -38,6 +38,7 @@ spring:
       - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
       - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
       - org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
+      - org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration
 
 # override default of true, this service does not use the registry (when eureka client is enabled)
 eureka.client.fetch-registry: false

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -414,6 +414,32 @@
         <version>${gs.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.geoserver.security</groupId>
+        <artifactId>gs-sec-jdbc</artifactId>
+        <version>${gs.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.web</groupId>
+        <artifactId>gs-web-sec-jdbc</artifactId>
+        <version>${gs.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.security</groupId>
+        <artifactId>gs-sec-ldap</artifactId>
+        <version>${gs.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.web</groupId>
+        <artifactId>gs-web-sec-ldap</artifactId>
+        <version>${gs.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-rest</artifactId>
         <version>${gs.version}</version>

--- a/src/starters/security/pom.xml
+++ b/src/starters/security/pom.xml
@@ -53,6 +53,24 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.geoserver.security</groupId>
+      <artifactId>gs-sec-jdbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.web</groupId>
+      <artifactId>gs-web-sec-jdbc</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.security</groupId>
+      <artifactId>gs-sec-ldap</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.web</groupId>
+      <artifactId>gs-web-sec-ldap</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <!-- need it on the classpath just to avoid ClassNotFoundExceptions when loading some GeoServer bean definitions -->
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>

--- a/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/security/jdbc/JDBCSecurityAutoConfiguration.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/security/jdbc/JDBCSecurityAutoConfiguration.java
@@ -1,0 +1,28 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.security.jdbc;
+
+import org.geoserver.cloud.autoconfigure.security.ConditionalOnGeoServerSecurityEnabled;
+import org.geoserver.cloud.autoconfigure.security.GeoServerSecurityAutoConfiguration;
+import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.ImportResource;
+
+/** {@link AutoConfiguration @AutoConfiguration} to enable {@code gs-sec-jdbc} */
+// run before GeoServerSecurityAutoConfiguration so the provider is available when
+// GeoServerSecurityManager calls GeoServerExtensions.extensions(GeoServerSecurityProvider.class)
+@AutoConfiguration(before = GeoServerSecurityAutoConfiguration.class)
+@EnableConfigurationProperties(JDBCSecurityConfigProperties.class)
+@ConditionalOnGeoServerSecurityEnabled
+@ConditionalOnProperty(
+        name = "geoserver.security.jdbc",
+        havingValue = "true",
+        matchIfMissing = true)
+@ImportResource(
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = "jar:gs-sec-jdbc-.*!/applicationContext.xml")
+public class JDBCSecurityAutoConfiguration {}

--- a/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/security/jdbc/JDBCSecurityConfigProperties.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/security/jdbc/JDBCSecurityConfigProperties.java
@@ -1,0 +1,17 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.security.jdbc;
+
+import lombok.Data;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("geoserver.security")
+@Data
+public class JDBCSecurityConfigProperties {
+
+    /** Enable or disable GeoServer JDBC Security plugin */
+    private boolean jdbc = true;
+}

--- a/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/security/jdbc/JDBCSecurityWebUIAutoConfiguration.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/security/jdbc/JDBCSecurityWebUIAutoConfiguration.java
@@ -1,0 +1,34 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.security.jdbc;
+
+import org.geoserver.cloud.autoconfigure.security.ConditionalOnGeoServerSecurityEnabled;
+import org.geoserver.cloud.autoconfigure.security.GeoServerSecurityAutoConfiguration;
+import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.security.web.auth.AuthenticationFilterPanelInfo;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.ImportResource;
+
+/**
+ * {@link AutoConfiguration @AutoConfiguration} to enable {@code gs-web-sec-jdbc} when running with
+ * the webui components in the classpath
+ */
+// run before GeoServerSecurityAutoConfiguration so the provider is available when
+// GeoServerSecurityManager calls GeoServerExtensions.extensions(GeoServerSecurityProvider.class)
+@AutoConfiguration(before = GeoServerSecurityAutoConfiguration.class)
+@EnableConfigurationProperties(JDBCSecurityConfigProperties.class)
+@ConditionalOnClass(AuthenticationFilterPanelInfo.class)
+@ConditionalOnGeoServerSecurityEnabled
+@ConditionalOnProperty(
+        name = "geoserver.security.jdbc",
+        havingValue = "true",
+        matchIfMissing = true)
+@ImportResource(
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = "jar:gs-web-sec-jdbc-.*!/applicationContext.xml")
+public class JDBCSecurityWebUIAutoConfiguration {}

--- a/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/security/ldap/LDAPSecurityAutoConfiguration.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/security/ldap/LDAPSecurityAutoConfiguration.java
@@ -1,0 +1,28 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.security.ldap;
+
+import org.geoserver.cloud.autoconfigure.security.ConditionalOnGeoServerSecurityEnabled;
+import org.geoserver.cloud.autoconfigure.security.GeoServerSecurityAutoConfiguration;
+import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.ImportResource;
+
+/** {@link AutoConfiguration @AutoConfiguration} to enable {@code gs-sec-ldap} */
+// run before GeoServerSecurityAutoConfiguration so the provider is available when
+// GeoServerSecurityManager calls GeoServerExtensions.extensions(GeoServerSecurityProvider.class)
+@AutoConfiguration(before = GeoServerSecurityAutoConfiguration.class)
+@EnableConfigurationProperties(LDAPSecurityConfigProperties.class)
+@ConditionalOnGeoServerSecurityEnabled
+@ConditionalOnProperty(
+        name = "geoserver.security.ldap",
+        havingValue = "true",
+        matchIfMissing = true)
+@ImportResource(
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = "jar:gs-sec-ldap-.*!/applicationContext.xml")
+public class LDAPSecurityAutoConfiguration {}

--- a/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/security/ldap/LDAPSecurityConfigProperties.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/security/ldap/LDAPSecurityConfigProperties.java
@@ -1,0 +1,17 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.security.ldap;
+
+import lombok.Data;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("geoserver.security")
+@Data
+public class LDAPSecurityConfigProperties {
+
+    /** Enable or disable GeoServer LDAP Security plugin */
+    private boolean ldap = true;
+}

--- a/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/security/ldap/LDAPSecurityWebUIAutoConfiguration.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/security/ldap/LDAPSecurityWebUIAutoConfiguration.java
@@ -1,0 +1,34 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.security.ldap;
+
+import org.geoserver.cloud.autoconfigure.security.ConditionalOnGeoServerSecurityEnabled;
+import org.geoserver.cloud.autoconfigure.security.GeoServerSecurityAutoConfiguration;
+import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.security.web.auth.AuthenticationFilterPanelInfo;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.ImportResource;
+
+/**
+ * {@link AutoConfiguration @AutoConfiguration} to enable {@code gs-web-sec-ldap} when running with
+ * the webui components in the classpath
+ */
+// run before GeoServerSecurityAutoConfiguration so the provider is available when
+// GeoServerSecurityManager calls GeoServerExtensions.extensions(GeoServerSecurityProvider.class)
+@AutoConfiguration(before = GeoServerSecurityAutoConfiguration.class)
+@EnableConfigurationProperties(LDAPSecurityConfigProperties.class)
+@ConditionalOnClass(AuthenticationFilterPanelInfo.class)
+@ConditionalOnGeoServerSecurityEnabled
+@ConditionalOnProperty(
+        name = "geoserver.security.ldap",
+        havingValue = "true",
+        matchIfMissing = true)
+@ImportResource(
+        reader = FilteringXmlBeanDefinitionReader.class, //
+        locations = "jar:gs-web-sec-ldap-.*!/applicationContext.xml")
+public class LDAPSecurityWebUIAutoConfiguration {}

--- a/src/starters/security/src/main/resources/META-INF/spring.factories
+++ b/src/starters/security/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,8 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.geoserver.cloud.autoconfigure.authzn.AuthKeyAutoConfiguration,\
 org.geoserver.cloud.autoconfigure.authzn.GatewayPreAuthenticationAutoConfiguration,\
-org.geoserver.cloud.autoconfigure.authzn.GatewaySharedAuthenticationAutoConfiguration
+org.geoserver.cloud.autoconfigure.authzn.GatewaySharedAuthenticationAutoConfiguration,\
+org.geoserver.cloud.autoconfigure.security.jdbc.JDBCSecurityAutoConfiguration,\
+org.geoserver.cloud.autoconfigure.security.jdbc.JDBCSecurityWebUIAutoConfiguration,\
+org.geoserver.cloud.autoconfigure.security.ldap.LDAPSecurityAutoConfiguration,\
+org.geoserver.cloud.autoconfigure.security.ldap.LDAPSecurityWebUIAutoConfiguration

--- a/src/starters/security/src/test/java/org/geoserver/cloud/autoconfigure/security/jdbc/JDBCSecurityAutoConfigurationTest.java
+++ b/src/starters/security/src/test/java/org/geoserver/cloud/autoconfigure/security/jdbc/JDBCSecurityAutoConfigurationTest.java
@@ -1,0 +1,46 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.security.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.jdbc.JDBCSecurityProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+
+class JDBCSecurityAutoConfigurationTest {
+
+    private WebApplicationContextRunner runner =
+            new WebApplicationContextRunner()
+                    .withConfiguration(AutoConfigurations.of(JDBCSecurityAutoConfiguration.class))
+                    .withBean(
+                            GeoServerSecurityManager.class,
+                            () -> mock(GeoServerSecurityManager.class));
+
+    @Test
+    void testExpectedBeans() {
+        runner.run(
+                context ->
+                        assertThat(context)
+                                .hasNotFailed()
+                                .hasSingleBean(JDBCSecurityProvider.class)
+                                .getBean(JDBCSecurityConfigProperties.class)
+                                .hasFieldOrPropertyWithValue("jdbc", true));
+    }
+
+    @Test
+    void testDisabled() {
+        runner.withPropertyValues("geoserver.security.jdbc=false")
+                .run(
+                        context ->
+                                assertThat(context)
+                                        .hasNotFailed()
+                                        .doesNotHaveBean(JDBCSecurityProvider.class)
+                                        .doesNotHaveBean(JDBCSecurityConfigProperties.class));
+    }
+}

--- a/src/starters/security/src/test/java/org/geoserver/cloud/autoconfigure/security/jdbc/JDBCSecurityWebUIAutoConfigurationTest.java
+++ b/src/starters/security/src/test/java/org/geoserver/cloud/autoconfigure/security/jdbc/JDBCSecurityWebUIAutoConfigurationTest.java
@@ -1,0 +1,72 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.security.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.geoserver.platform.ModuleStatusImpl;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.web.auth.AuthenticationFilterPanelInfo;
+import org.geoserver.security.web.jdbc.JDBCAuthProviderPanelInfo;
+import org.geoserver.security.web.jdbc.JDBCRoleServicePanelInfo;
+import org.geoserver.security.web.jdbc.JDBCUserGroupServicePanelInfo;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+
+class JDBCSecurityWebUIAutoConfigurationTest {
+
+    private WebApplicationContextRunner runner =
+            new WebApplicationContextRunner()
+                    .withConfiguration(
+                            AutoConfigurations.of(
+                                    JDBCSecurityAutoConfiguration.class,
+                                    JDBCSecurityWebUIAutoConfiguration.class))
+                    .withBean(
+                            GeoServerSecurityManager.class,
+                            () -> mock(GeoServerSecurityManager.class));
+
+    @Test
+    void testConditionalOnClassNoMatch() {
+        runner.withClassLoader(new FilteredClassLoader(AuthenticationFilterPanelInfo.class))
+                .run(
+                        context ->
+                                assertThat(context)
+                                        .hasNotFailed()
+                                        .doesNotHaveBean(JDBCUserGroupServicePanelInfo.class)
+                                        .doesNotHaveBean(JDBCRoleServicePanelInfo.class)
+                                        .doesNotHaveBean(JDBCAuthProviderPanelInfo.class)
+                                        .doesNotHaveBean("jdbcSecurityWebExtension"));
+    }
+
+    @Test
+    void testConditionalOnClassMatch() {
+        runner.run(
+                context ->
+                        assertThat(context)
+                                .hasNotFailed()
+                                .hasSingleBean(JDBCUserGroupServicePanelInfo.class)
+                                .hasSingleBean(JDBCRoleServicePanelInfo.class)
+                                .hasSingleBean(JDBCAuthProviderPanelInfo.class)
+                                .hasBean("jdbcSecurityWebExtension")
+                                .getBean("jdbcSecurityWebExtension")
+                                .isInstanceOf(ModuleStatusImpl.class));
+    }
+
+    @Test
+    void testDisabled() {
+        runner.withPropertyValues("geoserver.security.jdbc=false")
+                .run(
+                        context ->
+                                assertThat(context)
+                                        .hasNotFailed()
+                                        .doesNotHaveBean(JDBCUserGroupServicePanelInfo.class)
+                                        .doesNotHaveBean(JDBCRoleServicePanelInfo.class)
+                                        .doesNotHaveBean(JDBCAuthProviderPanelInfo.class)
+                                        .doesNotHaveBean("jdbcSecurityWebExtension"));
+    }
+}

--- a/src/starters/security/src/test/java/org/geoserver/cloud/autoconfigure/security/ldap/LDAPSecurityAutoConfigurationTest.java
+++ b/src/starters/security/src/test/java/org/geoserver/cloud/autoconfigure/security/ldap/LDAPSecurityAutoConfigurationTest.java
@@ -1,0 +1,47 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.security.ldap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.geoserver.cloud.autoconfigure.security.jdbc.JDBCSecurityConfigProperties;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.ldap.LDAPSecurityProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+
+class LDAPSecurityAutoConfigurationTest {
+
+    private WebApplicationContextRunner runner =
+            new WebApplicationContextRunner()
+                    .withConfiguration(AutoConfigurations.of(LDAPSecurityAutoConfiguration.class))
+                    .withBean(
+                            GeoServerSecurityManager.class,
+                            () -> mock(GeoServerSecurityManager.class));
+
+    @Test
+    void testExpectedBeans() {
+        runner.run(
+                context ->
+                        assertThat(context)
+                                .hasNotFailed()
+                                .hasSingleBean(LDAPSecurityProvider.class)
+                                .getBean(LDAPSecurityConfigProperties.class)
+                                .hasFieldOrPropertyWithValue("ldap", true));
+    }
+
+    @Test
+    void testDisabled() {
+        runner.withPropertyValues("geoserver.security.ldap=false")
+                .run(
+                        context ->
+                                assertThat(context)
+                                        .hasNotFailed()
+                                        .doesNotHaveBean(LDAPSecurityProvider.class)
+                                        .doesNotHaveBean(JDBCSecurityConfigProperties.class));
+    }
+}

--- a/src/starters/security/src/test/java/org/geoserver/cloud/autoconfigure/security/ldap/LDAPSecurityWebUIAutoConfigurationTest.java
+++ b/src/starters/security/src/test/java/org/geoserver/cloud/autoconfigure/security/ldap/LDAPSecurityWebUIAutoConfigurationTest.java
@@ -1,0 +1,72 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.security.ldap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.geoserver.platform.ModuleStatusImpl;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.web.auth.AuthenticationFilterPanelInfo;
+import org.geoserver.web.security.ldap.LDAPAuthProviderPanelInfo;
+import org.geoserver.web.security.ldap.LDAPRoleServicePanelInfo;
+import org.geoserver.web.security.ldap.LDAPUserGroupServicePanelInfo;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+
+class LDAPSecurityWebUIAutoConfigurationTest {
+
+    private WebApplicationContextRunner runner =
+            new WebApplicationContextRunner()
+                    .withConfiguration(
+                            AutoConfigurations.of(
+                                    LDAPSecurityAutoConfiguration.class,
+                                    LDAPSecurityWebUIAutoConfiguration.class))
+                    .withBean(
+                            GeoServerSecurityManager.class,
+                            () -> mock(GeoServerSecurityManager.class));
+
+    @Test
+    void testConditionalOnClassNoMatch() {
+        runner.withClassLoader(new FilteredClassLoader(AuthenticationFilterPanelInfo.class))
+                .run(
+                        context ->
+                                assertThat(context)
+                                        .hasNotFailed()
+                                        .doesNotHaveBean(LDAPUserGroupServicePanelInfo.class)
+                                        .doesNotHaveBean(LDAPRoleServicePanelInfo.class)
+                                        .doesNotHaveBean(LDAPAuthProviderPanelInfo.class)
+                                        .doesNotHaveBean("ldapSecurityWebExtension"));
+    }
+
+    @Test
+    void testConditionalOnClassMatch() {
+        runner.run(
+                context ->
+                        assertThat(context)
+                                .hasNotFailed()
+                                .hasSingleBean(LDAPUserGroupServicePanelInfo.class)
+                                .hasSingleBean(LDAPRoleServicePanelInfo.class)
+                                .hasSingleBean(LDAPAuthProviderPanelInfo.class)
+                                .hasBean("ldapSecurityWebExtension")
+                                .getBean("ldapSecurityWebExtension")
+                                .isInstanceOf(ModuleStatusImpl.class));
+    }
+
+    @Test
+    void testDisabled() {
+        runner.withPropertyValues("geoserver.security.ldap=false")
+                .run(
+                        context ->
+                                assertThat(context)
+                                        .hasNotFailed()
+                                        .doesNotHaveBean(LDAPUserGroupServicePanelInfo.class)
+                                        .doesNotHaveBean(LDAPRoleServicePanelInfo.class)
+                                        .doesNotHaveBean(LDAPAuthProviderPanelInfo.class)
+                                        .doesNotHaveBean("ldapSecurityWebExtension"));
+    }
+}


### PR DESCRIPTION
Both plugins are enabled by default, can be disabled with

```
geoserver.security.ldap=false
geoserver.security.jdbc=false
```

[Default config updated](https://github.com/geoserver/geoserver-cloud-config/commit/2247a94055f592291a2f9dcf5e9c37b07c8152cc) to reflect the default values.