### PR TITLE
Set default values for min/max heap memory percentage in the base JRE image

### DIFF
--- a/compose/.env
+++ b/compose/.env
@@ -25,7 +25,7 @@ DISCOVERY_SERVER_DEFAULT_PROFILES=${LOGGING_PROFILE}
 # For more information, see https://cloud.spring.io/spring-cloud-config/multi/multi__spring_cloud_config_server.html#_git_backend
 CONFIG_SERVER_DEFAULT_PROFILES=${LOGGING_PROFILE},native,standalone
 
-JAVA_OPTS_DEFAULT=-XX:MaxRAMPercentage=80 -XshowSettings:system -Dlogging.config=file:/etc/geoserver/logback-spring.xml
+JAVA_OPTS_DEFAULT=-XshowSettings:system -Dlogging.config=file:/etc/geoserver/logback-spring.xml
 
 JAVA_OPTS_DISCOVERY=$JAVA_OPTS_DEFAULT
 JAVA_OPTS_CONFIG=$JAVA_OPTS_DEFAULT

--- a/docs/deploy/docker-compose/stable/pgconfig/compose.yml
+++ b/docs/deploy/docker-compose/stable/pgconfig/compose.yml
@@ -263,7 +263,6 @@ services:
     image: geoservercloud/geoserver-cloud-webui:1.8.12
     user: 1000:1000 # set the userid:groupid the container runs as
     environment:
-      JAVA_OPTS: -XX:MaxRAMPercentage=80 -XshowSettings:system 
       SPRING_PROFILES_ACTIVE: "pgconfig,acl"
       ACL_URL: http://acl:8080/acl/api
       ACL_USERNAME: admin

--- a/src/apps/base-images/jre/Dockerfile
+++ b/src/apps/base-images/jre/Dockerfile
@@ -13,7 +13,9 @@ ENV DEFAULT_JAVA_TOOL_OPTIONS="\
 --add-opens=java.desktop/sun.awt.image=ALL-UNNAMED \
 --add-opens=java.desktop/sun.java2d.pipe=ALL-UNNAMED \
 --add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED \
--Djava.awt.headless=true"
+-Djava.awt.headless=true \
+-XX:MaxRAMPercentage=80 \
+-XX:InitialRAMPercentage=30"
 
 ENV JAVA_TOOL_OPTIONS="${DEFAULT_JAVA_TOOL_OPTIONS}"
 ENV JAVA_OPTS=


### PR DESCRIPTION
Add `-XX:MaxRAMPercentage=80 -XX:InitialRAMPercentage=30` to the `DEFAULT_JAVA_TOOL_OPTIONS` env var in the base JRE docker image as they're good defaults so people doesn't need to be figuring it out themselves.