### PR TITLE
Upgrade GeoServer ACL 2.3.1 -> 2.4-SNAPSHOT

### DIFF
--- a/compose/localports.yml
+++ b/compose/localports.yml
@@ -3,6 +3,9 @@
 # Port numbers match the ones in the `local` spring profile used for development.
 services:
   # catalog microservice, provides a unified catalog backend to all services
+  acl:
+    ports:
+      - 9000:8080
   wfs:
     ports:
       - 9101:8080

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -27,7 +27,7 @@
     <jackson.version>2.18.2</jackson.version>
     <gs.version>2.27.0-SNAPSHOT</gs.version>
     <gt.version>33-SNAPSHOT</gt.version>
-    <acl.version>2.3.1</acl.version>
+    <acl.version>2.4-SNAPSHOT</acl.version>
     <postgresql.version>42.7.3</postgresql.version>
     <!-- Same netty.version used by geoserver for COG and GWC Azure plugin -->
     <netty.version>4.1.113.Final</netty.version>


### PR DESCRIPTION
Upgrade to gs-acl:2.4-SNAPSHOT to fix the plugin issues in the webui after the upgrade to Wicket 9
See https://github.com/geoserver/geoserver-acl/pull/78
