### PR TITLE
Upgrade GeoServer to 2.26.1.1

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -25,7 +25,7 @@
     <spring.version>5.3.39</spring.version>
     <spring.security.version>5.8.15</spring.security.version>
     <jackson.version>2.17.2</jackson.version>
-    <gs.version>2.26.1.0</gs.version>
+    <gs.version>2.26.1.1</gs.version>
     <gt.version>32.1</gt.version>
     <acl.version>2.3.1</acl.version>
     <postgresql.version>42.7.3</postgresql.version>


### PR DESCRIPTION
Applies the patch for

* [GEOS-11647](https://osgeo-org.atlassian.net/browse/GEOS-11647)