### PR TITLE
Add optional Inspire extension support to GeoServer Cloud

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
       </dependency>
       <dependency>
         <groupId>org.geoserver.cloud.extensions</groupId>
+        <artifactId>gs-cloud-extension-inspire</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.cloud.extensions</groupId>
         <artifactId>gs-cloud-extension-vector-formats</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/src/extensions/inspire/README.md
+++ b/src/extensions/inspire/README.md
@@ -1,0 +1,35 @@
+# INSPIRE Extension
+
+Auto-configuration for GeoServer INSPIRE extension.
+
+## Features
+
+This extension:
+- Provides auto-configuration for INSPIRE support in GeoServer
+- Conditionally enables or disables based on configuration properties
+
+## Configuration
+
+The extension can be configured using the following properties:
+
+```yaml
+geoserver:
+  extension:
+    inspire:
+      enabled: false  # Enable/disable INSPIRE extension (default: false)
+```
+
+## Implementation Details
+
+The extension uses Spring Boot auto-configuration to conditionally register INSPIRE support. Key classes:
+
+- `InspireAutoConfiguration`: Main auto-configuration class that controls the INSPIRE extension
+- `InspireConfigProperties`: Configuration properties class for INSPIRE settings
+- `ConditionalOnInspire`: Composite conditional annotation for enabling INSPIRE support
+
+The extension registers the INSPIRE extension when:
+1. The `geoserver.extension.inspire.enabled` property is `true` (default is false)
+
+## Related Documentation
+
+- [GeoServer INSPIRE User Guide](https://docs.geoserver.org/main/en/user/extensions/inspire/index.html)

--- a/src/extensions/inspire/pom.xml
+++ b/src/extensions/inspire/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.geoserver.cloud.extensions</groupId>
+    <artifactId>gs-cloud-extensions</artifactId>
+    <version>${revision}</version>
+  </parent>
+  <artifactId>gs-cloud-extension-inspire</artifactId>
+  <packaging>jar</packaging>
+  <description>GeoServer INSPIRE extension</description>
+  <dependencies>
+    <dependency>
+      <groupId>org.geoserver.cloud.extensions</groupId>
+      <artifactId>gs-cloud-extensions-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-inspire</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.geoserver.web</groupId>
+          <artifactId>gs-web-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.web</groupId>
+      <artifactId>gs-web-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/ConditionalOnInspire.java
+++ b/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/ConditionalOnInspire.java
@@ -1,0 +1,43 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.geoserver.cloud.autoconfigure.extensions.ConditionalOnGeoServer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+/**
+ * Conditional annotation that only matches when:
+ * <ul>
+ *   <li>A GeoServer instance is available in the application context
+ *   <li>The INSPIRE extension is enabled via configuration property
+ * </ul>
+ *
+ * <p>This can be used on any Spring components that should only be registered when the
+ * INSPIRE extension is enabled.
+ *
+ * <p>Usage example:
+ * <pre>{@code
+ * @Configuration
+ * @ConditionalOnInspire
+ * public class MyInspireConfiguration {
+ *     // Configuration only activated when INSPIRE is enabled
+ * }
+ * }</pre>
+ *
+ * @since 2.27.0.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Documented
+@Inherited
+@ConditionalOnGeoServer
+@ConditionalOnProperty(prefix = InspireConfigProperties.PREFIX, name = "enabled", havingValue = "true")
+public @interface ConditionalOnInspire {}

--- a/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/InspireAutoConfiguration.java
+++ b/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/InspireAutoConfiguration.java
@@ -1,0 +1,78 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire;
+
+import javax.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.geoserver.platform.ModuleStatus;
+import org.geoserver.platform.ModuleStatusImpl;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Auto-configuration for the GeoServer INSPIRE extension.
+ *
+ * <p>This extension enables some INSPIRE metadata features. It allows
+ * GeoServer to configure INSPIRE metadata that can be served by
+ * in GetCapabilities.
+ *
+ * <p>The extension is disabled by default and can be enabled with:
+ *
+ * <pre>{@code
+ * geoserver:
+ *   extension:
+ *     inspire:
+ *       enabled: true
+ * }</pre>
+ *
+ * @since 2.27.0.0
+ */
+@AutoConfiguration
+@SuppressWarnings("java:S1118") // Suppress SonarLint warning, constructor needs to be public
+@EnableConfigurationProperties(InspireConfigProperties.class)
+@Slf4j(topic = "org.geoserver.cloud.autoconfigure.extensions.inspire")
+public class InspireAutoConfiguration {
+
+    public @PostConstruct void log() {
+        log.info("INSPIRE configuration detected");
+    }
+
+    /**
+     * Creates the INSPIRE module status bean.
+     *
+     * <p>Equivalent to the following XML configuration:
+     *
+     * <pre>
+     * {@code
+     * <bean id="inspireExtension" class=
+     * "org.geoserver.platform.ModuleStatusImpl">
+     *  <property name="module" value="gs-inspire" />
+     *  <property name="name" value="INSPIRE Extension"/>
+     *  <property name="component" value="INSPIRE extension"/>
+     *  <property name="available" value="true"/>
+     *  <property name="enabled" value="true"/>
+     * </bean>
+     * }</pre>
+     *
+     * @param config the INSPIRE configuration properties
+     * @return the INSPIRE module status bean
+     */
+    @Bean
+    ModuleStatus inspireExtension(InspireConfigProperties config) {
+        ModuleStatusImpl mod = new ModuleStatusImpl("gs-inspire", "INSPIRE Extension", "INSPIRE extension");
+        mod.setAvailable(true);
+        mod.setEnabled(config.isEnabled());
+        if (config.isEnabled()) {
+            mod.setMessage(
+                    "INSPIRE extension enabled through config property geoserver.extension.inspire.enabled=true");
+        } else {
+            mod.setMessage(
+                    "INSPIRE extension disabled through config property geoserver.extension.inspire.enabled=false");
+        }
+
+        return mod;
+    }
+}

--- a/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/InspireConfigProperties.java
+++ b/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/InspireConfigProperties.java
@@ -1,0 +1,42 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for the INSPIRE extension.
+ *
+ * <p>Available properties:
+ *
+ * <pre>{@code
+ * geoserver:
+ *   extension:
+ *     inspire:
+ *       enabled: true  # Enables the INSPIRE extension (default: false)
+ * }</pre>
+ *
+ * @since 2.27.0.0
+ */
+@ConfigurationProperties(prefix = InspireConfigProperties.PREFIX)
+public @Data class InspireConfigProperties {
+
+    /** Prefix for configuration properties. */
+    public static final String PREFIX = "geoserver.extension.inspire";
+
+    /** Default value for the enabled property (false). */
+    static final boolean DEFAULT = false;
+
+    /**
+     * Whether the INSPIRE extension is enabled.
+     *
+     * <p>When set to true, the INSPIRE extension components will be registered in the application context.
+     * When false, the extension will not be available for use.
+     *
+     * <p>Default is {@code false}.
+     */
+    private boolean enabled = DEFAULT;
+}

--- a/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/gwc/ConditionalOnInspireGwc.java
+++ b/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/gwc/ConditionalOnInspireGwc.java
@@ -1,0 +1,32 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire.gwc;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.geoserver.cloud.autoconfigure.extensions.ConditionalOnGeoServerGWC;
+import org.geoserver.cloud.autoconfigure.extensions.inspire.ConditionalOnInspire;
+
+/**
+ * Conditional annotation that only matches when:
+ * <ul>
+ *   <li>A GeoServer instance is available in the application context
+ *   <li>The INSPIRE extension is enabled via configuration property
+ *   <li>GWC is available
+ * </ul>
+ *
+ * @since 2.27.0.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Documented
+@Inherited
+@ConditionalOnInspire
+@ConditionalOnGeoServerGWC
+public @interface ConditionalOnInspireGwc {}

--- a/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/gwc/InspireAutoConfigurationGwc.java
+++ b/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/gwc/InspireAutoConfigurationGwc.java
@@ -1,0 +1,16 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire.gwc;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Import;
+
+@AutoConfiguration
+@SuppressWarnings("java:S1118") // Suppress SonarLint warning, constructor needs to be public
+@Import(InspireConfigurationGwc.class)
+@Slf4j(topic = "org.geoserver.cloud.autoconfigure.extensions.inspire.gwc")
+@ConditionalOnInspireGwc
+public class InspireAutoConfigurationGwc {}

--- a/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/gwc/InspireConfigurationGwc.java
+++ b/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/gwc/InspireConfigurationGwc.java
@@ -1,0 +1,24 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire.gwc;
+
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration class that sets up the INSPIRE extension components.
+ *
+ * <p>This configuration is only active when the INSPIRE extension is enabled
+ * through the {@code geoserver.extension.inspire.enabled=true} property.
+ *
+ * @since 2.27.0.0
+ */
+@Configuration
+@ConditionalOnClass(name = "org.geoserver.inspire.wmts.WMTSExtendedCapabilitiesProvider")
+@ImportFilteredResource({
+    "jar:gs-inspire-.*!/applicationContext.xml#name=^(inspireWmtsExtendedCapsProvider|inspireGridSetLoader|languageCallback|inspireDirManager).*$"
+})
+public class InspireConfigurationGwc {}

--- a/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wcs/ConditionalOnInspireWcs.java
+++ b/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wcs/ConditionalOnInspireWcs.java
@@ -1,0 +1,32 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire.wcs;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.geoserver.cloud.autoconfigure.extensions.ConditionalOnGeoServerWCS;
+import org.geoserver.cloud.autoconfigure.extensions.inspire.ConditionalOnInspire;
+
+/**
+ * Conditional annotation that only matches when:
+ * <ul>
+ *   <li>A GeoServer instance is available in the application context
+ *   <li>The INSPIRE extension is enabled via configuration property
+ *   <li>WCS is available
+ * </ul>
+ *
+ * @since 2.27.0.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Documented
+@Inherited
+@ConditionalOnInspire
+@ConditionalOnGeoServerWCS
+public @interface ConditionalOnInspireWcs {}

--- a/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wcs/InspireAutoConfigurationWcs.java
+++ b/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wcs/InspireAutoConfigurationWcs.java
@@ -1,0 +1,16 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire.wcs;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Import;
+
+@AutoConfiguration
+@SuppressWarnings("java:S1118") // Suppress SonarLint warning, constructor needs to be public
+@Import(InspireConfigurationWcs.class)
+@Slf4j(topic = "org.geoserver.cloud.autoconfigure.extensions.inspire.wcs")
+@ConditionalOnInspireWcs
+public class InspireAutoConfigurationWcs {}

--- a/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wcs/InspireConfigurationWcs.java
+++ b/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wcs/InspireConfigurationWcs.java
@@ -1,0 +1,24 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire.wcs;
+
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration class that sets up the INSPIRE extension components.
+ *
+ * <p>This configuration is only active when the INSPIRE extension is enabled
+ * through the {@code geoserver.extension.inspire.enabled=true} property.
+ *
+ * @since 2.27.0.0
+ */
+@Configuration
+@ConditionalOnClass(name = "org.geoserver.inspire.wcs.WCSExtendedCapabilitiesProvider")
+@ImportFilteredResource({
+    "jar:gs-inspire-.*!/applicationContext.xml#name=^(inspireWcsExtendedCapsProvider|languageCallback|inspireDirManager).*$"
+})
+public class InspireConfigurationWcs {}

--- a/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/webui/ConditionalOnInspireWebUI.java
+++ b/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/webui/ConditionalOnInspireWebUI.java
@@ -1,0 +1,32 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire.webui;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.geoserver.cloud.autoconfigure.extensions.ConditionalOnGeoServerWebUI;
+import org.geoserver.cloud.autoconfigure.extensions.inspire.ConditionalOnInspire;
+
+/**
+ * Conditional annotation that only matches when:
+ * <ul>
+ *   <li>A GeoServer instance is available in the application context
+ *   <li>The INSPIRE extension is enabled via configuration property
+ *   <li>WebUI is available
+ * </ul>
+ *
+ * @since 2.27.0.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Documented
+@Inherited
+@ConditionalOnInspire
+@ConditionalOnGeoServerWebUI
+public @interface ConditionalOnInspireWebUI {}

--- a/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/webui/InspireAutoConfigurationWebUI.java
+++ b/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/webui/InspireAutoConfigurationWebUI.java
@@ -1,0 +1,16 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire.webui;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Import;
+
+@AutoConfiguration
+@SuppressWarnings("java:S1118") // Suppress SonarLint warning, constructor needs to be public
+@Import(InspireConfigurationWebUI.class)
+@Slf4j(topic = "org.geoserver.cloud.autoconfigure.extensions.inspire.webui")
+@ConditionalOnInspireWebUI
+public class InspireAutoConfigurationWebUI {}

--- a/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/webui/InspireConfigurationWebUI.java
+++ b/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/webui/InspireConfigurationWebUI.java
@@ -1,0 +1,25 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire.webui;
+
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration class that sets up the INSPIRE extension components.
+ *
+ * <p>This configuration is only active when the INSPIRE extension is enabled
+ * through the {@code geoserver.extension.inspire.enabled=true} property.
+ *
+ * @since 2.27.0.0
+ */
+@Configuration
+@ConditionalOnInspireWebUI
+@ConditionalOnClass(name = "org.geoserver.inspire.web.InspireAdminPanel")
+@ImportFilteredResource({
+    "jar:gs-inspire-.*!/applicationContext.xml#name=^(inspire.*AdminPanel|languageCallback|inspireDirManager).*$"
+})
+public class InspireConfigurationWebUI {}

--- a/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wfs/ConditionalOnInspireWfs.java
+++ b/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wfs/ConditionalOnInspireWfs.java
@@ -1,0 +1,32 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire.wfs;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.geoserver.cloud.autoconfigure.extensions.ConditionalOnGeoServerWFS;
+import org.geoserver.cloud.autoconfigure.extensions.inspire.ConditionalOnInspire;
+
+/**
+ * Conditional annotation that only matches when:
+ * <ul>
+ *   <li>A GeoServer instance is available in the application context
+ *   <li>The INSPIRE extension is enabled via configuration property
+ *   <li>WFS is available
+ * </ul>
+ *
+ * @since 2.27.0.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Documented
+@Inherited
+@ConditionalOnInspire
+@ConditionalOnGeoServerWFS
+public @interface ConditionalOnInspireWfs {}

--- a/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wfs/InspireAutoConfigurationWfs.java
+++ b/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wfs/InspireAutoConfigurationWfs.java
@@ -1,0 +1,16 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire.wfs;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Import;
+
+@AutoConfiguration
+@SuppressWarnings("java:S1118") // Suppress SonarLint warning, constructor needs to be public
+@Import(InspireConfigurationWfs.class)
+@Slf4j(topic = "org.geoserver.cloud.autoconfigure.extensions.inspire.wfs")
+@ConditionalOnInspireWfs
+public class InspireAutoConfigurationWfs {}

--- a/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wfs/InspireConfigurationWfs.java
+++ b/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wfs/InspireConfigurationWfs.java
@@ -1,0 +1,24 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire.wfs;
+
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration class that sets up the INSPIRE extension components.
+ *
+ * <p>This configuration is only active when the INSPIRE extension is enabled
+ * through the {@code geoserver.extension.inspire.enabled=true} property.
+ *
+ * @since 2.27.0.0
+ */
+@Configuration
+@ConditionalOnClass(name = "org.geoserver.inspire.wfs.WFSExtendedCapabilitiesProvider")
+@ImportFilteredResource({
+    "jar:gs-inspire-.*!/applicationContext.xml#name=^(inspireWfsExtendedCapsProvider|languageCallback|inspireDirManager).*$"
+})
+public class InspireConfigurationWfs {}

--- a/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wms/ConditionalOnInspireWms.java
+++ b/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wms/ConditionalOnInspireWms.java
@@ -1,0 +1,32 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire.wms;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.geoserver.cloud.autoconfigure.extensions.ConditionalOnGeoServerWMS;
+import org.geoserver.cloud.autoconfigure.extensions.inspire.ConditionalOnInspire;
+
+/**
+ * Conditional annotation that only matches when:
+ * <ul>
+ *   <li>A GeoServer instance is available in the application context
+ *   <li>The INSPIRE extension is enabled via configuration property
+ *   <li>WMS is available
+ * </ul>
+ *
+ * @since 2.27.0.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Documented
+@Inherited
+@ConditionalOnInspire
+@ConditionalOnGeoServerWMS
+public @interface ConditionalOnInspireWms {}

--- a/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wms/InspireAutoConfigurationWms.java
+++ b/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wms/InspireAutoConfigurationWms.java
@@ -1,0 +1,16 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire.wms;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Import;
+
+@AutoConfiguration
+@SuppressWarnings("java:S1118") // Suppress SonarLint warning, constructor needs to be public
+@Import(InspireConfigurationWms.class)
+@Slf4j(topic = "org.geoserver.cloud.autoconfigure.extensions.inspire.wms")
+@ConditionalOnInspireWms
+public class InspireAutoConfigurationWms {}

--- a/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wms/InspireConfigurationWms.java
+++ b/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wms/InspireConfigurationWms.java
@@ -1,0 +1,24 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire.wms;
+
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration class that sets up the INSPIRE extension components.
+ *
+ * <p>This configuration is only active when the INSPIRE extension is enabled
+ * through the {@code geoserver.extension.inspire.enabled=true} property.
+ *
+ * @since 2.27.0.0
+ */
+@Configuration
+@ConditionalOnClass(name = "org.geoserver.inspire.wms.WMSExtendedCapabilitiesProvider")
+@ImportFilteredResource({
+    "jar:gs-inspire-.*!/applicationContext.xml#name=^(inspireWmsExtendedCapsProvider|languageCallback|inspireDirManager).*$"
+})
+public class InspireConfigurationWms {}

--- a/src/extensions/inspire/src/main/resources/META-INF/spring.factories
+++ b/src/extensions/inspire/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,7 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.geoserver.cloud.autoconfigure.extensions.inspire.InspireAutoConfiguration,\
+org.geoserver.cloud.autoconfigure.extensions.inspire.webui.InspireAutoConfigurationWebUI,\
+org.geoserver.cloud.autoconfigure.extensions.inspire.gwc.InspireAutoConfigurationGwc,\
+org.geoserver.cloud.autoconfigure.extensions.inspire.wfs.InspireAutoConfigurationWfs,\
+org.geoserver.cloud.autoconfigure.extensions.inspire.wms.InspireAutoConfigurationWms,\
+org.geoserver.cloud.autoconfigure.extensions.inspire.wcs.InspireAutoConfigurationWcs

--- a/src/extensions/inspire/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/extensions/inspire/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,6 @@
+org.geoserver.cloud.autoconfigure.extensions.inspire.InspireAutoConfiguration
+org.geoserver.cloud.autoconfigure.extensions.inspire.webui.InspireAutoConfigurationWebUI
+org.geoserver.cloud.autoconfigure.extensions.inspire.gwc.InspireAutoConfigurationGwc
+org.geoserver.cloud.autoconfigure.extensions.inspire.wfs.InspireAutoConfigurationWfs
+org.geoserver.cloud.autoconfigure.extensions.inspire.wms.InspireAutoConfigurationWms
+org.geoserver.cloud.autoconfigure.extensions.inspire.wcs.InspireAutoConfigurationWcs

--- a/src/extensions/inspire/src/test/java/org/geoserver/cloud/autoconfigure/extensions/inspire/InspireAutoConfigurationTest.java
+++ b/src/extensions/inspire/src/test/java/org/geoserver/cloud/autoconfigure/extensions/inspire/InspireAutoConfigurationTest.java
@@ -1,0 +1,86 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.GeoServerDataDirectory;
+import org.geoserver.config.impl.GeoServerImpl;
+import org.geoserver.platform.GeoServerResourceLoader;
+import org.geoserver.platform.ModuleStatus;
+import org.geoserver.platform.resource.FileSystemResourceStore;
+import org.geoserver.platform.resource.ResourceStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+public class InspireAutoConfigurationTest {
+
+    @TempDir
+    File tempDir;
+
+    protected ApplicationContextRunner runner;
+
+    @BeforeEach
+    void setUp() {
+        runner = createContextRunner(tempDir);
+    }
+
+    protected ApplicationContextRunner createContextRunner(File tempDir) {
+        ResourceStore resourceStore = new FileSystemResourceStore(tempDir);
+        GeoServerResourceLoader resourceLoader = new GeoServerResourceLoader(resourceStore);
+        GeoServerDataDirectory datadir = new GeoServerDataDirectory(resourceLoader);
+
+        return new ApplicationContextRunner()
+                .withBean(ResourceStore.class, () -> resourceStore)
+                .withBean(GeoServerResourceLoader.class, () -> resourceLoader)
+                .withBean("dataDirectory", GeoServerDataDirectory.class, () -> datadir)
+                .withBean("geoServer", GeoServer.class, GeoServerImpl::new)
+                .withConfiguration(AutoConfigurations.of(InspireAutoConfiguration.class));
+    }
+
+    /**
+     *
+     */
+    @Test
+    void testDisabledByDefault() {
+        runner.run(context -> {
+            assertThat(context)
+                    .hasNotFailed()
+                    .hasBean("inspireExtension")
+                    .getBean("inspireExtension", ModuleStatus.class)
+                    .hasFieldOrPropertyWithValue("available", true)
+                    .hasFieldOrPropertyWithValue("enabled", false);
+        });
+    }
+
+    @Test
+    void testDisabledExplicitly() {
+        runner.withPropertyValues("geoserver.extension.inspire.enabled=false").run(context -> {
+            assertThat(context)
+                    .hasNotFailed()
+                    .hasBean("inspireExtension")
+                    .getBean("inspireExtension", ModuleStatus.class)
+                    .hasFieldOrPropertyWithValue("available", true)
+                    .hasFieldOrPropertyWithValue("enabled", false);
+        });
+    }
+
+    @Test
+    void testEnabled() {
+        runner.withPropertyValues("geoserver.extension.inspire.enabled=true").run(context -> {
+            assertThat(context)
+                    .hasNotFailed()
+                    .hasBean("inspireExtension")
+                    .getBean("inspireExtension", ModuleStatus.class)
+                    .hasFieldOrPropertyWithValue("available", true)
+                    .hasFieldOrPropertyWithValue("enabled", true);
+        });
+    }
+}

--- a/src/extensions/inspire/src/test/java/org/geoserver/cloud/autoconfigure/extensions/inspire/gwc/InspireAutoConfigurationGwcTest.java
+++ b/src/extensions/inspire/src/test/java/org/geoserver/cloud/autoconfigure/extensions/inspire/gwc/InspireAutoConfigurationGwcTest.java
@@ -1,0 +1,60 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire.gwc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import org.geoserver.cloud.autoconfigure.extensions.inspire.InspireAutoConfigurationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class InspireAutoConfigurationGwcTest extends InspireAutoConfigurationTest {
+
+    @Override
+    protected ApplicationContextRunner createContextRunner(File tempDir) {
+        return super.createContextRunner(tempDir)
+                .withConfiguration(AutoConfigurations.of(InspireAutoConfigurationGwc.class));
+    }
+
+    @Test
+    void testDisabledByDefault() {
+        runner.run(context -> {
+            assertThat(context)
+                    .hasNotFailed()
+                    .doesNotHaveBean(org.geoserver.inspire.wmts.WMTSExtendedCapabilitiesProvider.class)
+                    .doesNotHaveBean(org.geoserver.inspire.LanguagesDispatcherCallback.class)
+                    .doesNotHaveBean(org.geoserver.inspire.wmts.InspireGridSetLoader.class)
+                    .doesNotHaveBean(org.geoserver.inspire.InspireDirectoryManager.class);
+        });
+    }
+
+    @Test
+    void testDisabledExplicitly() {
+        runner.withPropertyValues("geoserver.extension.inspire.enabled=false", "geoserver.service.gwc.enabled=true")
+                .run(context -> {
+                    assertThat(context)
+                            .hasNotFailed()
+                            .doesNotHaveBean(org.geoserver.inspire.wmts.WMTSExtendedCapabilitiesProvider.class)
+                            .doesNotHaveBean(org.geoserver.inspire.LanguagesDispatcherCallback.class)
+                            .doesNotHaveBean(org.geoserver.inspire.wmts.InspireGridSetLoader.class)
+                            .doesNotHaveBean(org.geoserver.inspire.InspireDirectoryManager.class);
+                });
+    }
+
+    @Test
+    void testEnabled() {
+        runner.withPropertyValues("geoserver.extension.inspire.enabled=true", "geoserver.service.gwc.enabled=true")
+                .run(context -> {
+                    assertThat(context)
+                            .hasNotFailed()
+                            .hasSingleBean(org.geoserver.inspire.wmts.WMTSExtendedCapabilitiesProvider.class)
+                            .hasSingleBean(org.geoserver.inspire.LanguagesDispatcherCallback.class)
+                            .hasSingleBean(org.geoserver.inspire.wmts.InspireGridSetLoader.class)
+                            .hasSingleBean(org.geoserver.inspire.InspireDirectoryManager.class);
+                });
+    }
+}

--- a/src/extensions/inspire/src/test/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wcs/InspireAutoConfigurationWcsTest.java
+++ b/src/extensions/inspire/src/test/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wcs/InspireAutoConfigurationWcsTest.java
@@ -1,0 +1,57 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire.wcs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import org.geoserver.cloud.autoconfigure.extensions.inspire.InspireAutoConfigurationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class InspireAutoConfigurationWcsTest extends InspireAutoConfigurationTest {
+
+    @Override
+    protected ApplicationContextRunner createContextRunner(File tempDir) {
+        return super.createContextRunner(tempDir)
+                .withConfiguration(AutoConfigurations.of(InspireAutoConfigurationWcs.class));
+    }
+
+    @Test
+    void testDisabledByDefault() {
+        runner.run(context -> {
+            assertThat(context)
+                    .hasNotFailed()
+                    .doesNotHaveBean(org.geoserver.inspire.wmts.WMTSExtendedCapabilitiesProvider.class)
+                    .doesNotHaveBean(org.geoserver.inspire.LanguagesDispatcherCallback.class)
+                    .doesNotHaveBean(org.geoserver.inspire.InspireDirectoryManager.class);
+        });
+    }
+
+    @Test
+    void testDisabledExplicitly() {
+        runner.withPropertyValues("geoserver.extension.inspire.enabled=false", "geoserver.service.wcs.enabled=true")
+                .run(context -> {
+                    assertThat(context)
+                            .hasNotFailed()
+                            .doesNotHaveBean(org.geoserver.inspire.wcs.WCSExtendedCapabilitiesProvider.class)
+                            .doesNotHaveBean(org.geoserver.inspire.LanguagesDispatcherCallback.class)
+                            .doesNotHaveBean(org.geoserver.inspire.InspireDirectoryManager.class);
+                });
+    }
+
+    @Test
+    void testEnabled() {
+        runner.withPropertyValues("geoserver.extension.inspire.enabled=true", "geoserver.service.wcs.enabled=true")
+                .run(context -> {
+                    assertThat(context)
+                            .hasNotFailed()
+                            .hasSingleBean(org.geoserver.inspire.wcs.WCSExtendedCapabilitiesProvider.class)
+                            .hasSingleBean(org.geoserver.inspire.LanguagesDispatcherCallback.class)
+                            .hasSingleBean(org.geoserver.inspire.InspireDirectoryManager.class);
+                });
+    }
+}

--- a/src/extensions/inspire/src/test/java/org/geoserver/cloud/autoconfigure/extensions/inspire/webui/InspireAutoConfigurationWebUITest.java
+++ b/src/extensions/inspire/src/test/java/org/geoserver/cloud/autoconfigure/extensions/inspire/webui/InspireAutoConfigurationWebUITest.java
@@ -1,0 +1,68 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire.webui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import org.geoserver.cloud.autoconfigure.extensions.inspire.InspireAutoConfigurationTest;
+import org.geoserver.web.GeoServerApplication;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class InspireAutoConfigurationWebUITest extends InspireAutoConfigurationTest {
+
+    @Override
+    protected ApplicationContextRunner createContextRunner(File tempDir) {
+        return super.createContextRunner(tempDir)
+                .withBean("geoServerApplication", GeoServerApplication.class)
+                .withConfiguration(AutoConfigurations.of(InspireAutoConfigurationWebUI.class));
+    }
+
+    @Test
+    void testDisabledByDefault() {
+        runner.run(context -> {
+            assertThat(context)
+                    .hasNotFailed()
+                    .doesNotHaveBean("inspireWmsAdminPanel")
+                    .doesNotHaveBean("inspireWfsAdminPanel")
+                    .doesNotHaveBean("inspireWcsAdminPanel")
+                    .doesNotHaveBean("inspireWmtsAdminPanel")
+                    .doesNotHaveBean(org.geoserver.inspire.LanguagesDispatcherCallback.class)
+                    .doesNotHaveBean(org.geoserver.inspire.InspireDirectoryManager.class);
+        });
+    }
+
+    @Test
+    void testDisabledExplicitly() {
+        runner.withPropertyValues("geoserver.extension.inspire.enabled=false", "geoserver.service.webui.enabled=true")
+                .run(context -> {
+                    assertThat(context)
+                            .hasNotFailed()
+                            .doesNotHaveBean("inspireWmsAdminPanel")
+                            .doesNotHaveBean("inspireWfsAdminPanel")
+                            .doesNotHaveBean("inspireWcsAdminPanel")
+                            .doesNotHaveBean("inspireWmtsAdminPanel")
+                            .doesNotHaveBean(org.geoserver.inspire.LanguagesDispatcherCallback.class)
+                            .doesNotHaveBean(org.geoserver.inspire.InspireDirectoryManager.class);
+                });
+    }
+
+    @Test
+    void testEnabled() {
+        runner.withPropertyValues("geoserver.extension.inspire.enabled=true", "geoserver.service.webui.enabled=true")
+                .run(context -> {
+                    assertThat(context)
+                            .hasNotFailed()
+                            .hasBean("inspireWmsAdminPanel")
+                            .hasBean("inspireWfsAdminPanel")
+                            .hasBean("inspireWcsAdminPanel")
+                            .hasBean("inspireWmtsAdminPanel")
+                            .hasSingleBean(org.geoserver.inspire.LanguagesDispatcherCallback.class)
+                            .hasSingleBean(org.geoserver.inspire.InspireDirectoryManager.class);
+                });
+    }
+}

--- a/src/extensions/inspire/src/test/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wfs/InspireAutoConfigurationWfsTest.java
+++ b/src/extensions/inspire/src/test/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wfs/InspireAutoConfigurationWfsTest.java
@@ -1,0 +1,57 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire.wfs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import org.geoserver.cloud.autoconfigure.extensions.inspire.InspireAutoConfigurationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class InspireAutoConfigurationWfsTest extends InspireAutoConfigurationTest {
+
+    @Override
+    protected ApplicationContextRunner createContextRunner(File tempDir) {
+        return super.createContextRunner(tempDir)
+                .withConfiguration(AutoConfigurations.of(InspireAutoConfigurationWfs.class));
+    }
+
+    @Test
+    void testDisabledByDefault() {
+        runner.run(context -> {
+            assertThat(context)
+                    .hasNotFailed()
+                    .doesNotHaveBean(org.geoserver.inspire.wmts.WMTSExtendedCapabilitiesProvider.class)
+                    .doesNotHaveBean(org.geoserver.inspire.LanguagesDispatcherCallback.class)
+                    .doesNotHaveBean(org.geoserver.inspire.InspireDirectoryManager.class);
+        });
+    }
+
+    @Test
+    void testDisabledExplicitly() {
+        runner.withPropertyValues("geoserver.extension.inspire.enabled=false", "geoserver.service.wfs.enabled=true")
+                .run(context -> {
+                    assertThat(context)
+                            .hasNotFailed()
+                            .doesNotHaveBean(org.geoserver.inspire.wcs.WCSExtendedCapabilitiesProvider.class)
+                            .doesNotHaveBean(org.geoserver.inspire.LanguagesDispatcherCallback.class)
+                            .doesNotHaveBean(org.geoserver.inspire.InspireDirectoryManager.class);
+                });
+    }
+
+    @Test
+    void testEnabled() {
+        runner.withPropertyValues("geoserver.extension.inspire.enabled=true", "geoserver.service.wfs.enabled=true")
+                .run(context -> {
+                    assertThat(context)
+                            .hasNotFailed()
+                            .hasSingleBean(org.geoserver.inspire.wfs.WFSExtendedCapabilitiesProvider.class)
+                            .hasSingleBean(org.geoserver.inspire.LanguagesDispatcherCallback.class)
+                            .hasSingleBean(org.geoserver.inspire.InspireDirectoryManager.class);
+                });
+    }
+}

--- a/src/extensions/inspire/src/test/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wms/InspireAutoConfigurationWmsTest.java
+++ b/src/extensions/inspire/src/test/java/org/geoserver/cloud/autoconfigure/extensions/inspire/wms/InspireAutoConfigurationWmsTest.java
@@ -1,0 +1,57 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire.wms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import org.geoserver.cloud.autoconfigure.extensions.inspire.InspireAutoConfigurationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class InspireAutoConfigurationWmsTest extends InspireAutoConfigurationTest {
+
+    @Override
+    protected ApplicationContextRunner createContextRunner(File tempDir) {
+        return super.createContextRunner(tempDir)
+                .withConfiguration(AutoConfigurations.of(InspireAutoConfigurationWms.class));
+    }
+
+    @Test
+    void testDisabledByDefault() {
+        runner.run(context -> {
+            assertThat(context)
+                    .hasNotFailed()
+                    .doesNotHaveBean(org.geoserver.inspire.wmts.WMTSExtendedCapabilitiesProvider.class)
+                    .doesNotHaveBean(org.geoserver.inspire.LanguagesDispatcherCallback.class)
+                    .doesNotHaveBean(org.geoserver.inspire.InspireDirectoryManager.class);
+        });
+    }
+
+    @Test
+    void testDisabledExplicitly() {
+        runner.withPropertyValues("geoserver.extension.inspire.enabled=false", "geoserver.service.wms.enabled=true")
+                .run(context -> {
+                    assertThat(context)
+                            .hasNotFailed()
+                            .doesNotHaveBean(org.geoserver.inspire.wcs.WCSExtendedCapabilitiesProvider.class)
+                            .doesNotHaveBean(org.geoserver.inspire.LanguagesDispatcherCallback.class)
+                            .doesNotHaveBean(org.geoserver.inspire.InspireDirectoryManager.class);
+                });
+    }
+
+    @Test
+    void testEnabled() {
+        runner.withPropertyValues("geoserver.extension.inspire.enabled=true", "geoserver.service.wms.enabled=true")
+                .run(context -> {
+                    assertThat(context)
+                            .hasNotFailed()
+                            .hasSingleBean(org.geoserver.inspire.wms.WMSExtendedCapabilitiesProvider.class)
+                            .hasSingleBean(org.geoserver.inspire.LanguagesDispatcherCallback.class)
+                            .hasSingleBean(org.geoserver.inspire.InspireDirectoryManager.class);
+                });
+    }
+}

--- a/src/extensions/pom.xml
+++ b/src/extensions/pom.xml
@@ -13,6 +13,7 @@
   <modules>
     <module>core</module>
     <module>app-schema</module>
+    <module>inspire</module>
     <module>security</module>
     <module>input-formats</module>
     <module>css-styling</module>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -704,6 +704,11 @@
       </dependency>
       <dependency>
         <groupId>org.geoserver.extension</groupId>
+        <artifactId>gs-inspire</artifactId>
+        <version>${gs.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.extension</groupId>
         <artifactId>gs-feature-pregeneralized</artifactId>
         <version>${gs.version}</version>
       </dependency>

--- a/src/starters/extensions/pom.xml
+++ b/src/starters/extensions/pom.xml
@@ -32,6 +32,10 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver.cloud.extensions</groupId>
+      <artifactId>gs-cloud-extension-inspire</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.cloud.extensions</groupId>
       <artifactId>gs-cloud-extension-css-styling</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
**Description:** This PR introduces the optional activation of the [Inspire extension](https://docs.geoserver.org/main/en/user/extensions/inspire/index.html) in GeoServer Cloud. The Inspire extension enhances GetCapabilities documents for WMS, WFS, WCS, and WMTS to comply with metadata requirements from the European Union.

### Key Changes:

- Introduce a new configuration option: `geoserver.extension.inspire.enabled=false` (activate the integration with `true`) https://github.com/geoserver/geoserver-cloud-config/pull/21
- Conditionally integrate the required beans into the respective Web-UI, WMS, WFS, WCS and GWC/WMTS apps.
- Implemented numerous tests and extended existing ones
- Fix for Deserialization Issues with pgconfig (see below)

### Fix for Deserialization Issues with pgconfig:

When using pgconfig, deserialization issues arose due to JSONB column handling. Specifically, the `LiteralDeserializer` expected attributes to be parsed in a specific order (1. `contentType`, 2. `value`), which was not guaranteed with JSONB storage. This caused issues (especially in case of WCS and WMTS as they persist a `spatialDatasetIdentifier` property, see below). The PR implements a fallback to handle cases where the `value` attribute is parsed before `contentType`.

#### Example JSONB Snippet from the `info` column of the `serviceinfo` table:

```json
"inspire.spatialDatasetIdentifier": {
  "Literal": {
    "type": "java.util.List",
    "value": [
      {
        "code": "25833",
        "namespace": "wcs",
        "metadataURL": "wcs"
      }
    ],
    "contentType": "org.geoserver.inspire.UniqueResourceIdentifier"
  }
}
```

Looking forward to your feedback @groldan :smile: 

