### PR TITLE
Run catalog-datadir dev compose with a Docker-managed volume

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,8 +164,6 @@ run-acceptance-tests-datadir:
 .PHONY: clean-acceptance-tests-datadir
 clean-acceptance-tests-datadir:
 	(cd compose/ && ./acceptance_datadir down -v)
-	rm -rf compose/catalog-datadir/*
-	touch compose/catalog-datadir/.keep
 
 .PHONY: acceptance-tests-pgconfig
 acceptance-tests-pgconfig: build-acceptance start-acceptance-tests-pgconfig run-acceptance-tests-pgconfig

--- a/compose/catalog-datadir.yml
+++ b/compose/catalog-datadir.yml
@@ -7,11 +7,11 @@
 name: gscloud_dev_datadir
 
 volumes:
-  datadir:
-    driver_opts:
-      type: none
-      o: bind
-      device: $PWD/catalog-datadir
+  data_directory:
+#    driver_opts:
+#      type: none
+#      o: bind
+#      device: $PWD/catalog-datadir
   
 services:
   init-datadir:
@@ -19,7 +19,7 @@ services:
     user: ${GS_USER}
     command: sh -c "cd /opt/app/data_directory; if [ ! -f global.xml ]; then tar xvzf /tmp/datadir.tgz; fi"
     volumes:
-      - datadir:/opt/app/data_directory
+      - data_directory:/opt/app/data_directory
       - ./catalog-datadir.tgz:/tmp/datadir.tgz
   wfs:
     environment:
@@ -28,7 +28,7 @@ services:
       init-datadir:
         condition: service_completed_successfully
     volumes:
-      - datadir:/opt/app/data_directory:z
+      - data_directory:/opt/app/data_directory:z
 
   wms:
     environment:
@@ -37,7 +37,7 @@ services:
       init-datadir:
         condition: service_completed_successfully
     volumes:
-      - datadir:/opt/app/data_directory:z
+      - data_directory:/opt/app/data_directory:z
 
   wcs:
     environment:
@@ -46,7 +46,7 @@ services:
       init-datadir:
         condition: service_completed_successfully
     volumes:
-      - datadir:/opt/app/data_directory:z
+      - data_directory:/opt/app/data_directory:z
 
   wps:
     environment:
@@ -55,7 +55,7 @@ services:
       init-datadir:
         condition: service_completed_successfully
     volumes:
-      - datadir:/opt/app/data_directory:z
+      - data_directory:/opt/app/data_directory:z
 
   rest:
     environment:
@@ -64,7 +64,7 @@ services:
       init-datadir:
         condition: service_completed_successfully
     volumes:
-      - datadir:/opt/app/data_directory:z
+      - data_directory:/opt/app/data_directory:z
 
   webui:
     environment:
@@ -73,7 +73,7 @@ services:
       init-datadir:
         condition: service_completed_successfully
     volumes:
-      - datadir:/opt/app/data_directory:z
+      - data_directory:/opt/app/data_directory:z
 
   gwc:
     environment:
@@ -82,4 +82,5 @@ services:
       init-datadir:
         condition: service_completed_successfully
     volumes:
-      - datadir:/opt/app/data_directory:z
+      - data_directory:/opt/app/data_directory:z
+


### PR DESCRIPTION
This commit updates the **catalog-datadir** development environment to use a **Docker-managed volume** instead of a bind mount.

This improves portability, simplifies volume management, and avoids potential permission issues when running on different environments.

---

- **Replaced `datadir` bind-mounted volume** with a **Docker-managed volume (`data_directory`)**.
- **Updated `Makefile` cleanup process**:
  - Removed manual deletion of `compose/catalog-datadir/*` to prevent conflicts with Docker-managed volumes.
  - Deleted the `.keep` file since the directory is now managed by Docker.
- **Updated all services (`wfs`, `wms`, `wcs`, `wps`, `rest`, `webui`, `gwc`)** to use `data_directory` instead of `datadir`.

---

✅ **Improves portability** – Works across environments without needing to manually create `catalog-datadir/`.
 ✅ **Fixes permission issues** – Avoids bind-mounting a directory owned by the host, which could cause write issues inside containers.
 ✅ **Simplifies cleanup** – No need to manually delete files; Docker handles volume persistence.