### PR TITLE
Fix GeoServer LDAP Authentication

### DIFF
--- a/compose/infra.yml
+++ b/compose/infra.yml
@@ -59,3 +59,32 @@ services:
         limits:
           cpus: '2.0'
           memory: 512M
+
+  # Sample LDAP server to test LDAP Auth against
+  # Go to Authentication -> Authentication Providers -> Add new -> LDAP
+  # * Server URL: ldap://ldap:389/dc=georchestra,dc=org
+  # * User lookup pattern: uid={0},ou=users
+  # * Use LDAP groups for authorization: check
+  # * Enable Hierarchical groups search: check
+  # * Nested group search filter: member={0}
+  # Save
+  # Provider Chain -> add the ldap provider to the "Selected" list
+  # Save
+  # Then login with either testadmin/testadmin or testuser/testuser
+  ldap:
+    image: georchestra/ldap:latest
+    environment:
+        - SLAPD_ORGANISATION=georchestra
+        - SLAPD_DOMAIN=georchestra.org
+        - SLAPD_PASSWORD=secret
+        - SLAPD_LOG_LEVEL=32768 # See https://www.openldap.org/doc/admin24/slapdconfig.html#loglevel%20%3Clevel%3E
+    restart: unless-stopped
+    ports:
+      - 389:389
+    deploy:
+      mode: replicated
+      replicas: 0
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 512M

--- a/src/library/spring-boot-simplejndi/pom.xml
+++ b/src/library/spring-boot-simplejndi/pom.xml
@@ -38,5 +38,10 @@
       <artifactId>postgresql</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/library/spring-boot-simplejndi/src/main/java/org/geoserver/cloud/jndi/SimpleNamingContextBuilder.java
+++ b/src/library/spring-boot-simplejndi/src/main/java/org/geoserver/cloud/jndi/SimpleNamingContextBuilder.java
@@ -4,15 +4,29 @@
  */
 package org.geoserver.cloud.jndi;
 
+import static javax.naming.Context.INITIAL_CONTEXT_FACTORY;
+
 import java.util.Hashtable;
+import java.util.Map;
+import java.util.Optional;
 import javax.naming.spi.InitialContextFactory;
 import javax.naming.spi.InitialContextFactoryBuilder;
 import org.springframework.lang.Nullable;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
 
 /**
- * Simple implementation of a JNDI naming context builder.
+ * A simple implementation of a JNDI naming context builder that provides an
+ * initial context factory for applications requiring JNDI support.
  *
- * <p>Sample usage:
+ * <p>
+ * This builder allows the configuration of an {@link InitialContextFactory}
+ * dynamically based on environment properties. If no factory is explicitly
+ * provided in the environment, a default {@link SimpleNamingContextFactory} is
+ * used.
+ *
+ * <p>
+ * Example usage:
  *
  * <pre class="code">
  * SimpleNamingContextBuilder builder = new SimpleNamingContextBuilder();
@@ -27,10 +41,74 @@ import org.springframework.lang.Nullable;
  */
 public class SimpleNamingContextBuilder implements InitialContextFactoryBuilder {
 
+    /**
+     * Default factory instance used when no custom factory is provided in the
+     * environment.
+     */
     private final SimpleNamingContextFactory factory = new SimpleNamingContextFactory();
 
+    /**
+     * Creates an {@link InitialContextFactory} instance based on the provided
+     * environment properties.
+     *
+     * <p>
+     * If the environment specifies an {@link InitialContextFactory} class name or
+     * instance, through the {@code java.naming.factory.initial} parameter, this
+     * method attempts to instantiate and return it. Otherwise, it falls back to the
+     * default {@link SimpleNamingContextFactory}.
+     *
+     * @param environment a {@link Hashtable} containing JNDI environment
+     *                    properties, or {@code null}
+     * @return an instance of {@link InitialContextFactory}
+     * @throws IllegalArgumentException if the specified factory class is invalid or
+     *                                  does not implement
+     *                                  {@link InitialContextFactory}
+     * @throws IllegalStateException    if the specified factory class cannot be
+     *                                  instantiated
+     */
     @Override
     public InitialContextFactory createInitialContextFactory(@Nullable Hashtable<?, ?> environment) {
-        return factory;
+        // Return the default factory if no specific factory is provided in the
+        // environment's java.naming.factory.initial key.
+        return createFromEnvironment(environment).orElseGet(() -> this.factory);
+    }
+
+    private Optional<InitialContextFactory> createFromEnvironment(Map<?, ?> environment) {
+        InitialContextFactory fac = null;
+
+        Object factoryParam = (environment == null ? Map.of() : environment).get(INITIAL_CONTEXT_FACTORY);
+        if (factoryParam != null) {
+            Class<?> icfClass =
+                    switch (factoryParam) {
+                        case Class<?> c -> c;
+                        case String className -> loadClass(className);
+                        default -> throw invalidType(factoryParam);
+                    };
+
+            if (!InitialContextFactory.class.isAssignableFrom(icfClass)) {
+                throw new IllegalArgumentException("Specified class does not implement [%s]: %s"
+                        .formatted(InitialContextFactory.class.getName(), factoryParam));
+            }
+            fac = newInstance(icfClass);
+        }
+        return Optional.ofNullable(fac);
+    }
+
+    private InitialContextFactory newInstance(Class<?> icfClass) {
+        try {
+            return (InitialContextFactory)
+                    ReflectionUtils.accessibleConstructor(icfClass).newInstance();
+        } catch (Exception ex) {
+            throw new IllegalStateException("Unable to instantiate specified InitialContextFactory: " + icfClass, ex);
+        }
+    }
+
+    private IllegalArgumentException invalidType(Object factoryParam) {
+        return new IllegalArgumentException("Invalid value type for environment key [%s]: %s"
+                .formatted(INITIAL_CONTEXT_FACTORY, factoryParam.getClass().getName()));
+    }
+
+    private Class<?> loadClass(String className) {
+        return ClassUtils.resolveClassName(className, getClass().getClassLoader());
     }
 }

--- a/src/library/spring-boot-simplejndi/src/test/java/org/geoserver/cloud/config/jndi/SimpleJNDIStaticContextInitializerTest.java
+++ b/src/library/spring-boot-simplejndi/src/test/java/org/geoserver/cloud/config/jndi/SimpleJNDIStaticContextInitializerTest.java
@@ -24,7 +24,7 @@ class SimpleJNDIStaticContextInitializerTest {
             new ApplicationContextRunner().withInitializer(new SimpleJNDIStaticContextInitializer());
 
     @Test
-    void test() {
+    void testDefaultInitialContext() {
         runner.run(context -> {
             InitialContext initialContext = new InitialContext();
             Context ctx = NamingManager.getInitialContext(new Hashtable<>());
@@ -38,7 +38,7 @@ class SimpleJNDIStaticContextInitializerTest {
             assertThat(ctx.lookup("java:comp/env/test")).isSameAs(value);
 
             initialContext = new InitialContext();
-            ctx = NamingManager.getInitialContext(new Hashtable<>());
+            ctx = NamingManager.getInitialContext(null);
             assertThat(ctx).isInstanceOf(SimpleNamingContext.class);
 
             assertThat(initialContext.lookup("java:comp/env/test")).isSameAs(value);

--- a/src/library/spring-boot-simplejndi/src/test/java/org/geoserver/cloud/jndi/GeorchestraLdapContainer.java
+++ b/src/library/spring-boot-simplejndi/src/test/java/org/geoserver/cloud/jndi/GeorchestraLdapContainer.java
@@ -1,0 +1,44 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.jndi;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.Base58;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * A <a href="https://www.testcontainers.org">Testconainers</a> container to run
+ * georchestra's LDAP server as a JUnit {@code @Rule} based on
+ * {@code georchestra/ldap:latest}.
+ * <p>
+ * Get the host mapped port for {@code 389} with {@link #getMappedPort(int)
+ * getMappedPort(389)}, or directly with {@link #getMappedLdapPort()}
+ */
+class GeorchestraLdapContainer extends GenericContainer<GeorchestraLdapContainer> {
+
+    public GeorchestraLdapContainer() {
+        this(DockerImageName.parse("georchestra/ldap:latest"));
+    }
+
+    GeorchestraLdapContainer(final DockerImageName dockerImageName) {
+        super(dockerImageName);
+        withExposedPorts(389);
+        addEnv("SLAPD_ORGANISATION", "georchestra");
+        addEnv("SLAPD_DOMAIN", "georchestra.org");
+        addEnv("SLAPD_PASSWORD", "secret");
+        addEnv("SLAPD_LOG_LEVEL", "32768");
+
+        withCreateContainerCmdModifier(it -> it.withName("testcontainers-georchestra-ldap-" + Base58.randomString(8)));
+
+        // this is faster than Wait.forHealthcheck() which is set every 30secs in
+        // georchestra/ldap's Dockerfile
+        waitingFor(Wait.forLogMessage(".*slapd starting.*\\n", 1));
+    }
+
+    public int getMappedLdapPort() {
+        return getMappedPort(389);
+    }
+}

--- a/src/library/spring-boot-simplejndi/src/test/java/org/geoserver/cloud/jndi/SimpleNamingContextBuilderTest.java
+++ b/src/library/spring-boot-simplejndi/src/test/java/org/geoserver/cloud/jndi/SimpleNamingContextBuilderTest.java
@@ -14,16 +14,40 @@ import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.naming.NoInitialContextException;
+import javax.naming.directory.DirContext;
 import javax.naming.spi.NamingManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
  * Test suite for {@link SimpleNamingContextBuilder}
  *
  * @since 1.0
  */
+@Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS) // Use per-class lifecycle to initialize container once
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class SimpleNamingContextBuilderTest {
 
+    @Container
+    private static final GeorchestraLdapContainer LDAP_CONTAINER = new GeorchestraLdapContainer();
+
+    @BeforeAll
+    static void beforeAll() {
+        LDAP_CONTAINER.start();
+        System.setProperty("ldapPort", String.valueOf(LDAP_CONTAINER.getMappedLdapPort()));
+        System.setProperty("ldapHost", LDAP_CONTAINER.getHost());
+        System.out.println("Automatically set system property ldapPort=" + LDAP_CONTAINER.getMappedLdapPort());
+        System.out.println("Automatically set system property ldapHost=" + LDAP_CONTAINER.getHost());
+    }
+
+    @Order(1)
     @Test
     void testInitialContext() throws NamingException {
         assertFalse(NamingManager.hasInitialContextFactoryBuilder());
@@ -36,11 +60,59 @@ class SimpleNamingContextBuilderTest {
         assertThat(context).isInstanceOf(SimpleNamingContext.class);
     }
 
+    @Order(2)
     @Test
     void testNewInitialContext() throws NamingException {
         System.setProperty(Context.INITIAL_CONTEXT_FACTORY, SimpleNamingContextFactory.class.getName());
         InitialContext ctx = new InitialContext();
         Context subcontext = ctx.createSubcontext("java:comp");
         assertThat(subcontext).isInstanceOf(SimpleNamingContext.class);
+    }
+
+    /**
+     * Simulates an LDAP authentication request as performed by GeoServer
+     */
+    @Order(3)
+    @Test
+    void testParameterizedLDAPInitialContextFactory() throws NamingException, ClassNotFoundException {
+        Hashtable<Object, Object> env = new Hashtable<>();
+        // should work if java.naming.factory.initial is a String
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+        env.put("java.naming.factory.object", "org.springframework.ldap.core.support.DefaultDirObjectFactory");
+        env.put("java.naming.ldap.version", "3");
+
+        final int ldapPort = LDAP_CONTAINER.getMappedLdapPort();
+        env.put("org.springframework.ldap.base.path", "dc=georchestra,dc=org");
+        env.put("java.naming.provider.url", "ldap://localhost:%d/dc=georchestra,dc=org".formatted(ldapPort));
+        env.put("java.naming.security.principal", "uid=testadmin,ou=users,dc=georchestra,dc=org");
+        env.put("java.naming.security.authentication", "simple");
+        env.put("java.naming.security.credentials", "testadmin");
+
+        Context context = NamingManager.getInitialContext(env);
+        assertThat(context).isInstanceOf(DirContext.class);
+
+        // and should work if java.naming.factory.initial is a Class
+        env.put(Context.INITIAL_CONTEXT_FACTORY, Class.forName("com.sun.jndi.ldap.LdapCtxFactory"));
+        context = NamingManager.getInitialContext(env);
+        assertThat(context).isInstanceOf(DirContext.class);
+    }
+
+    @Order(4)
+    @Test
+    void testInvalidInitialContextFactoryParams() {
+
+        Hashtable<Object, Object> env = new Hashtable<>();
+
+        env.put(Context.INITIAL_CONTEXT_FACTORY, java.lang.Integer.class);
+        assertThrows(IllegalArgumentException.class, () -> NamingManager.getInitialContext(env));
+
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "java.lang.Integer");
+        assertThrows(IllegalArgumentException.class, () -> NamingManager.getInitialContext(env));
+
+        env.put(Context.INITIAL_CONTEXT_FACTORY, Integer.valueOf(1));
+        assertThrows(IllegalArgumentException.class, () -> NamingManager.getInitialContext(env));
+
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "no.such.Class");
+        assertThrows(IllegalArgumentException.class, () -> NamingManager.getInitialContext(env));
     }
 }


### PR DESCRIPTION
This commit fixes an issue where GeoServer Cloud's LDAP authentication was failing due to the JNDI context builder not correctly handling a parameterized `java.naming.factory.initial` value.

- **Fixed `SimpleNamingContextBuilder` to respect a provided `INITIAL_CONTEXT_FACTORY` parameter**:
  - If a JNDI environment specifies `java.naming.factory.initial`, the builder now correctly instantiates and returns the corresponding `InitialContextFactory`.
  - Previously, the builder ignored the parameter, always returning the default `SimpleNamingContextFactory`, preventing external JNDI implementations (such as LDAP) from being used.
  - Refactored logic into `createFromEnvironment()` for better readability and maintainability.

- **Enhanced tests for `SimpleNamingContextBuilder`**:
  - Added a test case to verify that a custom JNDI factory (e.g., `com.sun.jndi.ldap.LdapCtxFactory`) is instantiated when specified.
  - Ensured incorrect values (e.g., non-class types, invalid class names) trigger expected exceptions.
  - Refactored test class to use `@TestMethodOrder` to ensure execution order consistency.

- **Added a sample OpenLDAP service to `infra.yml`**:
  - Provides a test LDAP server for validating authentication against GeoServer Cloud.
  - Includes setup instructions for configuring LDAP authentication in GeoServer.

1. Run the updated GeoServer Cloud stack with the new LDAP service:
```
   cd compose/
   ./datadir up -d
   ./datadir scale ldap=1
```

(or `./pgconfig` instead of `./datadir`)

2. Configure LDAP authentication in GeoServer:
   - Go to **Authentication → Authentication Providers → Add new → LDAP**.
   - Set **Server URL**: `ldap://ldap:389/dc=georchestra,dc=org`.
   - Configure:
     - **User lookup pattern**: `uid={0},ou=users`
     - **Enable LDAP groups for authorization**: check
     - **Enable Hierarchical groups search**: check
     - **Nested group search filter**: `member={0}`

3. Save and add the new LDAP provider to the authentication chain.

4. Test authentication using:
   - Username: `testadmin`, Password: `testadmin`
   - Username: `testuser`, Password: `testuser`

5. Check the logs to ensure no `NotContextException` errors occur.

- Fixes LDAP authentication issues when running GeoServer Cloud with JNDI-based user authentication.
- Improves modularity and correctness of JNDI context initialization.
- Allows external authentication providers to function as expected.