### PR TITLE
Update acl docker image version to 2.3.1

### DIFF
--- a/docs/deploy/docker-compose/stable/pgconfig/compose.yml
+++ b/docs/deploy/docker-compose/stable/pgconfig/compose.yml
@@ -26,7 +26,7 @@ services:
           memory: 4G
     
   acl:
-    image: geoservercloud/geoserver-acl:2.2.0
+    image: geoservercloud/geoserver-acl:2.3.1
     user: 1000:1000
     depends_on:
       pgconfigdb:


### PR DESCRIPTION
This fixes an issue where the plugin on the geoserver uses an endpoint that was released in 2.3.0, resulting in a 404 when trying to call an endpoint using acl.

Relevant change: https://github.com/geoserver/geoserver-acl/pull/68