### PR TITLE
Enforce Maven 3.9+ for improved plugin version resolution

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -989,6 +989,16 @@
           <artifactId>versions-maven-plugin</artifactId>
           <version>2.16.1</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.5.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>2.18.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -999,7 +1009,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.4.1</version>
         <executions>
           <execution>
             <id>enforce</id>
@@ -1012,7 +1021,19 @@
                   <version>[21,)</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
-                  <version>[3.6.3,)</version>
+                  <!--
+                    Enforcing a minimum Maven version is crucial to ensure that:
+                    - Plugin version resolution works as expected: Different Maven versions
+                      may resolve plugin versions differently due to changes in the default
+                      lifecycle mappings, dependency resolution behavior, and plugin inheritance.
+                    - Features and bug fixes required by newer plugins are available: For example,
+                      some plugins (e.g., surefire-plugin 3.x) require Maven 3.6+ or 3.8+.
+                    - Consistent builds across environments: Without enforcing a Maven version,
+                      developers or CI/CD pipelines using different Maven versions may face
+                      unexpected build failures or inconsistencies.
+                  -->
+                  <version>3.9+</version>
+                  <message>You must use Maven 3.9 or higher to build this project.</message>
                 </requireMavenVersion>
                 <dependencyConvergence>
                   <excludedScopes>test</excludedScopes>
@@ -1021,6 +1042,10 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Enforcing Maven 3.9+ ensures consistent plugin version resolution across all environments. Different Maven versions may resolve plugin versions differently due to changes in:

- Default lifecycle plugin mappings (e.g., maven-compiler-plugin, maven-surefire-plugin)
- Dependency resolution behavior for both plugins and their transitive dependencies
- Compatibility improvements and bug fixes in newer Maven versions

By standardizing the required Maven version, we can ensure:
- Plugins work correctly with the expected Maven features
- Consistent builds in both developer machines and CI/CD environments
- Easier decision-making regarding which plugin versions to use for compatibility and stability

This change will prevent unexpected build failures or inconsistencies caused by older Maven versions and will help identify the best plugin versions to use that are fully compatible with Maven 3.9+.