### PR TITLE
chore: Fix several spelling errors

### DIFF
--- a/compose/catalog-datadir.yml
+++ b/compose/catalog-datadir.yml
@@ -14,7 +14,7 @@ volumes:
 #      o: bind
 #      device: $PWD/catalog-datadir
 
-# Appned the shared data directory to the geoserver_volumes anchor
+# Append the shared data directory to the geoserver_volumes anchor
 x-volume-mounts: &geoserver_volumes
   - data_directory:/opt/app/data_directory:z
 

--- a/docs/deploy/docker-compose/stable/datadir/compose.yml
+++ b/docs/deploy/docker-compose/stable/datadir/compose.yml
@@ -47,12 +47,12 @@ services:
     user: 1000:1000 # set the userid:groupid the container runs as
     environment:
       # default to `native` loading the config embedded in /etc/geoserver
-      # use `git` to fetch the config from a git reposiroty, and CONFIG_GIT_URI to change
+      # use `git` to fetch the config from a git repository, and CONFIG_GIT_URI to change
       # the default repository https://github.com/geoserver/geoserver-cloud-config.git
       SPRING_PROFILES_ACTIVE: native
       # If using the `git` profile, get the config from this tag
       SPRING_CLOUD_CONFIG_SERVER_GIT_DEFAULT_LABEL: v2.27.0-SNAPSHOT
-    # Uncoment to bind to a local filesystem directory if using the 'native' profile
+    # Uncomment to bind to a local filesystem directory if using the 'native' profile
     #volumes:
     #  - ./config:/etc/geoserver
     deploy:

--- a/docs/deploy/docker-compose/stable/jdbcconfig/compose.yml
+++ b/docs/deploy/docker-compose/stable/jdbcconfig/compose.yml
@@ -62,12 +62,12 @@ services:
     user: 1000:1000 # set the userid:groupid the container runs as
     environment:
       # default to `native` loading the config embedded in /etc/geoserver
-      # use `git` to fetch the config from a git reposiroty, and CONFIG_GIT_URI to change
+      # use `git` to fetch the config from a git repository, and CONFIG_GIT_URI to change
       # the default repository https://github.com/geoserver/geoserver-cloud-config.git
       SPRING_PROFILES_ACTIVE: native
       # If using the `git` profile, get the config from this tag
       SPRING_CLOUD_CONFIG_SERVER_GIT_DEFAULT_LABEL: v2.26.2.0
-    # Uncoment to bind to a local filesystem directory if using the 'native' profile
+    # Uncomment to bind to a local filesystem directory if using the 'native' profile
     #volumes:
     #  - ./config:/etc/geoserver
     deploy:

--- a/docs/deploy/docker-compose/stable/pgconfig/compose.yml
+++ b/docs/deploy/docker-compose/stable/pgconfig/compose.yml
@@ -99,12 +99,12 @@ services:
     user: 1000:1000 # set the userid:groupid the container runs as
     environment:
       # default to `native` loading the config embedded in /etc/geoserver
-      # use `git` to fetch the config from a git reposiroty, and CONFIG_GIT_URI to change
+      # use `git` to fetch the config from a git repository, and CONFIG_GIT_URI to change
       # the default repository https://github.com/geoserver/geoserver-cloud-config.git
       SPRING_PROFILES_ACTIVE: native
       # If using the `git` profile, get the config from this tag
       SPRING_CLOUD_CONFIG_SERVER_GIT_DEFAULT_LABEL: v2.26.2.0
-    # Uncoment to bind to a local filesystem directory if using the 'native' profile
+    # Uncomment to bind to a local filesystem directory if using the 'native' profile
     #volumes:
     #  - ./config:/etc/geoserver
     deploy:

--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -63,7 +63,7 @@ Please check out the [docker-compose](./docker-compose/index.md) deployment docu
 
 ## Kubernetes
 
-Pleae check out the example [Helm](https://helm.sh/) chart on this [helm-geoserver-cloud](https://github.com/camptocamp/helm-geoserver-cloud) repository as a starting point to deploy to K8s.
+Please check out the example [Helm](https://helm.sh/) chart on this [helm-geoserver-cloud](https://github.com/camptocamp/helm-geoserver-cloud) repository as a starting point to deploy to K8s.
 
 ## Podman
 

--- a/docs/deploy/podman/index.md
+++ b/docs/deploy/podman/index.md
@@ -17,7 +17,7 @@ Integration with systemd including dependencies is also a feature of podman.
 
 https://fedoramagazine.org/auto-updating-podman-containers-with-systemd/
 
-For futher information please have a look at the project page:
+For further information please have a look at the project page:
 
 https://podman.io/whatis.html
 

--- a/docs/deploy/podman/traditional/manual/podman.md
+++ b/docs/deploy/podman/traditional/manual/podman.md
@@ -1,6 +1,6 @@
 ## Running GeoServer Cloud
 
-This documentation describes how to run GeoServer Cloud with podman withouth pods (traditional way) based on 
+This documentation describes how to run GeoServer Cloud with podman without pods (traditional way) based on 
 
 ### Creating network
 

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/geotools/GeoToolsHttpClientProxyConfigurationProperties.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/geotools/GeoToolsHttpClientProxyConfigurationProperties.java
@@ -66,6 +66,6 @@ public @Data class GeoToolsHttpClientProxyConfigurationProperties {
     public ProxyHostConfig ofProtocol(@NonNull String protocol) {
         if ("http".equals(protocol)) return http == null ? new ProxyHostConfig() : http;
         if ("https".equals(protocol)) return https == null ? new ProxyHostConfig() : https;
-        throw new IllegalArgumentException("Uknown protocol %s. Expected http(s)".formatted(protocol));
+        throw new IllegalArgumentException("Unknown protocol %s. Expected http(s)".formatted(protocol));
     }
 }

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/config/catalog/backend/core/CoreBackendConfiguration.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/config/catalog/backend/core/CoreBackendConfiguration.java
@@ -112,7 +112,7 @@ public class CoreBackendConfiguration {
     }
 
     /**
-     * Actual {@link LayerGroupContainmentCache}, matches if the config proeprty {@code
+     * Actual {@link LayerGroupContainmentCache}, matches if the config property {@code
      * geoserver.security.layergroup-containmentcache=true}
      *
      * @see #noOpLayerGroupContainmentCache(Catalog)
@@ -130,7 +130,7 @@ public class CoreBackendConfiguration {
     }
 
     /**
-     * Default {@link LayerGroupContainmentCache} is a no-op, matches if the config proeprty {@code
+     * Default {@link LayerGroupContainmentCache} is a no-op, matches if the config property {@code
      * geoserver.security.layergroup-containmentcache=false} or is not specified
      *
      * @see #enabledLayerGroupContainmentCache(Catalog)

--- a/src/catalog/backends/common/src/main/java/org/geoserver/security/impl/GsCloudLayerGroupContainmentCache.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/security/impl/GsCloudLayerGroupContainmentCache.java
@@ -55,7 +55,7 @@ import org.springframework.web.context.WebApplicationContext;
  *       through {@link Catalog#getLayerGroups()}
  * </ul>
  *
- * With this, it takes 1 mintue to build the cache with the pgconfig catalog backend, on a catalog
+ * With this, it takes 1 minute to build the cache with the pgconfig catalog backend, on a catalog
  * with 70k layer groups, whereas previously it would go out of memory after several minutes.
  *
  * <p>Further improvements may involve making the cache being build lazily as required by calls to

--- a/src/catalog/backends/common/src/main/java/org/geoserver/security/impl/NoopLayerGroupContainmentCache.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/security/impl/NoopLayerGroupContainmentCache.java
@@ -9,7 +9,7 @@ import org.geoserver.catalog.impl.CatalogImpl;
 
 /**
  * A no-op {@link LayerGroupContainmentCache}, since some services like WFS do not deal with {@link
- * LayerGroupInfo layer groups} at all, then avoid the starup overhead.
+ * LayerGroupInfo layer groups} at all, then avoid the startup overhead.
  *
  * @since 1.8.2
  */

--- a/src/catalog/backends/common/src/test/java/org/geoserver/security/impl/GsCloudLayerGroupContainmentCacheTest.java
+++ b/src/catalog/backends/common/src/test/java/org/geoserver/security/impl/GsCloudLayerGroupContainmentCacheTest.java
@@ -61,7 +61,7 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.web.context.WebApplicationContext;
 
 /**
- * Tests {@link LayerGroupContainmentCache} udpates in face of catalog setup and changes
+ * Tests {@link LayerGroupContainmentCache} updates in face of catalog setup and changes
  *
  * <p>copied and adapted from {@link LayerGroupContainmentCacheTest}
  */
@@ -262,7 +262,7 @@ class GsCloudLayerGroupContainmentCacheTest {
         assertEquals(CONTAINER_GROUP, summary.getName());
         assertThat(summary.getContainerGroups(), empty());
 
-        // container has no contaning groups
+        // container has no containing groups
         assertThat(cc.getContainerGroupsFor(container), empty());
 
         // now check the groups containing the layers (nature being SINGLE, not a container)

--- a/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/catalog/backend/datadir/EventualConsistencyEnforcer.java
+++ b/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/catalog/backend/datadir/EventualConsistencyEnforcer.java
@@ -132,7 +132,7 @@ public class EventualConsistencyEnforcer implements GeoServerLifecycleHandler {
             tryResolvePending(found.orElseThrow());
         } else {
             log.debug(
-                    "missing ref {} still not found, the follwing operations wait for it: {}",
+                    "missing ref {} still not found, the following operations wait for it: {}",
                     missingRef,
                     pendingOperations.get(missingRef));
         }
@@ -446,8 +446,8 @@ public class EventualConsistencyEnforcer implements GeoServerLifecycleHandler {
 
             // complete or discard any pending op waiting for this object
             var waitingForThis = clearDependants();
-            for (var dependant : waitingForThis) {
-                completeOrDiscard(dependant);
+            for (var dependent : waitingForThis) {
+                completeOrDiscard(dependent);
             }
 
             rawFacade.remove(ModificationProxy.unwrap(info));
@@ -455,19 +455,19 @@ public class EventualConsistencyEnforcer implements GeoServerLifecycleHandler {
             return null;
         }
 
-        private void completeOrDiscard(ConsistencyOp<?> dependant) {
+        private void completeOrDiscard(ConsistencyOp<?> dependent) {
             final String id = info.getId();
-            execute(dependant);
-            if (dependant.completedSuccessfully()) {
-                log.debug("successfully executed {} depending on {} before removing it", dependant, id);
+            execute(dependent);
+            if (dependent.completedSuccessfully()) {
+                log.debug("successfully executed {} depending on {} before removing it", dependent, id);
             } else {
                 log.warn(
-                        "operation dependant on {} didn't complete successfully before removing it. It will be discarded: {}",
+                        "operation dependent on {} didn't complete successfully before removing it. It will be discarded: {}",
                         id,
-                        dependant);
+                        dependent);
                 // discard the op in case its waiting for some other ref besides the object removed
                 // by this op
-                discard(dependant);
+                discard(dependent);
             }
         }
     }

--- a/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/catalog/backend/datadir/EventuallyConsistentCatalogFacade.java
+++ b/src/catalog/backends/datadir/src/main/java/org/geoserver/cloud/catalog/backend/datadir/EventuallyConsistentCatalogFacade.java
@@ -52,7 +52,7 @@ public class EventuallyConsistentCatalogFacade extends ForwardingExtendedCatalog
     private final EventualConsistencyEnforcer enforcer;
 
     /**
-     * number of retry attemps and milliseconds to wait between retries
+     * number of retry attempts and milliseconds to wait between retries
      *
      * @see #retry
      */

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/filter/CatalogInfoLiteralAdaptor.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/filter/CatalogInfoLiteralAdaptor.java
@@ -91,7 +91,7 @@ class CatalogInfoLiteralAdaptor extends DuplicatingFilterVisitor {
     }
 
     /**
-     * Converts a binary comparision operator using a property name and a {@link CatalogInfo}
+     * Converts a binary comparison operator using a property name and a {@link CatalogInfo}
      * instance literal as a comparison by id.
      *
      * <p>For example, a filter like {@code workspace = WorkspaceInfo} is translated to {@code
@@ -114,7 +114,7 @@ class CatalogInfoLiteralAdaptor extends DuplicatingFilterVisitor {
                     boolean matchingCase = filter.isMatchingCase();
                     MatchAction matchAction = filter.getMatchAction();
                     filter = builder.build(prop, literal, matchingCase, matchAction);
-                    log.debug("Fitler with CatalogInfo literal '{}' translated to '{}'", orig, filter);
+                    log.debug("Filter with CatalogInfo literal '{}' translated to '{}'", orig, filter);
                 }
             }
         }

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/LoggingTemplate.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/LoggingTemplate.java
@@ -90,12 +90,12 @@ public class LoggingTemplate {
         }
     }
 
-    private void logAfter(long reqId, String sql, Duration ellapsed, DataAccessException error) {
+    private void logAfter(long reqId, String sql, Duration elapsed, DataAccessException error) {
         if (!log.isDebugEnabled()) return;
 
         if (sql.endsWith("\n")) sql = sql.substring(0, sql.length() - 1);
 
-        final String time = ellapsed == null ? "" : "%.2f ms".formatted(ellapsed.toNanos() / 1_000_000d);
+        final String time = elapsed == null ? "" : "%.2f ms".formatted(elapsed.toNanos() / 1_000_000d);
 
         final String errMsg = error == null
                 ? ""

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceStore.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceStore.java
@@ -342,7 +342,7 @@ public class PgconfigResourceStore implements ResourceStore {
     }
 
     /**
-     * @return direct children of resource iif resource is a directory, empty list otherwise
+     * @return direct children of resource if resource is a directory, empty list otherwise
      */
     public List<Resource> list(PgconfigResource resource) {
         if (!resource.exists() || !resource.isDirectory()) return List.of();

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgconfig/PgconfigMigrationAutoConfigurationTest.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgconfig/PgconfigMigrationAutoConfigurationTest.java
@@ -69,11 +69,11 @@ class PgconfigMigrationAutoConfigurationTest {
         try (Connection c = ds.getConnection()) {
             try (ResultSet tables = c.getMetaData().getTables(null, schema, null, null)) {
                 while (tables.next()) {
-                    String schem = tables.getString("TABLE_SCHEM");
+                    String scheme = tables.getString("TABLE_SCHEM");
                     String name = tables.getString("TABLE_NAME");
                     String type = tables.getString("TABLE_TYPE");
                     if (Set.of("VIEW", "TABLE", "SEQUENCE").contains(type)) {
-                        actual.put("%s.%s".formatted(schem, name), type);
+                        actual.put("%s.%s".formatted(scheme, name), type);
                     }
                 }
             }

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceTest.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceTest.java
@@ -360,7 +360,7 @@ public class PgconfigResourceTest extends ResourceTheoryTest {
 
     /**
      * Verify resiliency when moving a resource to the same path. Something that happens for example
-     * when NamespaceWorkspaceConsistencyListener blindly updtes a workspace upon a namespace change
+     * when NamespaceWorkspaceConsistencyListener blindly updates a workspace upon a namespace change
      * even if the workspace name is already equal to the namespace prefix
      */
     @Test

--- a/src/catalog/cache/src/main/java/org/geoserver/cloud/catalog/cache/CachedReferenceCleaner.java
+++ b/src/catalog/cache/src/main/java/org/geoserver/cloud/catalog/cache/CachedReferenceCleaner.java
@@ -161,7 +161,7 @@ class CachedReferenceCleaner {
         @NonNull
         private final ConcurrentMap<?, ?> cache;
 
-        /** key for the evicted oject. Will evict any cached object that has a reference to it */
+        /** key for the evicted object. Will evict any cached object that has a reference to it */
         @NonNull
         private final InfoIdKey evictedKey;
 

--- a/src/catalog/cache/src/main/java/org/geoserver/cloud/catalog/cache/CachingFacadesLifeCycleHandler.java
+++ b/src/catalog/cache/src/main/java/org/geoserver/cloud/catalog/cache/CachingFacadesLifeCycleHandler.java
@@ -57,7 +57,7 @@ class CachingFacadesLifeCycleHandler implements GeoServerReinitializer, GeoServe
     private final @NonNull GeoServerImpl rawGeoServer;
 
     /**
-     * {@link GeoServerReinitializer} method called before reloading the configuration, overidden to
+     * {@link GeoServerReinitializer} method called before reloading the configuration, overridden to
      * disable caching
      */
     @Override

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ConfigInfoAdded.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ConfigInfoAdded.java
@@ -44,7 +44,7 @@ public abstract class ConfigInfoAdded<I extends Info> extends InfoAdded<I> imple
                     case SETTINGS -> SettingsAdded.createLocal(updateSequence, (SettingsInfo) info);
                     case LOGGING -> LoggingInfoSet.createLocal(updateSequence, (LoggingInfo) info);
                     default -> throw new IllegalArgumentException(
-                            "Uknown or unsupported config Info type: %s. %s".formatted(type, info));
+                            "Unknown or unsupported config Info type: %s. %s".formatted(type, info));
                 };
     }
 }

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ConfigInfoModified.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ConfigInfoModified.java
@@ -49,7 +49,7 @@ public abstract class ConfigInfoModified extends InfoModified implements ConfigI
             case SETTINGS -> settings(updateSequence, (SettingsInfo) info, patch);
             case LOGGING -> logging(updateSequence, (LoggingInfo) info, patch);
             default -> throw new IllegalArgumentException(
-                    "Uknown or unsupported config Info type: %s. %s".formatted(type, info));
+                    "Unknown or unsupported config Info type: %s. %s".formatted(type, info));
         };
     }
 

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ConfigInfoRemoved.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/config/ConfigInfoRemoved.java
@@ -37,7 +37,7 @@ public abstract class ConfigInfoRemoved extends InfoRemoved implements ConfigInf
             case SERVICE -> ServiceRemoved.createLocal(updateSequence, (ServiceInfo) configInfo);
             case SETTINGS -> SettingsRemoved.createLocal(updateSequence, (SettingsInfo) configInfo);
             default -> throw new IllegalArgumentException(
-                    "Uknown or unsupported config Info type: %s. %s".formatted(type, configInfo));
+                    "Unknown or unsupported config Info type: %s. %s".formatted(type, configInfo));
         };
     }
 }

--- a/src/catalog/jackson-bindings/geotools/src/main/java/org/geotools/jackson/databind/filter/GeoToolsFilterModule.java
+++ b/src/catalog/jackson-bindings/geotools/src/main/java/org/geotools/jackson/databind/filter/GeoToolsFilterModule.java
@@ -103,8 +103,8 @@ public class GeoToolsFilterModule extends SimpleModule {
         addCustomLiteralValueSerializers();
     }
 
-    private <T> GeoToolsFilterModule addSerializer(Class<T> type, JsonSerializer<T> ser, JsonDeserializer<T> deser) {
-        super.addSerializer(type, ser);
+    private <T> GeoToolsFilterModule addSerializer(Class<T> type, JsonSerializer<T> set, JsonDeserializer<T> deser) {
+        super.addSerializer(type, set);
         super.addDeserializer(type, deser);
         return this;
     }

--- a/src/catalog/jackson-bindings/geotools/src/main/java/org/geotools/jackson/databind/filter/dto/LiteralDeserializer.java
+++ b/src/catalog/jackson-bindings/geotools/src/main/java/org/geotools/jackson/databind/filter/dto/LiteralDeserializer.java
@@ -57,7 +57,7 @@ public class LiteralDeserializer extends JsonDeserializer<Literal> {
         final Object value;
 
         String fieldName = parser.nextFieldName();
-        requireNonNull(fieldName, "expected contentType or value attribtue, got null");
+        requireNonNull(fieldName, "expected contentType or value attribute, got null");
         if (COLLECTION_CONTENT_TYPE_KEY.equals(fieldName)) {
             String contentTypeVal = parser.nextTextValue();
             requireNonNull(contentTypeVal, "expected value for contentType, got null");

--- a/src/catalog/jackson-bindings/geotools/src/main/java/org/geotools/jackson/databind/filter/mapper/GeoToolsValueMappers.java
+++ b/src/catalog/jackson-bindings/geotools/src/main/java/org/geotools/jackson/databind/filter/mapper/GeoToolsValueMappers.java
@@ -228,7 +228,7 @@ public abstract class GeoToolsValueMappers {
 
         LoggerFactory.getLogger(getClass())
                 .warn(
-                        "Uknown InternationalString implementation: {}. Returning the default value",
+                        "Unknown InternationalString implementation: {}. Returning the default value",
                         s.getClass().getName());
         return Map.of("", s.toString());
     }

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogInfoRepository.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogInfoRepository.java
@@ -65,7 +65,7 @@ public interface CatalogInfoRepository<T extends CatalogInfo> {
      * Applies the provided {@link Patch patch} to this repository's copy of the provided {@code
      * value} object and returns the "patched" object.
      *
-     * <p>In contrast to a typical {@code save(I value)} method, the patch helps implementors to
+     * <p>In contrast to a typical {@code save(I value)} method, the patch helps implementers to
      * apply MVCC (Multi-Version Concurrency Control) semantics to the operation. It provides the
      * property names and values that need to be changed, and hence the implementation can choose
      * the best mechanism to apply those specific changes without overriding the whole object. For

--- a/src/catalog/plugin/src/main/java/org/geoserver/config/plugin/GeoServerImpl.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/config/plugin/GeoServerImpl.java
@@ -191,7 +191,7 @@ public class GeoServerImpl implements GeoServer, ApplicationContextAware {
         if (workspace == null) {
             throw new IllegalArgumentException("Settings must be part of a workspace");
         }
-        // make sure the workspace exists and is not dettached from the catalog
+        // make sure the workspace exists and is not detached from the catalog
         final WorkspaceInfo realws = getCatalog().getWorkspace(workspace.getId());
         Objects.requireNonNull(realws, () -> "Workspace %s(%s) attached to SettingsInfo does not exist"
                 .formatted(workspace.getName(), workspace.getId()));

--- a/src/catalog/plugin/src/test/java/org/geoserver/catalog/faker/CatalogFaker.java
+++ b/src/catalog/plugin/src/test/java/org/geoserver/catalog/faker/CatalogFaker.java
@@ -369,12 +369,12 @@ public class CatalogFaker {
     }
 
     public NamespaceInfo namespace(String id, String name, String uri) {
-        NamespaceInfo namesapce = catalogFactory().createNamespace();
-        OwsUtils.set(namesapce, "id", id);
-        namesapce.setPrefix(name);
-        namesapce.setURI(uri);
-        OwsUtils.resolveCollections(namesapce);
-        return namesapce;
+        NamespaceInfo namespace = catalogFactory().createNamespace();
+        OwsUtils.set(namespace, "id", id);
+        namespace.setPrefix(name);
+        namespace.setURI(uri);
+        OwsUtils.resolveCollections(namespace);
+        return namespace;
     }
 
     public GeoServerInfo geoServerInfo() {

--- a/src/catalog/plugin/src/test/java/org/geoserver/catalog/plugin/XmlCatalogInfoLookup.java
+++ b/src/catalog/plugin/src/test/java/org/geoserver/catalog/plugin/XmlCatalogInfoLookup.java
@@ -46,7 +46,7 @@ import org.geotools.util.logging.Logging;
  * <p>This is not for production, it will have the worse possible performance since all the lookups
  * are performed by de-serializing on the fly with only an id to serialized form lookup table. The
  * point is to have a test implementation that mimics what'd happen when the {@link CatalogInfo}
- * back-end is not the {@link CatalogInfoLookup default in-memory} one, by returning "dettached"
+ * back-end is not the {@link CatalogInfoLookup default in-memory} one, by returning "detached"
  * objects.
  *
  * @see XmlCatalogInfoLookupConformanceTest

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/event/GeoWebCacheEvent.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/event/GeoWebCacheEvent.java
@@ -12,7 +12,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEvent;
 
 /**
- * Local {@link ApplicationContext} event issued to replace the tighly coupled {@link
+ * Local {@link ApplicationContext} event issued to replace the tightly coupled {@link
  * TileLayerCatalogListener} by loosely coupled application events
  *
  * @since 1.0

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/repository/CloudGwcXmlConfiguration.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/repository/CloudGwcXmlConfiguration.java
@@ -114,7 +114,7 @@ public class CloudGwcXmlConfiguration extends XMLConfiguration {
                 }
                 break;
             default:
-                throw new IllegalArgumentException("Uknown event type: " + event.getEventType());
+                throw new IllegalArgumentException("Unknown event type: " + event.getEventType());
         }
         return true;
     }

--- a/src/gwc/integration-bus/src/main/java/org/geoserver/cloud/gwc/bus/RemoteTileLayerEvent.java
+++ b/src/gwc/integration-bus/src/main/java/org/geoserver/cloud/gwc/bus/RemoteTileLayerEvent.java
@@ -13,7 +13,7 @@ import org.geoserver.gwc.layer.TileLayerCatalogListener;
 import org.springframework.context.ApplicationContext;
 
 /**
- * Local {@link ApplicationContext} event issued to replace the tighly coupled {@link
+ * Local {@link ApplicationContext} event issued to replace the tightly coupled {@link
  * TileLayerCatalogListener} by loosely coupled application events
  *
  * @since 1.0

--- a/src/gwc/services/src/main/java/org/geoserver/cloud/gwc/config/services/RESTConfigConfiguration.java
+++ b/src/gwc/services/src/main/java/org/geoserver/cloud/gwc/config/services/RESTConfigConfiguration.java
@@ -62,7 +62,7 @@ public class RESTConfigConfiguration {
 
     /**
      * Replacement for {@link SeedController#doPost(javax.servlet.http.HttpServletRequest, java.io.InputStream, String, java.util.Map)}
-     * working wit spring-boot's stricter path pattern matching
+     * working with spring-boot's stricter path pattern matching
      */
     @Bean
     org.geoserver.cloud.gwc.config.services.SeedControllerOverride seedController() {

--- a/src/gwc/services/src/main/java/org/gwc/web/rest/GeoWebCacheController.java
+++ b/src/gwc/services/src/main/java/org/gwc/web/rest/GeoWebCacheController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * Modified top-level dispatcher controller for use by GeoServer. Same as {@link
  * GeoWebCacheDispatcherController}, except the "/service/**" endpoint is excluded. This is handled
- * seperately by the GeoServer Dispatcher.
+ * separately by the GeoServer Dispatcher.
  *
  * <p>Copied from {@link GeoServerGWCDispatcherController}
  */

--- a/src/starters/observability/src/main/java/org/geoserver/cloud/logging/mdc/servlet/MDCAuthenticationFilter.java
+++ b/src/starters/observability/src/main/java/org/geoserver/cloud/logging/mdc/servlet/MDCAuthenticationFilter.java
@@ -24,7 +24,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 /**
  * Appends the {@code enduser.id} and {@code enduser.role} MDC properties depending on whether
  * {@link MDCConfigProperties#isUser() user} and {@link MDCConfigProperties#isRoles() roles} config
- * properties are enabled, respectivelly.
+ * properties are enabled, respectively.
  *
  * <p>Note the appended MDC properties follow the <a href=
  * "https://opentelemetry.io/docs/specs/semconv/general/attributes/#general-identity-attributes">OpenTelemetry

--- a/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/DisabledConfiguration.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/DisabledConfiguration.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.Configuration;
 
 /**
  * Contributes a {@link GatewaySharedAuthenticationProvider} in disabled mode, essentially a no-op
- * {@link AbstractFilterProvider} to avoid starup failure when the gateway shared auth was enabled,
+ * {@link AbstractFilterProvider} to avoid startup failure when the gateway shared auth was enabled,
  * then disabled, and geoserver restarted.
  *
  * @see ClientConfiguration

--- a/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/GatewaySharedAuthenticationFilter.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/sharedauth/GatewaySharedAuthenticationFilter.java
@@ -76,7 +76,7 @@ class GatewaySharedAuthenticationFilter extends GeoServerSecurityFilter implemen
     /**
      * @return a {@link GatewaySharedAuthenticationFilter} proxy filter with a
      *     <strong>no-op</strong> {@link DisabledFilter} delegate. This prevents startup failures
-     *     and WebUI security settings editting failures, when the filter has been disabled through
+     *     and WebUI security settings editing failures, when the filter has been disabled through
      *     {@code geoserver.security.gateway-shared-auth.enabled=false} after it's been enabled.
      */
     public static GeoServerSecurityFilter disabled() {
@@ -146,8 +146,8 @@ class GatewaySharedAuthenticationFilter extends GeoServerSecurityFilter implemen
         }
 
         /**
-         * Override to handle muilti-valued roles header, the superclass assumes a single-valued
-         * header with a delimiter to handle mutliple values
+         * Override to handle multi-valued roles header, the super-class assumes a single-valued
+         * header with a delimiter to handle multiple values
          */
         @Override
         protected Collection<GeoServerRole> getRolesFromHttpAttribute(HttpServletRequest request, String principal) {


### PR DESCRIPTION
Use the `codespell`  CLI to fix typos

```shell
brew install codespell
codespell -w
```

(deal with mistakes made by codespell manually)