### PR TITLE
Avoid log flooding with exceptions on catalog events tests

### DIFF
--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/core/RemoteEventResourcePoolCleanupUpAutoConfiguration.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/catalog/backend/core/RemoteEventResourcePoolCleanupUpAutoConfiguration.java
@@ -4,8 +4,8 @@
  */
 package org.geoserver.cloud.autoconfigure.catalog.backend.core;
 
+import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.ResourcePool;
-import org.geoserver.catalog.plugin.CatalogPlugin;
 import org.geoserver.cloud.autoconfigure.catalog.event.ConditionalOnCatalogEvents;
 import org.geoserver.cloud.event.info.InfoEvent;
 import org.geoserver.cloud.event.remote.resourcepool.RemoteEventResourcePoolProcessor;
@@ -25,8 +25,7 @@ import org.springframework.context.annotation.Bean;
 public class RemoteEventResourcePoolCleanupUpAutoConfiguration {
 
     @Bean
-    RemoteEventResourcePoolProcessor remoteEventResourcePoolProcessor(
-            @Qualifier("rawCatalog") CatalogPlugin rawCatalog) {
+    RemoteEventResourcePoolProcessor remoteEventResourcePoolProcessor(@Qualifier("rawCatalog") Catalog rawCatalog) {
 
         return new RemoteEventResourcePoolProcessor(rawCatalog);
     }

--- a/src/catalog/backends/common/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/core/RemoteEventResourcePoolCleanupUpAutoConfigurationTest.java
+++ b/src/catalog/backends/common/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/core/RemoteEventResourcePoolCleanupUpAutoConfigurationTest.java
@@ -6,9 +6,10 @@ package org.geoserver.cloud.autoconfigure.catalog.backend.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.geoserver.catalog.plugin.CatalogPlugin;
+import org.geoserver.catalog.Catalog;
 import org.geoserver.cloud.event.info.InfoEvent;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -16,7 +17,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 class RemoteEventResourcePoolCleanupUpAutoConfigurationTest {
 
     private final ApplicationContextRunner runner = new ApplicationContextRunner()
-            .withBean("rawCatalog", CatalogPlugin.class)
+            .withBean("rawCatalog", Catalog.class, () -> Mockito.mock(Catalog.class))
             .withConfiguration(AutoConfigurations.of(RemoteEventResourcePoolCleanupUpAutoConfiguration.class));
 
     @Test

--- a/src/catalog/event-bus/src/test/java/org/geoserver/cloud/event/bus/TestConfigurationAutoConfiguration.java
+++ b/src/catalog/event-bus/src/test/java/org/geoserver/cloud/event/bus/TestConfigurationAutoConfiguration.java
@@ -4,24 +4,57 @@
  */
 package org.geoserver.cloud.event.bus;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Optional;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.plugin.CatalogPlugin;
+import org.geoserver.config.ConfigurationListener;
 import org.geoserver.config.DefaultGeoServerLoader;
 import org.geoserver.config.GeoServer;
+import org.geoserver.config.GeoServerConfigPersister;
 import org.geoserver.config.GeoServerLoader;
+import org.geoserver.config.ServicePersister;
 import org.geoserver.config.plugin.GeoServerImpl;
 import org.geoserver.config.util.XStreamPersisterFactory;
+import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.platform.config.DefaultUpdateSequence;
 import org.geoserver.platform.config.UpdateSequence;
+import org.geoserver.util.IOUtils;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.event.ContextClosedEvent;
 
 @EnableAutoConfiguration
 @SpringBootConfiguration
-public class TestConfigurationAutoConfiguration {
+public class TestConfigurationAutoConfiguration implements InitializingBean, ApplicationListener<ContextClosedEvent> {
+
+    private File tmpDir;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        this.tmpDir = java.nio.file.Files.createTempDirectory("gs").toFile();
+    }
+
+    @Override
+    public void onApplicationEvent(ContextClosedEvent event) {
+        try {
+            IOUtils.delete(tmpDir, true);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Bean
+    GeoServerResourceLoader geoServerResourceLoader() {
+        return new GeoServerResourceLoader(tmpDir);
+    }
 
     @Bean
     UpdateSequence testUpdateSequence(GeoServer gs) {
@@ -34,8 +67,9 @@ public class TestConfigurationAutoConfiguration {
     }
 
     @Bean(name = {"catalog", "rawCatalog"})
-    public Catalog catalog() {
-        return new CatalogPlugin(false);
+    Catalog catalog() {
+        final boolean isolated = false;
+        return new CatalogPlugin(isolated);
     }
 
     @Bean
@@ -46,8 +80,8 @@ public class TestConfigurationAutoConfiguration {
     }
 
     @Bean
-    GeoServerResourceLoader geoServerResourceLoader() {
-        return new GeoServerResourceLoader();
+    GeoServerExtensions geoserverExtensions() {
+        return new GeoServerExtensions();
     }
 
     @Bean
@@ -56,6 +90,19 @@ public class TestConfigurationAutoConfiguration {
             @Qualifier("geoServerResourceLoader") GeoServerResourceLoader geoServerResourceLoader) {
         DefaultGeoServerLoader loader = new DefaultGeoServerLoader(geoServerResourceLoader);
         loader.postProcessBeforeInitialization(geoServer, "geoserver");
+
+        removeListener(geoServer, ServicePersister.class);
+        removeListener(geoServer, GeoServerConfigPersister.class);
+
         return loader;
+    }
+
+    private void removeListener(GeoServer geoServer, Class<? extends ConfigurationListener> type) {
+        Optional<ConfigurationListener> listener =
+                geoServer.getListeners().stream().filter(type::isInstance).findFirst();
+
+        if (listener.isPresent()) {
+            geoServer.removeListener(listener.orElseThrow());
+        }
     }
 }


### PR DESCRIPTION
Catalog events tests are not running off a full GeoServer instance, and the GeoServerLoader is trying to find unavailable service loaders, resulting in unnecessary log flooding.