### PR TITLE
Fix a bug where changes to GWC layers won't be propagated to other pods.

### DIFF
--- a/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/CachingTileLayerInfoRepository.java
+++ b/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/CachingTileLayerInfoRepository.java
@@ -20,6 +20,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
+/**
+ * {@link TileLayerInfoRepository} decorator cache {@link TileLayerInfo}s on demand, alleviating the
+ * load on the delegate, especially under load.
+ */
 @RequiredArgsConstructor
 @Slf4j(topic = "org.geoserver.cloud.gwc.backend.pgconfig.caching")
 public class CachingTileLayerInfoRepository implements TileLayerInfoRepository {

--- a/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigTileLayerInfoRepository.java
+++ b/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigTileLayerInfoRepository.java
@@ -11,7 +11,6 @@ import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.cloud.backend.pgconfig.catalog.repository.LoggingTemplate;
 import org.geoserver.gwc.layer.CatalogConfiguration;
 import org.geoserver.gwc.layer.GeoServerTileLayerInfo;
-import org.geoserver.gwc.layer.TileLayerCatalog;
 import org.geoserver.platform.resource.ResourceStore;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -26,8 +25,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Implementation of {@link TileLayerCatalog} for {@link CatalogConfiguration} to manage {@link
- * GeoServerTileLayerInfo}s directly from the database instead of going through {@link
+ * Implementation of {@link TileLayerInfoRepository} for {@link CatalogConfiguration} to manage
+ * {@link GeoServerTileLayerInfo}s directly from the database instead of going through {@link
  * ResourceStore}.
  *
  * @since 1.7

--- a/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/TileLayerInfoRepository.java
+++ b/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/TileLayerInfoRepository.java
@@ -10,6 +10,11 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
+/**
+ * {@code TileLayerInfoRepository} defines CRUD operations on {@link TileLayerInfo}.
+ *
+ * @see PgconfigTileLayerCatalog
+ */
 public interface TileLayerInfoRepository {
 
     void add(TileLayerInfo pgInfo) throws DataAccessException;

--- a/src/gwc/core/pom.xml
+++ b/src/gwc/core/pom.xml
@@ -45,5 +45,15 @@
       <artifactId>gs-web-gwc</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.xmlunit</groupId>
+      <artifactId>xmlunit-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xmlunit</groupId>
+      <artifactId>xmlunit-assertj</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/event/TileLayerEvent.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/event/TileLayerEvent.java
@@ -41,11 +41,6 @@ public class TileLayerEvent extends GeoWebCacheEvent {
         this.name = layerName;
     }
 
-    public static TileLayerEvent ofId(
-            @NonNull Object source, @NonNull Type eventType, @NonNull String layerId) {
-        return new TileLayerEvent(source, eventType, layerId, layerId);
-    }
-
     public static TileLayerEvent created(
             @NonNull Object source, @NonNull String publishedId, @NonNull String layerName) {
         return valueOf(source, Type.CREATED, publishedId, layerName, null);
@@ -77,8 +72,20 @@ public class TileLayerEvent extends GeoWebCacheEvent {
 
     @Override
     public String toString() {
-        return "%s[%s id: %s, name: %s]"
-                .formatted(getClass().getSimpleName(), getEventType(), getPublishedId(), getName());
+        if (null == getOldName())
+            return "%s[%s id: %s, name: %s]"
+                    .formatted(
+                            getClass().getSimpleName(),
+                            getEventType(),
+                            getPublishedId(),
+                            getName());
+        return "%s[%s id: %s, name: %s, oldname: %s]"
+                .formatted(
+                        getClass().getSimpleName(),
+                        getEventType(),
+                        getPublishedId(),
+                        getName(),
+                        getOldName());
     }
 
     protected @Override String getObjectId() {

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/repository/ForwardingTileLayerCatalog.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/repository/ForwardingTileLayerCatalog.java
@@ -1,0 +1,20 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.gwc.repository;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Delegate;
+
+import org.geoserver.gwc.layer.TileLayerCatalog;
+
+/** Base class for {@link TileLayerCatalog} decorators */
+@RequiredArgsConstructor
+public abstract class ForwardingTileLayerCatalog implements TileLayerCatalog {
+
+    /** Note all {@link TileLayerCatalog} methods are delegated to this subject */
+    @Getter @Delegate @NonNull protected final TileLayerCatalog delegate;
+}

--- a/src/gwc/core/src/test/java/org/geoserver/cloud/gwc/repository/CachingTileLayerCatalogTest.java
+++ b/src/gwc/core/src/test/java/org/geoserver/cloud/gwc/repository/CachingTileLayerCatalogTest.java
@@ -1,0 +1,252 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.gwc.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.geoserver.cloud.gwc.event.TileLayerEvent;
+import org.geoserver.gwc.layer.GWCGeoServerConfigurationProvider;
+import org.geoserver.gwc.layer.GeoServerTileLayerInfo;
+import org.geoserver.gwc.layer.GeoServerTileLayerInfoImpl;
+import org.geoserver.gwc.layer.TileLayerCatalog;
+import org.geoserver.gwc.layer.TileLayerCatalogListener;
+import org.geoserver.platform.GeoServerResourceLoader;
+import org.geoserver.platform.resource.ResourceStore;
+import org.geowebcache.config.XMLConfigurationProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.io.File;
+import java.util.Map;
+import java.util.Optional;
+
+class CachingTileLayerCatalogTest {
+
+    private CachingTileLayerCatalog caching;
+    private ResourceStoreTileLayerCatalog catalog;
+
+    private @TempDir File baseDirectory;
+    private ResourceStore resourceLoader;
+
+    private CacheManager cacheManager;
+
+    @BeforeEach
+    void beforeEach() {
+        resourceLoader = new GeoServerResourceLoader(baseDirectory);
+        new File(baseDirectory, "gwc-layers").mkdir();
+
+        WebApplicationContext context = mock(WebApplicationContext.class);
+
+        Map<String, XMLConfigurationProvider> configProviders =
+                Map.of("gs", new GWCGeoServerConfigurationProvider());
+
+        when(context.getBeansOfType(XMLConfigurationProvider.class)).thenReturn(configProviders);
+        when(context.getBean("gs")).thenReturn(configProviders.get("gs"));
+
+        Optional<WebApplicationContext> webappCtx = Optional.of(context);
+        catalog = new ResourceStoreTileLayerCatalog(resourceLoader, webappCtx);
+        catalog.initialize();
+
+        cacheManager = new CaffeineCacheManager();
+        caching = new CachingTileLayerCatalog(cacheManager, catalog);
+        caching.initialize();
+    }
+
+    @Test
+    public void initialize() {
+        caching = new CachingTileLayerCatalog(cacheManager, catalog);
+        assertThat(caching.idCache).isNull();
+        assertThat(caching.namesById).isNotNull().isEmpty();
+
+        add(catalog, "tl1");
+        add(catalog, "tl2");
+
+        caching.initialize();
+        assertThat(caching.idCache).isNotNull();
+        assertThat(caching.namesById).isNotNull().hasSize(2);
+    }
+
+    @Test
+    public void reset() {
+
+        assertThat(caching.idCache).isNotNull();
+        add(caching, "tl1");
+        add(caching, "tl2");
+        assertThat(caching.namesById).isNotNull().hasSize(2);
+
+        caching.reset();
+        assertThat(caching.idCache).isNull();
+        assertThat(caching.namesById).isNotNull().isEmpty();
+    }
+
+    @Test
+    public void onTileLayerEvent() {
+        final String origName = "origName";
+        final String newName = "newName";
+        catalog.addListener(
+                new TileLayerCatalogListener() {
+                    @Override
+                    public void onEvent(String layerId, Type type) {
+                        TileLayerEvent event =
+                                switch (type) {
+                                    case CREATE -> TileLayerEvent.created(this, layerId, origName);
+                                    case MODIFY -> TileLayerEvent.modified(
+                                            this, layerId, newName, origName);
+                                    case DELETE -> TileLayerEvent.deleted(this, layerId, newName);
+                                    default -> throw new IllegalStateException();
+                                };
+                        caching.onTileLayerEvent(event);
+                    }
+                });
+
+        // do crud ops bypassing the caching decorator, expect the events have the desired effect
+        assertThat(caching.idCache.get("tl1")).isNull();
+        var tl1 = add(catalog, "tl1", origName);
+        assertThat(caching.namesById.get("tl1"))
+                .as("create event should have added the id->name mapping")
+                .isNotNull()
+                .isEqualTo(origName);
+        assertThat(caching.idCache.get("tl1")).as("create event doesn't cache a value").isNull();
+
+        // force caching the entry
+        caching.getLayerById("tl1");
+        assertThat(caching.idCache.get("tl1")).isNotNull();
+
+        tl1.setName(newName);
+        catalog.save(tl1);
+        assertThat(caching.namesById.get("tl1"))
+                .isNotNull()
+                .as("update event should have updated the id->name mapping")
+                .isEqualTo(newName);
+
+        assertThat(caching.idCache.get("tl1")).as("update event should have evicted").isNull();
+
+        assertThat(caching.getLayerById("tl1"))
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("name", newName);
+
+        catalog.delete(tl1.getId());
+        assertThat(caching.idCache.get("tl1")).as("delete event should have evicted").isNull();
+        assertThat(caching.namesById.get("tl1")).isNull();
+    }
+
+    @Test
+    public void getLayerNames() {
+        add(catalog, "tl1");
+        add(catalog, "tl2");
+        caching.initialize();
+        assertThat(caching.getLayerNames()).isEqualTo(catalog.getLayerNames());
+    }
+
+    @Test
+    public void save() {
+        add(caching, "tl1");
+        var tl = add(caching, "tl2");
+
+        tl.setEnabled(false);
+        tl.setMetaTilingX(9);
+
+        caching.save(tl);
+
+        assertThat(catalog.getLayerById(tl.getId())).isNotSameAs(tl).isEqualTo(tl);
+        assertThat(caching.idCache.get(tl.getId(), GeoServerTileLayerInfo.class)).isEqualTo(tl);
+
+        tl.setName("newname");
+        caching.save(tl);
+
+        assertThat(caching.namesById.get(tl.getId())).isEqualTo("newname");
+        assertThat(caching.idCache.get(tl.getId(), GeoServerTileLayerInfo.class)).isEqualTo(tl);
+        assertThat(catalog.getLayerById(tl.getId())).isNotSameAs(tl).isEqualTo(tl);
+    }
+
+    @Test
+    public void delete() {
+        add(caching, "tl1");
+        add(caching, "tl2");
+
+        assertThat(caching.idCache.get("tl1", GeoServerTileLayerInfo.class)).isNotNull();
+        assertThat(caching.idCache.get("tl2", GeoServerTileLayerInfo.class)).isNotNull();
+
+        caching.delete("tl2");
+        assertThat(caching.idCache.get("tl2", GeoServerTileLayerInfo.class)).isNull();
+        assertThat(catalog.getLayerById("tl2")).isNull();
+        assertThat(caching.getLayerById("tl2")).isNull();
+
+        assertThat(caching.idCache.get("tl1", GeoServerTileLayerInfo.class)).isNotNull();
+        assertThat(caching.getLayerById("tl1")).isNotNull();
+    }
+
+    @Test
+    public void getLayerId() {
+        add(caching, "tl1", "name1");
+        add(caching, "tl2", "name2");
+
+        assertThat(caching.getLayerId("name1")).isEqualTo("tl1");
+        assertThat(caching.getLayerId("name2")).isEqualTo("tl2");
+    }
+
+    @Test
+    public void getLayerName() {
+        // bypass cache
+        add(catalog, "tl1", "name1");
+        add(catalog, "tl2", "name2");
+
+        assertThat(caching.getLayerName("tl1")).isNotNull().isEqualTo("name1");
+        assertThat(caching.getLayerName("tl2")).isNotNull().isEqualTo("name2");
+    }
+
+    @Test
+    public void getLayerById() {
+        add(catalog, "tl1", "name1");
+        add(catalog, "tl2", "name2");
+
+        assertThat(caching.getLayerById("tl1"))
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("name", "name1");
+        assertThat(caching.getLayerById("tl3")).isNull();
+    }
+
+    @Test
+    public void getLayerByName() {
+        // bypass cache
+        add(catalog, "tl1", "name1");
+        add(catalog, "tl2", "name2");
+
+        assertThat(caching.getLayerByName("name1"))
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("id", "tl1");
+
+        // simulate a cache evicted, id to name mapping exists but layer is not cached
+        caching.namesById.put("tl2", "name2");
+        assertThat(caching.getLayerByName("name2"))
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("id", "tl2");
+
+        assertThat(caching.getLayerByName("name3")).isNull();
+    }
+
+    private GeoServerTileLayerInfo add(TileLayerCatalog target, String name) {
+        return add(target, name, name);
+    }
+
+    private GeoServerTileLayerInfo add(TileLayerCatalog target, String id, String name) {
+        GeoServerTileLayerInfo info = create(id, name);
+        target.save(info);
+        return info;
+    }
+
+    private GeoServerTileLayerInfo create(String id, String name) {
+        GeoServerTileLayerInfo info = new GeoServerTileLayerInfoImpl();
+        info.setId(id);
+        info.setName(name);
+        return info;
+    }
+}


### PR DESCRIPTION
In vanilla GeoServer, `CatalogConfiguration` is the `TileLayerConfiguration` contributed to the app context to serve `TileLayer`s (`GeoServerTileLayer`) from the GeoServer `Catalog` by means of a `TileLayerCatalog`.

This update contributes a different `TileLayerConfiguration` for the same purpose, `GeoServerTileLayerConfiguration`, which is a distributed-event-aware decorator over the actual `CloudCatalogConfiguration` implementation of `TileLayerCatalog`.

Since `CloudCatalogConfiguration` is therefore not a Spring bean (to avoid registering it as a delegate to `TileLayerDispatcher`), `TileLayerEvents` need to be relayed from `GeoServerTileLayerConfiguration` to `CloudCatalogConfiguration#onTileLayerEventEvict()`.