### PR TITLE
Upgrade GeoServer to 2.26.3-SNAPSHOT

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -25,8 +25,8 @@
     <spring.version>5.3.39</spring.version>
     <spring.security.version>5.8.16</spring.security.version>
     <jackson.version>2.17.2</jackson.version>
-    <gs.version>2.26.2.0</gs.version>
-    <gt.version>32.2</gt.version>
+    <gs.version>2.26.3-SNAPSHOT</gs.version>
+    <gt.version>32-SNAPSHOT</gt.version>
     <acl.version>2.3.1</acl.version>
     <postgresql.version>42.7.3</postgresql.version>
     <!-- Same netty.version used by geoserver for COG and GWC Azure plugin -->


### PR DESCRIPTION
Required to include the fix for [GEOT-7718 make the parsing of LogoURL lenient](https://osgeo-org.atlassian.net/browse/GEOT-7718)