### PR TITLE
Enable restconfig-wmts extension

### DIFF
--- a/src/apps/geoserver/restconfig/pom.xml
+++ b/src/apps/geoserver/restconfig/pom.xml
@@ -41,10 +41,10 @@
       <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-cloud-starter-wms-extensions</artifactId>
     </dependency>
-    <!--    <dependency>-->
-    <!--      <groupId>org.geoserver</groupId>-->
-    <!--      <artifactId>gs-restconfig-wmts</artifactId>-->
-    <!--    </dependency>-->
+    <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-restconfig-wmts</artifactId>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>


### PR DESCRIPTION
The `restconfig-wmts` was missing for the `restconfig` service.