### PR TITLE
Resolve ambiguous handler mapping in SeedController

### DIFF
--- a/src/gwc/services/src/main/java/org/geoserver/cloud/gwc/config/services/RESTConfigConfiguration.java
+++ b/src/gwc/services/src/main/java/org/geoserver/cloud/gwc/config/services/RESTConfigConfiguration.java
@@ -7,12 +7,14 @@ package org.geoserver.cloud.gwc.config.services;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.gwc.controller.GwcUrlHandlerMapping;
 import org.geoserver.gwc.layer.GWCGeoServerRESTConfigurationProvider;
+import org.geowebcache.rest.controller.SeedController;
 import org.geowebcache.rest.converter.GWCConverter;
 import org.geowebcache.util.ApplicationContextProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 
 /**
  * The original {@literal geowebcache-rest-context.xml}:
@@ -51,8 +53,15 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(GWCConverter.class)
-@ComponentScan(basePackages = "org.geowebcache.rest")
+@ComponentScan(
+        basePackages = "org.geowebcache.rest",
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SeedController.class))
 public class RESTConfigConfiguration {
+
+    @Bean
+    org.geoserver.cloud.gwc.config.services.SeedController seedController() {
+        return new org.geoserver.cloud.gwc.config.services.SeedController();
+    }
 
     /**
      * The original {@literal geowebcache-rest-context.xml}:

--- a/src/gwc/services/src/main/java/org/geoserver/cloud/gwc/config/services/SeedController.java
+++ b/src/gwc/services/src/main/java/org/geoserver/cloud/gwc/config/services/SeedController.java
@@ -1,0 +1,46 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.gwc.config.services;
+
+import java.io.InputStream;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.*;
+
+@Component
+@RestController
+@RequestMapping(path = "${gwc.context.suffix:}/rest")
+public class SeedController extends org.geowebcache.rest.controller.SeedController {
+
+    /**
+     *
+     * {@inheritDoc}
+     * <p>
+     * Override for the {@code path} pattern to exclude {@code .xml} and
+     * {@code .json} suffixes to avoid an exception like the following with
+     * {@link #seedOrTruncateWithJsonPayload} and
+     * {@link #seedOrTruncateWithXmlPayload}:
+     * <pre>
+     * <code>
+     * java.lang.IllegalStateException: Ambiguous handler methods mapped for '.../rest/seed/workspace:layer.xml': {
+     *   public org.springframework.http.ResponseEntity org.geoserver.cloud.gwc.config.services.SeedController.seedOrTruncateWithXmlPayload(...),
+     *   public org.springframework.http.ResponseEntity org.geoserver.cloud.gwc.config.services.SeedController.doPost(...)
+     *  }
+     * </code>
+     * </pre>
+     */
+    @Override
+    @PostMapping("/seed/{layer:^(?!.*\\.(?:xml|json)$).+}")
+    public ResponseEntity<?> doPost(
+            HttpServletRequest request,
+            InputStream inputStream,
+            @PathVariable String layer,
+            @RequestParam Map<String, String> params) {
+
+        return super.doPost(request, inputStream, layer, params);
+    }
+}


### PR DESCRIPTION
Override the `@PostMapping` path pattern in `SeedController` to exclude `.xml` and `.json` suffixes, addressing a stricter behavior in Spring Boot compared to regular Spring. This resolves a potential `IllegalStateException` caused by ambiguous handler methods.

- Updated `doPost` endpoint path to use regex excluding `.xml` and `.json`.
- Prevents conflicts between JSON and XML payload handlers (`seedOrTruncateWithJsonPayload` and `seedOrTruncateWithXmlPayload`).
- Fixes mapping collision issues observed when calling endpoints like `/rest/seed/workspace:layer.xml` under Spring Boot.

This change ensures compatibility with Spring Boot's stricter handler mapping rules while maintaining functionality consistent with the base `SeedController` logic.

---

Fixes #502