### PR TITLE
Catalog Plugin: Enhance Documentation

### DIFF
--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogFacadeExtensionAdapter.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogFacadeExtensionAdapter.java
@@ -31,7 +31,6 @@ import org.geoserver.catalog.event.CatalogListener;
 import org.geoserver.catalog.impl.CatalogImpl;
 import org.geoserver.catalog.impl.ClassMappings;
 import org.geoserver.catalog.impl.ModificationProxy;
-import org.geoserver.catalog.plugin.forwarding.ForwardingCatalog;
 import org.geoserver.catalog.plugin.forwarding.ForwardingCatalogFacade;
 import org.geoserver.catalog.util.CloseableIterator;
 import org.geotools.api.filter.Filter;
@@ -39,16 +38,50 @@ import org.geotools.api.filter.sort.SortBy;
 import org.geotools.util.logging.Logging;
 
 /**
- * Adapts a regular {@link CatalogFacade} to a {@link ExtendedCatalogFacade}
+ * Adapts a legacy {@link CatalogFacade} implementation to the {@link ExtendedCatalogFacade} interface.
  *
- * <p>Overrides {@link #setCatalog} with a catalog decorator that doesn't publish events, further
- * adapting a legacy {@link CatalogFacade} implementation, that mixes up responsibilities with the
- * catalog itself.
+ * <p>This class bridges the gap between traditional {@link CatalogFacade} implementations and the
+ * enhanced {@link ExtendedCatalogFacade} API introduced in GeoServer Cloud. It extends
+ * {@link ForwardingCatalogFacade} to wrap an existing facade, adding support for modern methods like
+ * {@link #update(CatalogInfo, Patch)} and {@link #query(Query)} while suppressing unwanted event
+ * publishing from legacy facades. The adapter ensures compatibility with older facade implementations
+ * that may intertwine catalog operations with event handling, a responsibility now delegated to the
+ * {@link Catalog} itself.
+ *
+ * <p>Key adaptations:
+ * <ul>
+ *   <li><strong>Event Suppression:</strong> Wraps the catalog in a {@link SilentCatalog} to mute event
+ *       firing from legacy facade operations.</li>
+ *   <li><strong>Update Bridging:</strong> Maps {@link #update(CatalogInfo, Patch)} to legacy {@code save}
+ *       methods using a type registry.</li>
+ *   <li><strong>Query Support:</strong> Adapts {@link #query(Query)} to the legacy {@link #list} method
+ *       with stream-based results.</li>
+ * </ul>
+ *
+ * <p>This adapter is intended as a transitional tool until {@link ExtendedCatalogFacade} features are
+ * fully integrated into GeoServer’s core {@link CatalogFacade}.
+ *
+ * @since 1.0
+ * @see ExtendedCatalogFacade
+ * @see CatalogFacade
+ * @see SilentCatalog
  */
 public class CatalogFacadeExtensionAdapter extends ForwardingCatalogFacade implements ExtendedCatalogFacade {
 
     private CatalogInfoTypeRegistry<Consumer<?>> updateToSaveBridge = new CatalogInfoTypeRegistry<>();
 
+    /**
+     * Constructs a new adapter wrapping a legacy {@link CatalogFacade}.
+     *
+     * <p>Initializes the adapter by decorating the provided facade and setting up a bridge from
+     * {@link #update(CatalogInfo, Patch)} to the legacy {@code save} methods for each catalog info type.
+     * If the facade already implements {@link ExtendedCatalogFacade}, an exception is thrown to avoid
+     * unnecessary wrapping.
+     *
+     * @param facade The legacy {@link CatalogFacade} to adapt; must not be null.
+     * @throws NullPointerException if {@code facade} is null.
+     * @throws IllegalArgumentException if {@code facade} is already an {@link ExtendedCatalogFacade}.
+     */
     public CatalogFacadeExtensionAdapter(CatalogFacade facade) {
         super(facade);
         if (facade instanceof ExtendedCatalogFacade) {
@@ -70,6 +103,22 @@ public class CatalogFacadeExtensionAdapter extends ForwardingCatalogFacade imple
         }
     }
 
+    /**
+     * Sets the catalog for this facade, wrapping it to suppress event publishing.
+     *
+     * <p>Overrides the parent method to ensure the catalog is a {@link CatalogPlugin} instance and
+     * decorates it with {@link SilentCatalog} if it isn’t already silent. This prevents legacy facade
+     * implementations from firing catalog events, aligning with GeoServer Cloud’s design where event
+     * handling is the catalog’s responsibility.
+     *
+     * @param catalog The catalog to set; may be null to unset.
+     * @throws IllegalArgumentException if {@code catalog} is non-null and not a {@link CatalogPlugin}.
+     * @example Setting a catalog:
+     *          <pre>
+     *          CatalogPlugin catalog = new CatalogPlugin(facade);
+     *          adapter.setCatalog(catalog);
+     *          </pre>
+     */
     @Override
     public void setCatalog(Catalog catalog) {
         if (catalog != null) {
@@ -87,12 +136,26 @@ public class CatalogFacadeExtensionAdapter extends ForwardingCatalogFacade imple
     }
 
     /**
-     * Bridges the new {@link ExtendedCatalogFacade#update(CatalogInfo, Patch)} method to the
-     * corresponding {@link CatalogFacade#save} method in the decorated old style {@link
-     * CatalogFacade}.
+     * Updates a catalog object with a patch, bridging to legacy {@code save} methods.
      *
-     * <p>This would be unnecessary if {@link ExtendedCatalogFacade}'s {@code update()} is
-     * incorporated to the official {@link CatalogFacade} interface.
+     * <p>This method adapts the modern {@link ExtendedCatalogFacade#update(CatalogInfo, Patch)} API to
+     * the legacy {@link CatalogFacade#save} methods of the wrapped facade. It creates a proxy of the
+     * original object, applies the patch, and delegates to the appropriate {@code save} method via the
+     * {@code updateToSaveBridge} registry. This bridge is temporary and would be unnecessary if
+     * {@code update} is integrated into {@link CatalogFacade}.
+     *
+     * @param <I>   The type of {@link CatalogInfo} to update.
+     * @param info  The catalog object to update; must not be null.
+     * @param patch The patch containing changes to apply; must not be null.
+     * @return The updated {@link CatalogInfo} object after applying the patch.
+     * @throws NullPointerException if {@code info} or {@code patch} is null.
+     * @throws IllegalArgumentException if the object type is not supported by the bridge.
+     * @example Updating a layer’s title:
+     *          <pre>
+     *          LayerInfo layer = ...; // fetched from catalog
+     *          Patch patch = new Patch().with("title", "New Title");
+     *          LayerInfo updated = adapter.update(layer, patch);
+     *          </pre>
      */
     @Override
     public <I extends CatalogInfo> I update(final I info, final Patch patch) {
@@ -105,12 +168,38 @@ public class CatalogFacadeExtensionAdapter extends ForwardingCatalogFacade imple
         return proxied;
     }
 
+    /**
+     * Retrieves a type-specific {@code save} consumer from the update bridge registry.
+     *
+     * @param <T>  The type of {@link CatalogInfo}.
+     * @param cm   The {@link ClassMappings} key identifying the type.
+     * @return A {@link Consumer} that invokes the legacy {@code save} method for the type.
+     */
     @SuppressWarnings("unchecked")
     private <T extends CatalogInfo> Consumer<T> saving(ClassMappings cm) {
         return (Consumer<T>) updateToSaveBridge.of(cm);
     }
 
-    /** Adapts a {@link ExtendedCatalogFacade#query} call to {@link CatalogFacade#list} */
+    /**
+     * Queries the catalog by adapting to the legacy {@link CatalogFacade#list} method.
+     *
+     * <p>This method converts a {@link Query} into parameters for the underlying facade’s {@code list}
+     * method, returning a {@link Stream} of results. The stream is configured with characteristics
+     * ({@code ORDERED}, {@code DISTINCT}, {@code IMMUTABLE}, {@code NONNULL}) and ensures proper resource
+     * closure via {@link CloseableIterator}.
+     *
+     * @param <T>   The type of {@link CatalogInfo} to query.
+     * @param query The query defining type, filter, sorting, and pagination; must not be null.
+     * @return A {@link Stream} of matching catalog objects; never null.
+     * @throws NullPointerException if {@code query} is null.
+     * @example Querying layers:
+     *          <pre>
+     *          Query<LayerInfo> query = Query.valueOf(LayerInfo.class, Filter.INCLUDE);
+     *          try (Stream<LayerInfo> layers = adapter.query(query)) {
+     *              layers.forEach(l -> System.out.println(l.getName()));
+     *          }
+     *          </pre>
+     */
     @Override
     public <T extends CatalogInfo> Stream<T> query(Query<T> query) {
         Class<T> of = query.getType();
@@ -134,19 +223,32 @@ public class CatalogFacadeExtensionAdapter extends ForwardingCatalogFacade imple
     }
 
     /**
-     * Catalog decorator that mutes all calls to fire catalog events, so legacy {@link
-     * CatalogFacade}s trying to publish events have no effect, as its now catalog's sole
-     * responsibility to do so.
+     * A catalog decorator that suppresses event publishing from legacy {@link CatalogFacade} implementations.
      *
-     * <p>Note this class extends {@link CatalogPlugin} and not {@link ForwardingCatalog} because of
-     * the astonishing coupling of legacy {@link CatalogFacade} implementations on {@link
-     * CatalogImpl}
+     * <p>This nested class extends {@link CatalogPlugin} to wrap an existing catalog, muting all event firing
+     * methods (e.g., {@link #fireAdded}) to prevent legacy facades from publishing events. Event handling is
+     * now the sole responsibility of the catalog, addressing the tight coupling in legacy {@link CatalogImpl}
+     * designs. It logs suppression actions for debugging purposes.
+     *
+     * @since 1.0
+     * @see CatalogPlugin
+     * @see CatalogImpl
      */
     @SuppressWarnings({"serial", "rawtypes"})
     public static class SilentCatalog extends CatalogPlugin {
         private static final Logger LOGGER = Logging.getLogger(SilentCatalog.class);
         private CatalogPlugin orig;
 
+        /**
+         * Constructs a silent catalog wrapper around an existing {@link CatalogPlugin}.
+         *
+         * <p>Initializes the wrapper with the provided facade and original catalog, copying resource-related
+         * fields and removing listeners to mute event propagation.
+         *
+         * @param orig   The original {@link CatalogPlugin} to wrap; must not be null.
+         * @param facade The facade associated with this catalog; must not be null.
+         * @throws NullPointerException if {@code orig} or {@code facade} is null.
+         */
         public SilentCatalog(CatalogPlugin orig, CatalogFacadeExtensionAdapter facade) {
             super(facade, orig.isolated);
             this.orig = orig;
@@ -155,37 +257,78 @@ public class CatalogFacadeExtensionAdapter extends ForwardingCatalogFacade imple
             super.removeListeners(CatalogListener.class);
         }
 
+        /**
+         * Returns the underlying {@link CatalogImpl} subject being wrapped.
+         *
+         * @return The original {@link CatalogImpl} instance.
+         */
         public CatalogImpl getSubject() {
             return orig;
         }
 
+        /**
+         * Suppresses adding a catalog listener, logging the action.
+         *
+         * @param listener The listener to suppress; may be null (ignored).
+         */
         @Override
         public void addListener(CatalogListener listener) {
-            LOGGER.fine(
-                    () -> "Suppressing catalog listener " + listener.getClass().getCanonicalName());
+            LOGGER.fine(() -> "Suppressing catalog listener "
+                    + (listener != null ? listener.getClass().getCanonicalName() : "null"));
         }
 
+        /**
+         * Overrides facade setting to ensure proper delegation.
+         *
+         * @param facade The facade to set; must not be null.
+         */
         @Override
         public void setFacade(CatalogFacade facade) {
             super.rawFacade = facade;
             super.facade = facade;
         }
 
+        /**
+         * Suppresses firing an add event, logging the suppression.
+         *
+         * @param object The object added (ignored).
+         */
         @Override
         public void fireAdded(CatalogInfo object) {
             LOGGER.fine("Suppressing catalog add event from legacy CatalogFacade");
         }
 
+        /**
+         * Suppresses firing a pre-modify event, logging the suppression.
+         *
+         * @param object        The modified object (ignored).
+         * @param propertyNames The property names (ignored).
+         * @param oldValues     The old values (ignored).
+         * @param newValues     The new values (ignored).
+         */
         @Override
         public void fireModified(CatalogInfo object, List propertyNames, List oldValues, List newValues) {
             LOGGER.fine("Suppressing catalog pre-modify event from legacy CatalogFacade");
         }
 
+        /**
+         * Suppresses firing a post-modify event, logging the suppression.
+         *
+         * @param object        The modified object (ignored).
+         * @param propertyNames The property names (ignored).
+         * @param oldValues     The old values (ignored).
+         * @param newValues     The new values (ignored).
+         */
         @Override
         public void firePostModified(CatalogInfo object, List propertyNames, List oldValues, List newValues) {
             LOGGER.fine("Suppressing catalog post-modify event from legacy CatalogFacade");
         }
 
+        /**
+         * Suppresses firing a remove event, logging the suppression.
+         *
+         * @param object The removed object (ignored).
+         */
         @Override
         public void fireRemoved(CatalogInfo object) {
             LOGGER.fine("Suppressing catalog removed event from legacy CatalogFacade");

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogInfoRepository.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogInfoRepository.java
@@ -16,29 +16,38 @@ import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WMSLayerInfo;
+import org.geoserver.catalog.WMTSLayerInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geotools.api.filter.Filter;
 import org.springframework.lang.Nullable;
 
 /**
- * Raw data access API for {@link CatalogInfo} back-end implementations.
+ * A raw data access API for {@link CatalogInfo} back-end implementations in GeoServer.
  *
- * <p>This is a null-free, DDD inspired "repository" API to provide storage and querying of plain
- * {@link CatalogInfo} objects, with precise semantics. No method that receives an argument can
- * receive {@code null}. In cases where different semantics shall be applied, each specialization
- * provides alternative, semantically clear query methods. For example, {@link
- * StyleRepository#findAllByNullWorkspace()} and {@link
- * StyleRepository#findAllByWorkspace(WorkspaceInfo)} are self-explanatory, no magic is involved nor
- * decision making, which are handled at a higher level of abstraction ({@code CatalogFacade} and/or
- * {@code Catalog}).
+ * <p>This interface defines a null-safe, domain-driven design (DDD)-inspired "repository" API for storing
+ * and querying plain {@link CatalogInfo} objects (e.g., workspaces, layers, styles) with precise semantics.
+ * <p>
+ * It serves as a low-level abstraction for catalog persistence, eschewing null arguments to ensure clear,
+ * predictable behavior. Each method has unambiguous intent, avoiding magic or decision-making that is
+ * delegated to higher-level abstractions like {@link CatalogFacade} or {@link org.geoserver.catalog.Catalog}.
  *
- * <p>All query methods that could return zero or one result, return {@link Optional}. All query
- * methods that could return zero or more results, return {@link Stream}.
+ * <p>Key features:
+ * <ul>
+ *   <li><strong>Null Safety:</strong> No method accepts null arguments; violations throw {@link NullPointerException}.</li>
+ *   <li><strong>Query Semantics:</strong> Specialized methods (e.g., {@link StyleRepository#findAllByNullWorkspace()})
+ *       provide explicit alternatives rather than relying on null checks or overloading.</li>
+ *   <li><strong>Return Types:</strong> Single-result queries return {@link Optional}; multi-result queries return
+ *       {@link Stream}, which must be closed to release resources.</li>
+ *   <li><strong>Resource Management:</strong> Streams implement {@link AutoCloseable}, requiring proper closure
+ *       (e.g., via try-with-resources) to avoid resource leaks in implementations using live connections.</li>
+ * </ul>
  *
- * <p>Care shall be taken that {@code Stream} implements {@link AutoCloseable} and hence it is
- * expected for users of this api to properly close the received stream, may the implementation be
- * using live connections to some back-end storage and need to release resources.
+ * <p>Specialized sub-interfaces (e.g., {@link WorkspaceRepository}, {@link LayerRepository}) extend this
+ * interface with type-specific operations, tailoring the API to each catalog entity type.
  *
+ * @param <T> The specific type of {@link CatalogInfo} this repository manages (e.g., {@link LayerInfo}).
+ * @since 1.0
  * @see WorkspaceRepository
  * @see NamespaceRepository
  * @see StoreRepository
@@ -47,157 +56,520 @@ import org.springframework.lang.Nullable;
  * @see LayerGroupRepository
  * @see StyleRepository
  * @see MapRepository
- * @param <T>
  */
 public interface CatalogInfoRepository<T extends CatalogInfo> {
 
     /**
-     * @return the less concrete {@link CatalogInfo} type this repository handles (e.g. if {@link
-     *     ResourceInfo}, then this repository handles all {@code ResourceInfo} subtypes)
+     * Returns the least specific {@link CatalogInfo} type this repository handles.
+     *
+     * <p>This method identifies the base type of objects managed by the repository. For example, a
+     * {@link ResourceRepository} would return {@link ResourceInfo}, indicating it handles all subtypes
+     * like {@link FeatureTypeInfo}, {@link CoverageInfo}, {@link WMSLayerInfo}, and {@link WMTSLayerInfo}.
+     *
+     * @return The {@link Class} representing the repository’s content type; never null.
      */
     Class<T> getContentType();
 
+    /**
+     * Adds a new catalog object to the repository.
+     *
+     * <p>The object is persisted to the underlying storage, and its state may be updated (e.g., with a
+     * generated ID). The added object remains unchanged in memory unless explicitly reassigned.
+     *
+     * @param value The catalog object to add; must not be null.
+     * @throws NullPointerException if {@code value} is null.
+     * @example Adding a workspace:
+     *          <pre>
+     *          WorkspaceInfo ws = new WorkspaceInfoImpl();
+     *          ws.setName("myWorkspace");
+     *          repository.add(ws);
+     */
     void add(@NonNull T value);
 
+    /**
+     * Removes a catalog object from the repository.
+     *
+     * <p>The object is deleted from the underlying storage, and associated resources may be cleaned up
+     * depending on the implementation. The provided object remains unchanged in memory.
+     *
+     * @param value The catalog object to remove; must not be null.
+     * @throws NullPointerException if {@code value} is null.
+     * @example Removing a layer:
+     *          <pre>
+     *          LayerInfo layer = ...; // existing layer
+     *          repository.remove(layer);
+     *          </pre>
+     */
     void remove(@NonNull T value);
 
     /**
-     * Applies the provided {@link Patch patch} to this repository's copy of the provided {@code
-     * value} object and returns the "patched" object.
+     * Updates an existing catalog object in the repository with the specified patch of changes.
      *
-     * <p>In contrast to a typical {@code save(I value)} method, the patch helps implementers to
-     * apply MVCC (Multi-Version Concurrency Control) semantics to the operation. It provides the
-     * property names and values that need to be changed, and hence the implementation can choose
-     * the best mechanism to apply those specific changes without overriding the whole object. For
-     * example, it can be translated to an SQL {@code UPDATE} with only the required column changes,
-     * or improve concurrency on an in-memory store by only having to lock the live-object while the
-     * patch is applied.
+     * <p>This method applies the provided {@link Patch} to the repository’s copy of the object identified
+     * by {@code value}, returning the updated object. The patch specifies only the properties to change,
+     * enabling efficient updates (e.g., translating to an SQL {@code UPDATE} for specific columns) and
+     * supporting multi-version concurrency control (MVCC) semantics. The original {@code value} object
+     * is not modified; the returned object may be a new instance or the same instance, depending on the
+     * implementation.
      *
-     * <p>The provided value shall not be modified by this method. Whether the provided value and
-     * the updated repository copy refer to the same object instance is up to the implementation,
-     * but they're considered different from the point of view of the API.
+     * @param <I>   The specific type of {@link CatalogInfo} being updated.
+     * @param value The catalog object to update (identifies the target); must not be null.
+     * @param patch The patch containing property changes to apply; must not be null.
+     * @return The updated catalog object reflecting the applied patch.
+     * @throws NullPointerException if {@code value} or {@code patch} is null.
+     * @throws IllegalArgumentException if {@code value} is not found in the repository.
+     * @example Updating a layer’s title:
+     *          <pre>
+     *          LayerInfo layer = ...; // existing layer
+     *          Patch patch = new Patch().with("title", "New Title");
+     *          LayerInfo updated = repository.update(layer, patch);
+     *          </pre>
      */
     <I extends T> I update(@NonNull I value, @NonNull Patch patch);
 
+    /**
+     * Releases any resources held by this repository.
+     *
+     * <p>This method should be called when the repository is no longer needed to ensure proper cleanup
+     * (e.g., closing database connections). Implementations may use this to free resources explicitly.
+     */
     void dispose();
 
+    /**
+     * Retrieves all objects managed by this repository without restrictions.
+     *
+     * <p>This default implementation uses {@link #findAll(Query)} with a query that includes all objects
+     * of the repository’s content type ({@link #getContentType()}) and {@link Filter#INCLUDE}. The returned
+     * stream must be closed after use to release resources.
+     *
+     * @return A {@link Stream} of all catalog objects managed by this repository; never null.
+     * @example Listing all resources:
+     *          <pre>
+     *          try (Stream<ResourceInfo> resources = repository.findAll()) {
+     *              resources.forEach(r -> System.out.println(r.getName()));
+     *          }
+     *          </pre>
+     */
     default Stream<T> findAll() {
         return findAll(Query.all(getContentType()));
     }
 
     /**
-     * Returns all objects in this repository that satisfy the query criteria (type and filter),
-     * additional restrictions such as paging and order.
+     * Retrieves all objects matching the specified query criteria.
      *
-     * @see Query
+     * <p>This method returns a stream of objects that satisfy the {@link Query}’s type, filter, sorting,
+     * and pagination constraints. The stream must be closed after use to release resources, ideally via
+     * a try-with-resources block.
+     *
+     * @param <U>   The specific type of {@link CatalogInfo} being queried.
+     * @param query The query defining the criteria; must not be null.
+     * @return A {@link Stream} of matching catalog objects; never null.
+     * @throws NullPointerException if {@code query} is null.
+     * @example Querying layers by name:
+     *          <pre>
+     *          Query<LayerInfo> query = Query.valueOf(LayerInfo.class, nameFilter);
+     *          try (Stream<LayerInfo> layers = repository.findAll(query)) {
+     *              layers.forEach(l -> System.out.println(l.getName()));
+     *          }
+     *          </pre>
      */
     <U extends T> Stream<U> findAll(Query<U> query);
 
+    /**
+     * Counts the number of objects of a specific type matching the given filter.
+     *
+     * @param <U>    The specific type of {@link CatalogInfo} to count.
+     * @param of     The class of objects to count; must not be null.
+     * @param filter The filter to apply; must not be null.
+     * @return The number of matching objects.
+     * @throws NullPointerException if {@code of} or {@code filter} is null.
+     * @example Counting layers in a namespace:
+     *          <pre>
+     *          Filter nsFilter = ...; // filter by namespace
+     *          long count = repository.count(LayerInfo.class, nsFilter);
+     *          </pre>
+     */
     <U extends T> long count(Class<U> of, Filter filter);
 
-    /** Looks up a CatalogInfo by class and identifier */
+    /**
+     * Retrieves a catalog object by its ID and type.
+     *
+     * <p>This method looks up an object with the specified ID, optionally constrained by the given type.
+     * If {@code clazz} is null, it returns the first match of any subtype of {@code T}.
+     *
+     * @param <U>   The specific type of {@link CatalogInfo} to retrieve.
+     * @param id    The unique identifier of the object; must not be null.
+     * @param clazz The type of object to find, or null for any subtype of {@code T}.
+     * @return An {@link Optional} containing the found object, or empty if not found.
+     * @throws NullPointerException if {@code id} is null.
+     * @example Finding a layer by ID:
+     *          <pre>
+     *          Optional<LayerInfo> layer = repository.findById("layer1", LayerInfo.class);
+     *          layer.ifPresent(l -> System.out.println(l.getName()));
+     *          </pre>
+     */
     <U extends T> Optional<U> findById(@NonNull String id, @Nullable Class<U> clazz);
 
     /**
-     * Looks up a CatalogInfo by class and name
+     * Retrieves the first catalog object matching the specified name and type.
      *
-     * @param name
-     * @return the first match found based on {@code name}, or {@code null}
+     * <p>This method searches for an object by name within the repository’s scope, returning the first
+     * match of the given type, or an empty {@link Optional} if none is found.
+     *
+     * @param <U>   The specific type of {@link CatalogInfo} to retrieve.
+     * @param name  The name of the object; must not be null.
+     * @param clazz The type of object to find; must not be null.
+     * @return An {@link Optional} containing the first matching object, or empty if not found.
+     * @throws NullPointerException if {@code name} or {@code clazz} is null.
+     * @example Finding a style by name:
+     *          <pre>
+     *          Optional<StyleInfo> style = repository.findFirstByName("point", StyleInfo.class);
+     *          </pre>
      */
     <U extends T> Optional<U> findFirstByName(@NonNull String name, Class<U> clazz);
 
+    /**
+     * Checks if this repository supports sorting by the specified property.
+     *
+     * <p>This method indicates whether the underlying storage can sort results by the given property name,
+     * useful for optimizing queries with {@link SortBy}.
+     *
+     * @param propertyName The name of the property to check; must not be null. Nested properties are specified with a {@code .}
+     * separator, for example: {@code workspace.id}, {@code resource.store.namespace.prefix}, etc.
+     * @return {@code true} if sorting by the property is supported; {@code false} otherwise.
+     * @throws NullPointerException if {@code propertyName} is null.
+     */
     public boolean canSortBy(@NonNull String propertyName);
 
-    // revisit: some sort of progress listener/cancel flag would be nice
+    /**
+     * Synchronizes this repository’s contents to another repository.
+     *
+     * <p>This method copies all objects from this repository to the target, potentially overwriting
+     * existing entries in the target. It is intended for backup or migration purposes. Note: Future
+     * enhancements could include a progress listener or cancellation mechanism.
+     * <p>
+     * Additionally, a {@code synchFrom} method might be more appropriate, as concrete implementations
+     * would know better which optimizations to apply.
+     *
+     * @param target The target repository to sync to; must not be null.
+     * @throws NullPointerException if {@code target} is null.
+     * @example Syncing to another repository:
+     *          <pre>
+     *          CatalogInfoRepository<LayerInfo> source = ...;
+     *          CatalogInfoRepository<LayerInfo> target = ...;
+     *          source.syncTo(target);
+     *          </pre>
+     */
     void syncTo(@NonNull CatalogInfoRepository<T> target);
 
+    /**
+     * Specialized repository for managing {@link NamespaceInfo} objects.
+     */
     public interface NamespaceRepository extends CatalogInfoRepository<NamespaceInfo> {
-        /** Establishes {@code namespace} as the {@link #getDefaultNamespace() default} on */
+        /**
+         * Sets the specified namespace as the default namespace.
+         *
+         * @param namespace The namespace to set as default; must not be null.
+         * @throws NullPointerException if {@code namespace} is null.
+         */
         void setDefaultNamespace(@NonNull NamespaceInfo namespace);
 
-        /** Unlinks the current default namespace, leaving no default */
+        /**
+         * Removes the current default namespace designation, leaving no default.
+         */
         void unsetDefaultNamespace();
 
+        /**
+         * Retrieves the current default namespace.
+         *
+         * @return An {@link Optional} containing the default {@link NamespaceInfo}, or empty if none is set.
+         */
         Optional<NamespaceInfo> getDefaultNamespace();
 
+        /**
+         * Finds a namespace by its URI (e.g., "http://example.com").
+         *
+         * @param uri The URI to search for; must not be null.
+         * @return An {@link Optional} containing the matching {@link NamespaceInfo}, or empty if not found.
+         * @throws NullPointerException if {@code uri} is null.
+         */
         Optional<NamespaceInfo> findOneByURI(@NonNull String uri);
 
+        /**
+         * Retrieves all namespaces matching the specified URI.
+         *
+         * @param uri The URI to search for; must not be null.
+         * @return A {@link Stream} of matching {@link NamespaceInfo} objects; never null.
+         * @throws NullPointerException if {@code uri} is null.
+         */
         Stream<NamespaceInfo> findAllByURI(@NonNull String uri);
     }
 
     public interface WorkspaceRepository extends CatalogInfoRepository<WorkspaceInfo> {
-        /** Unlinks the current default workspace, leaving no default */
-        void unsetDefaultWorkspace();
-
-        /** Establishes {@code workspace} as the {@link #getDefaultWorkspace() default} on */
+        /**
+         * Sets the specified workspace as the default workspace.
+         *
+         * @param workspace The workspace to set as default; must not be null.
+         * @throws NullPointerException if {@code workspace} is null.
+         */
         void setDefaultWorkspace(@NonNull WorkspaceInfo workspace);
 
+        /**
+         * Removes the current default workspace designation, leaving no default.
+         */
+        void unsetDefaultWorkspace();
+
+        /**
+         * Retrieves the current default workspace.
+         *
+         * @return An {@link Optional} containing the default {@link WorkspaceInfo}, or empty if none is set.
+         */
         Optional<WorkspaceInfo> getDefaultWorkspace();
     }
 
+    /**
+     * Specialized repository for managing {@link StoreInfo} objects.
+     */
     public interface StoreRepository extends CatalogInfoRepository<StoreInfo> {
-
+        /**
+         * Sets the specified data store as the default for the given workspace.
+         *
+         * @param workspace The workspace to configure; must not be null.
+         * @param dataStore The data store to set as default; must not be null.
+         * @throws NullPointerException if {@code workspace} or {@code dataStore} is null.
+         */
         void setDefaultDataStore(@NonNull WorkspaceInfo workspace, @NonNull DataStoreInfo dataStore);
 
+        /**
+         * Removes the default data store designation for the specified workspace.
+         *
+         * @param workspace The workspace to modify; must not be null.
+         * @throws NullPointerException if {@code workspace} is null.
+         */
         void unsetDefaultDataStore(@NonNull WorkspaceInfo workspace);
 
+        /**
+         * Retrieves the default data store for the specified workspace.
+         *
+         * @param workspace The workspace to query; must not be null.
+         * @return An {@link Optional} containing the default {@link DataStoreInfo}, or empty if none is set.
+         * @throws NullPointerException if {@code workspace} is null.
+         */
         Optional<DataStoreInfo> getDefaultDataStore(@NonNull WorkspaceInfo workspace);
 
+        /**
+         * Retrieves all default data stores across all workspaces.
+         *
+         * @return A {@link Stream} of default {@link DataStoreInfo} objects; never null.
+         */
         Stream<DataStoreInfo> getDefaultDataStores();
 
+        /**
+         * Retrieves all stores of a specific type within a workspace.
+         *
+         * @param workspace The workspace to query; must not be null.
+         * @param clazz     The type of {@link StoreInfo} to retrieve; must not be null.
+         * @return A {@link Stream} of matching stores; never null.
+         * @throws NullPointerException if {@code workspace} or {@code clazz} is null.
+         */
         <T extends StoreInfo> Stream<T> findAllByWorkspace(@NonNull WorkspaceInfo workspace, @NonNull Class<T> clazz);
 
+        /**
+         * Retrieves all stores of a specific type.
+         *
+         * @param clazz The type of {@link StoreInfo} to retrieve; must not be null.
+         * @return A {@link Stream} of matching stores; never null.
+         * @throws NullPointerException if {@code clazz} is null.
+         */
         <T extends StoreInfo> Stream<T> findAllByType(@NonNull Class<T> clazz);
 
+        /**
+         * Finds a store by name and workspace.
+         *
+         * @param name      The name of the store; must not be null.
+         * @param workspace The workspace to query; must not be null.
+         * @param clazz     The type of {@link StoreInfo} to retrieve; must not be null.
+         * @return An {@link Optional} containing the matching store, or empty if not found.
+         * @throws NullPointerException if {@code name}, {@code workspace}, or {@code clazz} is null.
+         */
         <T extends StoreInfo> Optional<T> findByNameAndWorkspace(
                 @NonNull String name, @NonNull WorkspaceInfo workspace, @NonNull Class<T> clazz);
     }
 
+    /**
+     * Specialized repository for managing {@link ResourceInfo} objects.
+     */
     public interface ResourceRepository extends CatalogInfoRepository<ResourceInfo> {
-
+        /**
+         * Finds a resource by name and namespace.
+         *
+         * @param name      The name of the resource; must not be null.
+         * @param namespace The namespace to query; must not be null.
+         * @param clazz     The type of {@link ResourceInfo} to retrieve; must not be null.
+         * @return An {@link Optional} containing the matching resource, or empty if not found.
+         * @throws NullPointerException if {@code name}, {@code namespace}, or {@code clazz} is null.
+         */
         <T extends ResourceInfo> Optional<T> findByNameAndNamespace(
                 @NonNull String name, @NonNull NamespaceInfo namespace, @NonNull Class<T> clazz);
 
+        /**
+         * Retrieves all resources of a specific type.
+         *
+         * @param clazz The type of {@link ResourceInfo} to retrieve; must not be null.
+         * @return A {@link Stream} of matching resources; never null.
+         * @throws NullPointerException if {@code clazz} is null.
+         */
         <T extends ResourceInfo> Stream<T> findAllByType(@NonNull Class<T> clazz);
 
+        /**
+         * Retrieves all resources within a namespace.
+         *
+         * @param ns    The namespace to query; must not be null.
+         * @param clazz The type of {@link ResourceInfo} to retrieve; must not be null.
+         * @return A {@link Stream} of matching resources; never null.
+         * @throws NullPointerException if {@code ns} or {@code clazz} is null.
+         */
         <T extends ResourceInfo> Stream<T> findAllByNamespace(@NonNull NamespaceInfo ns, @NonNull Class<T> clazz);
 
+        /**
+         * Finds a resource by store and name.
+         *
+         * @param store The store containing the resource; must not be null.
+         * @param name  The name of the resource; must not be null.
+         * @param clazz The type of {@link ResourceInfo} to retrieve; must not be null.
+         * @return An {@link Optional} containing the matching resource, or empty if not found.
+         * @throws NullPointerException if {@code store}, {@code name}, or {@code clazz} is null.
+         */
         <T extends ResourceInfo> Optional<T> findByStoreAndName(
                 @NonNull StoreInfo store, @NonNull String name, @NonNull Class<T> clazz);
 
+        /**
+         * Retrieves all resources associated with a store.
+         *
+         * @param store The store to query; must not be null.
+         * @param clazz The type of {@link ResourceInfo} to retrieve; must not be null.
+         * @return A {@link Stream} of matching resources; never null.
+         * @throws NullPointerException if {@code store} or {@code clazz} is null.
+         */
         <T extends ResourceInfo> Stream<T> findAllByStore(StoreInfo store, Class<T> clazz);
     }
 
+    /**
+     * Specialized repository for managing {@link LayerInfo} objects.
+     */
     public interface LayerRepository extends CatalogInfoRepository<LayerInfo> {
-
+        /**
+         * Finds a layer by its possibly prefixed name (e.g., "namespace:layer").
+         *
+         * @param possiblyPrefixedName The name of the layer; must not be null.
+         * @return An {@link Optional} containing the matching layer, or empty if not found.
+         * @throws NullPointerException if {@code possiblyPrefixedName} is null.
+         */
         Optional<LayerInfo> findOneByName(@NonNull String possiblyPrefixedName);
 
+        /**
+         * Retrieves all layers using the specified style as default or in their styles list.
+         *
+         * @param style The style to query; must not be null.
+         * @return A {@link Stream} of matching layers; never null.
+         * @throws NullPointerException if {@code style} is null.
+         */
         Stream<LayerInfo> findAllByDefaultStyleOrStyles(@NonNull StyleInfo style);
 
+        /**
+         * Retrieves all layers associated with a resource.
+         *
+         * @param resource The resource to query; must not be null.
+         * @return A {@link Stream} of matching layers; never null.
+         * @throws NullPointerException if {@code resource} is null.
+         */
         Stream<LayerInfo> findAllByResource(@NonNull ResourceInfo resource);
     }
 
+    /**
+     * Specialized repository for managing {@link LayerGroupInfo} objects.
+     */
     public interface LayerGroupRepository extends CatalogInfoRepository<LayerGroupInfo> {
-
+        /**
+         * Finds a layer group by name with no associated workspace.
+         *
+         * @param name The name of the layer group; must not be null.
+         * @return An {@link Optional} containing the matching layer group, or empty if not found.
+         * @throws NullPointerException if {@code name} is null.
+         */
         Optional<LayerGroupInfo> findByNameAndWorkspaceIsNull(@NonNull String name);
 
+        /**
+         * Finds a layer group by name and workspace.
+         *
+         * @param name      The name of the layer group; must not be null.
+         * @param workspace The workspace to query; must not be null.
+         * @return An {@link Optional} containing the matching layer group, or empty if not found.
+         * @throws NullPointerException if {@code name} or {@code workspace} is null.
+         */
         Optional<LayerGroupInfo> findByNameAndWorkspace(@NonNull String name, @NonNull WorkspaceInfo workspace);
 
+        /**
+         * Retrieves all layer groups with no associated workspace.
+         *
+         * @return A {@link Stream} of matching layer groups; never null.
+         */
         Stream<LayerGroupInfo> findAllByWorkspaceIsNull();
 
+        /**
+         * Retrieves all layer groups within a workspace.
+         *
+         * @param workspace The workspace to query; must not be null.
+         * @return A {@link Stream} of matching layer groups; never null.
+         * @throws NullPointerException if {@code workspace} is null.
+         */
         Stream<LayerGroupInfo> findAllByWorkspace(WorkspaceInfo workspace);
     }
 
+    /**
+     * Specialized repository for managing {@link StyleInfo} objects.
+     */
     public interface StyleRepository extends CatalogInfoRepository<StyleInfo> {
-
+        /**
+         * Retrieves all styles with no associated workspace.
+         *
+         * @return A {@link Stream} of matching styles; never null.
+         */
         Stream<StyleInfo> findAllByNullWorkspace();
 
+        /**
+         * Retrieves all styles within a workspace.
+         *
+         * @param ws The workspace to query; must not be null.
+         * @return A {@link Stream} of matching styles; never null.
+         * @throws NullPointerException if {@code ws} is null.
+         */
         Stream<StyleInfo> findAllByWorkspace(@NonNull WorkspaceInfo ws);
 
+        /**
+         * Finds a style by name with no associated workspace.
+         *
+         * @param name The name of the style; must not be null.
+         * @return An {@link Optional} containing the matching style, or empty if not found.
+         * @throws NullPointerException if {@code name} is null.
+         */
         Optional<StyleInfo> findByNameAndWordkspaceNull(@NonNull String name);
 
+        /**
+         * Finds a style by name and workspace.
+         *
+         * @param name      The name of the style; must not be null.
+         * @param workspace The workspace to query; must not be null.
+         * @return An {@link Optional} containing the matching style, or empty if not found.
+         * @throws NullPointerException if {@code name} or {@code workspace} is null.
+         */
         Optional<StyleInfo> findByNameAndWorkspace(@NonNull String name, @NonNull WorkspaceInfo workspace);
     }
 
+    /**
+     * Specialized repository for managing {@link MapInfo} objects.
+     *
+     * <p>This interface currently provides no additional methods beyond the base repository operations.
+     */
     public interface MapRepository extends CatalogInfoRepository<MapInfo> {}
 }

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogInfoRepositoryHolder.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogInfoRepositoryHolder.java
@@ -1,6 +1,6 @@
 /*
- * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
- * GPL 2.0 license, available at the root application directory.
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root application directory.
  */
 package org.geoserver.catalog.plugin;
 
@@ -14,41 +14,205 @@ import org.geoserver.catalog.plugin.CatalogInfoRepository.StoreRepository;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.StyleRepository;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.WorkspaceRepository;
 
+/**
+ * Interface for managing and accessing specialized {@link CatalogInfoRepository} instances in GeoServer Cloud.
+ *
+ * <p>This interface acts as a central holder or registry for type-specific catalog repositories, providing
+ * uniform access to repositories for different {@link CatalogInfo} subtypes (e.g., workspaces, layers,
+ * styles). It enables retrieval of repositories either by catalog info type or instance, and supports
+ * setting and getting each repository explicitly. This design facilitates a modular, repository-based
+ * approach to catalog data access, decoupling storage operations from higher-level catalog logic.
+ *
+ * <p>Key features:
+ * <ul>
+ *   <li>Generic retrieval methods ({@link #repository(Class)}, {@link #repositoryFor(CatalogInfo)}) for
+ *       type-safe access to repositories.</li>
+ *   <li>Specific getter and setter methods for each repository type (e.g., {@link #getLayerRepository()},
+ *       {@link #setStyleRepository(StyleRepository)}).</li>
+ *   <li>Support for all core catalog info types defined in {@link CatalogInfoRepository} sub-interfaces.</li>
+ * </ul>
+ *
+ * <p>Implementations of this interface are expected to maintain a consistent mapping between catalog info
+ * types and their corresponding repositories, throwing exceptions if a requested repository is unavailable
+ * or misconfigured.
+ *
+ * @since 1.0
+ * @see CatalogInfoRepository
+ * @see CatalogInfo
+ */
 public interface CatalogInfoRepositoryHolder {
 
+    /**
+     * Retrieves the repository responsible for managing objects of the specified {@link CatalogInfo} type.
+     *
+     * <p>This generic method returns a type-specific repository based on the provided class (e.g.,
+     * {@link WorkspaceInfo.class} returns a {@link WorkspaceRepository}). It enables dynamic access to
+     * repositories without requiring explicit casting in most cases.
+     *
+     * @param <T> The type of {@link CatalogInfo} to query (e.g., {@link LayerInfo}).
+     * @param <R> The corresponding repository type (e.g., {@link LayerRepository}).
+     * @param of  The class of catalog info objects to retrieve the repository for; must not be null.
+     * @return The repository managing objects of type {@code T}; never null.
+     * @throws NullPointerException if {@code of} is null.
+     * @throws IllegalArgumentException if no repository is configured for the specified type.
+     * @example Retrieving a layer repository:
+     *          <pre>
+     *          LayerRepository layerRepo = holder.repository(LayerInfo.class);
+     *          </pre>
+     */
     <T extends CatalogInfo, R extends CatalogInfoRepository<T>> R repository(Class<T> of);
 
+    /**
+     * Retrieves the repository responsible for managing the type of the provided {@link CatalogInfo} instance.
+     *
+     * <p>This method infers the repository type from the given object (e.g., passing a {@link LayerInfo}
+     * returns a {@link LayerRepository}). It provides a convenient alternative to {@link #repository(Class)}
+     * when an instance is available.
+     *
+     * @param <T>  The type of {@link CatalogInfo} (e.g., {@link StyleInfo}).
+     * @param <R>  The corresponding repository type (e.g., {@link StyleRepository}).
+     * @param info The catalog info object whose type determines the repository; must not be null.
+     * @return The repository managing objects of the same type as {@code info}; never null.
+     * @throws NullPointerException if {@code info} is null.
+     * @throws IllegalArgumentException if no repository is configured for the object’s type.
+     * @example Retrieving a repository for a specific style:
+     *          <pre>
+     *          StyleInfo style = ...; // existing style
+     *          StyleRepository styleRepo = holder.repositoryFor(style);
+     *          </pre>
+     */
     <T extends CatalogInfo, R extends CatalogInfoRepository<T>> R repositoryFor(T info);
 
+    /**
+     * Sets the repository for managing {@link NamespaceInfo} objects.
+     *
+     * @param namespaces The {@link NamespaceRepository} to set; must not be null.
+     * @throws NullPointerException if {@code namespaces} is null.
+     * @example Setting a namespace repository:
+     *          <pre>
+     *          NamespaceRepository nsRepo = new DefaultNamespaceRepository();
+     *          holder.setNamespaceRepository(nsRepo);
+     *          </pre>
+     */
     void setNamespaceRepository(NamespaceRepository namespaces);
 
+    /**
+     * Retrieves the repository for managing {@link NamespaceInfo} objects.
+     *
+     * @return The configured {@link NamespaceRepository}; never null.
+     * @throws IllegalStateException if no namespace repository has been set.
+     */
     NamespaceRepository getNamespaceRepository();
 
+    /**
+     * Sets the repository for managing {@link WorkspaceInfo} objects.
+     *
+     * @param workspaces The {@link WorkspaceRepository} to set; must not be null.
+     * @throws NullPointerException if {@code workspaces} is null.
+     */
     void setWorkspaceRepository(WorkspaceRepository workspaces);
 
+    /**
+     * Retrieves the repository for managing {@link WorkspaceInfo} objects.
+     *
+     * @return The configured {@link WorkspaceRepository}; never null.
+     * @throws IllegalStateException if no workspace repository has been set.
+     */
     WorkspaceRepository getWorkspaceRepository();
 
+    /**
+     * Sets the repository for managing {@link StoreInfo} objects.
+     *
+     * @param stores The {@link StoreRepository} to set; must not be null.
+     * @throws NullPointerException if {@code stores} is null.
+     */
     void setStoreRepository(StoreRepository stores);
 
+    /**
+     * Retrieves the repository for managing {@link StoreInfo} objects.
+     *
+     * @return The configured {@link StoreRepository}; never null.
+     * @throws IllegalStateException if no store repository has been set.
+     */
     StoreRepository getStoreRepository();
 
+    /**
+     * Sets the repository for managing {@link ResourceInfo} objects.
+     *
+     * @param resources The {@link ResourceRepository} to set; must not be null.
+     * @throws NullPointerException if {@code resources} is null.
+     */
     void setResourceRepository(ResourceRepository resources);
 
+    /**
+     * Retrieves the repository for managing {@link ResourceInfo} objects.
+     *
+     * @return The configured {@link ResourceRepository}; never null.
+     * @throws IllegalStateException if no resource repository has been set.
+     */
     ResourceRepository getResourceRepository();
 
+    /**
+     * Sets the repository for managing {@link LayerInfo} objects.
+     *
+     * @param layers The {@link LayerRepository} to set; must not be null.
+     * @throws NullPointerException if {@code layers} is null.
+     */
     void setLayerRepository(LayerRepository layers);
 
+    /**
+     * Retrieves the repository for managing {@link LayerInfo} objects.
+     *
+     * @return The configured {@link LayerRepository}; never null.
+     * @throws IllegalStateException if no layer repository has been set.
+     */
     LayerRepository getLayerRepository();
 
+    /**
+     * Sets the repository for managing {@link LayerGroupInfo} objects.
+     *
+     * @param layerGroups The {@link LayerGroupRepository} to set; must not be null.
+     * @throws NullPointerException if {@code layerGroups} is null.
+     */
     void setLayerGroupRepository(LayerGroupRepository layerGroups);
 
+    /**
+     * Retrieves the repository for managing {@link LayerGroupInfo} objects.
+     *
+     * @return The configured {@link LayerGroupRepository}; never null.
+     * @throws IllegalStateException if no layer group repository has been set.
+     */
     LayerGroupRepository getLayerGroupRepository();
 
+    /**
+     * Sets the repository for managing {@link StyleInfo} objects.
+     *
+     * @param styles The {@link StyleRepository} to set; must not be null.
+     * @throws NullPointerException if {@code styles} is null.
+     */
     void setStyleRepository(StyleRepository styles);
 
+    /**
+     * Retrieves the repository for managing {@link StyleInfo} objects.
+     *
+     * @return The configured {@link StyleRepository}; never null.
+     * @throws IllegalStateException if no style repository has been set.
+     */
     StyleRepository getStyleRepository();
 
+    /**
+     * Sets the repository for managing {@link MapInfo} objects.
+     *
+     * @param maps The {@link MapRepository} to set; must not be null.
+     * @throws NullPointerException if {@code maps} is null.
+     */
     void setMapRepository(MapRepository maps);
 
+    /**
+     * Retrieves the repository for managing {@link MapInfo} objects.
+     *
+     * @return The configured {@link MapRepository}; never null.
+     * @throws IllegalStateException if no map repository has been set.
+     */
     MapRepository getMapRepository();
 }

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogInfoRepositoryHolderImpl.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogInfoRepositoryHolderImpl.java
@@ -1,6 +1,6 @@
 /*
- * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
- * GPL 2.0 license, available at the root application directory.
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root application directory.
  */
 package org.geoserver.catalog.plugin;
 
@@ -23,6 +23,35 @@ import org.geoserver.catalog.plugin.CatalogInfoRepository.StoreRepository;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.StyleRepository;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.WorkspaceRepository;
 
+/**
+ * A concrete implementation of {@link CatalogInfoRepositoryHolder} that manages a registry of type-specific
+ * catalog repositories in GeoServer Cloud.
+ *
+ * <p>This class maintains a collection of {@link CatalogInfoRepository} instances, each responsible for a
+ * specific type of {@link CatalogInfo} (e.g., {@link WorkspaceInfo}, {@link LayerInfo}), using a
+ * {@link CatalogInfoTypeRegistry} for type-safe mapping and retrieval. It provides methods to set and get
+ * repositories for all core catalog info types, ensuring that catalog operations can access the appropriate
+ * persistence layer. The implementation supports hierarchical types (e.g., {@link StoreInfo} and its
+ * subtypes) through recursive registration where applicable.
+ *
+ * <p>Key features:
+ * <ul>
+ *   <li><strong>Type-Safe Registry:</strong> Maps {@link CatalogInfo} types to their repositories using
+ *       {@link CatalogInfoTypeRegistry}.</li>
+ *   <li><strong>Comprehensive Coverage:</strong> Handles all standard catalog info types via dedicated
+ *       setters and getters.</li>
+ *   <li><strong>Resource Management:</strong> Provides a {@link #dispose()} method to clean up repository
+ *       resources.</li>
+ * </ul>
+ *
+ * <p>This class is typically used within a {@link RepositoryCatalogFacade} to coordinate repository access
+ * for catalog operations in GeoServer Cloud.
+ *
+ * @since 1.0
+ * @see CatalogInfoRepositoryHolder
+ * @see CatalogInfoRepository
+ * @see CatalogInfoTypeRegistry
+ */
 public class CatalogInfoRepositoryHolderImpl implements CatalogInfoRepositoryHolder {
 
     protected NamespaceRepository namespaces;
@@ -36,111 +65,283 @@ public class CatalogInfoRepositoryHolderImpl implements CatalogInfoRepositoryHol
 
     protected CatalogInfoTypeRegistry<CatalogInfoRepository<?>> repos = new CatalogInfoTypeRegistry<>();
 
+    /**
+     * Retrieves the repository for a specific {@link CatalogInfo} type from the internal registry.
+     *
+     * <p>This method uses the {@link CatalogInfoTypeRegistry} to map the provided type to its corresponding
+     * repository (e.g., {@link LayerInfo.class} to {@link LayerRepository}). It ensures type safety through
+     * generics, suppressing unchecked warnings due to the registry’s type erasure handling.
+     *
+     * @param <T> The type of {@link CatalogInfo} to query (e.g., {@link WorkspaceInfo}).
+     * @param <R> The corresponding repository type (e.g., {@link WorkspaceRepository}).
+     * @param of  The class of catalog info objects to retrieve the repository for; must not be null.
+     * @return The repository managing objects of type {@code T}; never null.
+     * @throws NullPointerException if {@code of} is null.
+     * @throws IllegalArgumentException if no repository is configured for the specified type.
+     * @example Retrieving a layer repository:
+     *          <pre>
+     *          LayerRepository layerRepo = holder.repository(LayerInfo.class);
+     *          </pre>
+     */
     @SuppressWarnings("unchecked")
     @Override
     public <T extends CatalogInfo, R extends CatalogInfoRepository<T>> R repository(Class<T> of) {
         return (R) repos.of(of);
     }
 
+    /**
+     * Retrieves the repository for the type of a given {@link CatalogInfo} instance.
+     *
+     * <p>This method determines the repository based on the object’s runtime type (e.g., a {@link StyleInfo}
+     * instance returns a {@link StyleRepository}), using the {@link CatalogInfoTypeRegistry} for mapping.
+     * It suppresses unchecked warnings due to type erasure in the registry.
+     *
+     * @param <T>  The type of {@link CatalogInfo} (e.g., {@link StyleInfo}).
+     * @param <R>  The corresponding repository type (e.g., {@link StyleRepository}).
+     * @param info The catalog info object whose type determines the repository; must not be null.
+     * @return The repository managing objects of the same type as {@code info}; never null.
+     * @throws NullPointerException if {@code info} is null.
+     * @throws IllegalArgumentException if no repository is configured for the object’s type.
+     * @example Retrieving a repository for a specific style:
+     *          <pre>
+     *          StyleInfo style = new StyleInfoImpl();
+     *          StyleRepository styleRepo = holder.repositoryFor(style);
+     *          </pre>
+     */
     @SuppressWarnings("unchecked")
     @Override
     public <T extends CatalogInfo, R extends CatalogInfoRepository<T>> R repositoryFor(T info) {
         return (R) repos.forObject(info);
     }
 
+    /**
+     * Returns a list of all configured repositories.
+     *
+     * <p>This method provides access to all repositories registered in the internal
+     * {@link CatalogInfoTypeRegistry}, useful for introspection or bulk operations. The wildcard return
+     * type is intentionally suppressed as the list contains heterogeneous repository types.
+     *
+     * @return A list of all {@link CatalogInfoRepository} instances; never null.
+     * @SuppressWarnings("java:S1452") Wildcard return type is intentional due to mixed repository types.
+     */
     @SuppressWarnings("java:S1452")
     public List<CatalogInfoRepository<?>> all() {
         return repos.getAll();
     }
 
+    /**
+     * Sets the repository for managing {@link NamespaceInfo} objects.
+     *
+     * <p>Registers the provided {@link NamespaceRepository} in the internal type registry and assigns it
+     * to the namespaces field.
+     *
+     * @param namespaces The {@link NamespaceRepository} to set; must not be null.
+     * @throws NullPointerException if {@code namespaces} is null.
+     * @example Setting a namespace repository:
+     *          <pre>
+     *          NamespaceRepository nsRepo = new DefaultNamespaceRepository();
+     *          holder.setNamespaceRepository(nsRepo);
+     *          </pre>
+     */
     @Override
     public void setNamespaceRepository(NamespaceRepository namespaces) {
         this.namespaces = namespaces;
         repos.register(NamespaceInfo.class, namespaces);
     }
 
+    /**
+     * Retrieves the repository for managing {@link NamespaceInfo} objects.
+     *
+     * @return The configured {@link NamespaceRepository}; may be null if not set.
+     */
     @Override
     public NamespaceRepository getNamespaceRepository() {
         return namespaces;
     }
 
+    /**
+     * Sets the repository for managing {@link WorkspaceInfo} objects.
+     *
+     * <p>Registers the provided {@link WorkspaceRepository} in the internal type registry and assigns it
+     * to the workspaces field.
+     *
+     * @param workspaces The {@link WorkspaceRepository} to set; must not be null.
+     * @throws NullPointerException if {@code workspaces} is null.
+     */
     @Override
     public void setWorkspaceRepository(WorkspaceRepository workspaces) {
         this.workspaces = workspaces;
         repos.register(WorkspaceInfo.class, workspaces);
     }
 
+    /**
+     * Retrieves the repository for managing {@link WorkspaceInfo} objects.
+     *
+     * @return The configured {@link WorkspaceRepository}; may be null if not set.
+     */
     @Override
     public WorkspaceRepository getWorkspaceRepository() {
         return workspaces;
     }
 
+    /**
+     * Sets the repository for managing {@link StoreInfo} objects and its subtypes.
+     *
+     * <p>Registers the provided {@link StoreRepository} recursively in the internal type registry to
+     * support all {@link StoreInfo} subtypes (e.g., {@link DataStoreInfo}) and assigns it to the stores
+     * field.
+     *
+     * @param stores The {@link StoreRepository} to set; must not be null.
+     * @throws NullPointerException if {@code stores} is null.
+     */
     @Override
     public void setStoreRepository(StoreRepository stores) {
         this.stores = stores;
         repos.registerRecursively(StoreInfo.class, stores);
     }
 
+    /**
+     * Retrieves the repository for managing {@link StoreInfo} objects.
+     *
+     * @return The configured {@link StoreRepository}; may be null if not set.
+     */
     @Override
     public StoreRepository getStoreRepository() {
         return stores;
     }
 
+    /**
+     * Sets the repository for managing {@link ResourceInfo} objects and its subtypes.
+     *
+     * <p>Registers the provided {@link ResourceRepository} recursively in the internal type registry to
+     * support all {@link ResourceInfo} subtypes (e.g., {@link org.geoserver.catalog.FeatureTypeInfo}) and
+     * assigns it to the resources field.
+     *
+     * @param resources The {@link ResourceRepository} to set; must not be null.
+     * @throws NullPointerException if {@code resources} is null.
+     */
     @Override
     public void setResourceRepository(ResourceRepository resources) {
         this.resources = resources;
         repos.registerRecursively(ResourceInfo.class, resources);
     }
 
+    /**
+     * Retrieves the repository for managing {@link ResourceInfo} objects.
+     *
+     * @return The configured {@link ResourceRepository}; may be null if not set.
+     */
     @Override
     public ResourceRepository getResourceRepository() {
         return resources;
     }
 
+    /**
+     * Sets the repository for managing {@link LayerInfo} objects.
+     *
+     * <p>Registers the provided {@link LayerRepository} in the internal type registry and assigns it to
+     * the layers field.
+     *
+     * @param layers The {@link LayerRepository} to set; must not be null.
+     * @throws NullPointerException if {@code layers} is null.
+     */
     @Override
     public void setLayerRepository(LayerRepository layers) {
         this.layers = layers;
         repos.register(LayerInfo.class, layers);
     }
 
+    /**
+     * Retrieves the repository for managing {@link LayerInfo} objects.
+     *
+     * @return The configured {@link LayerRepository}; may be null if not set.
+     */
     @Override
     public LayerRepository getLayerRepository() {
         return layers;
     }
 
+    /**
+     * Sets the repository for managing {@link LayerGroupInfo} objects.
+     *
+     * <p>Registers the provided {@link LayerGroupRepository} in the internal type registry and assigns it
+     * to the layerGroups field.
+     *
+     * @param layerGroups The {@link LayerGroupRepository} to set; must not be null.
+     * @throws NullPointerException if {@code layerGroups} is null.
+     */
     @Override
     public void setLayerGroupRepository(LayerGroupRepository layerGroups) {
         this.layerGroups = layerGroups;
         repos.register(LayerGroupInfo.class, layerGroups);
     }
 
+    /**
+     * Retrieves the repository for managing {@link LayerGroupInfo} objects.
+     *
+     * @return The configured {@link LayerGroupRepository}; may be null if not set.
+     */
     @Override
     public LayerGroupRepository getLayerGroupRepository() {
         return layerGroups;
     }
 
+    /**
+     * Sets the repository for managing {@link StyleInfo} objects.
+     *
+     * <p>Registers the provided {@link StyleRepository} in the internal type registry and assigns it to
+     * the styles field.
+     *
+     * @param styles The {@link StyleRepository} to set; must not be null.
+     * @throws NullPointerException if {@code styles} is null.
+     */
     @Override
     public void setStyleRepository(StyleRepository styles) {
         this.styles = styles;
         repos.register(StyleInfo.class, styles);
     }
 
+    /**
+     * Retrieves the repository for managing {@link StyleInfo} objects.
+     *
+     * @return The configured {@link StyleRepository}; may be null if not set.
+     */
     @Override
     public StyleRepository getStyleRepository() {
         return styles;
     }
 
+    /**
+     * Sets the repository for managing {@link MapInfo} objects.
+     *
+     * <p>Registers the provided {@link MapRepository} in the internal type registry and assigns it to the
+     * maps field.
+     *
+     * @param maps The {@link MapRepository} to set; must not be null.
+     * @throws NullPointerException if {@code maps} is null.
+     */
     @Override
     public void setMapRepository(MapRepository maps) {
         this.maps = maps;
         repos.register(MapInfo.class, maps);
     }
 
+    /**
+     * Retrieves the repository for managing {@link MapInfo} objects.
+     *
+     * @return The configured {@link MapRepository}; may be null if not set.
+     */
     @Override
     public MapRepository getMapRepository() {
         return maps;
     }
 
+    /**
+     * Disposes of all resources held by the configured repositories.
+     *
+     * <p>Iterates through all registered repositories and calls their {@code dispose()} methods to release
+     * resources (e.g., database connections). Null repositories are skipped.
+     */
     public void dispose() {
         dispose(stores);
         dispose(resources);
@@ -152,6 +353,13 @@ public class CatalogInfoRepositoryHolderImpl implements CatalogInfoRepositoryHol
         dispose(styles);
     }
 
+    /**
+     * Disposes of a single repository’s resources if it exists.
+     *
+     * <p>Calls the {@code dispose()} method on the provided repository, safely handling null cases.
+     *
+     * @param repository The {@link CatalogInfoRepository} to dispose; may be null.
+     */
     private void dispose(CatalogInfoRepository<?> repository) {
         if (repository != null) repository.dispose();
     }

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/DefaultMemoryCatalogFacade.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/DefaultMemoryCatalogFacade.java
@@ -13,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.CatalogInfo;
-import org.geoserver.catalog.CatalogRepository;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.MapInfo;
@@ -42,16 +41,58 @@ import org.geoserver.catalog.plugin.CatalogInfoLookup.WorkspaceInfoLookup;
 import org.geoserver.ows.util.OwsUtils;
 
 /**
- * Default catalog facade implementation using in-memory {@link CatalogRepository repositories} to
- * store the {@link CatalogInfo}
+ * A default in-memory implementation of {@link CatalogFacade} that uses {@link CatalogInfoLookup}
+ * instances to store {@link CatalogInfo} objects.
+ *
+ * <p>This class extends {@link RepositoryCatalogFacadeImpl} to provide a memory-based catalog facade
+ * for GeoServer Cloud, leveraging in-memory {@link CatalogInfoLookup} repositories for all core catalog
+ * info types (e.g., workspaces, layers, styles). It manages catalog data in memory, resolving references
+ * between objects (e.g., layers to resources, stores to workspaces) during initialization or updates.
+ * This implementation is lightweight and suitable for testing or small-scale deployments where persistence
+ * to an external store is not required.
+ *
+ * <p>Key features:
+ * <ul>
+ *   <li><strong>In-Memory Storage:</strong> Uses lookup-based repositories (e.g., {@link LayerInfoLookup})
+ *       for fast, transient storage of catalog data.</li>
+ *   <li><strong>Reference Resolution:</strong> Resolves proxies and ensures object relationships (e.g.,
+ *       layer-to-resource links) via {@link #resolve()} and type-specific resolve methods.</li>
+ *   <li><strong>Automatic ID Generation:</strong> Assigns unique IDs to objects lacking them using
+ *       {@link #setId(Object)}.</li>
+ * </ul>
+ *
+ * <p>The facade initializes with default in-memory repositories and supports all standard catalog
+ * operations (e.g., add, remove, query) inherited from {@link RepositoryCatalogFacadeImpl}, with added
+ * logic for in-memory reference management.
+ *
+ * @since 1.0
+ * @see RepositoryCatalogFacadeImpl
+ * @see CatalogInfoLookup
+ * @see CatalogFacade
  */
 @Slf4j
 public class DefaultMemoryCatalogFacade extends RepositoryCatalogFacadeImpl implements CatalogFacade {
 
+    /**
+     * Constructs a new in-memory catalog facade with no associated catalog.
+     *
+     * <p>Initializes the facade with default in-memory repositories for all catalog info types. Use
+     * {@link #setCatalog(Catalog)} to associate a catalog instance after construction if needed.
+     */
     public DefaultMemoryCatalogFacade() {
         this(null);
     }
 
+    /**
+     * Constructs a new in-memory catalog facade with the specified catalog.
+     *
+     * <p>Initializes the facade with default in-memory repositories (e.g., {@link WorkspaceInfoLookup})
+     * and associates it with the provided catalog. The repositories are configured to handle all core
+     * {@link CatalogInfo} types, with the {@link ResourceInfoLookup} linked to the layer repository for
+     * consistency.
+     *
+     * @param catalog The {@link Catalog} instance to associate with this facade; may be null.
+     */
     public DefaultMemoryCatalogFacade(Catalog catalog) {
         super(catalog);
         setNamespaceRepository(new NamespaceInfoLookup());
@@ -64,6 +105,20 @@ public class DefaultMemoryCatalogFacade extends RepositoryCatalogFacadeImpl impl
         setStyleRepository(new StyleInfoLookup());
     }
 
+    /**
+     * Resolves references for all catalog objects in memory.
+     *
+     * <p>Iterates through all repositories (workspaces, namespaces, stores, etc.) and resolves internal
+     * references (e.g., layer-to-resource, store-to-workspace) by calling type-specific resolve methods.
+     * Ensures that all {@link CatalogInfo} objects are fully resolved and consistent, replacing proxies
+     * with actual instances where possible.
+     *
+     * @example Resolving catalog state:
+     *          <pre>
+     *          DefaultMemoryCatalogFacade facade = new DefaultMemoryCatalogFacade(catalog);
+     *          facade.resolve();
+     *          </pre>
+     */
     @Override
     public void resolve() {
         getWorkspaceRepository().findAll().forEach(this::resolve);
@@ -76,6 +131,16 @@ public class DefaultMemoryCatalogFacade extends RepositoryCatalogFacadeImpl impl
         getMapRepository().findAll().forEach(this::resolve);
     }
 
+    /**
+     * Resolves references within a {@link LayerInfo} object.
+     *
+     * <p>Ensures the layer has an ID (assigning one if missing), resolves its resource and default style
+     * to actual instances from the catalog, and updates its additional styles set by replacing proxies
+     * with resolved objects.
+     *
+     * @param layer The {@link LayerInfo} to resolve; must not be null.
+     * @throws NullPointerException if {@code layer} is null.
+     */
     protected void resolve(LayerInfo layer) {
         setId(layer);
 
@@ -100,6 +165,15 @@ public class DefaultMemoryCatalogFacade extends RepositoryCatalogFacadeImpl impl
         ((LayerInfoImpl) layer).setStyles(styles);
     }
 
+    /**
+     * Resolves references within a {@link LayerGroupInfo} object.
+     *
+     * <p>Ensures the layer group has an ID (assigning one if missing), resolves its layers and styles lists,
+     * and recursively resolves nested layers and styles within any {@link LayerGroupStyle} objects.
+     *
+     * @param layerGroup The {@link LayerGroupInfo} to resolve; must not be null.
+     * @throws NullPointerException if {@code layerGroup} is null.
+     */
     protected void resolve(LayerGroupInfo layerGroup) {
         setId(layerGroup);
 
@@ -114,6 +188,18 @@ public class DefaultMemoryCatalogFacade extends RepositoryCatalogFacadeImpl impl
         }
     }
 
+    /**
+     * Resolves styles within a layer group, handling special cases for layer group style references.
+     *
+     * <p>Iterates through the styles list, resolving each style to its catalog instance. If a style
+     * represents a {@link LayerGroupStyle} reference (not stored in the catalog), creates a new
+     * {@link StyleInfo} instance based on its name. Ensures the styles align with their assigned layers.
+     *
+     * @param assignedLayers The list of {@link PublishedInfo} objects (layers or groups) corresponding to
+     *                       the styles; must not be null.
+     * @param styles         The list of {@link StyleInfo} objects to resolve; must not be null.
+     * @throws NullPointerException if {@code assignedLayers} or {@code styles} is null.
+     */
     private void resolveLayerGroupStyles(List<PublishedInfo> assignedLayers, List<StyleInfo> styles) {
         for (int i = 0; i < styles.size(); i++) {
             StyleInfo s = styles.get(i);
@@ -139,6 +225,15 @@ public class DefaultMemoryCatalogFacade extends RepositoryCatalogFacadeImpl impl
         }
     }
 
+    /**
+     * Resolves layers within a layer group’s layers list.
+     *
+     * <p>Iterates through the layers list, resolving each {@link PublishedInfo} (layer or nested group)
+     * to its catalog instance and updating the list with resolved objects.
+     *
+     * @param layers The list of {@link PublishedInfo} objects to resolve; must not be null.
+     * @throws NullPointerException if {@code layers} is null.
+     */
     private void resolveLayerGroupLayers(List<PublishedInfo> layers) {
         for (int i = 0; i < layers.size(); i++) {
             PublishedInfo published = layers.get(i);
@@ -150,6 +245,17 @@ public class DefaultMemoryCatalogFacade extends RepositoryCatalogFacadeImpl impl
         }
     }
 
+    /**
+     * Resolves a single {@link PublishedInfo} object (layer or layer group) within a layer group.
+     *
+     * <p>Resolves the object to its catalog instance, falling back to the original object if resolution
+     * fails (e.g., during catalog loading when nested objects aren’t yet available).
+     *
+     * @param published The {@link PublishedInfo} to resolve (either a {@link LayerInfo} or
+     *                  {@link LayerGroupInfo}); must not be null.
+     * @return The resolved {@link PublishedInfo}, or the original if unresolved.
+     * @throws NullPointerException if {@code published} is null.
+     */
     private PublishedInfo resolveLayerGroupLayers(@NonNull PublishedInfo published) {
         PublishedInfo resolved = unwrap(ResolvingProxy.resolve(getCatalog(), published));
         // special case to handle catalog loading, when nested publishables might not be loaded.
@@ -159,6 +265,15 @@ public class DefaultMemoryCatalogFacade extends RepositoryCatalogFacadeImpl impl
         return resolved;
     }
 
+    /**
+     * Resolves references within a {@link StyleInfo} object.
+     *
+     * <p>Ensures the style has an ID (assigning one if missing) and resolves its workspace to the actual
+     * catalog instance, logging a message if resolution fails (e.g., workspace not yet added).
+     *
+     * @param style The {@link StyleInfo} to resolve; must not be null.
+     * @throws NullPointerException if {@code style} is null.
+     */
     protected void resolve(StyleInfo style) {
         setId(style);
 
@@ -180,18 +295,54 @@ public class DefaultMemoryCatalogFacade extends RepositoryCatalogFacadeImpl impl
         }
     }
 
+    /**
+     * Resolves references within a {@link MapInfo} object.
+     *
+     * <p>Ensures the map has an ID (assigning one if missing). No additional references are resolved as
+     * maps typically lack complex dependencies in this implementation.
+     *
+     * @param map The {@link MapInfo} to resolve; must not be null.
+     * @throws NullPointerException if {@code map} is null.
+     */
     protected void resolve(MapInfo map) {
         setId(map);
     }
 
+    /**
+     * Resolves references within a {@link WorkspaceInfo} object.
+     *
+     * <p>Ensures the workspace has an ID (assigning one if missing). No additional references are resolved
+     * as workspaces are top-level objects in this implementation.
+     *
+     * @param workspace The {@link WorkspaceInfo} to resolve; must not be null.
+     * @throws NullPointerException if {@code workspace} is null.
+     */
     protected void resolve(WorkspaceInfo workspace) {
         setId(workspace);
     }
 
+    /**
+     * Resolves references within a {@link NamespaceInfo} object.
+     *
+     * <p>Ensures the namespace has an ID (assigning one if missing). No additional references are resolved
+     * as namespaces are top-level objects in this implementation.
+     *
+     * @param namespace The {@link NamespaceInfo} to resolve; must not be null.
+     * @throws NullPointerException if {@code namespace} is null.
+     */
     protected void resolve(NamespaceInfo namespace) {
         setId(namespace);
     }
 
+    /**
+     * Resolves references within a {@link StoreInfo} object.
+     *
+     * <p>Ensures the store has an ID (assigning one if missing) and resolves its workspace to the actual
+     * catalog instance, logging a message if resolution fails (e.g., workspace not yet added).
+     *
+     * @param store The {@link StoreInfo} to resolve; must not be null.
+     * @throws NullPointerException if {@code store} is null.
+     */
     protected void resolve(StoreInfo store) {
         setId(store);
         StoreInfoImpl s = (StoreInfoImpl) store;
@@ -211,6 +362,15 @@ public class DefaultMemoryCatalogFacade extends RepositoryCatalogFacadeImpl impl
         }
     }
 
+    /**
+     * Resolves references within a {@link ResourceInfo} object.
+     *
+     * <p>Ensures the resource has an ID (assigning one if missing), resolves its store and namespace to
+     * actual catalog instances, and updates the resource accordingly.
+     *
+     * @param resource The {@link ResourceInfo} to resolve; must not be null.
+     * @throws NullPointerException if {@code resource} is null.
+     */
     protected void resolve(ResourceInfo resource) {
         setId(resource);
         ResourceInfoImpl r = (ResourceInfoImpl) resource;
@@ -230,6 +390,15 @@ public class DefaultMemoryCatalogFacade extends RepositoryCatalogFacadeImpl impl
         }
     }
 
+    /**
+     * Assigns a unique ID to a catalog object if it lacks one.
+     *
+     * <p>Generates a unique ID using {@link UID} prefixed with the object’s class name (e.g.,
+     * "WorkspaceInfo-uid") and sets it via {@link OwsUtils#set(Object, String, Object)}.
+     *
+     * @param o The object to assign an ID to; must not be null.
+     * @throws NullPointerException if {@code o} is null.
+     */
     protected void setId(Object o) {
         if (OwsUtils.get(o, "id") == null) {
             String uid = new UID().toString();
@@ -238,6 +407,16 @@ public class DefaultMemoryCatalogFacade extends RepositoryCatalogFacadeImpl impl
         }
     }
 
+    /**
+     * Unwraps a {@link CatalogInfo} object from its proxy, if applicable.
+     *
+     * <p>Delegates to {@link ModificationProxy#unwrap(Object)} to remove any proxy wrapper, returning the
+     * underlying instance or null if the input is null.
+     *
+     * @param <T> The type of {@link CatalogInfo}.
+     * @param obj The object to unwrap; may be null.
+     * @return The unwrapped {@link CatalogInfo}, or null if {@code obj} is null.
+     */
     @Nullable
     public static <T> T unwrap(@Nullable T obj) {
         return ModificationProxy.unwrap(obj);

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/ExtendedCatalogFacade.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/ExtendedCatalogFacade.java
@@ -1,14 +1,12 @@
 /*
- * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
- * GPL 2.0 license, available at the root application directory.
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root application directory.
  */
 package org.geoserver.catalog.plugin;
 
 import java.io.Closeable;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Consumer;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import lombok.NonNull;
@@ -30,30 +28,55 @@ import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.sort.SortBy;
 
 /**
- * {@link CatalogFacade} with additional methods
+ * An enhanced version of {@link CatalogFacade} providing additional methods for querying and manipulating
+ * the GeoServer Cloud catalog.
  *
- * <p>If this were going to be merged into geoserver's main module, the new methods could be added
- * directly to {@link CatalogFacade}
+ * <p>This interface extends the standard {@link CatalogFacade} with modern, streamlined operations for
+ * interacting with the GeoServer Cloud catalog. It introduces type-safe retrieval by ID, patch-based
+ * updates, and stream-based querying, enhancing flexibility and usability over the base facade. These
+ * enhancements reduce boilerplate code and align with contemporary Java practices, such as using
+ * {@link Optional} and {@link Stream}.
+ *
+ * <p>The following methods could potentially be upstreamed to {@link CatalogFacade} in GeoServer’s main
+ * module:
+ * <ul>
+ *   <li>{@link #get(String)}: Retrieves a catalog object by ID without type specification.</li>
+ *   <li>{@link #get(String, Class)}: Retrieves a typed catalog object by ID with type safety.</li>
+ *   <li>{@link #getPublished(String)}: Retrieves a published object (layer or layer group) by ID.</li>
+ *   <li>{@link #add(CatalogInfo)}: Adds a new catalog object with type-specific dispatching.</li>
+ *   <li>{@link #remove(CatalogInfo)}: Removes a catalog object with type-specific dispatching.</li>
+ *   <li>{@link #update(CatalogInfo, Patch)}: Updates an existing object using a patch for precise changes.</li>
+ *   <li>{@link #query(Query)}: Queries the catalog with advanced filtering, sorting, and pagination.</li>
+ * </ul>
+ *
+ * <p>All methods are default implementations, delegating to the underlying {@link CatalogFacade} where
+ * applicable, allowing implementers to override them for optimized behavior. Deprecated methods like
+ * {@link #save(CatalogInfo)} are replaced by {@link #update(CatalogInfo, Patch)}, and {@link #list} is
+ * superseded by {@link #query(Query)} for modern stream-based access.
+ *
+ * @since 1.0
+ * @see CatalogFacade
+ * @see Query
+ * @see Patch
  */
 public interface ExtendedCatalogFacade extends CatalogFacade {
 
-    default void forEach(Consumer<? super CatalogInfo> consumer) {
-        List<Class<? extends CatalogInfo>> types = List.of(
-                WorkspaceInfo.class,
-                NamespaceInfo.class,
-                StoreInfo.class,
-                ResourceInfo.class,
-                StyleInfo.class,
-                LayerInfo.class,
-                LayerGroupInfo.class);
-
-        for (var type : types) {
-            try (var stream = query(Query.valueOf(type, Filter.INCLUDE))) {
-                stream.forEach(consumer);
-            }
-        }
-    }
-
+    /**
+     * Retrieves a catalog object by its ID, searching across all supported types.
+     *
+     * <p>This method sequentially queries for a match among workspaces, namespaces, stores, resources,
+     * published objects (layers or layer groups), styles, and maps, returning the first object found.
+     * If no object matches the ID, an empty {@link Optional} is returned.
+     *
+     * @param id The unique identifier of the catalog object; must not be null.
+     * @return An {@link Optional} containing the found {@link CatalogInfo}, or empty if not found.
+     * @throws NullPointerException if {@code id} is null.
+     * @example Retrieving an object by ID:
+     *          <pre>
+     *          Optional<CatalogInfo> info = facade.get("ws1");
+     *          info.ifPresent(i -> System.out.println("Found: " + i.getClass().getSimpleName()));
+     *          </pre>
+     */
     default Optional<CatalogInfo> get(@NonNull String id) {
         CatalogInfo found = getWorkspace(id);
         if (null == found) found = getNamespace(id);
@@ -65,6 +88,27 @@ public interface ExtendedCatalogFacade extends CatalogFacade {
         return Optional.ofNullable(found);
     }
 
+    /**
+     * Retrieves a catalog object by its ID with type safety.
+     *
+     * <p>This method fetches an object by ID and ensures it matches the specified type (e.g.,
+     * {@link LayerInfo}, {@link WorkspaceInfo}). It uses {@link ClassMappings} to dispatch to the
+     * appropriate type-specific retrieval method from {@link CatalogFacade}, filtering the result
+     * to confirm type compatibility. Returns an empty {@link Optional} if no matching object is found
+     * or if the object doesn’t match the type.
+     *
+     * @param <T>  The expected type of {@link CatalogInfo}.
+     * @param id   The unique identifier of the catalog object; must not be null.
+     * @param type The interface type to retrieve (e.g., {@link LayerInfo.class}); must not be null.
+     * @return An {@link Optional} containing the found object cast to type {@code T}, or empty if not found.
+     * @throws NullPointerException if {@code id} or {@code type} is null.
+     * @throws IllegalArgumentException if {@code type} is not an interface or is an unknown {@link CatalogInfo} subtype.
+     * @example Retrieving a typed object:
+     *          <pre>
+     *          Optional<LayerInfo> layer = facade.get("layer1", LayerInfo.class);
+     *          layer.ifPresent(l -> System.out.println("Layer name: " + l.getName()));
+     *          </pre>
+     */
     default <T extends CatalogInfo> Optional<T> get(@NonNull String id, @NonNull Class<T> type) {
         if (!type.isInterface()) {
             throw new IllegalArgumentException("Expected an interface type, got " + type);
@@ -95,6 +139,21 @@ public interface ExtendedCatalogFacade extends CatalogFacade {
         return Optional.ofNullable(found).filter(type::isInstance).map(type::cast);
     }
 
+    /**
+     * Retrieves a published catalog object (layer or layer group) by its ID.
+     *
+     * <p>This method attempts to find a {@link LayerInfo} or {@link LayerGroupInfo} by ID, returning the
+     * first match as a {@link PublishedInfo}. If no match is found, returns null.
+     *
+     * @param id The unique identifier of the published object; must not be null.
+     * @return The found {@link PublishedInfo} (either a layer or layer group), or null if not found.
+     * @throws NullPointerException if {@code id} is null.
+     * @example Retrieving a published object:
+     *          <pre>
+     *          PublishedInfo pub = facade.getPublished("layer1");
+     *          if (pub != null) System.out.println("Published name: " + pub.getName());
+     *          </pre>
+     */
     default PublishedInfo getPublished(@NonNull String id) {
         return get(id, LayerInfo.class)
                 .map(PublishedInfo.class::cast)
@@ -102,6 +161,26 @@ public interface ExtendedCatalogFacade extends CatalogFacade {
                 .orElse(null);
     }
 
+    /**
+     * Adds a new catalog object to the catalog with type-specific dispatching.
+     *
+     * <p>This method identifies the type of the provided {@link CatalogInfo} object and delegates to the
+     * appropriate {@link CatalogFacade} add method, ensuring type safety via pattern matching. The added
+     * object is returned, potentially updated with generated IDs or other properties by the catalog.
+     *
+     * @param <T>  The type of {@link CatalogInfo} to add.
+     * @param info The catalog object to add; must not be null.
+     * @return The added object, cast to type {@code T}.
+     * @throws NullPointerException if {@code info} is null.
+     * @throws IllegalArgumentException if {@code info} is an unrecognized {@link CatalogInfo} subtype.
+     * @example Adding a workspace:
+     *          <pre>
+     *          WorkspaceInfo ws = new WorkspaceInfoImpl();
+     *          ws.setName("newWorkspace");
+     *          WorkspaceInfo added = facade.add(ws);
+     *          System.out.println("Added ID: " + added.getId());
+     *          </pre>
+     */
     @SuppressWarnings("unchecked")
     default <T extends CatalogInfo> T add(@NonNull T info) {
         return switch (info) {
@@ -117,6 +196,22 @@ public interface ExtendedCatalogFacade extends CatalogFacade {
         };
     }
 
+    /**
+     * Removes a catalog object from the catalog with type-specific dispatching.
+     *
+     * <p>This method identifies the type of the provided {@link CatalogInfo} object and delegates to the
+     * appropriate {@link CatalogFacade} remove method, ensuring proper cleanup of associated resources.
+     *
+     * @param info The catalog object to remove; must not be null.
+     * @throws NullPointerException if {@code info} is null.
+     * @throws IllegalArgumentException if {@code info} is an unrecognized {@link CatalogInfo} subtype.
+     * @example Removing a layer:
+     *          <pre>
+     *          LayerInfo layer = facade.get("layer1", LayerInfo.class).get();
+     *          facade.remove(layer);
+     *          System.out.println("Layer removed");
+     *          </pre>
+     */
     default void remove(@NonNull CatalogInfo info) {
         switch (info) {
             case WorkspaceInfo ws -> remove(ws);
@@ -129,24 +224,79 @@ public interface ExtendedCatalogFacade extends CatalogFacade {
             case MapInfo m -> remove(m);
             default -> throw new IllegalArgumentException("Unexpected value: %s".formatted(info));
         }
+        ;
     }
 
+    /**
+     * Updates an existing catalog object with the specified patch of changes.
+     *
+     * <p>This method applies a {@link Patch} to modify properties of the given {@link CatalogInfo} object,
+     * persisting the changes in the catalog. The updated object is returned, reflecting the applied changes.
+     * Unlike the deprecated {@code save} methods, this approach allows precise, incremental updates without
+     * requiring a full object replacement, supporting efficient storage operations.
+     *
+     * @param <I>   The type of {@link CatalogInfo} to update.
+     * @param info  The catalog object to update; must not be null.
+     * @param patch The patch containing property changes to apply; must not be null.
+     * @return The updated {@link CatalogInfo} object after applying the patch.
+     * @throws NullPointerException if {@code info} or {@code patch} is null.
+     * @throws IllegalArgumentException if {@code info} is not found in the catalog or the patch is invalid.
+     * @example Updating a layer’s title:
+     *          <pre>
+     *          LayerInfo layer = facade.get("layer1", LayerInfo.class).get();
+     *          Patch patch = new Patch().with("title", "Updated Title");
+     *          LayerInfo updated = facade.update(layer, patch);
+     *          System.out.println("New title: " + updated.getTitle());
+     *          </pre>
+     */
     <I extends CatalogInfo> I update(I info, Patch patch);
 
     /**
-     * Returns all objects in this that satisfy the query criteria (type and filter), and additional
-     * restrictions such as paging and order.
+     * Queries the catalog for objects matching the specified criteria, returning a stream of results.
      *
-     * <p>Be sure to {@link Stream#close} close the returned stream once consumed or before
-     * discarding. Since {@link Stream} implements {@link AutoCloseable} it can be used in a
-     * try-with-resources block, and eliminates the need to return {@link CloseableIterator}
+     * <p>This method retrieves all {@link CatalogInfo} objects that satisfy the {@link Query}’s type,
+     * filter, sorting, and pagination constraints. The returned {@link Stream} must be closed after use
+     * to release resources, ideally using a try-with-resources block since {@link Stream} implements
+     * {@link AutoCloseable}. This replaces the deprecated {@link #list} method for modern, stream-based
+     * access.
      *
-     * @see Query
+     * @param <T>   The type of {@link CatalogInfo} to query.
+     * @param query The query defining the criteria (type, filter, sorting, pagination); must not be null.
+     * @return A {@link Stream} of matching catalog objects; never null.
+     * @throws NullPointerException if {@code query} is null.
+     * @example Querying layers with a filter:
+     *          <pre>
+     *          Query<LayerInfo> query = Query.valueOf(LayerInfo.class, someFilter);
+     *          try (Stream<LayerInfo> layers = facade.query(query)) {
+     *              layers.forEach(l -> System.out.println(l.getName()));
+     *          }
+     *          </pre>
      */
     <T extends CatalogInfo> Stream<T> query(Query<T> query);
 
     /**
-     * @deprecated use {@link #query(Query)} instead
+     * Retrieves a list of catalog objects matching the specified criteria, using a legacy iterator approach.
+     *
+     * <p>This method is deprecated in favor of {@link #query(Query)}, which provides a modern
+     * {@link Stream}-based API. It constructs a {@link Query} from the parameters and adapts the result
+     * to a {@link CloseableIterator} for backward compatibility.
+     *
+     * @param <T>       The type of {@link CatalogInfo} to list.
+     * @param of        The class of catalog objects to retrieve; must not be null.
+     * @param filter    The filter to apply; must not be null.
+     * @param offset    The number of objects to skip, or null for no offset.
+     * @param count     The maximum number of objects to return, or null for no limit.
+     * @param sortOrder Variable number of {@link SortBy} directives for ordering (nulls ignored).
+     * @return A {@link CloseableIterator} over the matching catalog objects.
+     * @throws NullPointerException if {@code of} or {@code filter} is null.
+     * @deprecated since 1.0, for removal; use {@link #query(Query)} instead.
+     * @example Legacy listing of layers:
+     *          <pre>
+     *          CloseableIterator<LayerInfo> it = facade.list(LayerInfo.class, Filter.INCLUDE, 0, 10);
+     *          try (it) {
+     *              while (it.hasNext()) System.out.println(it.next().getName());
+     *          }
+     *          </pre>
      */
     @Deprecated(since = "1.0", forRemoval = true)
     @Override
@@ -168,8 +318,9 @@ public interface ExtendedCatalogFacade extends CatalogFacade {
     }
 
     /**
-     * @deprecated Throws {@link UnsupportedOperationException}, use {@link #update(CatalogInfo,
-     *     Patch)}
+     * Throws an exception to enforce use of {@link #update(CatalogInfo, Patch)}.
+     * @throws UnsupportedOperationException always, directing users to {@link #update(CatalogInfo, Patch)}.
+     * @deprecated since 1.0, for removal; use {@link #update(CatalogInfo, Patch)} instead.
      */
     @Deprecated(since = "1.0", forRemoval = true)
     @Override
@@ -178,18 +329,19 @@ public interface ExtendedCatalogFacade extends CatalogFacade {
     }
 
     /**
-     * @deprecated Throws {@link UnsupportedOperationException}, use {@link #update(CatalogInfo,
-     *     Patch)}
+     * Throws an exception to enforce use of {@link #update(CatalogInfo, Patch)}.
+     * @throws UnsupportedOperationException always, directing users to {@link #update(CatalogInfo, Patch)}.
+     * @deprecated since 1.0, for removal; use {@link #update(CatalogInfo, Patch)} instead.
      */
-    @Deprecated(since = "1.0", forRemoval = true)
     @Override
     default void save(LayerInfo layer) {
         throw new UnsupportedOperationException("Expected use of update(CatalogInfo, Patch)");
     }
 
     /**
-     * @deprecated Throws {@link UnsupportedOperationException}, use {@link #update(CatalogInfo,
-     *     Patch)}
+     * Throws an exception to enforce use of {@link #update(CatalogInfo, Patch)}.
+     * @throws UnsupportedOperationException always, directing users to {@link #update(CatalogInfo, Patch)}.
+     * @deprecated since 1.0, for removal; use {@link #update(CatalogInfo, Patch)} instead.
      */
     @Deprecated(since = "1.0", forRemoval = true)
     @Override
@@ -198,8 +350,9 @@ public interface ExtendedCatalogFacade extends CatalogFacade {
     }
 
     /**
-     * @deprecated Throws {@link UnsupportedOperationException}, use {@link #update(CatalogInfo,
-     *     Patch)}
+     * Throws an exception to enforce use of {@link #update(CatalogInfo, Patch)}.
+     * @throws UnsupportedOperationException always, directing users to {@link #update(CatalogInfo, Patch)}.
+     * @deprecated since 1.0, for removal; use {@link #update(CatalogInfo, Patch)} instead.
      */
     @Deprecated(since = "1.0", forRemoval = true)
     @Override
@@ -208,8 +361,9 @@ public interface ExtendedCatalogFacade extends CatalogFacade {
     }
 
     /**
-     * @deprecated Throws {@link UnsupportedOperationException}, use {@link #update(CatalogInfo,
-     *     Patch)}
+     * Throws an exception to enforce use of {@link #update(CatalogInfo, Patch)}.
+     * @throws UnsupportedOperationException always, directing users to {@link #update(CatalogInfo, Patch)}.
+     * @deprecated since 1.0, for removal; use {@link #update(CatalogInfo, Patch)} instead.
      */
     @Deprecated(since = "1.0", forRemoval = true)
     @Override
@@ -218,8 +372,9 @@ public interface ExtendedCatalogFacade extends CatalogFacade {
     }
 
     /**
-     * @deprecated Throws {@link UnsupportedOperationException}, use {@link #update(CatalogInfo,
-     *     Patch)}
+     * Throws an exception to enforce use of {@link #update(CatalogInfo, Patch)}.
+     * @throws UnsupportedOperationException always, directing users to {@link #update(CatalogInfo, Patch)}.
+     * @deprecated since 1.0, for removal; use {@link #update(CatalogInfo, Patch)} instead.
      */
     @Deprecated(since = "1.0", forRemoval = true)
     @Override
@@ -228,8 +383,9 @@ public interface ExtendedCatalogFacade extends CatalogFacade {
     }
 
     /**
-     * @deprecated Throws {@link UnsupportedOperationException}, use {@link #update(CatalogInfo,
-     *     Patch)}
+     * Throws an exception to enforce use of {@link #update(CatalogInfo, Patch)}.
+     * @throws UnsupportedOperationException always, directing users to {@link #update(CatalogInfo, Patch)}.
+     * @deprecated since 1.0, for removal; use {@link #update(CatalogInfo, Patch)} instead.
      */
     @Deprecated(since = "1.0", forRemoval = true)
     @Override
@@ -238,8 +394,9 @@ public interface ExtendedCatalogFacade extends CatalogFacade {
     }
 
     /**
-     * @deprecated Throws {@link UnsupportedOperationException}, use {@link #update(CatalogInfo,
-     *     Patch)}
+     * Throws an exception to enforce use of {@link #update(CatalogInfo, Patch)}.
+     * @throws UnsupportedOperationException always, directing users to {@link #update(CatalogInfo, Patch)}.
+     * @deprecated since 1.0, for removal; use {@link #update(CatalogInfo, Patch)} instead.
      */
     @Deprecated(since = "1.0", forRemoval = true)
     @Override
@@ -247,41 +404,81 @@ public interface ExtendedCatalogFacade extends CatalogFacade {
         throw new UnsupportedOperationException("Expected use of update(CatalogInfo, Patch)");
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The default implementation simply returns the provided object unchanged, assuming no proxying by default.
+     */
     @Override
     default WorkspaceInfo detach(WorkspaceInfo info) {
         return info;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The default implementation simply returns the provided object unchanged, assuming no proxying by default.
+     */
     @Override
     default NamespaceInfo detach(NamespaceInfo info) {
         return info;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The default implementation simply returns the provided object unchanged, assuming no proxying by default.
+     */
     @Override
     default <T extends StoreInfo> T detach(T store) {
         return store;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The default implementation simply returns the provided object unchanged, assuming no proxying by default.
+     */
     @Override
     default <T extends ResourceInfo> T detach(T resource) {
         return resource;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The default implementation simply returns the provided object unchanged, assuming no proxying by default.
+     */
     @Override
     default LayerInfo detach(LayerInfo info) {
         return info;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The default implementation simply returns the provided object unchanged, assuming no proxying by default.
+     */
     @Override
     default LayerGroupInfo detach(LayerGroupInfo info) {
         return info;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The default implementation simply returns the provided object unchanged, assuming no proxying by default.
+     */
     @Override
     default StyleInfo detach(StyleInfo info) {
         return info;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The default implementation simply returns the provided object unchanged, assuming no proxying by default.
+     */
     @Override
     default MapInfo detach(MapInfo info) {
         return info;

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/IsolatedCatalogFacade.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/IsolatedCatalogFacade.java
@@ -1,6 +1,7 @@
 /*
- * (c) 2014 Open Source Geospatial Foundation - all rights reserved (c) 2001 - 2013 OpenPlans This
- * code is licensed under the GPL 2.0 license, available at the root application directory.
+ * (c) 2014 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root application directory.
  */
 package org.geoserver.catalog.plugin;
 
@@ -32,184 +33,456 @@ import org.geoserver.ows.LocalWorkspace;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.sort.SortBy;
 
-/** Copy of package private {@code org.geoserver.catalog.impl.IsolatedCatalogFacade} */
+/**
+ * A catalog facade that enforces workspace isolation in GeoServer Cloud, restricting visibility of
+ * catalog objects based on the current local workspace context.
+ *
+ * <p>This class extends {@link ForwardingExtendedCatalogFacade} to wrap an existing
+ * {@link ExtendedCatalogFacade} implementation, adding isolation logic inspired by GeoServer’s
+ * package-private {@code org.geoserver.catalog.impl.IsolatedCatalogFacade}. It ensures that catalog
+ * objects (e.g., stores, resources, layers) outside the current local workspace—set via
+ * {@link LocalWorkspace} during virtual service requests—are filtered out or return null, unless
+ * they are non-isolated or globally accessible.
+ *
+ * <p>Key features:
+ * <ul>
+ *   <li><strong>Isolation Enforcement:</strong> Methods like {@link #getStore(String, Class)} and
+ *       {@link #getResources(Class)} filter results based on workspace visibility, determined by
+ *       {@link #canSeeWorkspace(WorkspaceInfo)}.</li>
+ *   <li><strong>Type Safety:</strong> Generic methods maintain type safety while applying isolation.</li>
+ *   <li><strong>Stream Support:</strong> Modern {@link Stream}-based querying via {@link #query(Query)}.</li>
+ *   <li><strong>Legacy Compatibility:</strong> Overrides deprecated {@link #list} for backward compatibility.</li>
+ * </ul>
+ *
+ * <p>Isolation is context-dependent, relying on {@link Dispatcher#REQUEST} and {@link LocalWorkspace}
+ * to determine the active workspace during an OWS request. Outside a request context, isolation is
+ * bypassed, delegating to the underlying facade.
+ *
+ * @since 1.0
+ * @see ExtendedCatalogFacade
+ * @see LocalWorkspace
+ * @see Dispatcher
+ */
 public final class IsolatedCatalogFacade extends ForwardingExtendedCatalogFacade {
 
+    /**
+     * Constructs an {@code IsolatedCatalogFacade} wrapping the provided facade.
+     *
+     * @param facade The underlying {@link ExtendedCatalogFacade} to delegate to; must not be null.
+     * @throws NullPointerException if {@code facade} is null.
+     */
     IsolatedCatalogFacade(ExtendedCatalogFacade facade) {
         super(facade);
     }
 
+    /**
+     * Retrieves a store by ID, enforcing workspace isolation.
+     *
+     * <p>If the store’s workspace is not visible in the current context (per
+     * {@link #canSeeWorkspace(WorkspaceInfo)}), returns null.
+     *
+     * @param <T>   The specific type of {@link StoreInfo} to retrieve.
+     * @param id    The unique identifier of the store; must not be null.
+     * @param clazz The class of the store to retrieve; must not be null.
+     * @return The matching {@link StoreInfo} if visible, or null if not found or isolated.
+     * @throws NullPointerException if {@code id} or {@code clazz} is null.
+     * @example Retrieving a store:
+     *          <pre>
+     *          DataStoreInfo store = facade.getStore("store1", DataStoreInfo.class);
+     *          </pre>
+     */
     @Override
     public <T extends StoreInfo> T getStore(String id, Class<T> clazz) {
         return enforceStoreIsolation(facade.getStore(id, clazz));
     }
 
+    /**
+     * Retrieves a store by name and workspace, enforcing isolation.
+     *
+     * <p>If the workspace is not visible (per {@link #canSeeWorkspace(WorkspaceInfo)}), returns null.
+     *
+     * @param <T>       The specific type of {@link StoreInfo} to retrieve.
+     * @param workspace The workspace containing the store; may be null.
+     * @param name      The name of the store; must not be null.
+     * @param clazz     The class of the store to retrieve; must not be null.
+     * @return The matching {@link StoreInfo} if visible, or null if not found or isolated.
+     * @throws NullPointerException if {@code name} or {@code clazz} is null.
+     */
     @Override
     public <T extends StoreInfo> T getStoreByName(WorkspaceInfo workspace, String name, Class<T> clazz) {
         return canSeeWorkspace(workspace) ? facade.getStoreByName(workspace, name, clazz) : null;
     }
 
+    /**
+     * Retrieves all stores in a workspace, enforcing isolation.
+     *
+     * <p>If the workspace is not visible, returns an empty list.
+     *
+     * @param <T>       The specific type of {@link StoreInfo} to retrieve.
+     * @param workspace The workspace containing the stores; may be null.
+     * @param clazz     The class of the stores to retrieve; must not be null.
+     * @return A list of visible {@link StoreInfo} objects, or empty if workspace is isolated.
+     * @throws NullPointerException if {@code clazz} is null.
+     */
     @Override
     public <T extends StoreInfo> List<T> getStoresByWorkspace(WorkspaceInfo workspace, Class<T> clazz) {
         return canSeeWorkspace(workspace) ? facade.getStoresByWorkspace(workspace, clazz) : Collections.emptyList();
     }
 
+    /**
+     * Retrieves all stores of a specific type, filtering out isolated ones.
+     *
+     * @param <T>   The specific type of {@link StoreInfo} to retrieve.
+     * @param clazz The class of the stores to retrieve; must not be null.
+     * @return A list of visible {@link StoreInfo} objects.
+     * @throws NullPointerException if {@code clazz} is null.
+     */
     @Override
     public <T extends StoreInfo> List<T> getStores(Class<T> clazz) {
         return filterIsolated(facade.getStores(clazz), clazz, this::filter);
     }
 
+    /**
+     * Retrieves the default data store for a workspace, enforcing isolation.
+     *
+     * @param workspace The workspace to query; may be null.
+     * @return The default {@link DataStoreInfo} if visible, or null if not found or isolated.
+     */
     @Override
     public DataStoreInfo getDefaultDataStore(WorkspaceInfo workspace) {
         return enforceStoreIsolation(facade.getDefaultDataStore(workspace));
     }
 
+    /**
+     * Retrieves a resource by ID, enforcing isolation.
+     *
+     * @param <T>   The specific type of {@link ResourceInfo} to retrieve.
+     * @param id    The unique identifier of the resource; must not be null.
+     * @param clazz The class of the resource to retrieve; must not be null.
+     * @return The matching {@link ResourceInfo} if visible, or null if not found or isolated.
+     * @throws NullPointerException if {@code id} or {@code clazz} is null.
+     */
     @Override
     public <T extends ResourceInfo> T getResource(String id, Class<T> clazz) {
         return enforceResourceIsolation(facade.getResource(id, clazz));
     }
 
+    /**
+     * Retrieves a resource by name and namespace, enforcing isolation with namespace matching.
+     *
+     * <p>If a local workspace is active and its namespace URI matches the provided namespace’s URI,
+     * uses the local namespace; otherwise, applies isolation rules.
+     *
+     * @param <T>       The specific type of {@link ResourceInfo} to retrieve.
+     * @param namespace The namespace containing the resource; may be null.
+     * @param name      The name of the resource; must not be null.
+     * @param clazz     The class of the resource to retrieve; must not be null.
+     * @return The matching {@link ResourceInfo} if visible, or null if not found or isolated.
+     * @throws NullPointerException if {@code name} or {@code clazz} is null.
+     */
     @Override
     public <T extends ResourceInfo> T getResourceByName(NamespaceInfo namespace, String name, Class<T> clazz) {
         NamespaceInfo localNamespace = tryMatchLocalNamespace(namespace);
         if (localNamespace != null) {
-            // the URIs of the provided namespace and of the local workspace namespace matched
             return facade.getResourceByName(localNamespace, name, clazz);
         }
         return enforceResourceIsolation(facade.getResourceByName(namespace, name, clazz));
     }
 
+    /**
+     * Retrieves all resources of a specific type, filtering out isolated ones.
+     *
+     * @param <T>   The specific type of {@link ResourceInfo} to retrieve.
+     * @param clazz The class of the resources to retrieve; must not be null.
+     * @return A list of visible {@link ResourceInfo} objects.
+     * @throws NullPointerException if {@code clazz} is null.
+     */
     @Override
     public <T extends ResourceInfo> List<T> getResources(Class<T> clazz) {
         return filterIsolated(facade.getResources(clazz), clazz, this::filter);
     }
 
+    /**
+     * Retrieves all resources in a namespace, enforcing isolation with namespace matching.
+     *
+     * @param <T>       The specific type of {@link ResourceInfo} to retrieve.
+     * @param namespace The namespace containing the resources; may be null.
+     * @param clazz     The class of the resources to retrieve; must not be null.
+     * @return A list of visible {@link ResourceInfo} objects.
+     * @throws NullPointerException if {@code clazz} is null.
+     */
     @Override
     public <T extends ResourceInfo> List<T> getResourcesByNamespace(NamespaceInfo namespace, Class<T> clazz) {
         NamespaceInfo localNamespace = tryMatchLocalNamespace(namespace);
         if (localNamespace != null) {
-            // the URIs of the provided namespace and of the local workspace namespace matched
             return facade.getResourcesByNamespace(localNamespace, clazz);
         }
         return filterIsolated(facade.getResourcesByNamespace(namespace, clazz), clazz, this::filter);
     }
 
+    /**
+     * Retrieves a resource by store and name, enforcing isolation.
+     *
+     * @param <T>   The specific type of {@link ResourceInfo} to retrieve.
+     * @param store The store containing the resource; may be null.
+     * @param name  The name of the resource; must not be null.
+     * @param clazz The class of the resource to retrieve; must not be null.
+     * @return The matching {@link ResourceInfo} if visible, or null if not found or isolated.
+     * @throws NullPointerException if {@code name} or {@code clazz} is null.
+     */
     @Override
     public <T extends ResourceInfo> T getResourceByStore(StoreInfo store, String name, Class<T> clazz) {
         return enforceResourceIsolation(facade.getResourceByStore(store, name, clazz));
     }
 
+    /**
+     * Retrieves all resources in a store, filtering out isolated ones.
+     *
+     * @param <T>   The specific type of {@link ResourceInfo} to retrieve.
+     * @param store The store containing the resources; may be null.
+     * @param clazz The class of the resources to retrieve; must not be null.
+     * @return A list of visible {@link ResourceInfo} objects.
+     * @throws NullPointerException if {@code clazz} is null.
+     */
     @Override
     public <T extends ResourceInfo> List<T> getResourcesByStore(StoreInfo store, Class<T> clazz) {
         return filterIsolated(facade.getResourcesByStore(store, clazz), clazz, this::filter);
     }
 
+    /**
+     * Retrieves a layer by ID, enforcing isolation.
+     *
+     * @param id The unique identifier of the layer; must not be null.
+     * @return The matching {@link LayerInfo} if visible, or null if not found or isolated.
+     * @throws NullPointerException if {@code id} is null.
+     */
     @Override
     public LayerInfo getLayer(String id) {
         return enforceLayerIsolation(facade.getLayer(id));
     }
 
+    /**
+     * Retrieves a layer by name, enforcing isolation.
+     *
+     * @param name The name of the layer; must not be null.
+     * @return The matching {@link LayerInfo} if visible, or null if not found or isolated.
+     * @throws NullPointerException if {@code name} is null.
+     */
     @Override
     public LayerInfo getLayerByName(String name) {
         return enforceLayerIsolation(facade.getLayerByName(name));
     }
 
+    /**
+     * Retrieves all layers associated with a resource, filtering out isolated ones.
+     *
+     * @param resource The resource linked to the layers; may be null.
+     * @return A list of visible {@link LayerInfo} objects.
+     */
     @Override
     public List<LayerInfo> getLayers(ResourceInfo resource) {
         return filterIsolated(facade.getLayers(resource), LayerInfo.class, this::filter);
     }
 
+    /**
+     * Retrieves all layers using a style, filtering out isolated ones.
+     *
+     * @param style The style linked to the layers; may be null.
+     * @return A list of visible {@link LayerInfo} objects.
+     */
     @Override
     public List<LayerInfo> getLayers(StyleInfo style) {
         return filterIsolated(facade.getLayers(style), LayerInfo.class, this::filter);
     }
 
+    /**
+     * Retrieves all layers, filtering out isolated ones.
+     *
+     * @return A list of visible {@link LayerInfo} objects.
+     */
     @Override
     public List<LayerInfo> getLayers() {
         return filterIsolated(facade.getLayers(), LayerInfo.class, this::filter);
     }
 
+    /**
+     * Retrieves a layer group by ID, enforcing isolation.
+     *
+     * @param id The unique identifier of the layer group; must not be null.
+     * @return The matching {@link LayerGroupInfo} if visible, or null if not found or isolated.
+     * @throws NullPointerException if {@code id} is null.
+     */
     @Override
     public LayerGroupInfo getLayerGroup(String id) {
         return enforceLayerGroupIsolation(facade.getLayerGroup(id));
     }
 
+    /**
+     * Retrieves a layer group by name, enforcing isolation.
+     *
+     * @param name The name of the layer group; must not be null.
+     * @return The matching {@link LayerGroupInfo} if visible, or null if not found or isolated.
+     * @throws NullPointerException if {@code name} is null.
+     */
     @Override
     public LayerGroupInfo getLayerGroupByName(String name) {
         return enforceLayerGroupIsolation(facade.getLayerGroupByName(name));
     }
 
+    /**
+     * Retrieves a layer group by name and workspace, enforcing isolation.
+     *
+     * @param workspace The workspace containing the layer group; may be null.
+     * @param name      The name of the layer group; must not be null.
+     * @return The matching {@link LayerGroupInfo} if visible, or null if not found or isolated.
+     * @throws NullPointerException if {@code name} is null.
+     */
     @Override
     public LayerGroupInfo getLayerGroupByName(WorkspaceInfo workspace, String name) {
         return enforceLayerGroupIsolation(facade.getLayerGroupByName(workspace, name));
     }
 
+    /**
+     * Retrieves all layer groups, filtering out isolated ones.
+     *
+     * @return A list of visible {@link LayerGroupInfo} objects.
+     */
     @Override
     public List<LayerGroupInfo> getLayerGroups() {
         return filterIsolated(facade.getLayerGroups(), LayerGroupInfo.class, this::filter);
     }
 
+    /**
+     * Retrieves all layer groups in a workspace, filtering out isolated ones.
+     *
+     * @param workspace The workspace containing the layer groups; may be null.
+     * @return A list of visible {@link LayerGroupInfo} objects.
+     */
     @Override
     public List<LayerGroupInfo> getLayerGroupsByWorkspace(WorkspaceInfo workspace) {
         return filterIsolated(facade.getLayerGroupsByWorkspace(workspace), LayerGroupInfo.class, this::filter);
     }
 
+    /**
+     * Retrieves a namespace by URI, enforcing isolation with local workspace matching.
+     *
+     * <p>Prioritizes the local workspace’s namespace if its URI matches; otherwise, returns a global
+     * non-isolated namespace or null.
+     *
+     * @param uri The URI of the namespace; must not be null.
+     * @return The matching {@link NamespaceInfo} if visible, or null if not found or isolated.
+     * @throws NullPointerException if {@code uri} is null.
+     */
     @Override
     public NamespaceInfo getNamespaceByURI(String uri) {
         NamespaceInfo localNamespace = getLocalNamespace();
         if (localNamespace != null && Objects.equals(localNamespace.getURI(), uri)) {
-            // local workspace namespace URI is equal to the provided URI
             return localNamespace;
         }
-        // let's see if there is any global namespace matching the provided uri
         for (NamespaceInfo namespace : facade.getNamespacesByURI(uri)) {
             if (!namespace.isIsolated()) {
-                // we found a global namespace
                 return namespace;
             }
         }
-        // no global namespace found
         return null;
     }
 
+    /**
+     * Retrieves a style by ID, enforcing isolation.
+     *
+     * @param id The unique identifier of the style; must not be null.
+     * @return The matching {@link StyleInfo} if visible, or null if not found or isolated.
+     * @throws NullPointerException if {@code id} is null.
+     */
     @Override
     public StyleInfo getStyle(String id) {
         return enforceStyleIsolation(facade.getStyle(id));
     }
 
+    /**
+     * Retrieves a style by name, enforcing isolation.
+     *
+     * @param name The name of the style; must not be null.
+     * @return The matching {@link StyleInfo} if visible, or null if not found or isolated.
+     * @throws NullPointerException if {@code name} is null.
+     */
     @Override
     public StyleInfo getStyleByName(String name) {
         return enforceStyleIsolation(facade.getStyleByName(name));
     }
 
+    /**
+     * Retrieves a style by name and workspace, enforcing isolation.
+     *
+     * @param workspace The workspace containing the style; may be null.
+     * @param name      The name of the style; must not be null.
+     * @return The matching {@link StyleInfo} if visible, or null if not found or isolated.
+     * @throws NullPointerException if {@code name} is null.
+     */
     @Override
     public StyleInfo getStyleByName(WorkspaceInfo workspace, String name) {
         return enforceStyleIsolation(facade.getStyleByName(workspace, name));
     }
 
+    /**
+     * Retrieves all styles, filtering out isolated ones.
+     *
+     * @return A list of visible {@link StyleInfo} objects.
+     */
     @Override
     public List<StyleInfo> getStyles() {
         return filterIsolated(facade.getStyles(), StyleInfo.class, this::filter);
     }
 
+    /**
+     * Retrieves all styles in a workspace, filtering out isolated ones.
+     *
+     * @param workspace The workspace containing the styles; may be null.
+     * @return A list of visible {@link StyleInfo} objects.
+     */
     @Override
     public List<StyleInfo> getStylesByWorkspace(WorkspaceInfo workspace) {
         return filterIsolated(facade.getStylesByWorkspace(workspace), StyleInfo.class, this::filter);
     }
 
+    /**
+     * Counts catalog objects matching the type and filter, enforcing isolation during requests.
+     *
+     * <p>Within an OWS request context, uses {@link #query(Query)} to filter results; otherwise,
+     * delegates to the underlying facade.
+     *
+     * @param <T>    The type of {@link CatalogInfo} to count.
+     * @param of     The class of objects to count; must not be null.
+     * @param filter The filter to apply; must not be null.
+     * @return The number of visible matching objects.
+     * @throws NullPointerException if {@code of} or {@code filter} is null.
+     */
     @Override
     public <T extends CatalogInfo> int count(Class<T> of, Filter filter) {
         if (Dispatcher.REQUEST.get() == null) {
             return super.count(of, filter);
         }
-
         try (Stream<T> result = query(Query.valueOf(of, filter))) {
             return (int) result.count();
         }
     }
 
     /**
-     * @deprecated as per {@link ExtendedCatalogFacade#list} use {@link #query(Query)} instead
+     * Retrieves a list of catalog objects matching the criteria, enforcing isolation, using a legacy iterator.
+     *
+     * <p>This method is deprecated in favor of {@link #query(Query)}. It adapts the underlying facade’s
+     * results, filtering out isolated objects within a request context, ignoring offset/count for
+     * accuracy.
+     *
+     * @param <T>       The type of {@link CatalogInfo} to list.
+     * @param of        The class of objects to list; must not be null.
+     * @param filter    The filter to apply; must not be null.
+     * @param offset    The number of objects to skip, or null for no offset.
+     * @param count     The maximum number of objects to return, or null for no limit.
+     * @param sortOrder Variable number of {@link SortBy} directives (nulls ignored).
+     * @return A {@link CloseableIterator} of visible objects.
+     * @throws NullPointerException if {@code of} or {@code filter} is null.
+     * @deprecated since 1.0, for removal; use {@link #query(Query)} instead.
      */
     @Deprecated(since = "1.0", forRemoval = true)
     @Override
@@ -223,7 +496,6 @@ public final class IsolatedCatalogFacade extends ForwardingExtendedCatalogFacade
         if (Dispatcher.REQUEST.get() == null) {
             return facade.list(of, filter, offset, count, sortOrder);
         }
-        // Fix, gotta request all to be able of filtering, ditch offset and count
         final CloseableIterator<T> all = facade.list(of, filter, null, null, sortOrder);
         Iterator<T> filtered = Iterators.filter(all, this::filter);
         if (offset != null) {
@@ -235,6 +507,24 @@ public final class IsolatedCatalogFacade extends ForwardingExtendedCatalogFacade
         return new CloseableIteratorAdapter<>(filtered, all);
     }
 
+    /**
+     * Queries the catalog with isolation applied, filtering out non-visible objects.
+     *
+     * <p>Delegates to the underlying facade’s {@link ExtendedCatalogFacade#query(Query)}, then applies
+     * isolation rules to the results.
+     *
+     * @param <T>   The type of {@link CatalogInfo} to query.
+     * @param query The query specifying criteria; must not be null.
+     * @return A {@link Stream} of visible objects; never null.
+     * @throws NullPointerException if {@code query} is null.
+     * @example Querying visible layers:
+     *          <pre>
+     *          Query<LayerInfo> query = Query.valueOf(LayerInfo.class, someFilter);
+     *          try (Stream<LayerInfo> layers = facade.query(query)) {
+     *              layers.forEach(l -> System.out.println(l.getName()));
+     *          }
+     *          </pre>
+     */
     @Override
     public <T extends CatalogInfo> Stream<T> query(Query<T> query) {
         return ((ExtendedCatalogFacade) facade)
@@ -243,23 +533,38 @@ public final class IsolatedCatalogFacade extends ForwardingExtendedCatalogFacade
                 .filter(i -> i != null);
     }
 
+    /**
+     * Returns the catalog capabilities with isolation support enabled.
+     *
+     * <p>Extends the underlying facade’s capabilities by setting isolated workspace support to true.
+     *
+     * @return The {@link CatalogCapabilities} with isolation support indicated.
+     */
     @Override
     public CatalogCapabilities getCatalogCapabilities() {
         CatalogCapabilities capabilities = facade.getCatalogCapabilities();
-        // this wrapper adds support for isolated workspaces
         capabilities.setIsolatedWorkspacesSupport(true);
         return capabilities;
     }
 
     /**
-     * Helper method that just returns the current local workspace if available.
+     * Retrieves the current local workspace, if set.
      *
-     * @return current local workspace or NULL
+     * @return The current {@link WorkspaceInfo} from {@link LocalWorkspace}, or null if not set.
      */
     private WorkspaceInfo getLocalWorkspace() {
         return LocalWorkspace.get();
     }
 
+    /**
+     * Enforces isolation on a catalog object based on its type.
+     *
+     * <p>Delegates to type-specific isolation methods (e.g., {@link #enforceStoreIsolation}).
+     *
+     * @param <T>  The type of {@link CatalogInfo}.
+     * @param info The catalog object to check; may be null.
+     * @return The object if visible, or null if isolated.
+     */
     @SuppressWarnings("unchecked")
     private <T extends CatalogInfo> T enforceIsolation(T info) {
         if (info instanceof StoreInfo store) return (T) enforceStoreIsolation(store);
@@ -267,124 +572,106 @@ public final class IsolatedCatalogFacade extends ForwardingExtendedCatalogFacade
         if (info instanceof LayerInfo layer) return (T) enforceLayerIsolation(layer);
         if (info instanceof LayerGroupInfo lg) return (T) enforceLayerGroupIsolation(lg);
         if (info instanceof StyleInfo style) return (T) enforceStyleIsolation(style);
-
         return info;
     }
 
+    /**
+     * Filters a catalog object for visibility.
+     *
+     * @param <T>  The type of {@link CatalogInfo}.
+     * @param info The catalog object to filter; may be null.
+     * @return {@code true} if visible, {@code false} if isolated or null.
+     */
     private <T extends CatalogInfo> boolean filter(T info) {
         return enforceIsolation(info) != null;
     }
 
     /**
-     * Checks if the provided store is visible in the current context.
+     * Enforces isolation on a store, checking its workspace visibility.
      *
-     * @param store the store to check, may be NULL
-     * @return the store if visible, otherwise NULL
+     * @param <T>   The type of {@link StoreInfo}.
+     * @param store The store to check; may be null.
+     * @return The store if visible, or null if isolated.
      */
     private <T extends StoreInfo> T enforceStoreIsolation(T store) {
-        if (store == null) {
-            // nothing to do, the store is already NULL
-            return null;
-        }
+        if (store == null) return null;
         WorkspaceInfo workspace = store.getWorkspace();
-        // check if the store workspace is visible in this context
         return canSeeWorkspace(workspace) ? store : null;
     }
 
     /**
-     * Checks if the provided resource is visible in the current context.
+     * Enforces isolation on a resource, checking its store’s workspace visibility.
      *
-     * @param resource the resource to check, may be NULL
-     * @return the resource if visible, otherwise NULL
+     * @param <T>      The type of {@link ResourceInfo}.
+     * @param resource The resource to check; may be null.
+     * @return The resource if visible, or null if isolated.
      */
     private <T extends ResourceInfo> T enforceResourceIsolation(T resource) {
-        if (resource == null) {
-            // nothing to do, the resource is already NULL
-            return null;
-        }
-        // get the resource store
+        if (resource == null) return null;
         StoreInfo store = resource.getStore();
-        if (store == null) {
-            // since we can't check if the store is visible we let it go
-            return resource;
-        }
+        if (store == null) return resource;
         WorkspaceInfo workspace = store.getWorkspace();
-        // check if the resource store workspace is visible in this context
         return canSeeWorkspace(workspace) ? resource : null;
     }
 
     /**
-     * Checks if the provided layer is visible in the current context.
+     * Enforces isolation on a layer, checking its resource’s store workspace visibility.
      *
-     * @param layer the layer to check, may be NULL
-     * @return the layer if visible, otherwise NULL
+     * @param <T>   The type of {@link LayerInfo}.
+     * @param layer The layer to check; may be null.
+     * @return The layer if visible, or null if isolated.
      */
     private <T extends LayerInfo> T enforceLayerIsolation(T layer) {
-        if (layer == null) {
-            // nothing to do, the layer is already NULL
-            return null;
-        }
+        if (layer == null) return null;
         ResourceInfo resource = layer.getResource();
-        if (resource == null) {
-            // this should not happen, there is not much we can do
-            return layer;
-        }
+        if (resource == null) return layer;
         StoreInfo store = resource.getStore();
-        if (store == null) {
-            // since we can't check if the store is visible we let it go
-            return layer;
-        }
+        if (store == null) return layer;
         WorkspaceInfo workspace = store.getWorkspace();
-        // check if the layer resource store workspace is visible in this context
         return canSeeWorkspace(workspace) ? layer : null;
     }
 
     /**
-     * Checks if the provided style is visible in the current context.
+     * Enforces isolation on a style, checking its workspace visibility.
      *
-     * @param style the style to check, may be NULL
-     * @return the style if visible, otherwise NULL
+     * @param <T>   The type of {@link StyleInfo}.
+     * @param style The style to check; may be null.
+     * @return The style if visible, or null if isolated.
      */
     private <T extends StyleInfo> T enforceStyleIsolation(T style) {
-        if (style == null) {
-            // nothing to do, the style is already NULL
-            return null;
-        }
+        if (style == null) return null;
         WorkspaceInfo workspace = style.getWorkspace();
-        // check if the style workspace is visible in this context
         return canSeeWorkspace(workspace) ? style : null;
     }
 
     /**
-     * Checks if the provided layer group is visible in the current context. Note that layer group
-     * contained layer groups will not be filtered.
+     * Enforces isolation on a layer group, checking its workspace visibility.
      *
-     * @param layerGroup the layer group to check, may be NULL
-     * @return the layer group if visible, otherwise NULL
+     * <p>Note: Nested layer groups within the result are not filtered for isolation.
+     *
+     * @param <T>       The type of {@link LayerGroupInfo}.
+     * @param layerGroup The layer group to check; may be null.
+     * @return The layer group if visible, or null if isolated.
      */
     private <T extends LayerGroupInfo> T enforceLayerGroupIsolation(T layerGroup) {
-        if (layerGroup == null) {
-            // nothing to do, the layer group is already NULL
-            return null;
-        }
+        if (layerGroup == null) return null;
         WorkspaceInfo workspace = layerGroup.getWorkspace();
-        // check if the layer group workspace is visible in this context
         return canSeeWorkspace(workspace) ? layerGroup : null;
     }
 
     /**
-     * Helper method that checks if the provided workspace is visible in the current context.
+     * Determines if a workspace is visible in the current context.
      *
-     * <p>This method returns TRUE if the provided workspace is one of the default ones
-     * (NO_WORKSPACE or ANY_WORKSPACE) or if the provided workspace is NULL or is not isolated. If
-     * no OWS service request is in progress TRUE will also be returned.
+     * <p>A workspace is visible if:
+     * <ul>
+     *   <li>It is a special workspace ({@link CatalogFacade#NO_WORKSPACE}, {@link CatalogFacade#ANY_WORKSPACE}).</li>
+     *   <li>It is null or non-isolated.</li>
+     *   <li>No request context exists (outside OWS).</li>
+     *   <li>It matches the current local workspace (via {@link LocalWorkspace}).</li>
+     * </ul>
      *
-     * <p>If none of the conditions above is satisfied, then if a local workspace exists (i.e. we
-     * are in the context of a virtual service) and if the local workspace matches the provided
-     * workspace TRUE is returned, otherwise FALSE is returned.
-     *
-     * @param workspace the workspace to check for visibility
-     * @return TRUE if the workspace is visible in the current context, otherwise FALSE
+     * @param workspace The workspace to check; may be null.
+     * @return {@code true} if visible, {@code false} if isolated.
      */
     private boolean canSeeWorkspace(WorkspaceInfo workspace) {
         if (workspace == CatalogFacade.NO_WORKSPACE
@@ -392,64 +679,54 @@ public final class IsolatedCatalogFacade extends ForwardingExtendedCatalogFacade
                 || workspace == null
                 || !workspace.isIsolated()
                 || Dispatcher.REQUEST.get() == null) {
-            // the workspace content is visible in this context
             return true;
         }
         WorkspaceInfo localWorkspace = getLocalWorkspace();
-        // the workspace content will be visible only if we are in the context of one
-        // of its virtual services
         return localWorkspace != null && Objects.equals(localWorkspace.getName(), workspace.getName());
     }
 
     /**
-     * Helper method that removes from a list the catalog objects not visible in the current
-     * context. This method takes care of the proper modification proxy unwrapping \ wrapping.
+     * Filters a list of catalog objects, removing those not visible in the current context.
      *
-     * @param objects list of catalog object, wrapped with a modification proxy
-     * @param type the class of the list objects
-     * @param filter filter that checks if an element should be visible
-     * @return a list wrapped with a modification proxy that contains the visible catalog objects
+     * <p>Handles {@link ModificationProxy} unwrapping and rewrapping for consistency.
+     *
+     * @param <T>     The type of {@link CatalogInfo}.
+     * @param objects The list of objects to filter; may be null or empty.
+     * @param type    The class of the objects; must not be null.
+     * @param filter  The predicate to apply; must not be null.
+     * @return A filtered list wrapped with {@link ModificationProxy}.
+     * @throws NullPointerException if {@code type} or {@code filter} is null.
      */
     private <T extends CatalogInfo> List<T> filterIsolated(List<T> objects, Class<T> type, Predicate<T> filter) {
-        // unwrap the catalog objects list
         List<T> unwrapped = ModificationProxy.unwrap(objects);
-        // filter the non visible catalog objects and wrap the resulting list with a modification
-        // proxy
         return ModificationProxy.createList(unwrapped.stream().filter(filter).toList(), type);
     }
 
     /**
-     * If a local workspace is set (i.e. we are in the context of a virtual service) and if the URI
-     * of the provided namespace matches the local workspace associate namespace URI, we return the
-     * namespace associated with the current local workspace, otherwise NULL is returned.
+     * Attempts to match a namespace to the local workspace’s namespace by URI.
      *
-     * @param namespace the namespace we will try to match against the local workspace
-     * @return the namespace associated with the local workspace if matched, otherwise NULL
+     * @param namespace The namespace to match; may be null.
+     * @return The local workspace’s {@link NamespaceInfo} if URIs match, or null if no match.
      */
     private NamespaceInfo tryMatchLocalNamespace(NamespaceInfo namespace) {
         WorkspaceInfo localWorkspace = getLocalWorkspace();
         if (localWorkspace != null) {
-            // get the namespace for the current local workspace
             NamespaceInfo localNamespace = facade.getNamespaceByPrefix(localWorkspace.getName());
             if (localNamespace != null && Objects.equals(localNamespace.getURI(), namespace.getURI())) {
-                // the URIs match, let's return the local workspace namespace
                 return localNamespace;
             }
         }
-        // the provided namespace doesn't match the local workspace namespace
         return null;
     }
 
     /**
-     * If a local workspace is set returns the namespace associated to it.
+     * Retrieves the namespace associated with the current local workspace.
      *
-     * @return the namespace associated with the local workspace, or NULL if no local workspace is
-     *     set
+     * @return The local {@link NamespaceInfo}, or null if no local workspace is set.
      */
     private NamespaceInfo getLocalNamespace() {
         WorkspaceInfo localWorkspace = getLocalWorkspace();
         if (localWorkspace != null) {
-            // get the namespace associated with the local workspace
             return facade.getNamespaceByPrefix(localWorkspace.getName());
         }
         return null;

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/Patch.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/Patch.java
@@ -18,32 +18,99 @@ import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.impl.ModificationProxy;
 import org.geoserver.ows.util.OwsUtils;
 
+/**
+ * Represents a patch of changes to be applied to a catalog object, encapsulating a list of property
+ * updates. A patch is used to describe modifications (e.g., adding, updating, or removing properties)
+ * to entities like layers, styles, or workspaces in the {@link Catalog}.
+ *
+ * <p>This class provides a flexible, mutable container for property changes, allowing incremental
+ * construction of updates through methods like {@link #add} and {@link #with}. It is typically used
+ * by the Catalog to batch updates and apply them to catalog objects, propagating changes
+ * efficiently across the distributed system via events.
+ *
+ * <p>Each patch consists of a collection of {@link Property} objects, where each property specifies
+ * a name and its new value. Unlike a diff, this class focuses on the target state rather than tracking
+ * old values, enabling straightforward application of changes to objects.
+ */
 @NoArgsConstructor
 public @Data class Patch implements Serializable {
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Inner class representing a single property change within a {@link Patch}.
+     *
+     * <p>A {@code Property} encapsulates the name of the property to be updated and its new value.
+     * It supports type-safe value retrieval and custom equality checking for arrays and primitives.
+     *
+     * @see Patch
+     */
     public static @Data class Property {
         private final String name;
         private final Object value;
 
+        /**
+         * Retrieves the property value cast to the specified type.
+         *
+         * <p>This method provides a type-safe way to access the value, suppressing unchecked warnings
+         * since the caller is responsible for ensuring type compatibility.
+         *
+         * @param <V> The expected type of the value.
+         * @return The property value cast to type {@code V}.
+         * @throws ClassCastException if the value cannot be cast to the requested type.
+         * @example Accessing a string value:
+         *          <pre>
+         *          Property prop = new Property("title", "New Title");
+         *          String title = prop.value();
+         *          </pre>
+         */
         @SuppressWarnings("unchecked")
         public <V> V value() {
             return (V) value;
         }
 
+        /**
+         * Compares this property to another object for equality.
+         *
+         * <p>Equality is based on the property name and value, using custom logic to handle arrays
+         * and primitives via {@link #valueEquals}.
+         *
+         * @param o The object to compare with.
+         * @return {@code true} if the objects are equal; {@code false} otherwise.
+         */
         @Override
         public boolean equals(Object o) {
             return o instanceof Property p && valueEquals(value(), p.value());
         }
 
+        /**
+         * Computes the hash code for this property.
+         *
+         * <p>The hash code is derived from the property value, ensuring consistency with {@link #equals}.
+         *
+         * @return The hash code value.
+         */
         @Override
         public int hashCode() {
             return Objects.hash(Property.class, value);
         }
 
+        /**
+         * Compares two values for equality, with special handling for arrays.
+         *
+         * <p>This utility method supports deep equality checks for primitive and object arrays,
+         * ensuring accurate comparison of complex property values.
+         * <p>Nonetheless, the values themselves must implement equals()
+         *
+         * @param v1 The first value to compare.
+         * @param v2 The second value to compare.
+         * @return {@code true} if the values are equal; {@code false} otherwise.
+         * @throws IllegalArgumentException if an unexpected array component type is encountered.
+         * @see Arrays#deepEquals
+         */
         public static boolean valueEquals(final Object v1, final Object v2) {
             if (Objects.equals(v1, v2)) {
                 return true;
@@ -80,22 +147,74 @@ public @Data class Patch implements Serializable {
 
     private final List<Property> patches = new ArrayList<>();
 
+    /**
+     * Constructs a new Patch with the given list of property changes.
+     *
+     * <p>The provided list is iterated and added to the internal collection, allowing further
+     * modifications via {@link #add} or {@link #with}. If the input list is null or empty, the
+     * patch starts empty, representing no changes initially.
+     *
+     * @param patches The initial list of property changes to include. May be null or empty.
+     * @example Creating a patch to update a layer's title:
+     *          <pre>
+     *          List<Property> props = new ArrayList<>();
+     *          props.add(new Property("title", "New Title"));
+     *          Patch patch = new Patch(props);
+     *          </pre>
+     */
     public Patch(List<Property> patches) {
         patches.forEach(this::add);
     }
 
+    /**
+     * Returns the number of property changes in this patch.
+     *
+     * @return The size of the patches list.
+     */
     public int size() {
         return patches.size();
     }
-
+    /**
+     * Checks if this patch contains no property changes.
+     *
+     * <p>An empty patch indicates no modifications will be applied, useful for conditional logic
+     * in update workflows.
+     *
+     * @return {@code true} if the patch is empty; {@code false} otherwise.
+     */
     public boolean isEmpty() {
         return patches.isEmpty();
     }
 
+    /**
+     * Adds a property change to this patch.
+     *
+     * <p>The property is appended to the internal list, allowing incremental construction of the
+     * patch. This method ensures the property is non-null to maintain consistency.
+     *
+     * @param prop The property change to add.
+     * @throws NullPointerException if the property is null.
+     */
     public void add(@NonNull Property prop) {
         patches.add(prop);
     }
 
+    /**
+     * Adds a new property change with the specified name and value, returning the created property.
+     *
+     * <p>This convenience method creates a {@link Property} instance and adds it to the patch,
+     * useful for programmatic construction.
+     *
+     * @param name  The name of the property to update (e.g., "title").
+     * @param value The new value for the property.
+     * @return The created {@link Property} instance.
+     * @throws NullPointerException if the name is null.
+     * @example Adding a property:
+     *          <pre>
+     *          Patch patch = new Patch();
+     *          patch.add("enabled", true);
+     *          </pre>
+     */
     public Property add(String name, Object value) {
         Objects.requireNonNull(name, "name");
         Property p = new Property(name, value);
@@ -103,26 +222,56 @@ public @Data class Patch implements Serializable {
         return p;
     }
 
+    /**
+     * Adds a property change and returns this patch for method chaining.
+     */
     public Patch with(String name, Object value) {
         add(name, value);
         return this;
     }
 
+    /**
+     * Returns the list of property names in this patch. */
     public List<String> getPropertyNames() {
         return patches.stream().map(Property::getName).toList();
     }
 
+    /**
+     * Retrieves a property by its name, if present.
+     *
+     * @param propertyName The name of the property to find.
+     * @return An {@link Optional} containing the {@link Property} if found, or empty if not.
+     */
     public Optional<Property> get(String propertyName) {
         return patches.stream().filter(p -> p.getName().equals(propertyName)).findFirst();
     }
 
+    /**
+     * Retrieves the value of a property by its name, if present.
+     *
+     * @param propertyName The name of the property to find.
+     * @return An {@link Optional} containing the value if found, or empty if not.
+     */
     public Optional<Object> getValue(String propertyName) {
         return get(propertyName).map(Property::getValue);
     }
 
+    /**
+     * Applies this patch to the target object, inferring its type.
+     *
+     * <p>This method attempts to determine the target’s type and applies all property changes.
+     * If the target is a proxy, it unwraps it to find the actual type unless nested proxies prevent this.
+     *
+     * @param <T>   The type of the target object.
+     * @param target The object to apply the patch to.
+     * @return The modified target object.
+     * @throws NullPointerException if the target is null.
+     * @throws IllegalArgumentException if the target is a nested proxy and type cannot be inferred.
+     */
     public <T> T applyTo(T target) {
         Objects.requireNonNull(target);
         Class<?> targetType = target.getClass();
+
         if (Proxy.isProxyClass(targetType)) {
             Class<?> subject = ModificationProxy.unwrap(target).getClass();
             if (Proxy.isProxyClass(subject)) {
@@ -133,11 +282,33 @@ public @Data class Patch implements Serializable {
         return applyTo(target, targetType);
     }
 
+    /**
+     * Applies this patch to the target object using the specified type.
+     *
+     * <p>This method applies each property change to the target, handling collections and maps
+     * appropriately based on getter method signatures.
+     *
+     * @param <T>        The type of the target object.
+     * @param target     The object to apply the patch to.
+     * @param objectType The explicit type of the target object.
+     * @return The modified target object.
+     * @throws IllegalArgumentException if a property name does not exist in the target type.
+     */
     public <T> T applyTo(T target, Class<?> objectType) {
         patches.forEach(p -> apply(target, objectType, p));
         return target;
     }
 
+    /**
+     * Applies a single property change to the target object.
+     *
+     * <p>Handles simple properties, collections, and maps based on the getter’s return type.
+     *
+     * @param target     The object to modify.
+     * @param objectType The type of the target object.
+     * @param change     The property change to apply.
+     * @throws IllegalArgumentException if the property does not exist or is immutable.
+     */
     private static void apply(Object target, Class<?> objectType, final Property change) {
         final Method getter = findGetterOrThrow(objectType, change);
         if (isCollection(getter)) {
@@ -151,23 +322,55 @@ public @Data class Patch implements Serializable {
         }
     }
 
+    /**
+     * Applies a collection property change by updating the target object’s collection property.
+     *
+     * <p>If the new value is null, clears the existing collection if present. If the new value is
+     * empty, sets the collection to empty. If the new value is non-empty, replaces the existing
+     * collection’s contents or sets a new collection if none exists. Handles immutable collections
+     * by throwing an exception.
+     *
+     * @param target The object whose collection property is being updated.
+     * @param change The property change containing the property name and new collection value.
+     * @throws IllegalArgumentException if the collection is immutable or cannot be set.
+     */
     @SuppressWarnings({"unchecked", "rawtypes"})
     private static void applyCollectionValueChange(Object target, final Property change) {
         final String propertyName = change.getName();
         final var currentValue = (Collection) OwsUtils.get(target, propertyName);
         final var newValue = (Collection) change.getValue();
-        if (currentValue != null) {
+
+        if (newValue == null) {
+            if (currentValue != null) {
+                try {
+                    currentValue.clear();
+                } catch (UnsupportedOperationException e) {
+                    throw new IllegalArgumentException(
+                            "Collection property %s is immutable".formatted(propertyName), e);
+                }
+            }
+            // Optionally: OwsUtils.set(target, propertyName, null); if null is a valid state
+        } else if (currentValue != null) {
             try {
                 currentValue.clear();
+                if (!newValue.isEmpty()) {
+                    currentValue.addAll(newValue);
+                }
             } catch (UnsupportedOperationException e) {
                 throw new IllegalArgumentException("Collection property %s is immutable".formatted(propertyName), e);
             }
-            if (newValue != null) {
-                currentValue.addAll(newValue);
+        } else if (!newValue.isEmpty()) {
+            // Create a new collection and set it, assuming OwsUtils supports this
+            try {
+                OwsUtils.set(target, propertyName, new ArrayList<>(newValue));
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Failed to set collection property %s".formatted(propertyName), e);
             }
         }
     }
-
+    /**
+     * Applies a map property change by clearing and updating the existing map.
+     */
     @SuppressWarnings("unchecked")
     private static void applyMapValueChange(Object target, final Property change) {
         final String propertyName = change.getName();
@@ -181,6 +384,11 @@ public @Data class Patch implements Serializable {
         }
     }
 
+    /**
+     * Finds the getter method for a property or throws an exception if not found.
+     *
+     * @throws IllegalArgumentException if no getter exists for the property name.
+     */
     private static Method findGetterOrThrow(Class<?> objectType, Property change) {
         Method getter = OwsUtils.getter(objectType, change.getName(), null);
         if (getter == null) {
@@ -189,14 +397,34 @@ public @Data class Patch implements Serializable {
         return getter;
     }
 
+    /**
+     * Checks if the getter returns a map type.
+     *
+     * @param getter The getter method to inspect.
+     * @return {@code true} if the return type is a {@link Map}; {@code false} otherwise.
+     */
     private static boolean isMap(Method getter) {
         return Map.class.isAssignableFrom(getter.getReturnType());
     }
 
+    /**
+     * Checks if the getter returns a collection type.
+     *
+     * @param getter The getter method to inspect.
+     * @return {@code true} if the return type is a {@link Collection}; {@code false} otherwise.
+     */
     private static boolean isCollection(Method getter) {
         return Collection.class.isAssignableFrom(getter.getReturnType());
     }
 
+    /**
+     * Returns a string representation of this patch for debugging purposes.
+     *
+     * <p>Provides a concise summary of all property changes in the format "Patch[name: value, ...]".
+     *
+     * @return A string summarizing the patch’s contents.
+     * @example Output: "Patch[title: New Title, enabled: true]"
+     */
     @Override
     public String toString() {
         String props = this.getPatches().stream()

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/PropertyDiff.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/PropertyDiff.java
@@ -45,33 +45,108 @@ import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.api.util.InternationalString;
 import org.geotools.referencing.CRS;
 
+/**
+ * Represents a set of property changes (differences) between the old and new states of a catalog object
+ * in GeoServer. This class encapsulates a list of {@link Change} objects, each detailing a property
+ * name, its old value, and its new value, enabling precise tracking and application of modifications to
+ * entities like layers, styles, or workspaces.
+ *
+ * <p>{@code PropertyDiff} is used within the catalog system to compare states, generate patches (via
+ * {@link #toPatch}), and facilitate updates across the distributed microservices architecture. It provides methods to inspect and refine the changes
+ * (e.g., {@link #clean} to remove no-op changes).
+ *
+ * <p>The class is typically constructed using the {@link PropertyDiffBuilder} for incremental building or
+ * directly from a {@link ModificationProxy} to capture changes programmatically. It is mutable but provides
+ * immutable views of its data where appropriate.
+ */
 @Slf4j
 public @Data class PropertyDiff implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private List<Change> changes;
 
+    /**
+     * Creates a new builder for constructing a {@code PropertyDiff} from scratch.
+     *
+     * @param <T> The type of catalog object ({@link Info}) being diffed.
+     * @return A new {@link PropertyDiffBuilder} instance.
+     * @example Basic builder usage:
+     *          <pre>
+     *          PropertyDiff diff = PropertyDiff.builder()
+     *              .with("title", "Old Title", "New Title")
+     *              .build();
+     *          </pre>
+     */
     public static <T extends Info> PropertyDiffBuilder<T> builder() {
         return new PropertyDiffBuilder<>();
     }
 
+    /**
+     * Creates a builder initialized with an existing catalog object to compare against new values.
+     *
+     * @param <T>           The type of catalog object ({@link Info}).
+     * @param oldValueHolder The original catalog object to use as a baseline for diffs.
+     * @return A new {@link PropertyDiffBuilder} instance initialized with the old state.
+     * @throws NullPointerException if {@code oldValueHolder} is null.
+     * @example Builder with existing object:
+     *          <pre>
+     *          LayerInfo layer = ...; // existing layer
+     *          PropertyDiff diff = PropertyDiff.builder(layer)
+     *              .with("title", "New Title")
+     *              .build();
+     *          </pre>
+     */
     public static <T extends Info> PropertyDiffBuilder<T> builder(T oldValueHolder) {
         return new PropertyDiffBuilder<>(oldValueHolder);
     }
 
+    /**
+     * Constructs an empty {@code PropertyDiff} with no changes.
+     *
+     * <p>This is a convenience constructor for creating an empty diff, equivalent to calling
+     * {@link #PropertyDiff(List)} with an empty list.
+     */
     public PropertyDiff() {
         this(Collections.emptyList());
     }
 
+    /**
+     * Constructs a {@code PropertyDiff} with the specified list of changes.
+     *
+     * <p>The provided list is defensively copied to ensure the internal state remains independent.
+     *
+     * @param changes The initial list of property changes. Must not be null.
+     * @throws NullPointerException if {@code changes} is null.
+     */
     public PropertyDiff(@NonNull List<Change> changes) {
         this.changes = new ArrayList<>(changes);
     }
 
+    /**
+     * Ensures proper deserialization by initializing the changes list if null.
+     *
+     * <p>This method is invoked during deserialization to guarantee the object is in a valid state.
+     *
+     * @return This {@code PropertyDiff} instance.
+     */
     protected Object readResolve() {
         if (changes == null) changes = new ArrayList<>();
         return this;
     }
 
+    /**
+     * Converts this diff into a {@link Patch} containing only new values.
+     *
+     * <p>The resulting patch can be applied to update a catalog object, discarding old value
+     * information from the diff.
+     *
+     * @return A new {@link Patch} instance with properties derived from this diff’s new values.
+     * @example Converting to a patch:
+     *          <pre>
+     *          PropertyDiff diff = ...;
+     *          Patch patch = diff.toPatch();
+     *          </pre>
+     */
     public Patch toPatch() {
         Patch patch = new Patch();
         changes.stream()
@@ -80,43 +155,101 @@ public @Data class PropertyDiff implements Serializable {
         return patch;
     }
 
+    /**
+     * Returns the number of property changes in this diff.
+     *
+     * @return The size of the changes list.
+     */
     public int size() {
         return changes.size();
     }
 
+    /**
+     * Retrieves a specific change by its index.
+     *
+     * @param index The index of the change to retrieve (0-based).
+     * @return The {@link Change} at the specified index.
+     * @throws IndexOutOfBoundsException if the index is out of range.
+     */
     public Change get(int index) {
         return changes.get(index);
     }
 
+    /**
+     * Retrieves a change by its property name, if present.
+     *
+     * @param propertyName The name of the property to find.
+     * @return An {@link Optional} containing the {@link Change} if found, or empty if not.
+     * @throws NullPointerException if {@code propertyName} is null.
+     */
     public Optional<Change> get(@NonNull String propertyName) {
         return changes.stream()
                 .filter(c -> propertyName.equals(c.getPropertyName()))
                 .findFirst();
     }
 
+    /**
+     * Returns the list of property names affected by this diff.
+     *
+     * @return An unmodifiable list of property names.
+     */
     public List<String> getPropertyNames() {
         return getChanges().stream().map(Change::getPropertyName).toList();
     }
 
+    /**
+     * Returns the list of old values from this diff’s changes.
+     *
+     * @return An unmodifiable list of old values.
+     */
     public List<Object> getOldValues() {
         return getChanges().stream().map(Change::getOldValue).toList();
     }
 
+    /**
+     * Returns the list of new values from this diff’s changes.
+     *
+     * @return An unmodifiable list of new values.
+     */
     public List<Object> getNewValues() {
         return getChanges().stream().map(Change::getNewValue).toList();
     }
 
     /**
-     * @return a "clean copy", where no-op changes are ignored
+     * Creates a new {@code PropertyDiff} with no-op changes filtered out.
+     *
+     * <p>No-op changes (where old and new values are effectively equal) are removed using
+     * {@link Change#isNotEmpty}. This is useful for optimizing updates by excluding redundant
+     * modifications.
+     *
+     * @return A new {@code PropertyDiff} containing only meaningful changes.
+     * @example Cleaning a diff:
+     *          <pre>
+     *          PropertyDiff diff = ...; // contains some no-op changes
+     *          PropertyDiff cleanDiff = diff.clean();
+     *          </pre>
      */
     public PropertyDiff clean() {
         return new PropertyDiff(changes.stream().filter(Change::isNotEmpty).toList());
     }
 
+    /**
+     * Checks if this diff contains no changes.
+     *
+     * @return {@code true} if the diff is empty; {@code false} otherwise.
+     */
     public boolean isEmpty() {
         return changes.isEmpty();
     }
 
+    /**
+     * Represents a single property change within a {@link PropertyDiff}, capturing the property name,
+     * old value, and new value.
+     *
+     * <p>This class includes logic to determine if the change is a no-op (e.g., old and new values are
+     * equal or effectively equivalent), supporting special cases like collections, international strings,
+     * and coordinate reference systems.
+     */
     @NoArgsConstructor
     @AllArgsConstructor
     public static @Data class Change implements Serializable {
@@ -125,10 +258,30 @@ public @Data class PropertyDiff implements Serializable {
         private transient Object oldValue;
         private transient Object newValue;
 
+        /**
+         * Checks if this change has a meaningful effect.
+         *
+         * <p>A change is considered meaningful (not empty) if it’s not a no-op as determined by
+         * {@link #isNoChange}.
+         *
+         * @return {@code true} if the change is meaningful; {@code false} if it’s a no-op.
+         */
         boolean isNotEmpty() {
             return !isNoChange();
         }
 
+        /**
+         * Determines if this change is a no-op (i.e., no effective change).
+         *
+         * <p>Special cases are handled:
+         * <ul>
+         * <li>Equal objects (via {@link Objects#equals}).
+         * <li>Empty or null collections/maps.
+         * <li>Null or empty {@link InternationalString} values.
+         * <li>Equivalent {@link CoordinateReferenceSystem} instances.
+         * </ul>
+         * @return {@code true} if the change is a no-op; {@code false} otherwise.
+         */
         public boolean isNoChange() {
             if (Objects.equals(oldValue, newValue)) return true;
 
@@ -141,6 +294,14 @@ public @Data class PropertyDiff implements Serializable {
             return false;
         }
 
+        /**
+         * Compares two {@link CoordinateReferenceSystem} values for equivalence.
+         *
+         * <p>Equality is based on CRS identifiers and metadata-ignoring comparison, with fallback
+         * logging for errors.
+         *
+         * @return {@code true} if the CRS values are equivalent; {@code false} otherwise.
+         */
         protected boolean isSameCrs() {
             if (neitherIsNull()) {
                 try {
@@ -150,20 +311,33 @@ public @Data class PropertyDiff implements Serializable {
                     boolean sameId = Objects.equals(id1, id2);
                     return sameId && CRS.equalsIgnoreMetadata(oldValue, newValue);
                 } catch (Exception e) {
-                    log.trace("Error comparing PropertyDif CRS values", e);
+                    log.warn("Failed to compare CRS values in PropertyDiff {}", this, e);
                 }
             }
-            return false;
+            return bothAreNullOrEmpty();
         }
 
+        /**
+         * Checks if an {@link InternationalString} change is effectively a no-op.
+         *
+         * <p>Considers null or empty string representations as equivalent.
+         *
+         * @return {@code true} if both values are null or empty; {@code false} otherwise.
+         */
         protected boolean isNullInternationalStringOp() {
             return isNullOrEmpty(toStringOrNull(oldValue)) && isNullOrEmpty(toStringOrNull(newValue));
         }
 
+        /**
+         * Converts an object to its string representation or null if it’s null.
+         */
         private String toStringOrNull(Object o) {
             return o == null ? null : o.toString();
         }
 
+        /**
+         * Checks if an object is null, empty, or represents an empty collection/map/string.
+         */
         private boolean isNullOrEmpty(Object o) {
             if (o == null) return true;
             if (o instanceof String s) return s.isEmpty();
@@ -172,40 +346,81 @@ public @Data class PropertyDiff implements Serializable {
             return false;
         }
 
+        /**
+         * Checks if neither old nor new value is null.
+         */
         private boolean neitherIsNull() {
             return oldValue != null && newValue != null;
         }
 
+        /**
+         * Checks if both old and new values are null or empty (for collections/maps).
+         */
         private boolean bothAreNullOrEmpty() {
             return isNullOrEmpty(oldValue) && isNullOrEmpty(newValue);
         }
 
+        /**
+         * Determines if this change involves a collection or map property.
+         */
         private boolean isCollectionProperty() {
             return isA(Collection.class, oldValue, newValue) || isA(Map.class, oldValue, newValue);
         }
 
+        /**
+         * Checks if either value is an instance of the specified type.
+         */
         private boolean isA(@NonNull Class<?> type) {
             return isA(type, oldValue, newValue);
         }
 
+        /**
+         * Checks if either of two values is an instance of the specified type.
+         */
         private boolean isA(@NonNull Class<?> type, Object value1, Object value2) {
             return isA(type, value1) || isA(type, value2);
         }
 
+        /**
+         * Checks if a value is an instance of the specified type.
+         */
         private boolean isA(@NonNull Class<?> type, Object value) {
             return type.isInstance(value);
         }
 
+        /**
+         * Creates a new {@code Change} instance with the specified values.
+         *
+         * @param propertyName The name of the property.
+         * @param oldValue     The original value.
+         * @param newValue     The new value.
+         * @return A new {@code Change} instance.
+         * @throws NullPointerException if {@code propertyName} is null.
+         */
         public static Change valueOf(String propertyName, Object oldValue, Object newValue) {
             return new Change(propertyName, oldValue, newValue);
         }
 
+        /**
+         * Returns a string representation of this change for debugging.
+         *
+         * @return A string in the format "propertyName: {old: oldValue, new: newValue}".
+         */
         @Override
         public String toString() {
             return "%s: {old: %s, new: %s}".formatted(propertyName, oldValue, newValue);
         }
     }
 
+    /**
+     * Creates a {@code PropertyDiff} from a {@link ModificationProxy} instance.
+     *
+     * <p>Extracts property names, old values, and new values from the proxy to build the diff.
+     *
+     * @param proxy The modification proxy containing changes.
+     * @return A new {@code PropertyDiff} instance.
+     * @throws NullPointerException if {@code proxy} is null.
+     */
     public static PropertyDiff valueOf(ModificationProxy proxy) {
         Objects.requireNonNull(proxy);
         List<String> propertyNames = proxy.getPropertyNames();
@@ -214,10 +429,27 @@ public @Data class PropertyDiff implements Serializable {
         return valueOf(propertyNames, oldValues, newValues);
     }
 
+    /**
+     * Creates a {@code PropertyDiff} from lists of property names, old values, and new values.
+     *
+     * <p>Ensures consistency by handling proxies within the values and building the diff via a
+     * {@link PropertyDiffBuilder}.
+     *
+     * @param propertyNames The list of property names.
+     * @param oldValues     The list of old values.
+     * @param newValues     The list of new values.
+     * @return A new {@code PropertyDiff} instance.
+     * @throws NullPointerException if any argument is null.
+     * @throws IllegalArgumentException if the lists have different sizes.
+     */
     public static PropertyDiff valueOf(
             final @NonNull List<String> propertyNames,
             final @NonNull List<Object> oldValues,
             final @NonNull List<Object> newValues) {
+
+        if (propertyNames.size() != oldValues.size() || propertyNames.size() != newValues.size()) {
+            throw new IllegalArgumentException("Inconsistent property names and values list sizes");
+        }
 
         PropertyDiffBuilder<Info> builder = PropertyDiff.builder();
         IntStream.range(0, propertyNames.size()).forEach(i -> {
@@ -229,6 +461,13 @@ public @Data class PropertyDiff implements Serializable {
         return builder.build();
     }
 
+    /**
+     * Handles proxy objects by unwrapping and rewrapping them appropriately in order to hold a safe reference that's not affected by
+     * external changes to the proxy after this method is called.
+     *
+     * @param value The value to process.
+     * @return The unwrapped or rewrapped value, or the original if not a proxy.
+     */
     private static Object hanldeProxy(Object value) {
         if (value == null) return null;
         ModificationProxy proxy = ProxyUtils.handler(value, ModificationProxy.class);
@@ -243,6 +482,13 @@ public @Data class PropertyDiff implements Serializable {
     private static final Set<Class<? extends Info>> IGNORE =
             Set.of(Info.class, Catalog.class, ServiceInfo.class, PublishedInfo.class);
 
+    /**
+     * Finds the most concrete {@link Info} sub-interface implemented by a class.
+     *
+     * @param of The class to inspect.
+     * @return The most specific {@link Info} interface.
+     * @throws IllegalArgumentException if no suitable interface is found.
+     */
     @SuppressWarnings("unchecked")
     private static <T extends Info> Class<T> findInfoIterface(Class<?> of) {
         return (Class<T>) Arrays.stream(of.getInterfaces())
@@ -252,10 +498,22 @@ public @Data class PropertyDiff implements Serializable {
                         "Unable to find most concrete Info sub-interface of %s".formatted(of.getCanonicalName())));
     }
 
+    /**
+     * Returns an empty {@code PropertyDiff} instance.
+     */
     public static PropertyDiff empty() {
         return new PropertyDiff();
     }
 
+    /**
+     * Builder class for incrementally constructing a {@code PropertyDiff}.
+     *
+     * <p>Allows adding property changes with old and new values, optionally using an existing
+     * {@link Info} object as a baseline. Ensures safe copying of collection/map values and proper
+     * case handling for property names.
+     *
+     * @param <T> The type of catalog object ({@link Info}) being diffed.
+     */
     public static class PropertyDiffBuilder<T extends Info> {
 
         private T info;
@@ -267,6 +525,13 @@ public @Data class PropertyDiff implements Serializable {
             this.info = null;
         }
 
+        /**
+         * Constructs a builder initialized with an existing catalog object.
+         *
+         * @param info The original catalog object to use as a baseline.
+         * @throws NullPointerException if {@code info} is null.
+         * @throws IllegalArgumentException if {@code info} is a proxy or has an unknown class mapping.
+         */
         PropertyDiffBuilder(T info) {
             Objects.requireNonNull(info);
             if (Proxy.isProxyClass(info.getClass())) {
@@ -279,7 +544,15 @@ public @Data class PropertyDiff implements Serializable {
                     () -> "Unknown info class: " + info.getClass().getCanonicalName());
         }
 
+        /**
+         * Builds the {@code PropertyDiff} from accumulated changes.
+         *
+         * @return A new {@code PropertyDiff} instance containing all specified changes.
+         */
         public PropertyDiff build() {
+            if (propertyNames.size() != oldValues.size() || propertyNames.size() != newValues.size()) {
+                throw new IllegalStateException("Inconsistent list sizes in PropertyDiffBuilder");
+            }
             List<Change> changes = IntStream.range(0, propertyNames.size())
                     .mapToObj(i -> {
                         String name = propertyNames.get(i);
@@ -291,6 +564,14 @@ public @Data class PropertyDiff implements Serializable {
             return new PropertyDiff(changes);
         }
 
+        /**
+         * Adds a property change using the old value from the baseline object (if provided).
+         *
+         * @param property The property name.
+         * @param newValue The new value for the property.
+         * @return This builder for chaining.
+         * @throws IllegalArgumentException if {@code property} doesn’t exist or {@code info} is null.
+         */
         public PropertyDiffBuilder<T> with(String property, Object newValue) {
             property = fixCase(property);
             Class<? extends Info> type = info.getClass();
@@ -303,6 +584,14 @@ public @Data class PropertyDiff implements Serializable {
             return with(property, oldValue, newValue);
         }
 
+        /**
+         * Adds a property change with explicit old and new values.
+         *
+         * @param property The property name.
+         * @param oldValue The original value.
+         * @param newValue The new value.
+         * @return This builder for chaining.
+         */
         public PropertyDiffBuilder<T> with(String property, Object oldValue, Object newValue) {
             property = fixCase(property);
             oldValue = copySafe(oldValue);
@@ -314,6 +603,10 @@ public @Data class PropertyDiff implements Serializable {
             return this;
         }
 
+        /**
+         * Safely copies a value, handling collections and maps.
+         * @return A safely copied version of the value, or the original if not a collection/map.
+         */
         @SuppressWarnings({"unchecked"})
         public static <V> V copySafe(V val) {
             if (val instanceof Collection<?> c) return (V) copyOf(c);
@@ -321,10 +614,18 @@ public @Data class PropertyDiff implements Serializable {
             return val;
         }
 
+        /**
+         * Copies a collection with identity mapping.
+         * @return A new collection with the same elements.
+         */
         public static <V> Collection<V> copyOf(Collection<? extends V> val) {
             return copyOf(val, Function.identity());
         }
 
+        /**
+         * Copies a collection with a custom mapping function.
+         * @return A new collection with mapped elements.
+         */
         public static <V, R> Collection<R> copyOf(Collection<? extends V> val, Function<V, R> mapper) {
 
             Stream<R> stream = val.stream().map(PropertyDiffBuilder::copySafe).map(mapper);
@@ -340,10 +641,21 @@ public @Data class PropertyDiff implements Serializable {
             return stream.toList();
         }
 
+        /**
+         * Copies a map with identity mapping.
+         * @return A new map with the same key-value pairs.
+         */
         public static <K, V> Map<K, V> copyOf(final Map<K, V> val) {
             return copyOf(val, Function.identity());
         }
 
+        /**
+         * Copies a map with a custom value mapping function.
+         *
+         * @param val         The map to copy.
+         * @param valueMapper The function to map values.
+         * @return A new map with mapped values.
+         */
         @SuppressWarnings({"rawtypes", "unchecked"})
         public static <K, V, R> Map<K, R> copyOf(final Map<K, V> val, Function<V, R> valueMapper) {
             Map target;
@@ -364,16 +676,28 @@ public @Data class PropertyDiff implements Serializable {
             return target;
         }
 
+        /**
+         * Removes a property change from the builder by name.
+         *
+         * @param property The property name to remove.
+         * @return This builder for chaining.
+         */
         public PropertyDiffBuilder<T> remove(String property) {
             int i = propertyNames.indexOf(property);
             if (i > -1) {
                 propertyNames.remove(i);
                 oldValues.remove(i);
-                oldValues.remove(i);
+                newValues.remove(i);
             }
             return this;
         }
 
+        /**
+         * Normalizes property name case to lowercase first letter if needed.
+         *
+         * @param propertyName The property name to normalize.
+         * @return The normalized property name.
+         */
         private static String fixCase(String propertyName) {
             if (propertyName.length() > 1) {
                 char first = propertyName.charAt(0);

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/Query.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/Query.java
@@ -15,12 +15,31 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
+import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.Info;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.sort.SortBy;
 
-/** */
+/**
+ * Represents a query for retrieving catalog objects of a specific type from the an {@link ExtendedCatalogFacade}.
+ *
+ * <p>This class encapsulates the parameters for querying catalog entities (e.g., layers, styles, workspaces).
+ *  It supports filtering, sorting, and pagination through a type-safe,
+ * immutable design with fluent setters. Queries are typically used by the {@link Catalog} implementation  to fetch subsets
+ * of catalog data based on conditions defined by a {@link Filter}, ordered by {@link SortBy} criteria, and
+ * limited by offset and count constraints.
+ *
+ * <p>The class is immutable when constructed, with setters returning the same or a new instance to maintain
+ * chainability. It provides factory methods for common use cases (e.g., querying all objects of a type) and
+ * constructors for copying or retyping existing queries.
+ *
+ * @param <T> The specific type of {@link Info} being queried (e.g., {@link org.geoserver.catalog.LayerInfo}).
+ * @since 1.0
+ * @see Filter
+ * @see SortBy
+ * @see ExtendedCatalogFacade#query(Query)
+ */
 @NoArgsConstructor
 @RequiredArgsConstructor
 @Accessors(chain = true)
@@ -32,7 +51,22 @@ public @Data class Query<T extends Info> {
     private Integer offset;
     private Integer count;
 
-    /** retype constructor */
+    /**
+     * Constructs a new {@code Query} by retyping an existing query to a different {@link Info} subclass.
+     *
+     * <p>This constructor creates a new query instance with the same filter, sorting, offset, and count as the
+     * provided query, but with a new target type. It is useful for adapting a generic query to a specific
+     * catalog object type while preserving its parameters.
+     *
+     * @param type  The new type of {@link Info} to query.
+     * @param query The existing query to copy parameters from.
+     * @throws NullPointerException if {@code type} or {@code query} is null.
+     * @example Retyping a query:
+     *          <pre>
+     *          Query<Info> genericQuery = Query.valueOf(Info.class, someFilter);
+     *          Query<LayerInfo> layerQuery = new Query<>(LayerInfo.class, genericQuery);
+     *          </pre>
+     */
     public Query(@NonNull Class<T> type, @NonNull Query<?> query) {
         this.type = type;
         this.filter = query.getFilter();
@@ -41,7 +75,21 @@ public @Data class Query<T extends Info> {
         this.count = query.getCount();
     }
 
-    /** Copy constructor */
+    /**
+     * Constructs a new {@code Query} by copying an existing query of the same type.
+     *
+     * <p>This copy constructor creates a deep copy of the provided query’s properties, ensuring that changes to
+     * the new instance (e.g., via setters) do not affect the original. The {@code sortBy} list is defensively
+     * copied to maintain independence.
+     *
+     * @param query The query to copy.
+     * @throws NullPointerException if {@code query} is null.
+     * @example Copying a query:
+     *          <pre>
+     *          Query<LayerInfo> original = Query.valueOf(LayerInfo.class, someFilter);
+     *          Query<LayerInfo> copy = new Query<>(original);
+     *          </pre>
+     */
     public Query(@NonNull Query<T> query) {
         this.type = query.getType();
         this.filter = query.getFilter();
@@ -50,26 +98,113 @@ public @Data class Query<T extends Info> {
         this.count = query.getCount();
     }
 
+    /**
+     * Determines if this query specifies any sorting criteria.
+     *
+     * <p>This method checks whether the query includes any {@link SortBy} directives, indicating that results
+     * should be ordered rather than returned in their natural order.
+     *
+     * @return {@code true} if sorting is specified (i.e., {@code sortBy} is non-empty); {@code false} otherwise.
+     */
     public boolean isSorting() {
         return !sortBy.isEmpty();
     }
 
+    /**
+     * Returns the count (limit) of results as an {@link OptionalInt}.
+     *
+     * <p>The count specifies the maximum number of catalog objects to return. If no count is set, an empty
+     * {@link OptionalInt} is returned, indicating no limit.
+     *
+     * @return An {@link OptionalInt} containing the count if set, or empty if not.
+     * @example Checking count:
+     *          <pre>
+     *          Query<LayerInfo> query = Query.valueOf(LayerInfo.class, Filter.INCLUDE, null, 10);
+     *          OptionalInt count = query.count(); // returns OptionalInt.of(10)
+     *          </pre>
+     */
     public OptionalInt count() {
         return count == null ? OptionalInt.empty() : OptionalInt.of(count.intValue());
     }
 
+    /**
+     * Returns the offset (starting index) of results as an {@link OptionalInt}.
+     *
+     * <p>The offset specifies the number of catalog objects to skip before returning results. If no offset is
+     * set, an empty {@link OptionalInt} is returned, indicating the query starts from the beginning.
+     *
+     * @return An {@link OptionalInt} containing the offset if set, or empty if not.
+     * @example Checking offset:
+     *          <pre>
+     *          Query<LayerInfo> query = Query.valueOf(LayerInfo.class, Filter.INCLUDE, 5, null);
+     *          OptionalInt offset = query.offset(); // returns OptionalInt.of(5)
+     *          </pre>
+     */
     public OptionalInt offset() {
         return offset == null ? OptionalInt.empty() : OptionalInt.of(offset.intValue());
     }
 
+    /**
+     * Creates a query that retrieves all objects of a specified type without additional constraints.
+     *
+     * <p>This factory method constructs a query with the default filter {@link Filter#INCLUDE}, no sorting,
+     * and no pagination limits, effectively selecting all available objects of the given type.
+     *
+     * @param <C>  The type of {@link Info} to query.
+     * @param type The class of catalog objects to retrieve.
+     * @return A new {@code Query} instance for all objects of the specified type.
+     * @throws NullPointerException if {@code type} is null.
+     * @example Querying all layers:
+     *          <pre>
+     *          Query<LayerInfo> allLayers = Query.all(LayerInfo.class);
+     *          </pre>
+     */
     public static <C extends Info> Query<C> all(Class<? extends Info> type) {
         return valueOf(type, Filter.INCLUDE, null, null);
     }
 
+    /**
+     * Creates a query with a specified type and filter, without sorting or pagination.
+     *
+     * <p>This factory method provides a simple way to query catalog objects with a custom filter, using
+     * default values (null) for offset, count, and sorting.
+     *
+     * @param <T>   The type of {@link CatalogInfo} to query.
+     * @param type  The class of catalog objects to retrieve.
+     * @param filter The filter to apply to the query (e.g., to match specific properties).
+     * @return A new {@code Query} instance with the specified type and filter.
+     * @throws NullPointerException if {@code type} or {@code filter} is null.
+     * @example Querying layers by name:
+     *          <pre>
+     *          Filter nameFilter = ...; // e.g., filter by name "roads"
+     *          Query<LayerInfo> layerQuery = Query.valueOf(LayerInfo.class, nameFilter);
+     *          </pre>
+     */
     public static <T extends CatalogInfo> Query<T> valueOf(Class<T> type, Filter filter) {
         return valueOf(type, filter, null, null);
     }
 
+    /**
+     * Creates a fully customized query with type, filter, pagination, and sorting options.
+     *
+     * <p>This factory method constructs a query with all configurable parameters. Null values for filter
+     * default to {@link Filter#INCLUDE}, and null sort orders result in an empty sort list. The method
+     * ensures non-null {@code SortBy} elements in the list.
+     *
+     * @param <T>       The type of {@link Info} to query.
+     * @param type      The class of catalog objects to retrieve.
+     * @param filter    The filter to apply, or null for {@link Filter#INCLUDE}.
+     * @param offset    The number of objects to skip, or null for no offset.
+     * @param count     The maximum number of objects to return, or null for no limit.
+     * @param sortOrder Variable number of {@link SortBy} directives for ordering results (nulls ignored).
+     * @return A new {@code Query} instance with the specified parameters.
+     * @throws NullPointerException if {@code type} is null.
+     * @example Querying sorted and paginated layers:
+     *          <pre>
+     *          SortBy sortByName = ...; // e.g., sort by "name" ascending
+     *          Query<LayerInfo> query = Query.valueOf(LayerInfo.class, Filter.INCLUDE, 10, 5, sortByName);
+     *          </pre>
+     */
     @SuppressWarnings("unchecked")
     public static <T extends Info> Query<T> valueOf(
             Class<? extends Info> type, Filter filter, Integer offset, Integer count, SortBy... sortOrder) {
@@ -87,8 +222,20 @@ public @Data class Query<T extends Info> {
     }
 
     /**
-     * @return {@code this} if {@code filter} equals {@link #getFilter()}, a copy of this query with
-     *     the provided filter otherwise
+     * Returns this query if the provided filter matches the current one, or a new query with the updated filter.
+     *
+     * <p>This method allows modifying the filter while preserving immutability by returning a new instance
+     * unless the filter is unchanged. It leverages the fluent setter pattern for chainability.
+     *
+     * @param filter The new filter to apply.
+     * @return This {@code Query} instance if the filter is unchanged, or a new instance with the new filter.
+     * @throws NullPointerException if {@code filter} is null.
+     * @example Updating a filter:
+     *          <pre>
+     *          Query<LayerInfo> query = Query.all(LayerInfo.class);
+     *          Filter newFilter = ...; // e.g., filter by workspace
+     *          Query<LayerInfo> filteredQuery = query.withFilter(newFilter);
+     *          </pre>
      */
     public Query<T> withFilter(Filter filter) {
         return filter.equals(this.filter) ? this : new Query<>(this).setFilter(filter);

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/RepositoryCatalogFacade.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/RepositoryCatalogFacade.java
@@ -6,5 +6,35 @@ package org.geoserver.catalog.plugin;
 
 import org.geoserver.catalog.CatalogFacade;
 
-/** {@link CatalogFacade} extension backed by {@link CatalogInfoRepository} repositories */
+/**
+ * A {@link CatalogFacade} extension that integrates repository-based catalog management by combining
+ * {@link ExtendedCatalogFacade} and {@link CatalogInfoRepositoryHolder}.
+ *
+ * <p>This interface defines a catalog facade backed by {@link CatalogInfoRepository} instances, providing
+ * a unified API for accessing and manipulating catalog data through specialized repositories (e.g.,
+ * {@link WorkspaceRepository}, {@link LayerRepository}). It extends {@link ExtendedCatalogFacade} to
+ * offer modern catalog operations like type-safe retrieval ({@link #get(String, Class)}), patch-based
+ * updates ({@link #update(CatalogInfo, Patch)}), and stream-based querying ({@link #query(Query)}), while
+ * incorporating the repository management capabilities of {@link CatalogInfoRepositoryHolder} to handle
+ * type-specific data access (e.g., {@link #getNamespaceRepository()}).
+ *
+ * <p>Key features:
+ * <ul>
+ *   <li><strong>Repository-Backed:</strong> Delegates catalog operations to underlying repositories for
+ *       persistence and querying.</li>
+ *   <li><strong>Extended Functionality:</strong> Adds advanced methods beyond the standard
+ *       {@link CatalogFacade}, enhancing usability and flexibility.</li>
+ *   <li><strong>Type Safety:</strong> Ensures consistent mapping between {@link CatalogInfo} types and
+ *       their repositories.</li>
+ * </ul>
+ *
+ * <p>Implementations of this interface are expected to provide concrete repository instances and
+ * coordinate their use with catalog operations, serving as a bridge between high-level facade logic and
+ * low-level repository data access in GeoServer Cloud’s catalog system.
+ *
+ * @since 1.0
+ * @see ExtendedCatalogFacade
+ * @see CatalogInfoRepositoryHolder
+ * @see CatalogInfoRepository
+ */
 public interface RepositoryCatalogFacade extends ExtendedCatalogFacade, CatalogInfoRepositoryHolder {}

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/RepositoryCatalogFacadeImpl.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/RepositoryCatalogFacadeImpl.java
@@ -1,6 +1,7 @@
 /*
- * (c) 2014 Open Source Geospatial Foundation - all rights reserved (c) 2001 - 2013 OpenPlans This
- * code is licensed under the GPL 2.0 license, available at the root application directory.
+ * (c) 2014 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root application directory.
  */
 package org.geoserver.catalog.plugin;
 
@@ -53,6 +54,36 @@ import org.geotools.api.filter.sort.SortBy;
 import org.geotools.filter.visitor.SimplifyingFilterVisitor;
 import org.springframework.util.Assert;
 
+/**
+ * A concrete implementation of {@link RepositoryCatalogFacade} that manages catalog data using
+ * {@link CatalogInfoRepository} instances.
+ *
+ * <p>This class provides a repository-backed facade for GeoServer Cloud’s catalog, implementing both
+ * {@link ExtendedCatalogFacade} and {@link CatalogInfoRepositoryHolder} interfaces. It delegates all
+ * catalog operations (e.g., adding, removing, querying) to type-specific repositories (e.g.,
+ * {@link WorkspaceRepository}, {@link LayerRepository}) managed by a {@link CatalogInfoRepositoryHolderImpl}.
+ * It supports advanced features like stream-based querying ({@link #query(Query)}), patch-based updates
+ * ({@link #update(CatalogInfo, Patch)}), and synchronization with other facades ({@link #syncTo(CatalogFacade)}).
+ *
+ * <p>Key features:
+ * <ul>
+ *   <li><strong>Repository-Driven:</strong> Uses specialized repositories for persistence and retrieval
+ *       of {@link CatalogInfo} objects.</li>
+ *   <li><strong>Type Safety:</strong> Ensures consistent handling of catalog info types through generics.</li>
+ *   <li><strong>Query Optimization:</strong> Implements efficient querying for {@link PublishedInfo} with
+ *       merge-sorted streams.</li>
+ *   <li><strong>Capabilities:</strong> Reports catalog capabilities via {@link #getCatalogCapabilities()}.</li>
+ * </ul>
+ *
+ * <p>This implementation is designed to work within GeoServer Cloud’s catalog system, providing a robust
+ * and flexible facade that integrates repository-based data access with catalog operations.
+ *
+ * @since 1.0
+ * @see RepositoryCatalogFacade
+ * @see ExtendedCatalogFacade
+ * @see CatalogInfoRepositoryHolder
+ * @see CatalogInfoRepository
+ */
 public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, CatalogInfoRepositoryHolder {
 
     protected final CatalogInfoRepositoryHolderImpl repositories;
@@ -61,35 +92,91 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
 
     protected final CatalogCapabilities capabilities = new CatalogCapabilities();
 
+    /**
+     * Constructs a new repository-backed catalog facade with no associated catalog.
+     *
+     * <p>Initializes the internal {@link CatalogInfoRepositoryHolderImpl} for managing repositories.
+     * Use {@link #setCatalog(Catalog)} to associate a catalog instance after construction.
+     */
     public RepositoryCatalogFacadeImpl() {
         repositories = new CatalogInfoRepositoryHolderImpl();
     }
 
+    /**
+     * Constructs a new repository-backed catalog facade with the specified catalog.
+     *
+     * <p>Initializes the facade and sets the provided catalog, which is used as the context for all
+     * catalog operations.
+     *
+     * @param catalog The {@link Catalog} instance to associate with this facade; may be null.
+     * @see #setCatalog(Catalog)
+     */
     public RepositoryCatalogFacadeImpl(Catalog catalog) {
         this();
         setCatalog(catalog);
     }
 
+    /**
+     * Returns the catalog capabilities supported by this facade.
+     *
+     * <p>The capabilities reflect the features available through this repository-backed implementation,
+     * such as support for isolated workspaces or specific query operations.
+     *
+     * @return The {@link CatalogCapabilities} instance; never null.
+     */
     @Override
     public CatalogCapabilities getCatalogCapabilities() {
         return capabilities;
     }
 
+    /**
+     * Sets the catalog instance associated with this facade.
+     *
+     * <p>The catalog provides the context for all operations (e.g., default workspaces, namespaces).
+     * Setting it to null effectively clears the association.
+     *
+     * @param catalog The {@link Catalog} to set; may be null.
+     */
     @Override
     public void setCatalog(Catalog catalog) {
         this.catalog = catalog;
     }
 
+    /**
+     * Retrieves the catalog instance associated with this facade.
+     *
+     * @return The current {@link Catalog}, or null if none is set.
+     */
     @Override
     public Catalog getCatalog() {
         return catalog;
     }
 
+    /**
+     * Resolves any internal state or dependencies of the facade.
+     *
+     * <p>This default implementation is a no-op. Subclasses may override it to perform initialization
+     * or consistency checks as needed.
+     */
     @Override
     public void resolve() {
         // no-op, override as appropriate
     }
 
+    /**
+     * Adds a catalog object to the specified repository and retrieves the persisted instance.
+     *
+     * <p>This helper method ensures the object is not a proxy, adds it to the repository, and returns
+     * the persisted version by looking it up by ID. It’s used internally for type-specific add operations.
+     *
+     * @param <I>        The type of {@link CatalogInfo} to add.
+     * @param info       The catalog object to add; must not be null and not a proxy.
+     * @param type       The class of the catalog object; must not be null.
+     * @param repository The repository to add the object to; must not be null.
+     * @return The persisted {@link CatalogInfo} object, or null if not found after addition.
+     * @throws NullPointerException if {@code info}, {@code type}, or {@code repository} is null.
+     * @throws IllegalArgumentException if {@code info} is a proxy or lacks an ID.
+     */
     protected <I extends CatalogInfo> I add(I info, Class<I> type, CatalogInfoRepository<I> repository) {
         checkNotAProxy(info);
         Objects.requireNonNull(info.getId(), "Object id not provided");
@@ -100,24 +187,73 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
     //
     // Stores
     //
+    /**
+     * Adds a store to the catalog.
+     *
+     * <p>Persists the store via the {@link StoreRepository} and returns the added instance, which may
+     * include updates like a generated ID.
+     *
+     * @param store The {@link StoreInfo} to add; must not be null.
+     * @return The persisted {@link StoreInfo}.
+     * @throws NullPointerException if {@code store} is null.
+     * @throws IllegalArgumentException if {@code store} is a proxy or lacks an ID.
+     * @example Adding a data store:
+     *          <pre>
+     *          DataStoreInfo store = new DataStoreInfoImpl(catalog);
+     *          store.setId("ds1");
+     *          facade.add(store);
+     *          </pre>
+     */
     @Override
     public StoreInfo add(StoreInfo store) {
         return add(store, StoreInfo.class, getStoreRepository());
     }
 
+    /**
+     * Removes a store from the catalog.
+     *
+     * <p>Delegates to the {@link StoreRepository} to delete the store and associated resources.
+     *
+     * @param store The {@link StoreInfo} to remove; must not be null.
+     * @throws NullPointerException if {@code store} is null.
+     */
     @Override
     public void remove(StoreInfo store) {
         getStoreRepository().remove(store);
     }
 
+    /**
+     * Retrieves a store by its ID.
+     *
+     * <p>Queries the {@link StoreRepository} for a store matching the given ID and type.
+     *
+     * @param <T>   The specific type of {@link StoreInfo} to retrieve (e.g., {@link DataStoreInfo}).
+     * @param id    The unique identifier of the store; must not be null.
+     * @param clazz The class of the store to retrieve; must not be null.
+     * @return The matching {@link StoreInfo} if found, or null if not.
+     * @throws NullPointerException if {@code id} or {@code clazz} is null.
+     */
     @Override
     public <T extends StoreInfo> T getStore(String id, Class<T> clazz) {
         return getStoreRepository().findById(id, clazz).orElse(null);
     }
 
+    /**
+     * Retrieves a store by name and workspace.
+     *
+     * <p>If the workspace is {@link CatalogFacade#ANY_WORKSPACE} or null, searches for the first store
+     * matching the name across all workspaces. Otherwise, queries the {@link StoreRepository} for a store
+     * with the specified name within the given workspace.
+     *
+     * @param <T>       The specific type of {@link StoreInfo} to retrieve.
+     * @param workspace The workspace containing the store, or {@link CatalogFacade#ANY_WORKSPACE}; may be null.
+     * @param name      The name of the store; must not be null.
+     * @param clazz     The class of the store to retrieve; must not be null.
+     * @return The matching {@link StoreInfo} if found, or null if not.
+     * @throws NullPointerException if {@code name} or {@code clazz} is null.
+     */
     @Override
     public <T extends StoreInfo> T getStoreByName(WorkspaceInfo workspace, String name, Class<T> clazz) {
-
         Optional<T> result;
         if (workspace == ANY_WORKSPACE || workspace == null) {
             result = getStoreRepository().findFirstByName(name, clazz);
@@ -127,36 +263,70 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
         return result.orElse(null);
     }
 
+    /**
+     * Retrieves all stores within a workspace.
+     *
+     * <p>If the workspace is null, defaults to the current default workspace. Delegates to the
+     * {@link StoreRepository} to fetch stores of the specified type within the workspace.
+     *
+     * @param <T>       The specific type of {@link StoreInfo} to retrieve.
+     * @param workspace The workspace containing the stores; may be null to use the default.
+     * @param clazz     The class of the stores to retrieve; must not be null.
+     * @return A list of matching {@link StoreInfo} objects.
+     * @throws NullPointerException if {@code clazz} is null.
+     */
     @Override
     public <T extends StoreInfo> List<T> getStoresByWorkspace(WorkspaceInfo workspace, Class<T> clazz) {
-        // Question: do we need to support ANY_WORKSPACE? see "todo" comment in DefaultCatalogFacade
-        final WorkspaceInfo ws;
-        if (workspace == null) {
-            ws = getDefaultWorkspace();
-        } else {
-            ws = workspace;
-        }
-
+        final WorkspaceInfo ws = (workspace == null) ? getDefaultWorkspace() : workspace;
         return toList(() -> getStoreRepository().findAllByWorkspace(ws, clazz));
     }
 
+    /**
+     * Retrieves all stores of a specific type.
+     *
+     * <p>Queries the {@link StoreRepository} for all stores matching the given class.
+     *
+     * @param <T>   The specific type of {@link StoreInfo} to retrieve.
+     * @param clazz The class of the stores to retrieve; must not be null.
+     * @return A list of matching {@link StoreInfo} objects.
+     * @throws NullPointerException if {@code clazz} is null.
+     */
     @Override
     public <T extends StoreInfo> List<T> getStores(Class<T> clazz) {
         return toList(() -> getStoreRepository().findAllByType(clazz));
     }
 
+    /**
+     * Retrieves the default data store for a workspace.
+     *
+     * <p>Queries the {@link StoreRepository} for the default {@link DataStoreInfo} associated with the
+     * specified workspace.
+     *
+     * @param workspace The workspace to query; may be null.
+     * @return The default {@link DataStoreInfo} if set, or null if not found.
+     */
     @Override
     public DataStoreInfo getDefaultDataStore(WorkspaceInfo workspace) {
         return getStoreRepository().getDefaultDataStore(workspace).orElse(null);
     }
 
+    /**
+     * Sets or unsets the default data store for a workspace.
+     *
+     * <p>If {@code store} is null, unsets the default data store for the workspace. Otherwise, sets the
+     * specified store as the default, ensuring it belongs to the given workspace.
+     *
+     * @param workspace The workspace to configure; must not be null.
+     * @param store     The {@link DataStoreInfo} to set as default, or null to unset.
+     * @throws NullPointerException if {@code workspace} is null.
+     * @throws IllegalArgumentException if {@code store} is non-null and its workspace does not match {@code workspace}.
+     */
     @Override
     public void setDefaultDataStore(WorkspaceInfo workspace, DataStoreInfo store) {
         if (store != null) {
-            Objects.requireNonNull(store.getWorkspace());
+            Objects.requireNonNull(store.getWorkspace(), "Store workspace must not be null");
             Assert.isTrue(workspace.getId().equals(store.getWorkspace().getId()), "Store workspace mismatch");
         }
-
         if (store == null) getStoreRepository().unsetDefaultDataStore(workspace);
         else getStoreRepository().setDefaultDataStore(workspace, store);
     }
@@ -164,21 +334,64 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
     //
     // Resources
     //
+    /**
+     * Adds a resource to the catalog.
+     *
+     * <p>Persists the resource via the {@link ResourceRepository} and returns the added instance.
+     *
+     * @param resource The {@link ResourceInfo} to add; must not be null.
+     * @return The persisted {@link ResourceInfo}.
+     * @throws NullPointerException if {@code resource} is null.
+     * @throws IllegalArgumentException if {@code resource} is a proxy or lacks an ID.
+     */
     @Override
     public ResourceInfo add(ResourceInfo resource) {
         return add(resource, ResourceInfo.class, getResourceRepository());
     }
 
+    /**
+     * Removes a resource from the catalog.
+     *
+     * <p>Delegates to the {@link ResourceRepository} to delete the resource and associated data.
+     *
+     * @param resource The {@link ResourceInfo} to remove; must not be null.
+     * @throws NullPointerException if {@code resource} is null.
+     */
     @Override
     public void remove(ResourceInfo resource) {
         getResourceRepository().remove(resource);
     }
 
+    /**
+     * Retrieves a resource by its ID.
+     *
+     * <p>Queries the {@link ResourceRepository} for a resource matching the given ID and type.
+     *
+     * @param <T>   The specific type of {@link ResourceInfo} to retrieve (e.g., {@link org.geoserver.catalog.FeatureTypeInfo}).
+     * @param id    The unique identifier of the resource; must not be null.
+     * @param clazz The class of the resource to retrieve; must not be null.
+     * @return The matching {@link ResourceInfo} if found, or null if not.
+     * @throws NullPointerException if {@code id} or {@code clazz} is null.
+     */
     @Override
     public <T extends ResourceInfo> T getResource(String id, Class<T> clazz) {
         return getResourceRepository().findById(id, clazz).orElse(null);
     }
 
+    /**
+     * Retrieves a resource by name and namespace.
+     *
+     * <p>If the namespace is {@link CatalogFacade#ANY_NAMESPACE}, searches for the first resource matching
+     * the name across all namespaces. Otherwise, queries the {@link ResourceRepository} for a resource
+     * with the specified name within the given namespace.
+     *
+     * @param <T>       The specific type of {@link ResourceInfo} to retrieve.
+     * @param namespace The namespace containing the resource, or {@link CatalogFacade#ANY_NAMESPACE}; may be null (returns null).
+     * @param name      The name of the resource; must not be null.
+     * @param clazz     The class of the resource to retrieve; must not be null.
+     * @return The matching {@link ResourceInfo} if found, or null if not.
+     * @throws NullPointerException if {@code name} or {@code clazz} is null.
+     */
     @Override
     public <T extends ResourceInfo> T getResourceByName(NamespaceInfo namespace, String name, Class<T> clazz) {
         if (namespace == null) return null;
@@ -188,22 +401,56 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
         } else {
             result = getResourceRepository().findByNameAndNamespace(name, namespace, clazz);
         }
-
         return result.orElse(null);
     }
 
+    /**
+     * Retrieves all resources of a specific type.
+     *
+     * <p>Queries the {@link ResourceRepository} for all resources matching the given class.
+     *
+     * @param <T>   The specific type of {@link ResourceInfo} to retrieve.
+     * @param clazz The class of the resources to retrieve; must not be null.
+     * @return A list of matching {@link ResourceInfo} objects.
+     * @throws NullPointerException if {@code clazz} is null.
+     */
     @Override
     public <T extends ResourceInfo> List<T> getResources(Class<T> clazz) {
         return toList(() -> getResourceRepository().findAllByType(clazz));
     }
 
+    /**
+     * Retrieves all resources within a namespace.
+     *
+     * <p>If the namespace is null, defaults to the current default namespace. Queries the
+     * {@link ResourceRepository} for resources of the specified type within the namespace.
+     *
+     * @param <T>       The specific type of {@link ResourceInfo} to retrieve.
+     * @param namespace The namespace containing the resources; may be null to use the default.
+     * @param clazz     The class of the resources to retrieve; must not be null.
+     * @return A list of matching {@link ResourceInfo} objects.
+     * @throws NullPointerException if {@code clazz} is null.
+     */
     @Override
     public <T extends ResourceInfo> List<T> getResourcesByNamespace(NamespaceInfo namespace, Class<T> clazz) {
-        // Question: do we need to support ANY_WORKSPACE? see "todo" comment in DefaultCatalogFacade
         NamespaceInfo ns = namespace == null ? getDefaultNamespace() : namespace;
         return toList(() -> getResourceRepository().findAllByNamespace(ns, clazz));
     }
 
+    /**
+     * Retrieves a resource by store and name, ensuring namespace consistency.
+     *
+     * <p>Queries the {@link ResourceRepository} for a resource with the specified name in the store’s
+     * namespace, falling back to a store-specific search if namespace lookup fails (e.g., in test scenarios).
+     * Verifies the store matches the resource’s store to ensure consistency.
+     *
+     * @param <T>   The specific type of {@link ResourceInfo} to retrieve.
+     * @param store The store containing the resource; must not be null.
+     * @param name  The name of the resource; must not be null.
+     * @param clazz The class of the resource to retrieve; must not be null.
+     * @return The matching {@link ResourceInfo} if found and consistent with the store, or null if not.
+     * @throws NullPointerException if {@code store}, {@code name}, or {@code clazz} is null.
+     */
     @Override
     public <T extends ResourceInfo> T getResourceByStore(StoreInfo store, String name, Class<T> clazz) {
         Optional<T> resource;
@@ -217,14 +464,22 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
                 return null;
             }
         } else {
-            // should not happen, but some broken test code sets up namespaces without equivalent
-            // workspaces
-            // or stores without workspaces
             resource = getResourceRepository().findByStoreAndName(store, name, clazz);
         }
         return resource.orElse(null);
     }
 
+    /**
+     * Retrieves all resources associated with a store.
+     *
+     * <p>Queries the {@link ResourceRepository} for resources of the specified type linked to the store.
+     *
+     * @param <T>   The specific type of {@link ResourceInfo} to retrieve.
+     * @param store The store containing the resources; must not be null.
+     * @param clazz The class of the resources to retrieve; must not be null.
+     * @return A list of matching {@link ResourceInfo} objects.
+     * @throws NullPointerException if {@code store} or {@code clazz} is null.
+     */
     @Override
     public <T extends ResourceInfo> List<T> getResourcesByStore(StoreInfo store, Class<T> clazz) {
         return toList(() -> getResourceRepository().findAllByStore(store, clazz));
@@ -233,36 +488,99 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
     //
     // Layers
     //
+    /**
+     * Adds a layer to the catalog.
+     *
+     * <p>Persists the layer via the {@link LayerRepository} and returns the added instance.
+     *
+     * @param layer The {@link LayerInfo} to add; must not be null.
+     * @return The persisted {@link LayerInfo}.
+     * @throws NullPointerException if {@code layer} is null.
+     * @throws IllegalArgumentException if {@code layer} is a proxy or lacks an ID.
+     */
     @Override
     public LayerInfo add(LayerInfo layer) {
         return add(layer, LayerInfo.class, getLayerRepository());
     }
 
+    /**
+     * Removes a layer from the catalog.
+     *
+     * <p>Delegates to the {@link LayerRepository} to delete the layer and associated data.
+     *
+     * @param layer The {@link LayerInfo} to remove; must not be null.
+     * @throws NullPointerException if {@code layer} is null.
+     */
     @Override
     public void remove(LayerInfo layer) {
         getLayerRepository().remove(layer);
     }
 
+    /**
+     * Retrieves a layer by its ID.
+     *
+     * <p>Queries the {@link LayerRepository} for a layer matching the given ID.
+     *
+     * @param id The unique identifier of the layer; must not be null.
+     * @return The matching {@link LayerInfo} if found, or null if not.
+     * @throws NullPointerException if {@code id} is null.
+     */
     @Override
     public LayerInfo getLayer(String id) {
         return getLayerRepository().findById(id, LayerInfo.class).orElse(null);
     }
 
+    /**
+     * Retrieves a layer by its name.
+     *
+     * <p>Queries the {@link LayerRepository} for a layer matching the possibly prefixed name (e.g.,
+     * "namespace:layer").
+     *
+     * @param name The name of the layer (possibly prefixed); must not be null.
+     * @return The matching {@link LayerInfo} if found, or null if not.
+     * @throws NullPointerException if {@code name} is null.
+     */
     @Override
     public LayerInfo getLayerByName(String name) {
         return getLayerRepository().findOneByName(name).orElse(null);
     }
 
+    /**
+     * Retrieves all layers associated with a resource.
+     *
+     * <p>Queries the {@link LayerRepository} for layers linked to the specified resource.
+     *
+     * @param resource The {@link ResourceInfo} linked to the layers; must not be null.
+     * @return A list of matching {@link LayerInfo} objects.
+     * @throws NullPointerException if {@code resource} is null.
+     */
     @Override
     public List<LayerInfo> getLayers(ResourceInfo resource) {
         return toList(() -> getLayerRepository().findAllByResource(resource));
     }
 
+    /**
+     * Retrieves all layers using a specific style.
+     *
+     * <p>Queries the {@link LayerRepository} for layers where the style is either the default or included
+     * in their styles list.
+     *
+     * @param style The {@link StyleInfo} linked to the layers; must not be null.
+     * @return A list of matching {@link LayerInfo} objects.
+     * @throws NullPointerException if {@code style} is null.
+     */
     @Override
     public List<LayerInfo> getLayers(StyleInfo style) {
         return toList(() -> getLayerRepository().findAllByDefaultStyleOrStyles(style));
     }
 
+    /**
+     * Retrieves all layers in the catalog.
+     *
+     * <p>Queries the {@link LayerRepository} for all layers without restrictions.
+     *
+     * @return A list of all {@link LayerInfo} objects.
+     */
     @Override
     public List<LayerInfo> getLayers() {
         return toList(getLayerRepository()::findAll);
@@ -271,100 +589,218 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
     //
     // Maps
     //
+    /**
+     * Adds a map to the catalog.
+     *
+     * <p>Persists the map via the {@link MapRepository} and returns the added instance.
+     *
+     * @param map The {@link MapInfo} to add; must not be null.
+     * @return The persisted {@link MapInfo}.
+     * @throws NullPointerException if {@code map} is null.
+     * @throws IllegalArgumentException if {@code map} is a proxy or lacks an ID.
+     */
     @Override
     public MapInfo add(MapInfo map) {
         return add(map, MapInfo.class, getMapRepository());
     }
 
+    /**
+     * Removes a map from the catalog.
+     *
+     * <p>Delegates to the {@link MapRepository} to delete the map and associated data.
+     *
+     * @param map The {@link MapInfo} to remove; must not be null.
+     * @throws NullPointerException if {@code map} is null.
+     */
     @Override
     public void remove(MapInfo map) {
         getMapRepository().remove(map);
     }
 
+    /**
+     * Retrieves a map by its ID.
+     *
+     * <p>Queries the {@link MapRepository} for a map matching the given ID.
+     *
+     * @param id The unique identifier of the map; must not be null.
+     * @return The matching {@link MapInfo} if found, or null if not.
+     * @throws NullPointerException if {@code id} is null.
+     */
     @Override
     public MapInfo getMap(String id) {
         return getMapRepository().findById(id, MapInfo.class).orElse(null);
     }
 
+    /**
+     * Retrieves a map by its name.
+     *
+     * <p>Queries the {@link MapRepository} for the first map matching the given name.
+     *
+     * @param name The name of the map; must not be null.
+     * @return The matching {@link MapInfo} if found, or null if not.
+     * @throws NullPointerException if {@code name} is null.
+     */
     @Override
     public MapInfo getMapByName(String name) {
         return getMapRepository().findFirstByName(name, MapInfo.class).orElse(null);
     }
 
+    /**
+     * Retrieves all maps in the catalog.
+     *
+     * <p>Queries the {@link MapRepository} for all maps without restrictions.
+     *
+     * @return A list of all {@link MapInfo} objects.
+     */
     @Override
     public List<MapInfo> getMaps() {
         return toList(getMapRepository()::findAll);
     }
 
     //
-    // Layer groups
+    // Layer Groups
     //
+    /**
+     * Adds a layer group to the catalog.
+     *
+     * <p>Persists the layer group via the {@link LayerGroupRepository} and returns the added instance.
+     *
+     * @param layerGroup The {@link LayerGroupInfo} to add; must not be null.
+     * @return The persisted {@link LayerGroupInfo}.
+     * @throws NullPointerException if {@code layerGroup} is null.
+     * @throws IllegalArgumentException if {@code layerGroup} is a proxy or lacks an ID.
+     */
     @Override
     public LayerGroupInfo add(LayerGroupInfo layerGroup) {
         return add(layerGroup, LayerGroupInfo.class, getLayerGroupRepository());
     }
 
+    /**
+     * Removes a layer group from the catalog.
+     *
+     * <p>Delegates to the {@link LayerGroupRepository} to delete the layer group and associated data.
+     *
+     * @param layerGroup The {@link LayerGroupInfo} to remove; must not be null.
+     * @throws NullPointerException if {@code layerGroup} is null.
+     */
     @Override
     public void remove(LayerGroupInfo layerGroup) {
         getLayerGroupRepository().remove(layerGroup);
     }
 
+    /**
+     * Retrieves all layer groups in the catalog.
+     *
+     * <p>Queries the {@link LayerGroupRepository} for all layer groups without restrictions.
+     *
+     * @return A list of all {@link LayerGroupInfo} objects.
+     */
     @Override
     public List<LayerGroupInfo> getLayerGroups() {
         return toList(getLayerGroupRepository()::findAll);
     }
 
+    /**
+     * Retrieves all layer groups within a workspace.
+     *
+     * <p>If the workspace is null, defaults to the current default workspace. Handles special cases:
+     * {@link CatalogFacade#NO_WORKSPACE} retrieves global layer groups (no workspace), while others fetch
+     * workspace-specific groups via the {@link LayerGroupRepository}.
+     *
+     * @param workspace The workspace containing the layer groups; may be null to use the default.
+     * @return A list of matching {@link LayerGroupInfo} objects.
+     */
     @Override
     public List<LayerGroupInfo> getLayerGroupsByWorkspace(WorkspaceInfo workspace) {
-        // Question: do we need to support ANY_WORKSPACE? see comment in DefaultCatalogFacade
-
-        WorkspaceInfo ws;
-        if (workspace == null) {
-            ws = getDefaultWorkspace();
-        } else {
-            ws = workspace;
-        }
-        Stream<LayerGroupInfo> matches;
-        if (workspace == NO_WORKSPACE) {
-            matches = getLayerGroupRepository().findAllByWorkspaceIsNull();
-        } else {
-            matches = getLayerGroupRepository().findAllByWorkspace(ws);
-        }
+        WorkspaceInfo ws = (workspace == null) ? getDefaultWorkspace() : workspace;
+        Stream<LayerGroupInfo> matches = (workspace == NO_WORKSPACE)
+                ? getLayerGroupRepository().findAllByWorkspaceIsNull()
+                : getLayerGroupRepository().findAllByWorkspace(ws);
         return toList(() -> matches);
     }
 
+    /**
+     * Retrieves a layer group by its ID.
+     *
+     * <p>Queries the {@link LayerGroupRepository} for a layer group matching the given ID.
+     *
+     * @param id The unique identifier of the layer group; must not be null.
+     * @return The matching {@link LayerGroupInfo} if found, or null if not.
+     * @throws NullPointerException if {@code id} is null.
+     */
     @Override
     public LayerGroupInfo getLayerGroup(String id) {
         return getLayerGroupRepository().findById(id, LayerGroupInfo.class).orElse(null);
     }
 
+    /**
+     * Retrieves a layer group by its name, assuming no workspace context.
+     *
+     * <p>Delegates to {@link #getLayerGroupByName(WorkspaceInfo, String)} with
+     * {@link CatalogFacade#NO_WORKSPACE}.
+     *
+     * @param name The name of the layer group; must not be null.
+     * @return The matching {@link LayerGroupInfo} if found, or null if not.
+     * @throws NullPointerException if {@code name} is null.
+     */
     @Override
     public LayerGroupInfo getLayerGroupByName(String name) {
         return getLayerGroupByName(NO_WORKSPACE, name);
     }
 
+    /**
+     * Retrieves a layer group by name and workspace.
+     *
+     * <p>Handles special cases: {@link CatalogFacade#NO_WORKSPACE} queries global layer groups,
+     * {@link CatalogFacade#ANY_WORKSPACE} searches across all workspaces, and specific workspaces restrict
+     * the search to that context.
+     *
+     * @param workspace The workspace containing the layer group, or special values; must not be null.
+     * @param name      The name of the layer group; must not be null.
+     * @return The matching {@link LayerGroupInfo} if found, or null if not.
+     * @throws NullPointerException if {@code workspace} or {@code name} is null.
+     */
     @Override
     public LayerGroupInfo getLayerGroupByName(WorkspaceInfo workspace, String name) {
-
-        if (workspace == NO_WORKSPACE)
-            return getLayerGroupRepository().findByNameAndWorkspaceIsNull(name).orElse(null);
-
-        if (ANY_WORKSPACE == workspace)
-            return getLayerGroupRepository()
-                    .findFirstByName(name, LayerGroupInfo.class)
-                    .orElse(null);
-
-        return getLayerGroupRepository().findByNameAndWorkspace(name, workspace).orElse(null);
+        Objects.requireNonNull(workspace, "workspace");
+        Optional<LayerGroupInfo> match;
+        if (workspace == NO_WORKSPACE) {
+            match = getLayerGroupRepository().findByNameAndWorkspaceIsNull(name);
+        } else if (ANY_WORKSPACE == workspace) {
+            match = getLayerGroupRepository().findFirstByName(name, LayerGroupInfo.class);
+        } else {
+            match = getLayerGroupRepository().findByNameAndWorkspace(name, workspace);
+        }
+        return match.orElse(null);
     }
 
     //
     // Namespaces
     //
+    /**
+     * Adds a namespace to the catalog.
+     *
+     * <p>Persists the namespace via the {@link NamespaceRepository} and returns the added instance.
+     *
+     * @param namespace The {@link NamespaceInfo} to add; must not be null.
+     * @return The persisted {@link NamespaceInfo}.
+     * @throws NullPointerException if {@code namespace} is null.
+     * @throws IllegalArgumentException if {@code namespace} is a proxy or lacks an ID.
+     */
     @Override
     public NamespaceInfo add(NamespaceInfo namespace) {
         return add(namespace, NamespaceInfo.class, getNamespaceRepository());
     }
 
+    /**
+     * Removes a namespace from the catalog.
+     *
+     * <p>If the namespace is the default, unsets it before removal. Delegates to the
+     * {@link NamespaceRepository} to delete the namespace.
+     *
+     * @param namespace The {@link NamespaceInfo} to remove; must not be null.
+     * @throws NullPointerException if {@code namespace} is null.
+     */
     @Override
     public void remove(NamespaceInfo namespace) {
         NamespaceInfo defaultNamespace = getDefaultNamespace();
@@ -374,22 +810,55 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
         getNamespaceRepository().remove(namespace);
     }
 
+    /**
+     * Retrieves the default namespace.
+     *
+     * <p>Queries the {@link NamespaceRepository} for the current default namespace.
+     *
+     * @return The default {@link NamespaceInfo} if set, or null if not.
+     */
     @Override
     public NamespaceInfo getDefaultNamespace() {
         return getNamespaceRepository().getDefaultNamespace().orElse(null);
     }
 
+    /**
+     * Sets or unsets the default namespace.
+     *
+     * <p>If {@code defaultNamespace} is null, unsets the default namespace. Otherwise, sets the specified
+     * namespace as the default via the {@link NamespaceRepository}.
+     *
+     * @param defaultNamespace The {@link NamespaceInfo} to set as default, or null to unset.
+     */
     @Override
-    public void setDefaultNamespace(NamespaceInfo defaultNamnespace) {
-        if (defaultNamnespace == null) getNamespaceRepository().unsetDefaultNamespace();
-        else getNamespaceRepository().setDefaultNamespace(defaultNamnespace);
+    public void setDefaultNamespace(NamespaceInfo defaultNamespace) {
+        if (defaultNamespace == null) getNamespaceRepository().unsetDefaultNamespace();
+        else getNamespaceRepository().setDefaultNamespace(defaultNamespace);
     }
 
+    /**
+     * Retrieves a namespace by its ID.
+     *
+     * <p>Queries the {@link NamespaceRepository} for a namespace matching the given ID.
+     *
+     * @param id The unique identifier of the namespace; must not be null.
+     * @return The matching {@link NamespaceInfo} if found, or null if not.
+     * @throws NullPointerException if {@code id} is null.
+     */
     @Override
     public NamespaceInfo getNamespace(String id) {
         return getNamespaceRepository().findById(id, NamespaceInfo.class).orElse(null);
     }
 
+    /**
+     * Retrieves a namespace by its prefix.
+     *
+     * <p>Queries the {@link NamespaceRepository} for the first namespace matching the given prefix.
+     *
+     * @param prefix The prefix of the namespace; must not be null.
+     * @return The matching {@link NamespaceInfo} if found, or null if not.
+     * @throws NullPointerException if {@code prefix} is null.
+     */
     @Override
     public NamespaceInfo getNamespaceByPrefix(String prefix) {
         return getNamespaceRepository()
@@ -397,16 +866,41 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
                 .orElse(null);
     }
 
+    /**
+     * Retrieves a namespace by its URI.
+     *
+     * <p>Queries the {@link NamespaceRepository} for a namespace matching the given URI.
+     *
+     * @param uri The URI of the namespace; must not be null.
+     * @return The matching {@link NamespaceInfo} if found, or null if not.
+     * @throws NullPointerException if {@code uri} is null.
+     */
     @Override
     public NamespaceInfo getNamespaceByURI(String uri) {
         return getNamespaceRepository().findOneByURI(uri).orElse(null);
     }
 
+    /**
+     * Retrieves all namespaces matching a URI.
+     *
+     * <p>Queries the {@link NamespaceRepository} for namespaces with the specified URI.
+     *
+     * @param uri The URI to match; must not be null.
+     * @return A list of matching {@link NamespaceInfo} objects.
+     * @throws NullPointerException if {@code uri} is null.
+     */
     @Override
     public List<NamespaceInfo> getNamespacesByURI(String uri) {
         return toList(() -> getNamespaceRepository().findAllByURI(uri));
     }
 
+    /**
+     * Retrieves all namespaces in the catalog.
+     *
+     * <p>Queries the {@link NamespaceRepository} for all namespaces without restrictions.
+     *
+     * @return A list of all {@link NamespaceInfo} objects.
+     */
     @Override
     public List<NamespaceInfo> getNamespaces() {
         return toList(getNamespaceRepository()::findAll);
@@ -415,12 +909,30 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
     //
     // Workspaces
     //
-    // Workspace methods
+    /**
+     * Adds a workspace to the catalog.
+     *
+     * <p>Persists the workspace via the {@link WorkspaceRepository} and returns the added instance.
+     *
+     * @param workspace The {@link WorkspaceInfo} to add; must not be null.
+     * @return The persisted {@link WorkspaceInfo}.
+     * @throws NullPointerException if {@code workspace} is null.
+     * @throws IllegalArgumentException if {@code workspace} is a proxy or lacks an ID.
+     */
     @Override
     public WorkspaceInfo add(WorkspaceInfo workspace) {
         return add(workspace, WorkspaceInfo.class, getWorkspaceRepository());
     }
 
+    /**
+     * Removes a workspace from the catalog.
+     *
+     * <p>If the workspace is the default, unsets it before removal. Delegates to the
+     * {@link WorkspaceRepository} to delete the workspace.
+     *
+     * @param workspace The {@link WorkspaceInfo} to remove; must not be null.
+     * @throws NullPointerException if {@code workspace} is null.
+     */
     @Override
     public void remove(WorkspaceInfo workspace) {
         WorkspaceInfo defaultWorkspace = getDefaultWorkspace();
@@ -430,28 +942,67 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
         getWorkspaceRepository().remove(workspace);
     }
 
+    /**
+     * Retrieves the default workspace.
+     *
+     * <p>Queries the {@link WorkspaceRepository} for the current default workspace.
+     *
+     * @return The default {@link WorkspaceInfo} if set, or null if not.
+     */
     @Override
     public WorkspaceInfo getDefaultWorkspace() {
         return getWorkspaceRepository().getDefaultWorkspace().orElse(null);
     }
 
+    /**
+     * Sets or unsets the default workspace.
+     *
+     * <p>If {@code workspace} is null, unsets the default workspace. Otherwise, sets the specified
+     * workspace as the default via the {@link WorkspaceRepository}.
+     *
+     * @param workspace The {@link WorkspaceInfo} to set as default, or null to unset.
+     */
     @Override
     public void setDefaultWorkspace(WorkspaceInfo workspace) {
-        WorkspaceInfo ws = workspace;
-        if (ws == null) getWorkspaceRepository().unsetDefaultWorkspace();
-        else getWorkspaceRepository().setDefaultWorkspace(ws);
+        if (workspace == null) getWorkspaceRepository().unsetDefaultWorkspace();
+        else getWorkspaceRepository().setDefaultWorkspace(workspace);
     }
 
+    /**
+     * Retrieves all workspaces in the catalog.
+     *
+     * <p>Queries the {@link WorkspaceRepository} for all workspaces without restrictions.
+     *
+     * @return A list of all {@link WorkspaceInfo} objects.
+     */
     @Override
     public List<WorkspaceInfo> getWorkspaces() {
         return toList(getWorkspaceRepository()::findAll);
     }
 
+    /**
+     * Retrieves a workspace by its ID.
+     *
+     * <p>Queries the {@link WorkspaceRepository} for a workspace matching the given ID.
+     *
+     * @param id The unique identifier of the workspace; must not be null.
+     * @return The matching {@link WorkspaceInfo} if found, or null if not.
+     * @throws NullPointerException if {@code id} is null.
+     */
     @Override
     public WorkspaceInfo getWorkspace(String id) {
         return getWorkspaceRepository().findById(id, WorkspaceInfo.class).orElse(null);
     }
 
+    /**
+     * Retrieves a workspace by its name.
+     *
+     * <p>Queries the {@link WorkspaceRepository} for the first workspace matching the given name.
+     *
+     * @param name The name of the workspace; must not be null.
+     * @return The matching {@link WorkspaceInfo} if found, or null if not.
+     * @throws NullPointerException if {@code name} is null.
+     */
     @Override
     public WorkspaceInfo getWorkspaceByName(String name) {
         return getWorkspaceRepository()
@@ -462,21 +1013,58 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
     //
     // Styles
     //
+    /**
+     * Adds a style to the catalog.
+     *
+     * <p>Persists the style via the {@link StyleRepository} and returns the added instance.
+     *
+     * @param style The {@link StyleInfo} to add; must not be null.
+     * @return The persisted {@link StyleInfo}.
+     * @throws NullPointerException if {@code style} is null.
+     * @throws IllegalArgumentException if {@code style} is a proxy or lacks an ID.
+     */
     @Override
     public StyleInfo add(StyleInfo style) {
         return add(style, StyleInfo.class, getStyleRepository());
     }
 
+    /**
+     * Removes a style from the catalog.
+     *
+     * <p>Delegates to the {@link StyleRepository} to delete the style and associated data.
+     *
+     * @param style The {@link StyleInfo} to remove; must not be null.
+     * @throws NullPointerException if {@code style} is null.
+     */
     @Override
     public void remove(StyleInfo style) {
         getStyleRepository().remove(style);
     }
 
+    /**
+     * Retrieves a style by its ID.
+     *
+     * <p>Queries the {@link StyleRepository} for a style matching the given ID.
+     *
+     * @param id The unique identifier of the style; must not be null.
+     * @return The matching {@link StyleInfo} if found, or null if not.
+     * @throws NullPointerException if {@code id} is null.
+     */
     @Override
     public StyleInfo getStyle(String id) {
         return getStyleRepository().findById(id, StyleInfo.class).orElse(null);
     }
 
+    /**
+     * Retrieves a style by its name, preferring global styles.
+     *
+     * <p>Queries the {@link StyleRepository} first for a global style (no workspace) matching the name,
+     * falling back to the first workspace-specific match if no global style is found.
+     *
+     * @param name The name of the style; must not be null.
+     * @return The matching {@link StyleInfo} if found, or null if not.
+     * @throws NullPointerException if {@code name} is null.
+     */
     @Override
     public StyleInfo getStyleByName(String name) {
         Optional<StyleInfo> match = getStyleRepository().findByNameAndWordkspaceNull(name);
@@ -486,6 +1074,18 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
         return match.orElse(null);
     }
 
+    /**
+     * Retrieves a style by name and workspace.
+     *
+     * <p>Handles special cases: {@link CatalogFacade#NO_WORKSPACE} queries global styles,
+     * {@link CatalogFacade#ANY_WORKSPACE} searches across all workspaces, and specific workspaces restrict
+     * the search to that context.
+     *
+     * @param workspace The workspace containing the style, or special values; must not be null.
+     * @param name      The name of the style; must not be null.
+     * @return The matching {@link StyleInfo} if found, or null if not.
+     * @throws NullPointerException if {@code workspace} or {@code name} is null.
+     */
     @Override
     public StyleInfo getStyleByName(WorkspaceInfo workspace, String name) {
         Objects.requireNonNull(workspace, "workspace");
@@ -494,55 +1094,93 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
         if (workspace == ANY_WORKSPACE) {
             return getStyleByName(name);
         }
-        Optional<StyleInfo> match;
-        if (workspace == NO_WORKSPACE) {
-            match = getStyleRepository().findByNameAndWordkspaceNull(name);
-        } else {
-            match = getStyleRepository().findByNameAndWorkspace(name, workspace);
-        }
+        Optional<StyleInfo> match = (workspace == NO_WORKSPACE)
+                ? getStyleRepository().findByNameAndWordkspaceNull(name)
+                : getStyleRepository().findByNameAndWorkspace(name, workspace);
         return match.orElse(null);
     }
 
+    /**
+     * Retrieves all styles in the catalog.
+     *
+     * <p>Queries the {@link StyleRepository} for all styles without restrictions.
+     *
+     * @return A list of all {@link StyleInfo} objects.
+     */
     @Override
     public List<StyleInfo> getStyles() {
         return toList(getStyleRepository()::findAll);
     }
 
+    /**
+     * Retrieves all styles within a workspace.
+     *
+     * <p>If the workspace is null, defaults to the current default workspace. Handles
+     * {@link CatalogFacade#NO_WORKSPACE} for global styles via the {@link StyleRepository}.
+     *
+     * @param workspace The workspace containing the styles; may be null to use the default.
+     * @return A list of matching {@link StyleInfo} objects.
+     */
     @Override
     public List<StyleInfo> getStylesByWorkspace(WorkspaceInfo workspace) {
-        // Question: do we need to support ANY_WORKSPACE? see "todo" comment in DefaultCatalogFacade
         Stream<StyleInfo> matches;
         if (workspace == NO_WORKSPACE) {
             matches = getStyleRepository().findAllByNullWorkspace();
         } else {
-            WorkspaceInfo ws;
-            if (workspace == null) {
-                ws = getDefaultWorkspace();
-            } else {
-                ws = workspace;
-            }
-
+            WorkspaceInfo ws = (workspace == null) ? getDefaultWorkspace() : workspace;
             matches = getStyleRepository().findAllByWorkspace(ws);
         }
         return toList(() -> matches);
     }
 
+    /**
+     * Converts a stream supplier to a list, ensuring proper stream closure.
+     *
+     * <p>This utility method safely collects a stream into a list, closing the stream after use to
+     * prevent resource leaks.
+     *
+     * @param <T>      The type of objects in the stream.
+     * @param supplier A supplier providing the stream; must not be null.
+     * @return A list of objects from the stream.
+     * @throws NullPointerException if {@code supplier} is null.
+     */
     protected <T extends CatalogInfo> List<T> toList(Supplier<Stream<T>> supplier) {
         try (Stream<T> stream = supplier.get()) {
             return stream.toList();
         }
     }
 
+    /**
+     * Disposes of all resources held by this facade.
+     *
+     * <p>Delegates to the internal repository holder to release all repository resources (e.g., database
+     * connections).
+     */
     @Override
     public void dispose() {
         repositories.dispose();
     }
 
+    /**
+     * Synchronizes this facade’s catalog data to another facade.
+     *
+     * <p>If the target facade is a {@link CatalogInfoRepositoryHolder}, performs an optimized sync by
+     * delegating to each repository’s {@code syncTo} method. Otherwise, manually imports all objects using
+     * the target’s {@code add} methods. Also syncs default settings (workspace, namespace, data stores).
+     *
+     * @param to The target {@link CatalogFacade} to sync to; must not be null.
+     * @throws NullPointerException if {@code to} is null.
+     * @example Syncing to another facade:
+     *          <pre>
+     *          RepositoryCatalogFacadeImpl source = ...;
+     *          CatalogFacade target = new DefaultCatalogFacade();
+     *          source.syncTo(target);
+     *          </pre>
+     */
     @Override
     public void syncTo(CatalogFacade to) {
         final CatalogFacade dao = ProxyUtils.unwrap(to, LockingCatalogFacade.class);
         if (dao instanceof CatalogInfoRepositoryHolder other) {
-            // do an optimized sync
             this.getWorkspaceRepository().syncTo(other.getWorkspaceRepository());
             this.getNamespaceRepository().syncTo(other.getNamespaceRepository());
             this.getStoreRepository().syncTo(other.getStoreRepository());
@@ -553,7 +1191,6 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
             this.getMapRepository().syncTo(other.getMapRepository());
             dao.setCatalog(catalog);
         } else {
-            // do a manual import
             sync(getWorkspaceRepository()::findAll, dao::add);
             sync(getNamespaceRepository()::findAll, dao::add);
             sync(getStoreRepository()::findAll, dao::add);
@@ -563,7 +1200,6 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
             sync(getLayerGroupRepository()::findAll, dao::add);
             sync(getMapRepository()::findAll, dao::add);
         }
-
         dao.setDefaultWorkspace(getDefaultWorkspace());
         dao.setDefaultNamespace(getDefaultNamespace());
         try (Stream<DataStoreInfo> defaultDataStores = getStoreRepository().getDefaultDataStores()) {
@@ -571,12 +1207,37 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
         }
     }
 
+    /**
+     * Synchronizes a stream of catalog objects to a consumer, ensuring proper closure.
+     *
+     * <p>This helper method streams objects from a supplier and applies a consumer (e.g., {@code add}),
+     * closing the stream afterward.
+     *
+     * @param <T>      The type of {@link CatalogInfo}.
+     * @param from     A supplier providing the stream of objects; must not be null.
+     * @param to       The consumer to apply to each object; must not be null.
+     * @throws NullPointerException if {@code from} or {@code to} is null.
+     */
     private <T extends CatalogInfo> void sync(Supplier<Stream<T>> from, Consumer<T> to) {
         try (Stream<T> all = from.get()) {
             all.forEach(to::accept);
         }
     }
 
+    /**
+     * Counts catalog objects of a specific type matching a filter.
+     *
+     * <p>For {@link PublishedInfo}, splits the filter to count layers and layer groups separately, summing
+     * the results. Otherwise, delegates to the appropriate repository’s {@code count} method, capping at
+     * {@link Integer#MAX_VALUE}.
+     *
+     * @param <T>    The type of {@link CatalogInfo} to count.
+     * @param of     The class of objects to count; must not be null.
+     * @param filter The filter to apply; must not be null.
+     * @return The number of matching objects, capped at {@link Integer#MAX_VALUE}.
+     * @throws NullPointerException if {@code of} or {@code filter} is null.
+     * @throws CatalogException if counting fails due to repository errors.
+     */
     @Override
     public <T extends CatalogInfo> int count(final Class<T> of, Filter filter) {
         long count;
@@ -599,6 +1260,15 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
         return count > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) count;
     }
 
+    /**
+     * Splits an OR filter into type-specific filters for {@link PublishedInfo} queries.
+     *
+     * <p>Analyzes the filter for {@code IsInstanceOf} conditions to separate {@link LayerInfo} and
+     * {@link LayerGroupInfo} constraints, returning a map of type-to-filter pairs.
+     *
+     * @param filter The filter to split; must not be null.
+     * @return A map of {@link Class} to {@link Filter} for each type, or an empty map if not splittable.
+     */
     Map<Class<?>, Filter> splitOredInstanceOf(Filter filter) {
         Map<Class<?>, Filter> split = new HashMap<>();
         if (filter instanceof Or or) {
@@ -614,6 +1284,15 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
         return split;
     }
 
+    /**
+     * Finds an {@code IsInstanceOf} filter within a compound filter.
+     *
+     * <p>Recursively searches AND filters or checks binary comparisons for an {@code IsInstanceOf}
+     * expression.
+     *
+     * @param subFilter The filter to search; must not be null.
+     * @return The found {@link IsInstanceOf} filter, or null if none exists.
+     */
     private IsInstanceOf findInstanceOf(Filter subFilter) {
         if (subFilter instanceof And and) {
             for (Filter f : and.getChildren()) {
@@ -628,6 +1307,12 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
         return null;
     }
 
+    /**
+     * Extracts an {@code IsInstanceOf} expression from a binary comparison.
+     *
+     * @param f The binary comparison filter; must not be null.
+     * @return The {@link IsInstanceOf} expression if present, or null if not.
+     */
     private IsInstanceOf extractInstanceOf(BinaryComparisonOperator f) {
         if (f.getExpression1() instanceof IsInstanceOf i) return i;
         if (f.getExpression2() instanceof IsInstanceOf i) return i;
@@ -635,11 +1320,16 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
     }
 
     /**
-     * This default implementation supports sorting against properties (could be nested) that are
-     * either of a primitive type or implement {@link Comparable}.
+     * Checks if sorting by a property is supported for a given type.
      *
-     * @param type the type of object to sort
-     * @param propertyName the property name of the objects of type {@code type} to sort by
+     * <p>Supports sorting on properties (including nested ones) that are primitive or implement
+     * {@link Comparable}. For {@link PublishedInfo}, checks both {@link LayerInfo} and
+     * {@link LayerGroupInfo} capabilities.
+     *
+     * @param type         The type of {@link CatalogInfo} to sort; must not be null.
+     * @param propertyName The property name to sort by; must not be null.
+     * @return {@code true} if sorting is supported, {@code false} otherwise.
+     * @throws NullPointerException if {@code type} or {@code propertyName} is null.
      * @see CatalogInfoRepository#canSortBy(String)
      */
     @Override
@@ -650,10 +1340,25 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
         return repository(type).canSortBy(propertyName);
     }
 
+    /**
+     * Validates that a query’s sort order is supported for its type.
+     *
+     * @param <T>  The type of {@link CatalogInfo}.
+     * @param query The query to validate; must not be null.
+     * @throws IllegalArgumentException if any sort property is unsupported for the query’s type.
+     */
     private <T extends CatalogInfo> void checkCanSort(final Query<T> query) {
         query.getSortBy().forEach(sb -> checkCanSort(query.getType(), sb));
     }
 
+    /**
+     * Validates that a specific sort order is supported for a type.
+     *
+     * @param <T>  The type of {@link CatalogInfo}.
+     * @param type The class of objects to sort; must not be null.
+     * @param order The {@link SortBy} order to check; must not be null.
+     * @throws IllegalArgumentException if the sort property is unsupported.
+     */
     private <T extends CatalogInfo> void checkCanSort(final Class<T> type, SortBy order) {
         if (!canSort(type, order.getPropertyName().getPropertyName())) {
             throw new IllegalArgumentException(
@@ -661,6 +1366,27 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
         }
     }
 
+    /**
+     * Queries the catalog for objects matching the specified criteria.
+     *
+     * <p>For {@link PublishedInfo}, uses a merge-sorted approach via {@link #queryPublishedInfo(Query)}.
+     * Otherwise, delegates to the appropriate repository’s {@code findAll} method after validating sort
+     * order. Returns an empty stream if the filter is {@link Filter#EXCLUDE}.
+     *
+     * @param <T>   The type of {@link CatalogInfo} to query.
+     * @param query The query defining type, filter, sorting, and pagination; must not be null.
+     * @return A {@link Stream} of matching objects; never null.
+     * @throws NullPointerException if {@code query} is null.
+     * @throws CatalogException if querying fails due to repository errors.
+     * @throws IllegalArgumentException if sort order is unsupported.
+     * @example Querying layers:
+     *          <pre>
+     *          Query<LayerInfo> query = Query.valueOf(LayerInfo.class, someFilter);
+     *          try (Stream<LayerInfo> layers = facade.query(query)) {
+     *              layers.forEach(l -> System.out.println(l.getName()));
+     *          }
+     *          </pre>
+     */
     @Override
     public <T extends CatalogInfo> Stream<T> query(Query<T> query) {
         if (Filter.EXCLUDE.equals(query.getFilter())) {
@@ -679,13 +1405,16 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
     }
 
     /**
-     * Queries {@link LayerRepository} and {@link LayerGroupRepository}, and returns a merge-sorted
-     * stream.
+     * Queries {@link LayerRepository} and {@link LayerGroupRepository} for {@link PublishedInfo}, returning
+     * a merge-sorted stream.
      *
-     * <p>If the query does not specify a sort order, the {@code id} property is used to provide
-     * predictable order for the merge-sort algorithm
+     * <p>Splits the query filter to handle layers and layer groups separately, applying offset and limit
+     * in-memory if needed. Ensures predictable order with a default "id" sort if none is specified.
+     * Closes underlying streams when the result stream is closed.
      *
-     * <p>When the returned stream is closed, it'll close the two underlying streams
+     * @param query The query defining criteria for {@link PublishedInfo}; must not be null.
+     * @return A {@link Stream} of {@link PublishedInfo} objects (layers and layer groups); never null.
+     * @throws NullPointerException if {@code query} is null.
      */
     protected Stream<PublishedInfo> queryPublishedInfo(Query<?> query) {
         final Filter filter = SimplifyingFilterVisitor.simplify(query.getFilter());
@@ -697,7 +1426,6 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
         var lgQuery = new Query<>(LayerGroupInfo.class, query).setFilter(lgFilter);
 
         if (query.getSortBy().isEmpty()) {
-            // enforce predictable order
             List<SortBy> sortBy = List.of(Predicates.sortBy("id", true));
             layerQuery.setSortBy(sortBy);
             lgQuery.setSortBy(sortBy);
@@ -711,9 +1439,6 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
         try {
             layers = query(layerQuery);
             groups = query(lgQuery);
-
-            // merge-sort the two streams without additional memory allocation, they're guaranteed
-            // to be sorted
 
             Iterator<PublishedInfo> layersit =
                     layers.map(PublishedInfo.class::cast).iterator();
@@ -734,13 +1459,23 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
         }
     }
 
+    /**
+     * Determines if offset and limit should be applied in-memory for a {@link PublishedInfo} query.
+     *
+     * <p>Checks if either layer or layer group results are non-zero, resetting query offsets/limits to
+     * fetch all results for in-memory sorting if needed.
+     *
+     * @param offset     The offset from the original query; may be null.
+     * @param limit      The limit from the original query; may be null.
+     * @param layerQuery The query for layers; must not be null.
+     * @param lgQuery    The query for layer groups; must not be null.
+     * @return {@code true} if in-memory offset/limit is required, {@code false} otherwise.
+     */
     protected boolean shallApplyOffsetLimit(
             final Integer offset, final Integer limit, Query<LayerInfo> layerQuery, Query<LayerGroupInfo> lgQuery) {
         if (null == offset && null == limit) {
             return false;
         }
-        // bad luck, but try to discard the one(s) that don't match any first for a chance to
-        // avoid in-process offset/limit filtering
         int lgCount = count(LayerGroupInfo.class, lgQuery.getFilter());
         if (0 == lgCount) {
             lgQuery.setFilter(Filter.EXCLUDE);
@@ -751,7 +1486,6 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
             layerQuery.setFilter(Filter.EXCLUDE);
             return false;
         }
-        // neither is zero, we gotta do in-process offset/limit to preserve the sort order
         layerQuery.setOffset(null);
         layerQuery.setCount(null);
         lgQuery.setOffset(null);
@@ -759,12 +1493,35 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
         return true;
     }
 
+    /**
+     * Adds closure logic to a stream to close additional streams when done.
+     *
+     * <p>Ensures that auxiliary streams (e.g., layers and groups) are closed when the main stream is closed.
+     *
+     * @param <T>        The type of objects in the stream.
+     * @param stream     The main stream to extend; must not be null.
+     * @param closeables Additional streams to close; must not be null.
+     * @return The extended {@link Stream} with closure logic.
+     */
     private <T> Stream<T> closing(Stream<T> stream, Stream<?>... closeables) {
         return stream.onClose(() -> {
             for (var s : closeables) s.close();
         });
     }
 
+    /**
+     * Updates a catalog object with a patch.
+     *
+     * <p>Ensures the object is not a proxy, then delegates to the appropriate repository’s
+     * {@code update} method to apply the patch and return the updated instance.
+     *
+     * @param <I>   The type of {@link CatalogInfo} to update.
+     * @param info  The catalog object to update; must not be null and not a proxy.
+     * @param patch The {@link Patch} containing changes; must not be null.
+     * @return The updated {@link CatalogInfo} object.
+     * @throws NullPointerException if {@code info} or {@code patch} is null.
+     * @throws IllegalArgumentException if {@code info} is a proxy or not found in the repository.
+     */
     @Override
     public <I extends CatalogInfo> I update(I info, Patch patch) {
         checkNotAProxy(info);
@@ -772,97 +1529,239 @@ public class RepositoryCatalogFacadeImpl implements RepositoryCatalogFacade, Cat
         return repo.update(info, patch);
     }
 
+    /**
+     * Validates that a catalog object is not a proxy.
+     *
+     * @param value The {@link CatalogInfo} object to check; must not be null.
+     * @throws IllegalArgumentException if {@code value} is a proxy.
+     */
     private static void checkNotAProxy(CatalogInfo value) {
         if (Proxy.isProxyClass(value.getClass())) {
             throw new IllegalArgumentException("Proxy values shall not be passed to CatalogInfoLookup");
         }
     }
 
+    /**
+     * Retrieves the repository for a specific {@link CatalogInfo} type.
+     *
+     * <p>Delegates to the internal repository holder’s {@link CatalogInfoRepositoryHolder#repository(Class)}.
+     *
+     * @param <T> The type of {@link CatalogInfo}.
+     * @param <R> The corresponding repository type.
+     * @param of  The class of catalog info objects; must not be null.
+     * @return The repository for type {@code T}; never null.
+     * @throws NullPointerException if {@code of} is null.
+     * @throws IllegalArgumentException if no repository is configured for the type.
+     */
     @Override
     public <T extends CatalogInfo, R extends CatalogInfoRepository<T>> R repository(Class<T> of) {
         return repositories.repository(of);
     }
 
+    /**
+     * Retrieves the repository for the type of a given {@link CatalogInfo} instance.
+     *
+     * <p>Delegates to the internal repository holder’s {@link CatalogInfoRepositoryHolder#repositoryFor(CatalogInfo)}.
+     *
+     * @param <T>  The type of {@link CatalogInfo}.
+     * @param <R>  The corresponding repository type.
+     * @param info The catalog info object; must not be null.
+     * @return The repository for the object’s type; never null.
+     * @throws NullPointerException if {@code info} is null.
+     * @throws IllegalArgumentException if no repository is configured for the object’s type.
+     */
     @Override
     public <T extends CatalogInfo, R extends CatalogInfoRepository<T>> R repositoryFor(T info) {
         return repositories.repositoryFor(info);
     }
 
+    /**
+     * Sets the repository for managing {@link NamespaceInfo} objects.
+     *
+     * <p>Delegates to the internal repository holder’s {@link CatalogInfoRepositoryHolder#setNamespaceRepository(NamespaceRepository)}.
+     *
+     * @param namespaces The {@link NamespaceRepository} to set; must not be null.
+     * @throws NullPointerException if {@code namespaces} is null.
+     */
     @Override
     public void setNamespaceRepository(NamespaceRepository namespaces) {
         repositories.setNamespaceRepository(namespaces);
     }
 
+    /**
+     * Retrieves the repository for managing {@link NamespaceInfo} objects.
+     *
+     * @return The configured {@link NamespaceRepository}; never null.
+     * @throws IllegalStateException if no namespace repository has been set.
+     */
     @Override
     public NamespaceRepository getNamespaceRepository() {
         return repositories.getNamespaceRepository();
     }
 
+    /**
+     * Sets the repository for managing {@link WorkspaceInfo} objects.
+     *
+     * <p>Delegates to the internal repository holder’s {@link CatalogInfoRepositoryHolder#setWorkspaceRepository(WorkspaceRepository)}.
+     *
+     * @param workspaces The {@link WorkspaceRepository} to set; must not be null.
+     * @throws NullPointerException if {@code workspaces} is null.
+     */
     @Override
     public void setWorkspaceRepository(WorkspaceRepository workspaces) {
         repositories.setWorkspaceRepository(workspaces);
     }
 
+    /**
+     * Retrieves the repository for managing {@link WorkspaceInfo} objects.
+     *
+     * @return The configured {@link WorkspaceRepository}; never null.
+     * @throws IllegalStateException if no workspace repository has been set.
+     */
     @Override
     public WorkspaceRepository getWorkspaceRepository() {
         return repositories.getWorkspaceRepository();
     }
 
+    /**
+     * Sets the repository for managing {@link StoreInfo} objects.
+     *
+     * <p>Delegates to the internal repository holder’s {@link CatalogInfoRepositoryHolder#setStoreRepository(StoreRepository)}.
+     *
+     * @param stores The {@link StoreRepository} to set; must not be null.
+     * @throws NullPointerException if {@code stores} is null.
+     */
     @Override
     public void setStoreRepository(StoreRepository stores) {
         repositories.setStoreRepository(stores);
     }
 
+    /**
+     * Retrieves the repository for managing {@link StoreInfo} objects.
+     *
+     * @return The configured {@link StoreRepository}; never null.
+     * @throws IllegalStateException if no store repository has been set.
+     */
     @Override
     public StoreRepository getStoreRepository() {
         return repositories.getStoreRepository();
     }
 
+    /**
+     * Sets the repository for managing {@link ResourceInfo} objects.
+     *
+     * <p>Delegates to the internal repository holder’s {@link CatalogInfoRepositoryHolder#setResourceRepository(ResourceRepository)}.
+     *
+     * @param resources The {@link ResourceRepository} to set; must not be null.
+     * @throws NullPointerException if {@code resources} is null.
+     */
     @Override
     public void setResourceRepository(ResourceRepository resources) {
         repositories.setResourceRepository(resources);
     }
 
+    /**
+     * Retrieves the repository for managing {@link ResourceInfo} objects.
+     *
+     * @return The configured {@link ResourceRepository}; never null.
+     * @throws IllegalStateException if no resource repository has been set.
+     */
     @Override
     public ResourceRepository getResourceRepository() {
         return repositories.getResourceRepository();
     }
 
+    /**
+     * Sets the repository for managing {@link LayerInfo} objects.
+     *
+     * <p>Delegates to the internal repository holder’s {@link CatalogInfoRepositoryHolder#setLayerRepository(LayerRepository)}.
+     *
+     * @param layers The {@link LayerRepository} to set; must not be null.
+     * @throws NullPointerException if {@code layers} is null.
+     */
     @Override
     public void setLayerRepository(LayerRepository layers) {
         repositories.setLayerRepository(layers);
     }
 
+    /**
+     * Retrieves the repository for managing {@link LayerInfo} objects.
+     *
+     * @return The configured {@link LayerRepository}; never null.
+     * @throws IllegalStateException if no layer repository has been set.
+     */
     @Override
     public LayerRepository getLayerRepository() {
         return repositories.getLayerRepository();
     }
 
+    /**
+     * Sets the repository for managing {@link LayerGroupInfo} objects.
+     *
+     * <p>Delegates to the internal repository holder’s {@link CatalogInfoRepositoryHolder#setLayerGroupRepository(LayerGroupRepository)}.
+     *
+     * @param layerGroups The {@link LayerGroupRepository} to set; must not be null.
+     * @throws NullPointerException if {@code layerGroups} is null.
+     */
     @Override
     public void setLayerGroupRepository(LayerGroupRepository layerGroups) {
         repositories.setLayerGroupRepository(layerGroups);
     }
 
+    /**
+     * Retrieves the repository for managing {@link LayerGroupInfo} objects.
+     *
+     * @return The configured {@link LayerGroupRepository}; never null.
+     * @throws IllegalStateException if no layer group repository has been set.
+     */
     @Override
     public LayerGroupRepository getLayerGroupRepository() {
         return repositories.getLayerGroupRepository();
     }
 
+    /**
+     * Sets the repository for managing {@link StyleInfo} objects.
+     *
+     * <p>Delegates to the internal repository holder’s {@link CatalogInfoRepositoryHolder#setStyleRepository(StyleRepository)}.
+     *
+     * @param styles The {@link StyleRepository} to set; must not be null.
+     * @throws NullPointerException if {@code styles} is null.
+     */
     @Override
     public void setStyleRepository(StyleRepository styles) {
         repositories.setStyleRepository(styles);
     }
 
+    /**
+     * Retrieves the repository for managing {@link StyleInfo} objects.
+     *
+     * @return The configured {@link StyleRepository}; never null.
+     * @throws IllegalStateException if no style repository has been set.
+     */
     @Override
     public StyleRepository getStyleRepository() {
         return repositories.getStyleRepository();
     }
 
+    /**
+     * Sets the repository for managing {@link MapInfo} objects.
+     *
+     * <p>Delegates to the internal repository holder’s {@link CatalogInfoRepositoryHolder#setMapRepository(MapRepository)}.
+     *
+     * @param maps The {@link MapRepository} to set; must not be null.
+     * @throws NullPointerException if {@code maps} is null.
+     */
     @Override
     public void setMapRepository(MapRepository maps) {
         repositories.setMapRepository(maps);
     }
 
+    /**
+     * Retrieves the repository for managing {@link MapInfo} objects.
+     *
+     * @return The configured {@link MapRepository}; never null.
+     * @throws IllegalStateException if no map repository has been set.
+     */
     @Override
     public MapRepository getMapRepository() {
         return repositories.getMapRepository();

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingCatalog.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingCatalog.java
@@ -39,27 +39,52 @@ import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.sort.SortBy;
 
 /**
- * {@link Catalog} which forwards all its method calls to another {@code Catalog} aiding in
- * implementing a decorator.
+ * A decorator for {@link Catalog} that forwards all method calls to an underlying catalog instance.
  *
- * <p>Subclasses should override one or more methods to modify the behavior of the backing facade as
- * needed.
+ * <p>This class aids in implementing decorators by providing a base that delegates all operations to a
+ * subject {@link Catalog}, allowing subclasses to override specific methods to modify behavior as needed.
+ * It’s useful for adding functionality (e.g., logging, caching) without altering the core catalog
+ * implementation. The decorator is {@link Serializable} if the subject catalog is serializable.
  *
- * <p>The catalog is {@link Serializable serializable} if the subject catalog is so.
+ * <p>Subclasses should override one or more methods to modify the behavior of the backing catalog as needed.
+ *
+ * <p>Example usage:
+ * <pre>
+ * Catalog baseCatalog = ...;
+ * ForwardingCatalog decorator = new ForwardingCatalog(baseCatalog) {
+ *     &#64;Override
+ *     public void add(StoreInfo store) {
+ *         // Add custom logic before forwarding
+ *         super.add(store);
+ *     }
+ * };
+ * </pre>
+ *
+ * @since 1.0
+ * @see Catalog
  */
+@SuppressWarnings("serial")
 public class ForwardingCatalog implements Catalog {
-
-    private static final long serialVersionUID = 1L;
 
     protected final Catalog catalog;
 
+    /**
+     * Constructs a forwarding catalog wrapping the provided subject.
+     *
+     * @param catalog The underlying {@link Catalog} to forward calls to; must not be null.
+     * @throws NullPointerException if {@code catalog} is null.
+     */
     public ForwardingCatalog(Catalog catalog) {
-        Objects.requireNonNull(catalog);
+        Objects.requireNonNull(catalog, "Subject catalog must not be null");
         this.catalog = catalog;
     }
 
     /**
-     * @return this decorator's subject
+     * Returns this decorator's subject catalog.
+     *
+     * <p>Provides access to the underlying {@link Catalog} instance being decorated.
+     *
+     * @return The subject {@link Catalog}; never null.
      */
     public Catalog getSubject() {
         // if you're wondering, I refuse to derive from org.geotools.util.decorate.AbstractDecorator
@@ -67,779 +92,934 @@ public class ForwardingCatalog implements Catalog {
         return catalog;
     }
 
+    /** {@inheritDoc} */
     @Override
     public String getId() {
         return catalog.getId();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void accept(CatalogVisitor visitor) {
         catalog.accept(visitor);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Date getDateModified() {
         return catalog.getDateModified();
     }
 
+    /** {@inheritDoc} */
     @Override
     public Date getDateCreated() {
         return catalog.getDateCreated();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setDateCreated(Date dateCreated) {
         catalog.setDateCreated(dateCreated);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setDateModified(Date dateModified) {
         catalog.setDateModified(dateModified);
     }
 
+    /** {@inheritDoc} */
     @Override
     public CatalogFacade getFacade() {
         return catalog.getFacade();
     }
 
+    /** {@inheritDoc} */
     @Override
     public CatalogFactory getFactory() {
         return catalog.getFactory();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void add(StoreInfo store) {
         catalog.add(store);
     }
 
+    /** {@inheritDoc} */
     @Override
     public ValidationResult validate(StoreInfo store, boolean isNew) {
         return catalog.validate(store, isNew);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(StoreInfo store) {
         catalog.remove(store);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void save(StoreInfo store) {
         catalog.save(store);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends StoreInfo> T getStore(String id, Class<T> clazz) {
         return catalog.getStore(id, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends StoreInfo> T getStoreByName(String name, Class<T> clazz) {
         return catalog.getStoreByName(name, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends StoreInfo> T getStoreByName(String workspaceName, String name, Class<T> clazz) {
         return catalog.getStoreByName(workspaceName, name, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends StoreInfo> T getStoreByName(WorkspaceInfo workspace, String name, Class<T> clazz) {
         return catalog.getStoreByName(workspace, name, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends StoreInfo> List<T> getStores(Class<T> clazz) {
         return catalog.getStores(clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public WMSStoreInfo getWMSStore(String id) {
         return catalog.getWMSStore(id);
     }
 
+    /** {@inheritDoc} */
     @Override
     public WMSStoreInfo getWMSStoreByName(String name) {
         return catalog.getWMSStoreByName(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public WMTSStoreInfo getWMTSStore(String id) {
         return catalog.getWMTSStore(id);
     }
 
+    /** {@inheritDoc} */
     @Override
     public WMTSStoreInfo getWMTSStoreByName(String name) {
         return catalog.getWMTSStoreByName(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends StoreInfo> List<T> getStoresByWorkspace(WorkspaceInfo workspace, Class<T> clazz) {
         return catalog.getStoresByWorkspace(workspace, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends StoreInfo> List<T> getStoresByWorkspace(String workspaceName, Class<T> clazz) {
         return catalog.getStoresByWorkspace(workspaceName, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public DataStoreInfo getDataStore(String id) {
         return catalog.getDataStore(id);
     }
 
+    /** {@inheritDoc} */
     @Override
     public DataStoreInfo getDataStoreByName(String name) {
         return catalog.getDataStoreByName(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public DataStoreInfo getDataStoreByName(String workspaceName, String name) {
         return catalog.getDataStoreByName(workspaceName, name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public DataStoreInfo getDataStoreByName(WorkspaceInfo workspace, String name) {
         return catalog.getDataStoreByName(workspace, name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<DataStoreInfo> getDataStoresByWorkspace(String workspaceName) {
         return catalog.getDataStoresByWorkspace(workspaceName);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<DataStoreInfo> getDataStoresByWorkspace(WorkspaceInfo workspace) {
         return catalog.getDataStoresByWorkspace(workspace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<DataStoreInfo> getDataStores() {
         return catalog.getDataStores();
     }
 
+    /** {@inheritDoc} */
     @Override
     public DataStoreInfo getDefaultDataStore(WorkspaceInfo workspace) {
         return catalog.getDefaultDataStore(workspace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setDefaultDataStore(WorkspaceInfo workspace, DataStoreInfo defaultStore) {
         catalog.setDefaultDataStore(workspace, defaultStore);
     }
 
+    /** {@inheritDoc} */
     @Override
     public CoverageStoreInfo getCoverageStore(String id) {
         return catalog.getCoverageStore(id);
     }
 
+    /** {@inheritDoc} */
     @Override
     public CoverageStoreInfo getCoverageStoreByName(String name) {
         return catalog.getCoverageStoreByName(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public CoverageStoreInfo getCoverageStoreByName(String workspaceName, String name) {
         return catalog.getCoverageStoreByName(workspaceName, name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public CoverageStoreInfo getCoverageStoreByName(WorkspaceInfo workspace, String name) {
         return catalog.getCoverageStoreByName(workspace, name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<CoverageStoreInfo> getCoverageStoresByWorkspace(String workspaceName) {
         return catalog.getCoverageStoresByWorkspace(workspaceName);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<CoverageStoreInfo> getCoverageStoresByWorkspace(WorkspaceInfo workspace) {
         return catalog.getCoverageStoresByWorkspace(workspace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<CoverageStoreInfo> getCoverageStores() {
         return catalog.getCoverageStores();
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> T getResource(String id, Class<T> clazz) {
         return catalog.getResource(id, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> T getResourceByName(String ns, String name, Class<T> clazz) {
         return catalog.getResourceByName(ns, name, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> T getResourceByName(NamespaceInfo ns, String name, Class<T> clazz) {
         return catalog.getResourceByName(ns, name, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> T getResourceByName(Name name, Class<T> clazz) {
         return catalog.getResourceByName(name, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> T getResourceByName(String name, Class<T> clazz) {
         return catalog.getResourceByName(name, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void add(ResourceInfo resource) {
         catalog.add(resource);
     }
 
+    /** {@inheritDoc} */
     @Override
     public ValidationResult validate(ResourceInfo resource, boolean isNew) {
         return catalog.validate(resource, isNew);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(ResourceInfo resource) {
         catalog.remove(resource);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void save(ResourceInfo resource) {
         catalog.save(resource);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> T detach(T resource) {
         return catalog.detach(resource);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends StoreInfo> T detach(T store) {
         return catalog.detach(store);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> List<T> getResources(Class<T> clazz) {
         return catalog.getResources(clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> List<T> getResourcesByNamespace(NamespaceInfo namespace, Class<T> clazz) {
         return catalog.getResourcesByNamespace(namespace, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> List<T> getResourcesByNamespace(String namespace, Class<T> clazz) {
         return catalog.getResourcesByNamespace(namespace, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> T getResourceByStore(StoreInfo store, String name, Class<T> clazz) {
         return catalog.getResourceByStore(store, name, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> List<T> getResourcesByStore(StoreInfo store, Class<T> clazz) {
         return catalog.getResourcesByStore(store, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public FeatureTypeInfo getFeatureType(String id) {
         return catalog.getFeatureType(id);
     }
 
+    /** {@inheritDoc} */
     @Override
     public FeatureTypeInfo getFeatureTypeByName(String ns, String name) {
         return catalog.getFeatureTypeByName(ns, name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public FeatureTypeInfo getFeatureTypeByName(NamespaceInfo ns, String name) {
         return catalog.getFeatureTypeByName(ns, name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public FeatureTypeInfo getFeatureTypeByName(Name name) {
         return catalog.getFeatureTypeByName(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public FeatureTypeInfo getFeatureTypeByName(String name) {
         return catalog.getFeatureTypeByName(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<FeatureTypeInfo> getFeatureTypes() {
         return catalog.getFeatureTypes();
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<FeatureTypeInfo> getFeatureTypesByNamespace(NamespaceInfo namespace) {
         return catalog.getFeatureTypesByNamespace(namespace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public FeatureTypeInfo getFeatureTypeByDataStore(DataStoreInfo dataStore, String name) {
         return catalog.getFeatureTypeByDataStore(dataStore, name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<FeatureTypeInfo> getFeatureTypesByDataStore(DataStoreInfo store) {
         return catalog.getFeatureTypesByDataStore(store);
     }
 
+    /** {@inheritDoc} */
     @Override
     public CoverageInfo getCoverage(String id) {
         return catalog.getCoverage(id);
     }
 
+    /** {@inheritDoc} */
     @Override
     public CoverageInfo getCoverageByName(String ns, String name) {
         return catalog.getCoverageByName(ns, name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public CoverageInfo getCoverageByName(NamespaceInfo ns, String name) {
         return catalog.getCoverageByName(ns, name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public CoverageInfo getCoverageByName(Name name) {
         return catalog.getCoverageByName(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public CoverageInfo getCoverageByName(String name) {
         return catalog.getCoverageByName(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<CoverageInfo> getCoverages() {
         return catalog.getCoverages();
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<CoverageInfo> getCoveragesByNamespace(NamespaceInfo namespace) {
         return catalog.getCoveragesByNamespace(namespace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public CoverageInfo getCoverageByCoverageStore(CoverageStoreInfo coverageStore, String name) {
         return catalog.getCoverageByCoverageStore(coverageStore, name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<CoverageInfo> getCoveragesByCoverageStore(CoverageStoreInfo store) {
         return catalog.getCoveragesByCoverageStore(store);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void add(LayerInfo layer) {
         catalog.add(layer);
     }
 
+    /** {@inheritDoc} */
     @Override
     public ValidationResult validate(LayerInfo layer, boolean isNew) {
         return catalog.validate(layer, isNew);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(LayerInfo layer) {
         catalog.remove(layer);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void save(LayerInfo layer) {
         catalog.save(layer);
     }
 
+    /** {@inheritDoc} */
     @Override
     public LayerInfo detach(LayerInfo layer) {
         return catalog.detach(layer);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<CoverageInfo> getCoveragesByStore(CoverageStoreInfo store) {
         return catalog.getCoveragesByStore(store);
     }
 
+    /** {@inheritDoc} */
     @Override
     public LayerInfo getLayer(String id) {
         return catalog.getLayer(id);
     }
 
+    /** {@inheritDoc} */
     @Override
     public LayerInfo getLayerByName(String name) {
         return catalog.getLayerByName(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public LayerInfo getLayerByName(Name name) {
         return catalog.getLayerByName(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<LayerInfo> getLayers() {
         return catalog.getLayers();
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<LayerInfo> getLayers(ResourceInfo resource) {
         return catalog.getLayers(resource);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<LayerInfo> getLayers(StyleInfo style) {
         return catalog.getLayers(style);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void add(MapInfo map) {
         catalog.add(map);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(MapInfo map) {
         catalog.remove(map);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void save(MapInfo map) {
         catalog.save(map);
     }
 
+    /** {@inheritDoc} */
     @Override
     public MapInfo detach(MapInfo map) {
         return catalog.detach(map);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<MapInfo> getMaps() {
         return catalog.getMaps();
     }
 
+    /** {@inheritDoc} */
     @Override
     public MapInfo getMap(String id) {
         return catalog.getMap(id);
     }
 
+    /** {@inheritDoc} */
     @Override
     public MapInfo getMapByName(String name) {
         return catalog.getMapByName(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void add(LayerGroupInfo layerGroup) {
         catalog.add(layerGroup);
     }
 
+    /** {@inheritDoc} */
     @Override
     public ValidationResult validate(LayerGroupInfo layerGroup, boolean isNew) {
         return catalog.validate(layerGroup, isNew);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(LayerGroupInfo layerGroup) {
         catalog.remove(layerGroup);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void save(LayerGroupInfo layerGroup) {
         catalog.save(layerGroup);
     }
 
+    /** {@inheritDoc} */
     @Override
     public LayerGroupInfo detach(LayerGroupInfo layerGroup) {
         return catalog.detach(layerGroup);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<LayerGroupInfo> getLayerGroups() {
         return catalog.getLayerGroups();
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<LayerGroupInfo> getLayerGroupsByWorkspace(String workspaceName) {
         return catalog.getLayerGroupsByWorkspace(workspaceName);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<LayerGroupInfo> getLayerGroupsByWorkspace(WorkspaceInfo workspace) {
         return catalog.getLayerGroupsByWorkspace(workspace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public LayerGroupInfo getLayerGroup(String id) {
         return catalog.getLayerGroup(id);
     }
 
+    /** {@inheritDoc} */
     @Override
     public LayerGroupInfo getLayerGroupByName(String name) {
         return catalog.getLayerGroupByName(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public LayerGroupInfo getLayerGroupByName(String workspaceName, String name) {
         return catalog.getLayerGroupByName(workspaceName, name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public LayerGroupInfo getLayerGroupByName(WorkspaceInfo workspace, String name) {
         return catalog.getLayerGroupByName(workspace, name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void add(StyleInfo style) {
         catalog.add(style);
     }
 
+    /** {@inheritDoc} */
     @Override
     public ValidationResult validate(StyleInfo style, boolean isNew) {
         return catalog.validate(style, isNew);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(StyleInfo style) {
         catalog.remove(style);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void save(StyleInfo style) {
         catalog.save(style);
     }
 
+    /** {@inheritDoc} */
     @Override
     public StyleInfo detach(StyleInfo style) {
         return catalog.detach(style);
     }
 
+    /** {@inheritDoc} */
     @Override
     public StyleInfo getStyle(String id) {
         return catalog.getStyle(id);
     }
 
+    /** {@inheritDoc} */
     @Override
     public StyleInfo getStyleByName(String workspaceName, String name) {
         return catalog.getStyleByName(workspaceName, name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public StyleInfo getStyleByName(WorkspaceInfo workspace, String name) {
         return catalog.getStyleByName(workspace, name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public StyleInfo getStyleByName(String name) {
         return catalog.getStyleByName(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<StyleInfo> getStyles() {
         return catalog.getStyles();
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<StyleInfo> getStylesByWorkspace(String workspaceName) {
         return catalog.getStylesByWorkspace(workspaceName);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<StyleInfo> getStylesByWorkspace(WorkspaceInfo workspace) {
         return catalog.getStylesByWorkspace(workspace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void add(NamespaceInfo namespace) {
         catalog.add(namespace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public ValidationResult validate(NamespaceInfo namespace, boolean isNew) {
         return catalog.validate(namespace, isNew);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(NamespaceInfo namespace) {
         catalog.remove(namespace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void save(NamespaceInfo namespace) {
         catalog.save(namespace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public NamespaceInfo detach(NamespaceInfo namespace) {
         return catalog.detach(namespace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public NamespaceInfo getNamespace(String id) {
         return catalog.getNamespace(id);
     }
 
+    /** {@inheritDoc} */
     @Override
     public NamespaceInfo getNamespaceByPrefix(String prefix) {
         return catalog.getNamespaceByPrefix(prefix);
     }
 
+    /** {@inheritDoc} */
     @Override
     public NamespaceInfo getNamespaceByURI(String uri) {
         return catalog.getNamespaceByURI(uri);
     }
 
+    /** {@inheritDoc} */
     @Override
     public NamespaceInfo getDefaultNamespace() {
         return catalog.getDefaultNamespace();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setDefaultNamespace(NamespaceInfo defaultNamespace) {
         catalog.setDefaultNamespace(defaultNamespace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<NamespaceInfo> getNamespaces() {
         return catalog.getNamespaces();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void add(WorkspaceInfo workspace) {
         catalog.add(workspace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public ValidationResult validate(WorkspaceInfo workspace, boolean isNew) {
         return catalog.validate(workspace, isNew);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(WorkspaceInfo workspace) {
         catalog.remove(workspace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void save(WorkspaceInfo workspace) {
         catalog.save(workspace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public WorkspaceInfo detach(WorkspaceInfo workspace) {
         return catalog.detach(workspace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public WorkspaceInfo getDefaultWorkspace() {
         return catalog.getDefaultWorkspace();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setDefaultWorkspace(WorkspaceInfo workspace) {
         catalog.setDefaultWorkspace(workspace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<WorkspaceInfo> getWorkspaces() {
         return catalog.getWorkspaces();
     }
 
+    /** {@inheritDoc} */
     @Override
     public WorkspaceInfo getWorkspace(String id) {
         return catalog.getWorkspace(id);
     }
 
+    /** {@inheritDoc} */
     @Override
     public WorkspaceInfo getWorkspaceByName(String name) {
         return catalog.getWorkspaceByName(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Collection<CatalogListener> getListeners() {
         return catalog.getListeners();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void addListener(CatalogListener listener) {
         catalog.addListener(listener);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void removeListener(CatalogListener listener) {
         catalog.removeListener(listener);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void fireAdded(CatalogInfo object) {
         catalog.fireAdded(object);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void fireModified(
             CatalogInfo object, List<String> propertyNames, List<Object> oldValues, List<Object> newValues) {
         catalog.fireModified(object, propertyNames, oldValues, newValues);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void firePostModified(
             CatalogInfo object, List<String> propertyNames, List<Object> oldValues, List<Object> newValues) {
         catalog.firePostModified(object, propertyNames, oldValues, newValues);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void fireRemoved(CatalogInfo object) {
         catalog.fireRemoved(object);
     }
 
+    /** {@inheritDoc} */
     @Override
     public ResourcePool getResourcePool() {
         return catalog.getResourcePool();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setResourcePool(ResourcePool resourcePool) {
         catalog.setResourcePool(resourcePool);
     }
 
+    /** {@inheritDoc} */
     @Override
     public GeoServerResourceLoader getResourceLoader() {
         return catalog.getResourceLoader();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setResourceLoader(GeoServerResourceLoader resourceLoader) {
         catalog.setResourceLoader(resourceLoader);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void dispose() {
         catalog.dispose();
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends CatalogInfo> int count(Class<T> of, Filter filter) {
         return catalog.count(of, filter);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends CatalogInfo> T get(Class<T> type, Filter filter) throws IllegalArgumentException {
         return catalog.get(type, filter);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends CatalogInfo> CloseableIterator<T> list(Class<T> of, Filter filter) {
         return catalog.list(of, filter);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends CatalogInfo> CloseableIterator<T> list(
             Class<T> of, Filter filter, Integer offset, Integer count, SortBy sortBy) {
         return catalog.list(of, filter, offset, count, sortBy);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void removeListeners(Class<? extends CatalogListener> listenerClass) {
         catalog.removeListeners(listenerClass);
     }
 
+    /** {@inheritDoc} */
     @Override
     public CatalogCapabilities getCatalogCapabilities() {
         return catalog.getCatalogCapabilities();

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingCatalogFacade.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingCatalogFacade.java
@@ -24,23 +24,50 @@ import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.sort.SortBy;
 
 /**
- * {@link CatalogFacade} which forwards all its method calls to another {@code CatalogFacade} aiding
- * in implementing a decorator.
+ * A decorator for {@link CatalogFacade} that forwards all method calls to an underlying facade instance.
  *
- * <p>Subclasses should override one or more methods to modify the behavior of the backing facade as
- * needed.
+ * <p>This class facilitates the creation of decorators by delegating all operations to a subject
+ * {@link CatalogFacade}, allowing subclasses to override specific methods to customize behavior (e.g.,
+ * adding logging, caching, or validation). It serves as a foundation for extending facade functionality
+ * without altering the core implementation.
+ *
+ * <p>Subclasses should override one or more methods to modify the behavior of the backing facade as needed.
+ *
+ * <p>Example usage:
+ * <pre>
+ * CatalogFacade baseFacade = ...;
+ * ForwardingCatalogFacade decorator = new ForwardingCatalogFacade(baseFacade) {
+ *     &#64;Override
+ *     public StoreInfo add(StoreInfo store) {
+ *         // Custom logic before forwarding
+ *         return super.add(store);
+ *     }
+ * };
+ * </pre>
+ *
+ * @since 1.0
+ * @see CatalogFacade
  */
 public class ForwardingCatalogFacade implements CatalogFacade {
 
     // wrapped catalog facade
     protected final CatalogFacade facade;
 
+    /**
+     * Constructs a forwarding facade wrapping the provided subject.
+     *
+     * @param facade The underlying {@link CatalogFacade} to forward calls to; may be null (behavior depends on subclass).
+     */
     public ForwardingCatalogFacade(CatalogFacade facade) {
         this.facade = facade;
     }
 
     /**
-     * @return this decorator's subject
+     * Returns this decorator's subject facade.
+     *
+     * <p>Provides access to the underlying {@link CatalogFacade} instance being decorated.
+     *
+     * @return The subject {@link CatalogFacade}; may be null if not set.
      */
     public CatalogFacade getSubject() {
         // if you're wondering, I refuse to derive from org.geotools.util.decorate.AbstractDecorator
@@ -48,411 +75,493 @@ public class ForwardingCatalogFacade implements CatalogFacade {
         return facade;
     }
 
+    /** {@inheritDoc} */
     @Override
     public Catalog getCatalog() {
         return facade.getCatalog();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setCatalog(Catalog catalog) {
         facade.setCatalog(catalog);
     }
 
+    /** {@inheritDoc} */
     @Override
     public StoreInfo add(StoreInfo store) {
         return facade.add(store);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(StoreInfo store) {
         facade.remove(store);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void save(StoreInfo store) {
         facade.save(store);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends StoreInfo> T detach(T store) {
         return facade.detach(store);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends StoreInfo> T getStore(String id, Class<T> clazz) {
         return facade.getStore(id, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends StoreInfo> T getStoreByName(WorkspaceInfo workspace, String name, Class<T> clazz) {
         return facade.getStoreByName(workspace, name, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends StoreInfo> List<T> getStoresByWorkspace(WorkspaceInfo workspace, Class<T> clazz) {
         return facade.getStoresByWorkspace(workspace, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends StoreInfo> List<T> getStores(Class<T> clazz) {
         return facade.getStores(clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public DataStoreInfo getDefaultDataStore(WorkspaceInfo workspace) {
         return facade.getDefaultDataStore(workspace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setDefaultDataStore(WorkspaceInfo workspace, DataStoreInfo store) {
         facade.setDefaultDataStore(workspace, store);
     }
 
+    /** {@inheritDoc} */
     @Override
     public ResourceInfo add(ResourceInfo resource) {
         return facade.add(resource);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(ResourceInfo resource) {
         facade.remove(resource);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void save(ResourceInfo resource) {
         facade.save(resource);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> T detach(T resource) {
         return facade.detach(resource);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> T getResource(String id, Class<T> clazz) {
         return facade.getResource(id, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> T getResourceByName(NamespaceInfo namespace, String name, Class<T> clazz) {
         return facade.getResourceByName(namespace, name, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> List<T> getResources(Class<T> clazz) {
         return facade.getResources(clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> List<T> getResourcesByNamespace(NamespaceInfo namespace, Class<T> clazz) {
         return facade.getResourcesByNamespace(namespace, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> T getResourceByStore(StoreInfo store, String name, Class<T> clazz) {
         return facade.getResourceByStore(store, name, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> List<T> getResourcesByStore(StoreInfo store, Class<T> clazz) {
         return facade.getResourcesByStore(store, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public LayerInfo add(LayerInfo layer) {
         return facade.add(layer);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(LayerInfo layer) {
         facade.remove(layer);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void save(LayerInfo layer) {
         facade.save(layer);
     }
 
+    /** {@inheritDoc} */
     @Override
     public LayerInfo detach(LayerInfo layer) {
         return facade.detach(layer);
     }
 
+    /** {@inheritDoc} */
     @Override
     public LayerInfo getLayer(String id) {
         return facade.getLayer(id);
     }
 
+    /** {@inheritDoc} */
     @Override
     public LayerInfo getLayerByName(String name) {
         return facade.getLayerByName(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<LayerInfo> getLayers(ResourceInfo resource) {
         return facade.getLayers(resource);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<LayerInfo> getLayers(StyleInfo style) {
         return facade.getLayers(style);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<LayerInfo> getLayers() {
         return facade.getLayers();
     }
 
+    /** {@inheritDoc} */
     @Override
     public MapInfo add(MapInfo map) {
         return facade.add(map);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(MapInfo map) {
         facade.remove(map);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void save(MapInfo map) {
         facade.save(map);
     }
 
+    /** {@inheritDoc} */
     @Override
     public MapInfo detach(MapInfo map) {
         return facade.detach(map);
     }
 
+    /** {@inheritDoc} */
     @Override
     public MapInfo getMap(String id) {
         return facade.getMap(id);
     }
 
+    /** {@inheritDoc} */
     @Override
     public MapInfo getMapByName(String name) {
         return facade.getMapByName(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<MapInfo> getMaps() {
         return facade.getMaps();
     }
 
+    /** {@inheritDoc} */
     @Override
     public LayerGroupInfo add(LayerGroupInfo layerGroup) {
         return facade.add(layerGroup);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(LayerGroupInfo layerGroup) {
         facade.remove(layerGroup);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void save(LayerGroupInfo layerGroup) {
         facade.save(layerGroup);
     }
 
+    /** {@inheritDoc} */
     @Override
     public LayerGroupInfo detach(LayerGroupInfo layerGroup) {
         return facade.detach(layerGroup);
     }
 
+    /** {@inheritDoc} */
     @Override
     public LayerGroupInfo getLayerGroup(String id) {
         return facade.getLayerGroup(id);
     }
 
+    /** {@inheritDoc} */
     @Override
     public LayerGroupInfo getLayerGroupByName(String name) {
         return facade.getLayerGroupByName(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public LayerGroupInfo getLayerGroupByName(WorkspaceInfo workspace, String name) {
         return facade.getLayerGroupByName(workspace, name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<LayerGroupInfo> getLayerGroups() {
         return facade.getLayerGroups();
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<LayerGroupInfo> getLayerGroupsByWorkspace(WorkspaceInfo workspace) {
         return facade.getLayerGroupsByWorkspace(workspace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public NamespaceInfo add(NamespaceInfo namespace) {
         return facade.add(namespace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(NamespaceInfo namespace) {
         facade.remove(namespace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void save(NamespaceInfo namespace) {
         facade.save(namespace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public NamespaceInfo detach(NamespaceInfo namespace) {
         return facade.detach(namespace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public NamespaceInfo getDefaultNamespace() {
         return facade.getDefaultNamespace();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setDefaultNamespace(NamespaceInfo defaultNamespace) {
         facade.setDefaultNamespace(defaultNamespace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public NamespaceInfo getNamespace(String id) {
         return facade.getNamespace(id);
     }
 
+    /** {@inheritDoc} */
     @Override
     public NamespaceInfo getNamespaceByPrefix(String prefix) {
         return facade.getNamespaceByPrefix(prefix);
     }
 
+    /** {@inheritDoc} */
     @Override
     public NamespaceInfo getNamespaceByURI(String uri) {
         return facade.getNamespaceByURI(uri);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<NamespaceInfo> getNamespacesByURI(String uri) {
         return facade.getNamespacesByURI(uri);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<NamespaceInfo> getNamespaces() {
         return facade.getNamespaces();
     }
 
+    /** {@inheritDoc} */
     @Override
     public WorkspaceInfo add(WorkspaceInfo workspace) {
         return facade.add(workspace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(WorkspaceInfo workspace) {
         facade.remove(workspace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void save(WorkspaceInfo workspace) {
         facade.save(workspace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public WorkspaceInfo detach(WorkspaceInfo workspace) {
         return facade.detach(workspace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public WorkspaceInfo getDefaultWorkspace() {
         return facade.getDefaultWorkspace();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setDefaultWorkspace(WorkspaceInfo workspace) {
         facade.setDefaultWorkspace(workspace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public WorkspaceInfo getWorkspace(String id) {
         return facade.getWorkspace(id);
     }
 
+    /** {@inheritDoc} */
     @Override
     public WorkspaceInfo getWorkspaceByName(String name) {
         return facade.getWorkspaceByName(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<WorkspaceInfo> getWorkspaces() {
         return facade.getWorkspaces();
     }
 
+    /** {@inheritDoc} */
     @Override
     public StyleInfo add(StyleInfo style) {
         return facade.add(style);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(StyleInfo style) {
         facade.remove(style);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void save(StyleInfo style) {
         facade.save(style);
     }
 
+    /** {@inheritDoc} */
     @Override
     public StyleInfo detach(StyleInfo style) {
         return facade.detach(style);
     }
 
+    /** {@inheritDoc} */
     @Override
     public StyleInfo getStyle(String id) {
         return facade.getStyle(id);
     }
 
+    /** {@inheritDoc} */
     @Override
     public StyleInfo getStyleByName(String name) {
         return facade.getStyleByName(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public StyleInfo getStyleByName(WorkspaceInfo workspace, String name) {
         return facade.getStyleByName(workspace, name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<StyleInfo> getStyles() {
         return facade.getStyles();
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<StyleInfo> getStylesByWorkspace(WorkspaceInfo workspace) {
         return facade.getStylesByWorkspace(workspace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void dispose() {
         facade.dispose();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void resolve() {
         facade.resolve();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void syncTo(CatalogFacade other) {
         facade.syncTo(other);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends CatalogInfo> int count(Class<T> of, Filter filter) {
         return facade.count(of, filter);
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean canSort(Class<? extends CatalogInfo> type, String propertyName) {
         return facade.canSort(type, propertyName);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends CatalogInfo> CloseableIterator<T> list(
             Class<T> of,
@@ -463,6 +572,7 @@ public class ForwardingCatalogFacade implements CatalogFacade {
         return facade.list(of, filter, offset, count, sortOrder);
     }
 
+    /** {@inheritDoc} */
     @Override
     public CatalogCapabilities getCatalogCapabilities() {
         return facade.getCatalogCapabilities();

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingCatalogRepository.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingCatalogRepository.java
@@ -13,70 +13,113 @@ import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.catalog.plugin.Query;
 import org.geotools.api.filter.Filter;
 
+/**
+ * An abstract decorator for {@link CatalogInfoRepository} that forwards all method calls to an underlying repository.
+ *
+ * <p>This class simplifies the creation of repository decorators by delegating all operations to a subject
+ * {@link CatalogInfoRepository}, enabling subclasses to override specific methods to customize behavior
+ * (e.g., adding logging, validation, or caching). It’s designed for type-specific repositories managing
+ * {@link CatalogInfo} subtypes.
+ *
+ * <p>Example usage:
+ * <pre>
+ * CatalogInfoRepository&lt;StoreInfo&gt; baseRepo = ...;
+ * ForwardingCatalogRepository&lt;StoreInfo, CatalogInfoRepository&lt;StoreInfo&gt;&gt; decorator =
+ *     new ForwardingCatalogRepository&lt;&gt;(baseRepo) {
+ *         &#64;Override
+ *         public void add(StoreInfo value) {
+ *             // Custom logic before forwarding
+ *             super.add(value);
+ *         }
+ *     };
+ * </pre>
+ *
+ * @param <I> The type of {@link CatalogInfo} managed by this repository.
+ * @param <S> The specific {@link CatalogInfoRepository} subtype being decorated.
+ * @since 1.0
+ * @see CatalogInfoRepository
+ */
 public abstract class ForwardingCatalogRepository<I extends CatalogInfo, S extends CatalogInfoRepository<I>>
         implements CatalogInfoRepository<I> {
 
     protected S subject;
 
+    /**
+     * Constructs a forwarding repository wrapping the provided subject.
+     *
+     * @param subject The underlying {@link CatalogInfoRepository} to forward calls to; may be null (behavior depends on subclass).
+     */
     protected ForwardingCatalogRepository(S subject) {
         this.subject = subject;
     }
 
+    /** {@inheritDoc} */
     @Override
     public Class<I> getContentType() {
         return subject.getContentType();
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean canSortBy(@NonNull String propertyName) {
         return subject.canSortBy(propertyName);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void add(I value) {
         subject.add(value);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(I value) {
         subject.remove(value);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends I> T update(T value, Patch patch) {
         return subject.update(value, patch);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void dispose() {
         subject.dispose();
     }
 
+    /** {@inheritDoc} */
     @Override
     public Stream<I> findAll() {
         return subject.findAll();
     }
 
+    /** {@inheritDoc} */
     @Override
     public <U extends I> Stream<U> findAll(Query<U> query) {
         return subject.findAll(query);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <U extends I> long count(final Class<U> of, final Filter filter) {
         return subject.count(of, filter);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <U extends I> Optional<U> findById(String id, Class<U> clazz) {
         return subject.findById(id, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <U extends I> Optional<U> findFirstByName(@NonNull String name, Class<U> clazz) {
         return subject.findFirstByName(name, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void syncTo(CatalogInfoRepository<I> target) {
         subject.syncTo(target);

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingExtendedCatalogFacade.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingExtendedCatalogFacade.java
@@ -6,7 +6,6 @@ package org.geoserver.catalog.plugin.forwarding;
 
 import java.util.stream.Stream;
 import lombok.NonNull;
-import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
@@ -20,112 +19,165 @@ import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
 import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.catalog.plugin.Query;
 
-/** Adapts a regular {@link CatalogFacade} to a {@link ExtendedCatalogFacade} */
+/**
+ * A decorator that implements the forwarding pattern for an {@link ExtendedCatalogFacade}.
+ *
+ * <p>This class extends {@link ForwardingCatalogFacade} to wrap an {@link ExtendedCatalogFacade} subject,
+ * delegating all operations to it while providing the additional functionality of `ExtendedCatalogFacade`
+ * (e.g., stream-based queries, patch updates). Subclasses can override methods to customize behavior,
+ * such as adding logging, validation, or caching, without altering the core facade implementation.
+ *
+ * <p>Example usage:
+ * <pre>
+ * ExtendedCatalogFacade baseFacade = ...;
+ * ForwardingExtendedCatalogFacade decorator = new ForwardingExtendedCatalogFacade(baseFacade) {
+ *     &#64;Override
+ *     public &lt;T extends CatalogInfo&gt; T add(@NonNull T info) {
+ *         // Custom logic before forwarding
+ *         return super.add(info);
+ *     }
+ * };
+ * </pre>
+ *
+ * @since 1.0
+ * @see ExtendedCatalogFacade
+ * @see ForwardingCatalogFacade
+ */
 public class ForwardingExtendedCatalogFacade extends ForwardingCatalogFacade implements ExtendedCatalogFacade {
 
+    /**
+     * Constructs a forwarding facade wrapping an {@link ExtendedCatalogFacade} subject.
+     *
+     * @param facade The underlying {@link ExtendedCatalogFacade} to forward calls to; may be null (behavior depends on subclass).
+     */
     public ForwardingExtendedCatalogFacade(ExtendedCatalogFacade facade) {
         super(facade);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <I extends CatalogInfo> I update(final I info, final Patch patch) {
         return asExtendedFacade().update(info, patch);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends CatalogInfo> Stream<T> query(Query<T> query) {
         return asExtendedFacade().query(query);
     }
 
+    /**
+     * Casts the subject facade to {@link ExtendedCatalogFacade} for accessing extended methods.
+     *
+     * @return The subject as an {@link ExtendedCatalogFacade}; may be null if not set.
+     */
     protected ExtendedCatalogFacade asExtendedFacade() {
         return (ExtendedCatalogFacade) super.facade;
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends CatalogInfo> T add(@NonNull T info) {
         return asExtendedFacade().add(info);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(@NonNull CatalogInfo info) {
         asExtendedFacade().remove(info);
     }
 
+    /** {@inheritDoc} */
     @Override
     public WorkspaceInfo add(WorkspaceInfo info) {
         return (WorkspaceInfo) add((CatalogInfo) info);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(WorkspaceInfo info) {
         remove((CatalogInfo) info);
     }
 
+    /** {@inheritDoc} */
     @Override
     public NamespaceInfo add(NamespaceInfo info) {
         return (NamespaceInfo) add((CatalogInfo) info);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(NamespaceInfo info) {
         remove((CatalogInfo) info);
     }
 
+    /** {@inheritDoc} */
     @Override
     public StoreInfo add(StoreInfo info) {
         return (StoreInfo) add((CatalogInfo) info);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(StoreInfo info) {
         remove((CatalogInfo) info);
     }
 
+    /** {@inheritDoc} */
     @Override
     public ResourceInfo add(ResourceInfo info) {
         return (ResourceInfo) add((CatalogInfo) info);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(ResourceInfo info) {
         remove((CatalogInfo) info);
     }
 
+    /** {@inheritDoc} */
     @Override
     public LayerInfo add(LayerInfo info) {
         return (LayerInfo) add((CatalogInfo) info);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(LayerInfo info) {
         remove((CatalogInfo) info);
     }
 
+    /** {@inheritDoc} */
     @Override
     public LayerGroupInfo add(LayerGroupInfo info) {
         return (LayerGroupInfo) add((CatalogInfo) info);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(LayerGroupInfo info) {
         remove((CatalogInfo) info);
     }
 
+    /** {@inheritDoc} */
     @Override
     public StyleInfo add(StyleInfo info) {
         return (StyleInfo) add((CatalogInfo) info);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(StyleInfo info) {
         remove((CatalogInfo) info);
     }
 
+    /** {@inheritDoc} */
     @Override
     public MapInfo add(MapInfo info) {
         return (MapInfo) add((CatalogInfo) info);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void remove(MapInfo info) {
         remove((CatalogInfo) info);

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingLayerGroupRepository.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingLayerGroupRepository.java
@@ -11,28 +11,49 @@ import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.LayerGroupRepository;
 
+/**
+ * A decorator for {@link LayerGroupRepository} that forwards all method calls to an underlying repository.
+ *
+ * <p>This class extends {@link ForwardingCatalogRepository} to wrap a {@link LayerGroupRepository} subject,
+ * delegating all operations related to {@link LayerGroupInfo} management. It enables subclasses to override
+ * specific methods to customize behavior (e.g., adding validation or logging) without modifying the core
+ * repository implementation.
+ *
+ * @since 1.0
+ * @see LayerGroupRepository
+ * @see ForwardingCatalogRepository
+ */
 public class ForwardingLayerGroupRepository extends ForwardingCatalogRepository<LayerGroupInfo, LayerGroupRepository>
         implements LayerGroupRepository {
 
+    /**
+     * Constructs a forwarding layer group repository wrapping the provided subject.
+     *
+     * @param subject The underlying {@link LayerGroupRepository} to forward calls to; may be null (behavior depends on subclass).
+     */
     public ForwardingLayerGroupRepository(LayerGroupRepository subject) {
         super(subject);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Stream<LayerGroupInfo> findAllByWorkspaceIsNull() {
         return subject.findAllByWorkspaceIsNull();
     }
 
+    /** {@inheritDoc} */
     @Override
     public Stream<LayerGroupInfo> findAllByWorkspace(WorkspaceInfo workspace) {
         return subject.findAllByWorkspace(workspace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Optional<LayerGroupInfo> findByNameAndWorkspaceIsNull(@NonNull String name) {
         return subject.findByNameAndWorkspaceIsNull(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Optional<LayerGroupInfo> findByNameAndWorkspace(String name, WorkspaceInfo workspace) {
         return subject.findByNameAndWorkspace(name, workspace);

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingLayerRepository.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingLayerRepository.java
@@ -11,23 +11,43 @@ import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.LayerRepository;
 
+/**
+ * A decorator for {@link LayerRepository} that forwards all method calls to an underlying repository.
+ *
+ * <p>This class extends {@link ForwardingCatalogRepository} to wrap a {@link LayerRepository} subject,
+ * delegating all operations related to {@link LayerInfo} management. It enables subclasses to override
+ * specific methods to customize behavior (e.g., adding validation or logging) without modifying the core
+ * repository implementation.
+ *
+ * @since 1.0
+ * @see LayerRepository
+ * @see ForwardingCatalogRepository
+ */
 public class ForwardingLayerRepository extends ForwardingCatalogRepository<LayerInfo, LayerRepository>
         implements LayerRepository {
 
+    /**
+     * Constructs a forwarding layer repository wrapping the provided subject.
+     *
+     * @param subject The underlying {@link LayerRepository} to forward calls to; may be null (behavior depends on subclass).
+     */
     public ForwardingLayerRepository(LayerRepository subject) {
         super(subject);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Optional<LayerInfo> findOneByName(String name) {
         return subject.findOneByName(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Stream<LayerInfo> findAllByDefaultStyleOrStyles(StyleInfo style) {
         return subject.findAllByDefaultStyleOrStyles(style);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Stream<LayerInfo> findAllByResource(ResourceInfo resource) {
         return subject.findAllByResource(resource);

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingMapRepository.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingMapRepository.java
@@ -7,6 +7,11 @@ package org.geoserver.catalog.plugin.forwarding;
 import org.geoserver.catalog.MapInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.MapRepository;
 
+/**
+ * A decorator for {@link MapRepository} that forwards all method calls to an underlying repository.
+ *
+ * @since 1.0
+ */
 public class ForwardingMapRepository extends ForwardingCatalogRepository<MapInfo, MapRepository>
         implements MapRepository {
 

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingNamespaceRepository.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingNamespaceRepository.java
@@ -9,33 +9,55 @@ import java.util.stream.Stream;
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.NamespaceRepository;
 
+/**
+ * A decorator for {@link NamespaceRepository} that forwards all method calls to an underlying repository.
+ *
+ * <p>This class extends {@link ForwardingCatalogRepository} to wrap a {@link NamespaceRepository} subject,
+ * delegating all operations related to {@link NamespaceInfo} management. It enables subclasses to override
+ * specific methods to customize behavior (e.g., adding validation or logging) without modifying the core
+ * repository implementation.
+ *
+ * @since 1.0
+ * @see NamespaceRepository
+ * @see ForwardingCatalogRepository
+ */
 public class ForwardingNamespaceRepository extends ForwardingCatalogRepository<NamespaceInfo, NamespaceRepository>
         implements NamespaceRepository {
 
+    /**
+     * Constructs a forwarding namespace repository wrapping the provided subject.
+     *
+     * @param subject The underlying {@link NamespaceRepository} to forward calls to; may be null (behavior depends on subclass).
+     */
     public ForwardingNamespaceRepository(NamespaceRepository subject) {
         super(subject);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setDefaultNamespace(NamespaceInfo namespace) {
         subject.setDefaultNamespace(namespace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Optional<NamespaceInfo> getDefaultNamespace() {
         return subject.getDefaultNamespace();
     }
 
+    /** {@inheritDoc} */
     @Override
     public Optional<NamespaceInfo> findOneByURI(String uri) {
         return subject.findOneByURI(uri);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Stream<NamespaceInfo> findAllByURI(String uri) {
         return subject.findAllByURI(uri);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void unsetDefaultNamespace() {
         subject.unsetDefaultNamespace();

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingRepositoryCatalogFacade.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingRepositoryCatalogFacade.java
@@ -1,6 +1,6 @@
 /*
- * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
- * GPL 2.0 license, available at the root application directory.
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root application directory.
  */
 package org.geoserver.catalog.plugin.forwarding;
 
@@ -18,109 +18,300 @@ import org.geoserver.catalog.plugin.CatalogInfoRepository.WorkspaceRepository;
 import org.geoserver.catalog.plugin.RepositoryCatalogFacade;
 
 /**
- * {@link CatalogFacade} which forwards all its method calls to another {@code CatalogFacade} aiding
- * in implementing a decorator.
+ * A decorator implementation of {@link RepositoryCatalogFacade} that forwards all method calls to an underlying
+ * {@link RepositoryCatalogFacade} instance.
  *
- * <p>Subclasses should override one or more methods to modify the behavior of the backing facade as
- * needed.
+ * <p>This class extends {@link ForwardingExtendedCatalogFacade} to provide a base for creating decorators
+ * that modify or extend the behavior of an existing {@link RepositoryCatalogFacade}. It implements the full
+ * {@link RepositoryCatalogFacade} interface, including repository management methods, by delegating to the
+ * wrapped facade. Subclasses can override specific methods to customize functionality (e.g., adding logging,
+ * caching, or isolation) while retaining the default forwarding behavior for others.
+ *
+ * <p>Key characteristics:
+ * <ul>
+ *   <li><strong>Forwarding:</strong> All operations (e.g., {@link #get(String)}, {@link #query(Query)},
+ *       repository setters/getters) are passed to the underlying facade.</li>
+ *   <li><strong>Decorator Pattern:</strong> Facilitates extending facade behavior without altering the
+ *       original implementation.</li>
+ *   <li><strong>Repository Support:</strong> Implements {@link CatalogInfoRepositoryHolder} methods for
+ *       managing type-specific repositories.</li>
+ * </ul>
+ *
+ * <p>Use this class as a starting point when you need to enhance a {@link RepositoryCatalogFacade} with
+ * additional logic while preserving its core functionality.
+ *
+ * @since 1.0
+ * @see RepositoryCatalogFacade
+ * @see ForwardingExtendedCatalogFacade
+ * @see CatalogFacade
  */
 public class ForwardingRepositoryCatalogFacade extends ForwardingExtendedCatalogFacade
         implements RepositoryCatalogFacade {
 
+    /**
+     * Constructs a new forwarding facade that delegates to the provided {@link RepositoryCatalogFacade}.
+     *
+     * @param facade The underlying {@link RepositoryCatalogFacade} to forward calls to; must not be null.
+     * @throws NullPointerException if {@code facade} is null.
+     */
     public ForwardingRepositoryCatalogFacade(RepositoryCatalogFacade facade) {
         super(facade);
     }
 
+    /**
+     * Sets the repository for managing {@link NamespaceInfo} objects by delegating to the underlying facade.
+     *
+     * @param namespaces The {@link NamespaceRepository} to set; must not be null.
+     * @throws NullPointerException if {@code namespaces} is null.
+     * @see RepositoryCatalogFacade#setNamespaceRepository(NamespaceRepository)
+     */
     @Override
     public void setNamespaceRepository(NamespaceRepository namespaces) {
         asExtendedFacade().setNamespaceRepository(namespaces);
     }
 
+    /**
+     * Sets the repository for managing {@link WorkspaceInfo} objects by delegating to the underlying facade.
+     *
+     * @param workspaces The {@link WorkspaceRepository} to set; must not be null.
+     * @throws NullPointerException if {@code workspaces} is null.
+     * @see RepositoryCatalogFacade#setWorkspaceRepository(WorkspaceRepository)
+     */
     @Override
     public void setWorkspaceRepository(WorkspaceRepository workspaces) {
         asExtendedFacade().setWorkspaceRepository(workspaces);
     }
 
+    /**
+     * Sets the repository for managing {@link StoreInfo} objects by delegating to the underlying facade.
+     *
+     * @param stores The {@link StoreRepository} to set; must not be null.
+     * @throws NullPointerException if {@code stores} is null.
+     * @see RepositoryCatalogFacade#setStoreRepository(StoreRepository)
+     */
     @Override
     public void setStoreRepository(StoreRepository stores) {
         asExtendedFacade().setStoreRepository(stores);
     }
 
+    /**
+     * Sets the repository for managing {@link ResourceInfo} objects by delegating to the underlying facade.
+     *
+     * @param resources The {@link ResourceRepository} to set; must not be null.
+     * @throws NullPointerException if {@code resources} is null.
+     * @see RepositoryCatalogFacade#setResourceRepository(ResourceRepository)
+     */
     @Override
     public void setResourceRepository(ResourceRepository resources) {
         asExtendedFacade().setResourceRepository(resources);
     }
 
+    /**
+     * Sets the repository for managing {@link LayerInfo} objects by delegating to the underlying facade.
+     *
+     * @param layers The {@link LayerRepository} to set; must not be null.
+     * @throws NullPointerException if {@code layers} is null.
+     * @see RepositoryCatalogFacade#setLayerRepository(LayerRepository)
+     */
     @Override
     public void setLayerRepository(LayerRepository layers) {
         asExtendedFacade().setLayerRepository(layers);
     }
 
+    /**
+     * Sets the repository for managing {@link LayerGroupInfo} objects by delegating to the underlying facade.
+     *
+     * @param layerGroups The {@link LayerGroupRepository} to set; must not be null.
+     * @throws NullPointerException if {@code layerGroups} is null.
+     * @see RepositoryCatalogFacade#setLayerGroupRepository(LayerGroupRepository)
+     */
     @Override
     public void setLayerGroupRepository(LayerGroupRepository layerGroups) {
         asExtendedFacade().setLayerGroupRepository(layerGroups);
     }
 
+    /**
+     * Sets the repository for managing {@link StyleInfo} objects by delegating to the underlying facade.
+     *
+     * @param styles The {@link StyleRepository} to set; must not be null.
+     * @throws NullPointerException if {@code styles} is null.
+     * @see RepositoryCatalogFacade#setStyleRepository(StyleRepository)
+     */
     @Override
     public void setStyleRepository(StyleRepository styles) {
         asExtendedFacade().setStyleRepository(styles);
     }
 
+    /**
+     * Sets the repository for managing {@link MapInfo} objects by delegating to the underlying facade.
+     *
+     * @param maps The {@link MapRepository} to set; must not be null.
+     * @throws NullPointerException if {@code maps} is null.
+     * @see RepositoryCatalogFacade#setMapRepository(MapRepository)
+     */
     @Override
     public void setMapRepository(MapRepository maps) {
         asExtendedFacade().setMapRepository(maps);
     }
 
+    /**
+     * Retrieves the repository for managing {@link NamespaceInfo} objects.
+     *
+     * <p>Forwards the call to the underlying facade’s {@link RepositoryCatalogFacade#getNamespaceRepository()}.
+     *
+     * @return The configured {@link NamespaceRepository}; never null.
+     * @throws IllegalStateException if no namespace repository has been set in the underlying facade.
+     * @example Accessing the namespace repository:
+     *          <pre>
+     *          NamespaceRepository nsRepo = facade.getNamespaceRepository();
+     *          </pre>
+     */
     @Override
     public NamespaceRepository getNamespaceRepository() {
         return asExtendedFacade().getNamespaceRepository();
     }
 
+    /**
+     * Retrieves the repository for managing {@link WorkspaceInfo} objects.
+     *
+     * <p>Forwards the call to the underlying facade’s {@link RepositoryCatalogFacade#getWorkspaceRepository()}.
+     *
+     * @return The configured {@link WorkspaceRepository}; never null.
+     * @throws IllegalStateException if no workspace repository has been set in the underlying facade.
+     */
     @Override
     public WorkspaceRepository getWorkspaceRepository() {
         return asExtendedFacade().getWorkspaceRepository();
     }
 
+    /**
+     * Retrieves the repository for managing {@link StoreInfo} objects.
+     *
+     * <p>Forwards the call to the underlying facade’s {@link RepositoryCatalogFacade#getStoreRepository()}.
+     *
+     * @return The configured {@link StoreRepository}; never null.
+     * @throws IllegalStateException if no store repository has been set in the underlying facade.
+     */
     @Override
     public StoreRepository getStoreRepository() {
         return asExtendedFacade().getStoreRepository();
     }
 
+    /**
+     * Retrieves the repository for managing {@link ResourceInfo} objects.
+     *
+     * <p>Forwards the call to the underlying facade’s {@link RepositoryCatalogFacade#getResourceRepository()}.
+     *
+     * @return The configured {@link ResourceRepository}; never null.
+     * @throws IllegalStateException if no resource repository has been set in the underlying facade.
+     */
     @Override
     public ResourceRepository getResourceRepository() {
         return asExtendedFacade().getResourceRepository();
     }
 
+    /**
+     * Retrieves the repository for managing {@link LayerInfo} objects.
+     *
+     * <p>Forwards the call to the underlying facade’s {@link RepositoryCatalogFacade#getLayerRepository()}.
+     *
+     * @return The configured {@link LayerRepository}; never null.
+     * @throws IllegalStateException if no layer repository has been set in the underlying facade.
+     */
     @Override
     public LayerRepository getLayerRepository() {
         return asExtendedFacade().getLayerRepository();
     }
 
+    /**
+     * Retrieves the repository for managing {@link LayerGroupInfo} objects.
+     *
+     * <p>Forwards the call to the underlying facade’s {@link RepositoryCatalogFacade#getLayerGroupRepository()}.
+     *
+     * @return The configured {@link LayerGroupRepository}; never null.
+     * @throws IllegalStateException if no layer group repository has been set in the underlying facade.
+     */
     @Override
     public LayerGroupRepository getLayerGroupRepository() {
         return asExtendedFacade().getLayerGroupRepository();
     }
 
+    /**
+     * Retrieves the repository for managing {@link StyleInfo} objects.
+     *
+     * <p>Forwards the call to the underlying facade’s {@link RepositoryCatalogFacade#getStyleRepository()}.
+     *
+     * @return The configured {@link StyleRepository}; never null.
+     * @throws IllegalStateException if no style repository has been set in the underlying facade.
+     */
     @Override
     public StyleRepository getStyleRepository() {
         return asExtendedFacade().getStyleRepository();
     }
 
+    /**
+     * Retrieves the repository for managing {@link MapInfo} objects.
+     *
+     * <p>Forwards the call to the underlying facade’s {@link RepositoryCatalogFacade#getMapRepository()}.
+     *
+     * @return The configured {@link MapRepository}; never null.
+     * @throws IllegalStateException if no map repository has been set in the underlying facade.
+     */
     @Override
     public MapRepository getMapRepository() {
         return asExtendedFacade().getMapRepository();
     }
 
+    /**
+     * Casts the underlying facade to {@link RepositoryCatalogFacade} for method delegation.
+     *
+     * <p>Overrides the parent method to ensure type safety when accessing repository-specific methods.
+     *
+     * @return The wrapped {@link RepositoryCatalogFacade}; never null.
+     */
     @Override
     protected RepositoryCatalogFacade asExtendedFacade() {
         return (RepositoryCatalogFacade) facade;
     }
 
+    /**
+     * Retrieves the repository responsible for managing objects of the specified {@link CatalogInfo} type.
+     *
+     * <p>Forwards the call to the underlying facade’s {@link RepositoryCatalogFacade#repository(Class)}.
+     *
+     * @param <T> The type of {@link CatalogInfo} (e.g., {@link LayerInfo}).
+     * @param <R> The corresponding repository type (e.g., {@link LayerRepository}).
+     * @param of  The class of catalog info objects to retrieve the repository for; must not be null.
+     * @return The repository managing objects of type {@code T}; never null.
+     * @throws NullPointerException if {@code of} is null.
+     * @throws IllegalArgumentException if no repository is configured for the specified type in the underlying facade.
+     * @example Retrieving a layer repository:
+     *          <pre>
+     *          LayerRepository layerRepo = facade.repository(LayerInfo.class);
+     *          </pre>
+     */
     @Override
     public <T extends CatalogInfo, R extends CatalogInfoRepository<T>> R repository(Class<T> of) {
         return asExtendedFacade().repository(of);
     }
 
+    /**
+     * Retrieves the repository responsible for managing the type of the provided {@link CatalogInfo} instance.
+     *
+     * <p>Forwards the call to the underlying facade’s {@link RepositoryCatalogFacade#repositoryFor(CatalogInfo)}.
+     *
+     * @param <T>  The type of {@link CatalogInfo} (e.g., {@link StyleInfo}).
+     * @param <R>  The corresponding repository type (e.g., {@link StyleRepository}).
+     * @param info The catalog info object whose type determines the repository; must not be null.
+     * @return The repository managing objects of the same type as {@code info}; never null.
+     * @throws NullPointerException if {@code info} is null.
+     * @throws IllegalArgumentException if no repository is configured for the object’s type in the underlying facade.
+     * @example Retrieving a repository for a specific style:
+     *          <pre>
+     *          StyleInfo style = ...; // existing style
+     *          StyleRepository styleRepo = facade.repositoryFor(style);
+     *          </pre>
+     */
     @Override
     public <T extends CatalogInfo, R extends CatalogInfoRepository<T>> R repositoryFor(T info) {
         return asExtendedFacade().repositoryFor(info);

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingResourceRepository.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingResourceRepository.java
@@ -12,33 +12,55 @@ import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.ResourceRepository;
 
+/**
+ * A decorator for {@link ResourceRepository} that forwards all method calls to an underlying repository.
+ *
+ * <p>This class extends {@link ForwardingCatalogRepository} to wrap a {@link ResourceRepository} subject,
+ * delegating all operations related to {@link ResourceInfo} management. It enables subclasses to override
+ * specific methods to customize behavior (e.g., adding validation or logging) without modifying the core
+ * repository implementation.
+ *
+ * @since 1.0
+ * @see ResourceRepository
+ * @see ForwardingCatalogRepository
+ */
 public class ForwardingResourceRepository extends ForwardingCatalogRepository<ResourceInfo, ResourceRepository>
         implements ResourceRepository {
 
+    /**
+     * Constructs a forwarding resource repository wrapping the provided subject.
+     *
+     * @param subject The underlying {@link ResourceRepository} to forward calls to; may be null (behavior depends on subclass).
+     */
     public ForwardingResourceRepository(ResourceRepository subject) {
         super(subject);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> Stream<T> findAllByType(Class<T> clazz) {
         return subject.findAllByType(clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> Stream<T> findAllByNamespace(NamespaceInfo ns, Class<T> clazz) {
         return subject.findAllByNamespace(ns, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> Optional<T> findByStoreAndName(StoreInfo store, String name, Class<T> clazz) {
         return subject.findByStoreAndName(store, name, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> Stream<T> findAllByStore(StoreInfo store, Class<T> clazz) {
         return subject.findAllByStore(store, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends ResourceInfo> Optional<T> findByNameAndNamespace(
             @NonNull String name, @NonNull NamespaceInfo namespace, Class<T> clazz) {

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingStoreRepository.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingStoreRepository.java
@@ -12,44 +12,68 @@ import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.StoreRepository;
 
+/**
+ * A decorator for {@link StoreRepository} that forwards all method calls to an underlying repository.
+ *
+ * <p>This class extends {@link ForwardingCatalogRepository} to wrap a {@link StoreRepository} subject,
+ * delegating all operations related to {@link StoreInfo} management. It enables subclasses to override
+ * specific methods to customize behavior (e.g., adding validation or logging) without modifying the core
+ * repository implementation.
+ *
+ * @since 1.0
+ * @see StoreRepository
+ * @see ForwardingCatalogRepository
+ */
 public class ForwardingStoreRepository extends ForwardingCatalogRepository<StoreInfo, StoreRepository>
         implements StoreRepository {
 
+    /**
+     * Constructs a forwarding store repository wrapping the provided subject.
+     *
+     * @param subject The underlying {@link StoreRepository} to forward calls to; may be null (behavior depends on subclass).
+     */
     public ForwardingStoreRepository(StoreRepository subject) {
         super(subject);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setDefaultDataStore(WorkspaceInfo workspace, DataStoreInfo dataStore) {
         subject.setDefaultDataStore(workspace, dataStore);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Optional<DataStoreInfo> getDefaultDataStore(WorkspaceInfo workspace) {
         return subject.getDefaultDataStore(workspace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Stream<DataStoreInfo> getDefaultDataStores() {
         return subject.getDefaultDataStores();
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends StoreInfo> Stream<T> findAllByWorkspace(WorkspaceInfo workspace, Class<T> clazz) {
         return subject.findAllByWorkspace(workspace, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends StoreInfo> Stream<T> findAllByType(Class<T> clazz) {
         return subject.findAllByType(clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <T extends StoreInfo> Optional<T> findByNameAndWorkspace(
             String name, WorkspaceInfo workspace, Class<T> clazz) {
         return subject.findByNameAndWorkspace(name, workspace, clazz);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void unsetDefaultDataStore(@NonNull WorkspaceInfo workspace) {
         subject.unsetDefaultDataStore(workspace);

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingStyleRepository.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingStyleRepository.java
@@ -10,28 +10,52 @@ import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.StyleRepository;
 
+/**
+ * A decorator for {@link StyleRepository} that forwards all method calls to an underlying repository.
+ *
+ * <p>This class extends {@link ForwardingCatalogRepository} to wrap a {@link StyleRepository} subject,
+ * delegating all operations related to {@link StyleInfo} management. It enables subclasses to override
+ * specific methods to customize behavior (e.g., adding validation or logging) without modifying the core
+ * repository implementation.
+ *
+ * @since 1.0
+ * @see StyleRepository
+ * @see ForwardingCatalogRepository
+ */
 public class ForwardingStyleRepository extends ForwardingCatalogRepository<StyleInfo, StyleRepository>
         implements StyleRepository {
 
+    /**
+     * Constructs a forwarding style repository wrapping the provided subject.
+     *
+     * @param subject The underlying {@link StyleRepository} to forward calls to; may be null (behavior depends on subclass).
+     */
     public ForwardingStyleRepository(StyleRepository subject) {
         super(subject);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Stream<StyleInfo> findAllByNullWorkspace() {
         return subject.findAllByNullWorkspace();
     }
 
+    /** {@inheritDoc} */
     @Override
     public Stream<StyleInfo> findAllByWorkspace(WorkspaceInfo ws) {
         return subject.findAllByWorkspace(ws);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Note: Assuming "Wordkspace" is a typo for "Workspace" in the method name.
+     */
     @Override
     public Optional<StyleInfo> findByNameAndWordkspaceNull(String name) {
         return subject.findByNameAndWordkspaceNull(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Optional<StyleInfo> findByNameAndWorkspace(String name, WorkspaceInfo workspace) {
         return subject.findByNameAndWorkspace(name, workspace);

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingWorkspaceRepository.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ForwardingWorkspaceRepository.java
@@ -8,23 +8,43 @@ import java.util.Optional;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.WorkspaceRepository;
 
+/**
+ * A decorator for {@link WorkspaceRepository} that forwards all method calls to an underlying repository.
+ *
+ * <p>This class extends {@link ForwardingCatalogRepository} to wrap a {@link WorkspaceRepository} subject,
+ * delegating all operations related to {@link WorkspaceInfo} management. It enables subclasses to override
+ * specific methods to customize behavior (e.g., adding validation or logging) without modifying the core
+ * repository implementation.
+ *
+ * @since 1.0
+ * @see WorkspaceRepository
+ * @see ForwardingCatalogRepository
+ */
 public class ForwardingWorkspaceRepository extends ForwardingCatalogRepository<WorkspaceInfo, WorkspaceRepository>
         implements WorkspaceRepository {
 
+    /**
+     * Constructs a forwarding workspace repository wrapping the provided subject.
+     *
+     * @param subject The underlying {@link WorkspaceRepository} to forward calls to; may be null (behavior depends on subclass).
+     */
     public ForwardingWorkspaceRepository(WorkspaceRepository subject) {
         super(subject);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setDefaultWorkspace(WorkspaceInfo workspace) {
         subject.setDefaultWorkspace(workspace);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Optional<WorkspaceInfo> getDefaultWorkspace() {
         return subject.getDefaultWorkspace();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void unsetDefaultWorkspace() {
         subject.unsetDefaultWorkspace();

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ResolvingCatalogFacadeDecorator.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/forwarding/ResolvingCatalogFacadeDecorator.java
@@ -8,13 +8,11 @@ import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import lombok.NonNull;
 import org.geoserver.catalog.Catalog;
-import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.LayerGroupInfo;
@@ -27,7 +25,6 @@ import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.ModificationProxy;
-import org.geoserver.catalog.impl.ResolvingProxy;
 import org.geoserver.catalog.plugin.ExtendedCatalogFacade;
 import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.catalog.plugin.Query;
@@ -39,127 +36,288 @@ import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.sort.SortBy;
 
 /**
- * {@link ExtendedCatalogFacade} decorator that applies a possibly side-effect producing
- * {@link Function} to each {@link CatalogInfo} right before returning it.
+ * A concrete decorator for {@link ExtendedCatalogFacade} implementing {@link ResolvingCatalogFacade},
+ * applying inbound and outbound resolvers to {@link CatalogInfo} objects.
  *
- * <p>
- * By default the function applied is the {@link Function#identity() identity} function, use
- * {@link #setOutboundResolver} to establish the function to apply to each object before being
- * returned.
+ * <p>This class wraps an existing {@link ExtendedCatalogFacade} and uses {@link ResolvingFacadeSupport}
+ * to apply configurable {@link UnaryOperator} functions to objects entering (inbound) and leaving
+ * (outbound) the facade. By default, it uses the identity function for both directions, customizable via
+ * {@link #setOutboundResolver(UnaryOperator)} and {@link #setInboundResolver(UnaryOperator)}. It simplifies
+ * facade implementations by handling resolution logic, allowing the decorated facade to focus on raw data
+ * access.
  *
- * <p>
- * The function must accept {@code null} as argument. This {@link CatalogFacade} decorator does not
- * assume any special treatment for {@code null} objects, leaving the supplied resolving function
- * chain the freedom to return {@code null} or resolve to any other object.
- * <p>
- * Use function chaining to compose a resolving pipeline adequate to the {@link CatalogFacade}
- * implementation. For example, the following chain is appropriate for a raw catalog facade that
- * fetches new objects from a remote service, and where all {@link CatalogInfo} object references
- * (e.g. {@link StoreInfo#getWorkspace()}, etc.) are {@link ResolvingProxy} instances:
- *
+ * <p>Example usage:
  * <pre>
  * {@code
- * Catalog catalog = ...
- * Function<CatalogInfo, CatalogInfo> resolvingFunction;
- * resolvingFunction =
- *   CatalogPropertyResolver.of(catalog)
- *   .andThen(ResolvingProxyResolver.of(catalog)
- *   .andThen(CollectionPropertiesInitializer.instance())
- *   .andThen(ModificationProxyDecorator.wrap());
- *
- * ResolvingCatalogFacade facade = ...
- * facade.setOutboundResolver(resolvingFunction);
+ * Catalog catalog = ...;
+ * ExtendedCatalogFacade rawFacade = ...;
+ * ResolvingCatalogFacadeDecorator facade = new ResolvingCatalogFacadeDecorator(rawFacade);
+ * UnaryOperator<CatalogInfo> resolver =
+ *     CatalogPropertyResolver.of(catalog)
+ *         .andThen(ResolvingProxyResolver.of(catalog))
+ *         .andThen(CollectionPropertiesInitializer.instance())
+ *         .andThen(ModificationProxyDecorator.wrap());
+ * facade.setOutboundResolver(resolver);
  * facade.setInboundResolver(ModificationProxyDecorator.unwrap());
  * }
+ * </pre>
+ * In this example, outbound objects are resolved for catalog references, proxies, initialized collections,
+ * and wrapped in a {@link ModificationProxy}, while inbound objects are unwrapped from proxies.
  *
- * Will first set the catalog property if the object type requires it (e.g.
- * {@link ResourceInfo#setCatalog}), then resolve all {@link ResolvingProxy} proxied references,
- * then initialize collection properties that are {@code null} to empty collections, and finally
- * decorate the object with a {@link ModificationProxy}.
- * <p>
- * Note the caller is responsible of supplying a resolving function that utilizes the correct
- * {@link Catalog}, may some of the functions in the chain require one; {@link #setOutboundResolver}
- * is agnostic of such concerns.
+ * <p>Notes:
+ * <ul>
+ *   <li>The provided resolvers must be null-safe, as this decorator does not enforce special null handling.</li>
+ *   <li>The caller is responsible for ensuring resolvers use the correct {@link Catalog} instance if required.</li>
+ * </ul>
+ *
+ * @since 1.0
+ * @see ExtendedCatalogFacade
+ * @see ResolvingCatalogFacade
+ * @see ResolvingFacadeSupport
  */
 public class ResolvingCatalogFacadeDecorator extends ForwardingExtendedCatalogFacade implements ResolvingCatalogFacade {
 
     private ResolvingFacadeSupport<CatalogInfo> resolver;
 
+    /**
+     * Constructs a new resolving decorator wrapping the provided {@link ExtendedCatalogFacade}.
+     *
+     * <p>Initializes the decorator with default identity resolvers for both inbound and outbound operations.
+     * Use {@link #setOutboundResolver(UnaryOperator)} and {@link #setInboundResolver(UnaryOperator)} to
+     * configure custom resolution logic.
+     *
+     * @param facade The underlying {@link ExtendedCatalogFacade} to decorate; must not be null.
+     * @throws NullPointerException if {@code facade} is null.
+     */
     public ResolvingCatalogFacadeDecorator(ExtendedCatalogFacade facade) {
         super(facade);
         resolver = new ResolvingFacadeSupport<>();
     }
 
+    /**
+     * Sets the outbound resolver function applied to objects before they are returned.
+     *
+     * <p>The resolver transforms {@link CatalogInfo} objects after they are retrieved from the underlying
+     * facade but before they are returned to the caller. It must handle null inputs gracefully.
+     *
+     * @param resolvingFunction The {@link UnaryOperator} to apply to outbound objects; must not be null and
+     *                          must accept null arguments.
+     * @throws NullPointerException if {@code resolvingFunction} is null.
+     * @example Setting an outbound resolver:
+     *          <pre>
+     *          ResolvingCatalogFacadeDecorator facade = new ResolvingCatalogFacadeDecorator(rawFacade);
+     *          UnaryOperator<CatalogInfo> resolver = ModificationProxyDecorator.wrap();
+     *          facade.setOutboundResolver(resolver);
+     *          </pre>
+     */
     @Override
     public void setOutboundResolver(UnaryOperator<CatalogInfo> resolvingFunction) {
         resolver.setOutboundResolver(resolvingFunction);
     }
 
+    /**
+     * Retrieves the current outbound resolver function.
+     *
+     * @return The {@link UnaryOperator} applied to outbound {@link CatalogInfo} objects; never null,
+     *         defaults to {@link Function#identity()}.
+     */
     @Override
     public UnaryOperator<CatalogInfo> getOutboundResolver() {
         return resolver.getOutboundResolver();
     }
 
+    /**
+     * Sets the inbound resolver function applied to objects before they are passed to the underlying facade.
+     *
+     * <p>The resolver transforms {@link CatalogInfo} objects received from the caller before they are
+     * processed by the underlying facade (e.g., for add or update operations). It must handle null inputs
+     * gracefully.
+     *
+     * @param resolvingFunction The {@link UnaryOperator} to apply to inbound objects; must not be null and
+     *                          must accept null arguments.
+     * @throws NullPointerException if {@code resolvingFunction} is null.
+     * @example Setting an inbound resolver:
+     *          <pre>
+     *          ResolvingCatalogFacadeDecorator facade = new ResolvingCatalogFacadeDecorator(rawFacade);
+     *          UnaryOperator<CatalogInfo> resolver = ModificationProxyDecorator.unwrap();
+     *          facade.setInboundResolver(resolver);
+     *          </pre>
+     */
     @Override
     public void setInboundResolver(UnaryOperator<CatalogInfo> resolvingFunction) {
         resolver.setInboundResolver(resolvingFunction);
     }
 
+    /**
+     * Retrieves the current inbound resolver function.
+     *
+     * @return The {@link UnaryOperator} applied to inbound {@link CatalogInfo} objects; never null,
+     *         defaults to {@link Function#identity()}.
+     */
     @Override
     public UnaryOperator<CatalogInfo> getInboundResolver() {
         return resolver.getInboundResolver();
     }
 
+    /**
+     * Applies the outbound resolver to a {@link CatalogInfo} object.
+     *
+     * <p>Processes the object using the configured outbound resolver, which may transform it (e.g.,
+     * resolving proxies) or return null.
+     *
+     * @param <C>  The type of {@link CatalogInfo}.
+     * @param info The {@link CatalogInfo} object to resolve; may be null.
+     * @return The resolved {@link CatalogInfo}, or null if the resolver returns null.
+     */
     @Override
     public <C extends CatalogInfo> C resolveOutbound(C info) {
         return resolver.resolveOutbound(info);
     }
 
+    /**
+     * Applies the inbound resolver to a {@link CatalogInfo} object.
+     *
+     * <p>Processes the object using the configured inbound resolver, which may transform it (e.g.,
+     * unwrapping proxies) or return null.
+     *
+     * @param <C>  The type of {@link CatalogInfo}.
+     * @param info The {@link CatalogInfo} object to resolve; may be null.
+     * @return The resolved {@link CatalogInfo}, or null if the resolver returns null.
+     */
     @Override
     public <C extends CatalogInfo> C resolveInbound(C info) {
         return resolver.resolveInbound(info);
     }
 
+    /**
+     * Applies the outbound resolver to a list of {@link CatalogInfo} objects.
+     *
+     * <p>Transforms each object in the list using {@link #resolveOutbound(CatalogInfo)}, preserving the
+     * original order and allowing null results.
+     *
+     * @param <C>  The type of {@link CatalogInfo}.
+     * @param info The list of {@link CatalogInfo} objects to resolve; must not be null.
+     * @return A new list with resolved {@link CatalogInfo} objects, potentially including nulls.
+     * @throws NullPointerException if {@code info} is null.
+     */
     protected <C extends CatalogInfo> List<C> resolveOutbound(List<C> info) {
         return Lists.transform(info, this::resolveOutbound);
     }
 
     // ExtendedCatalogFacade-specific methods
+
+    /**
+     * Adds a catalog object after applying the inbound resolver.
+     *
+     * <p>Resolves the input object using the inbound resolver before passing it to the underlying facade’s
+     * {@link ExtendedCatalogFacade#add(CatalogInfo)} method, then applies the outbound resolver to the
+     * result.
+     *
+     * @param <T>  The type of {@link CatalogInfo} to add.
+     * @param info The {@link CatalogInfo} object to add; must not be null.
+     * @return The added {@link CatalogInfo} object after outbound resolution.
+     * @throws NullPointerException if {@code info} is null.
+     * @example Adding a resolved workspace:
+     *          <pre>
+     *          WorkspaceInfo ws = new WorkspaceInfoImpl();
+     *          ws.setName("test");
+     *          WorkspaceInfo added = facade.add(ws);
+     *          </pre>
+     */
     @Override
     public <T extends CatalogInfo> T add(@NonNull T info) {
         return super.add(resolveInbound(info));
     }
 
+    /**
+     * Updates a catalog object with a patch, applying both inbound and outbound resolvers.
+     *
+     * <p>Resolves the input object inbound, applies the patch via the underlying facade’s
+     * {@link ExtendedCatalogFacade#update(CatalogInfo, Patch)}, and resolves the result outbound.
+     *
+     * @param <I>   The type of {@link CatalogInfo} to update.
+     * @param info  The {@link CatalogInfo} object to update; must not be null.
+     * @param patch The {@link Patch} containing changes; must not be null.
+     * @return The updated {@link CatalogInfo} object after outbound resolution.
+     * @throws NullPointerException if {@code info} or {@code patch} is null.
+     */
     @Override
     public <I extends CatalogInfo> I update(I info, Patch patch) {
         return resolveOutbound(super.update(resolveInbound(info), patch));
     }
 
+    /**
+     * Removes a catalog object after applying the inbound resolver.
+     *
+     * <p>Resolves the input object using the inbound resolver before delegating to the underlying facade’s
+     * {@link ExtendedCatalogFacade#remove(CatalogInfo)} method.
+     *
+     * @param info The {@link CatalogInfo} object to remove; must not be null.
+     * @throws NullPointerException if {@code info} is null.
+     */
     @Override
     public void remove(@NonNull CatalogInfo info) {
         super.remove(resolveInbound(info));
     }
 
+    /**
+     * Retrieves a catalog object by ID, applying the outbound resolver.
+     *
+     * <p>Fetches the object via the underlying facade’s {@link ExtendedCatalogFacade#get(String)} and
+     * resolves it outbound.
+     *
+     * @param id The unique identifier of the object; must not be null.
+     * @return An {@link Optional} containing the resolved {@link CatalogInfo}, or empty if not found.
+     * @throws NullPointerException if {@code id} is null.
+     */
     @Override
     public Optional<CatalogInfo> get(@NonNull String id) {
         return super.get(id).map(this::resolveOutbound);
     }
 
+    /**
+     * Retrieves a typed catalog object by ID, applying the outbound resolver.
+     *
+     * <p>Fetches the object via the underlying facade’s {@link ExtendedCatalogFacade#get(String, Class)}
+     * and resolves it outbound.
+     *
+     * @param <T>  The type of {@link CatalogInfo} to retrieve.
+     * @param id   The unique identifier of the object; must not be null.
+     * @param type The class of the object to retrieve; must not be null.
+     * @return An {@link Optional} containing the resolved {@link CatalogInfo}, or empty if not found.
+     * @throws NullPointerException if {@code id} or {@code type} is null.
+     */
     @Override
     public <T extends CatalogInfo> Optional<T> get(@NonNull String id, @NonNull Class<T> type) {
         return super.get(id, type).map(this::resolveOutbound);
     }
 
+    /**
+     * Retrieves a published object (layer or layer group) by ID, applying the outbound resolver.
+     *
+     * <p>Fetches the object via the underlying facade’s {@link ExtendedCatalogFacade#getPublished(String)}
+     * and resolves it outbound.
+     *
+     * @param id The unique identifier of the published object; must not be null.
+     * @return The resolved {@link PublishedInfo}, or null if not found.
+     * @throws NullPointerException if {@code id} is null.
+     */
     @Override
     public PublishedInfo getPublished(@NonNull String id) {
         return resolveOutbound(super.getPublished(id));
     }
 
-    @Override
-    public void forEach(Consumer<? super CatalogInfo> consumer) {
-        super.forEach(info -> consumer.accept(resolveOutbound(info)));
-    }
-
+    /**
+     * Queries the catalog with a {@link Query}, applying the outbound resolver to results.
+     *
+     * <p>Delegates to the underlying facade’s {@link ExtendedCatalogFacade#query(Query)}, resolves each
+     * result outbound, and filters out nulls.
+     *
+     * @param <T>   The type of {@link CatalogInfo} to query.
+     * @param query The {@link Query} defining the criteria; must not be null.
+     * @return A {@link Stream} of resolved {@link CatalogInfo} objects; never null.
+     * @throws NullPointerException if {@code query} is null.
+     */
     @Override
     public <T extends CatalogInfo> Stream<T> query(Query<T> query) {
         return super.query(query).map(this::resolveOutbound).filter(Objects::nonNull);
@@ -167,254 +325,605 @@ public class ResolvingCatalogFacadeDecorator extends ForwardingExtendedCatalogFa
 
     // CatalogFacade methods
 
+    // <editor-fold desc="CatalogFacade method overrides">
+
+    /**
+     * Adds a store after applying the inbound resolver, resolving the result outbound.
+     *
+     * @param store The {@link StoreInfo} to add; must not be null.
+     * @return The added {@link StoreInfo} after outbound resolution.
+     * @throws NullPointerException if {@code store} is null.
+     */
     @Override
     public StoreInfo add(StoreInfo store) {
         return resolveOutbound(super.add(resolveInbound(store)));
     }
 
+    /**
+     * Retrieves a store by ID and type, applying the outbound resolver.
+     *
+     * @param <T>   The type of {@link StoreInfo}.
+     * @param id    The unique identifier; must not be null.
+     * @param clazz The class of the store; must not be null.
+     * @return The resolved {@link StoreInfo}, or null if not found.
+     * @throws NullPointerException if {@code id} or {@code clazz} is null.
+     */
     @Override
     public <T extends StoreInfo> T getStore(String id, Class<T> clazz) {
         return resolveOutbound(super.getStore(id, clazz));
     }
 
+    /**
+     * Retrieves a store by name, workspace, and type, applying the outbound resolver.
+     *
+     * @param <T>       The type of {@link StoreInfo}.
+     * @param workspace The workspace; may be null.
+     * @param name      The name; must not be null.
+     * @param clazz     The class of the store; must not be null.
+     * @return The resolved {@link StoreInfo}, or null if not found.
+     * @throws NullPointerException if {@code name} or {@code clazz} is null.
+     */
     @Override
     public <T extends StoreInfo> T getStoreByName(WorkspaceInfo workspace, String name, Class<T> clazz) {
         return resolveOutbound(super.getStoreByName(workspace, name, clazz));
     }
 
+    /**
+     * Retrieves stores by workspace and type, applying the outbound resolver.
+     *
+     * @param <T>       The type of {@link StoreInfo}.
+     * @param workspace The workspace; may be null.
+     * @param clazz     The class of the stores; must not be null.
+     * @return A list of resolved {@link StoreInfo} objects.
+     * @throws NullPointerException if {@code clazz} is null.
+     */
     @Override
     public <T extends StoreInfo> List<T> getStoresByWorkspace(WorkspaceInfo workspace, Class<T> clazz) {
         return resolveOutbound(super.getStoresByWorkspace(workspace, clazz));
     }
 
+    /**
+     * Retrieves all stores of a type, applying the outbound resolver.
+     *
+     * @param <T>   The type of {@link StoreInfo}.
+     * @param clazz The class of the stores; must not be null.
+     * @return A list of resolved {@link StoreInfo} objects.
+     * @throws NullPointerException if {@code clazz} is null.
+     */
     @Override
     public <T extends StoreInfo> List<T> getStores(Class<T> clazz) {
         return resolveOutbound(super.getStores(clazz));
     }
 
+    /**
+     * Retrieves the default data store for a workspace, applying the outbound resolver.
+     *
+     * @param workspace The workspace; may be null.
+     * @return The resolved {@link DataStoreInfo}, or null if not set.
+     */
     @Override
     public DataStoreInfo getDefaultDataStore(WorkspaceInfo workspace) {
         return resolveOutbound(super.getDefaultDataStore(workspace));
     }
 
+    /**
+     * Adds a resource after applying the inbound resolver, resolving the result outbound.
+     *
+     * @param resource The {@link ResourceInfo} to add; must not be null.
+     * @return The added {@link ResourceInfo} after outbound resolution.
+     * @throws NullPointerException if {@code resource} is null.
+     */
     @Override
     public ResourceInfo add(ResourceInfo resource) {
         return resolveOutbound(super.add(resolveInbound(resource)));
     }
 
+    /**
+     * Retrieves a resource by ID and type, applying the outbound resolver.
+     *
+     * @param <T>   The type of {@link ResourceInfo}.
+     * @param id    The unique identifier; must not be null.
+     * @param clazz The class of the resource; must not be null.
+     * @return The resolved {@link ResourceInfo}, or null if not found.
+     * @throws NullPointerException if {@code id} or {@code clazz} is null.
+     */
     @Override
     public <T extends ResourceInfo> T getResource(String id, Class<T> clazz) {
         return resolveOutbound(super.getResource(id, clazz));
     }
 
+    /**
+     * Retrieves a resource by name, namespace, and type, applying the outbound resolver.
+     *
+     * @param <T>       The type of {@link ResourceInfo}.
+     * @param namespace The namespace; may be null.
+     * @param name      The name; must not be null.
+     * @param clazz     The class of the resource; must not be null.
+     * @return The resolved {@link ResourceInfo}, or null if not found.
+     * @throws NullPointerException if {@code name} or {@code clazz} is null.
+     */
     @Override
     public <T extends ResourceInfo> T getResourceByName(NamespaceInfo namespace, String name, Class<T> clazz) {
         return resolveOutbound(super.getResourceByName(namespace, name, clazz));
     }
 
+    /**
+     * Retrieves all resources of a type, applying the outbound resolver.
+     *
+     * @param <T>   The type of {@link ResourceInfo}.
+     * @param clazz The class of the resources; must not be null.
+     * @return A list of resolved {@link ResourceInfo} objects.
+     * @throws NullPointerException if {@code clazz} is null.
+     */
     @Override
     public <T extends ResourceInfo> List<T> getResources(Class<T> clazz) {
         return resolveOutbound(super.getResources(clazz));
     }
 
+    /**
+     * Retrieves resources by namespace and type, applying the outbound resolver.
+     *
+     * @param <T>       The type of {@link ResourceInfo}.
+     * @param namespace The namespace; may be null.
+     * @param clazz     The class of the resources; must not be null.
+     * @return A list of resolved {@link ResourceInfo} objects.
+     * @throws NullPointerException if {@code clazz} is null.
+     */
     @Override
     public <T extends ResourceInfo> List<T> getResourcesByNamespace(NamespaceInfo namespace, Class<T> clazz) {
         return resolveOutbound(super.getResourcesByNamespace(namespace, clazz));
     }
 
+    /**
+     * Retrieves a resource by store, name, and type, applying the outbound resolver.
+     *
+     * @param <T>   The type of {@link ResourceInfo}.
+     * @param store The store; must not be null.
+     * @param name  The name; must not be null.
+     * @param clazz The class of the resource; must not be null.
+     * @return The resolved {@link ResourceInfo}, or null if not found.
+     * @throws NullPointerException if {@code store}, {@code name}, or {@code clazz} is null.
+     */
     @Override
     public <T extends ResourceInfo> T getResourceByStore(StoreInfo store, String name, Class<T> clazz) {
         return resolveOutbound(super.getResourceByStore(store, name, clazz));
     }
 
+    /**
+     * Retrieves resources by store and type, applying the outbound resolver.
+     *
+     * @param <T>   The type of {@link ResourceInfo}.
+     * @param store The store; must not be null.
+     * @param clazz The class of the resources; must not be null.
+     * @return A list of resolved {@link ResourceInfo} objects.
+     * @throws NullPointerException if {@code store} or {@code clazz} is null.
+     */
     @Override
     public <T extends ResourceInfo> List<T> getResourcesByStore(StoreInfo store, Class<T> clazz) {
         return resolveOutbound(super.getResourcesByStore(store, clazz));
     }
 
+    /**
+     * Adds a layer after applying the inbound resolver, resolving the result outbound.
+     *
+     * @param layer The {@link LayerInfo} to add; must not be null.
+     * @return The added {@link LayerInfo} after outbound resolution.
+     * @throws NullPointerException if {@code layer} is null.
+     */
     @Override
     public LayerInfo add(LayerInfo layer) {
         return resolveOutbound(super.add(resolveInbound(layer)));
     }
 
+    /**
+     * Retrieves a layer by ID, applying the outbound resolver.
+     *
+     * @param id The unique identifier; must not be null.
+     * @return The resolved {@link LayerInfo}, or null if not found.
+     * @throws NullPointerException if {@code id} is null.
+     */
     @Override
     public LayerInfo getLayer(String id) {
         return resolveOutbound(super.getLayer(id));
     }
 
+    /**
+     * Retrieves a layer by name, applying the outbound resolver.
+     *
+     * @param name The name; must not be null.
+     * @return The resolved {@link LayerInfo}, or null if not found.
+     * @throws NullPointerException if {@code name} is null.
+     */
     @Override
     public LayerInfo getLayerByName(String name) {
         return resolveOutbound(super.getLayerByName(name));
     }
 
+    /**
+     * Retrieves layers by resource, applying the outbound resolver.
+     *
+     * @param resource The resource; must not be null.
+     * @return A list of resolved {@link LayerInfo} objects.
+     * @throws NullPointerException if {@code resource} is null.
+     */
     @Override
     public List<LayerInfo> getLayers(ResourceInfo resource) {
         return resolveOutbound(super.getLayers(resource));
     }
 
+    /**
+     * Retrieves layers by style, applying the outbound resolver.
+     *
+     * @param style The style; must not be null.
+     * @return A list of resolved {@link LayerInfo} objects.
+     * @throws NullPointerException if {@code style} is null.
+     */
     @Override
     public List<LayerInfo> getLayers(StyleInfo style) {
         return resolveOutbound(super.getLayers(style));
     }
 
+    /**
+     * Retrieves all layers, applying the outbound resolver.
+     *
+     * @return A list of resolved {@link LayerInfo} objects.
+     */
     @Override
     public List<LayerInfo> getLayers() {
         return resolveOutbound(super.getLayers());
     }
 
+    /**
+     * Adds a map after applying the inbound resolver, resolving the result outbound.
+     *
+     * @param map The {@link MapInfo} to add; must not be null.
+     * @return The added {@link MapInfo} after outbound resolution.
+     * @throws NullPointerException if {@code map} is null.
+     */
     @Override
     public MapInfo add(MapInfo map) {
         return resolveOutbound(super.add(resolveInbound(map)));
     }
 
+    /**
+     * Retrieves a map by ID, applying the outbound resolver.
+     *
+     * @param id The unique identifier; must not be null.
+     * @return The resolved {@link MapInfo}, or null if not found.
+     * @throws NullPointerException if {@code id} is null.
+     */
     @Override
     public MapInfo getMap(String id) {
         return resolveOutbound(super.getMap(id));
     }
 
+    /**
+     * Retrieves a map by name, applying the outbound resolver.
+     *
+     * @param name The name; must not be null.
+     * @return The resolved {@link MapInfo}, or null if not found.
+     * @throws NullPointerException if {@code name} is null.
+     */
     @Override
     public MapInfo getMapByName(String name) {
         return resolveOutbound(super.getMapByName(name));
     }
 
+    /**
+     * Retrieves all maps, applying the outbound resolver.
+     *
+     * @return A list of resolved {@link MapInfo} objects.
+     */
     @Override
     public List<MapInfo> getMaps() {
         return resolveOutbound(super.getMaps());
     }
 
+    /**
+     * Adds a layer group after applying the inbound resolver, resolving the result outbound.
+     *
+     * @param layerGroup The {@link LayerGroupInfo} to add; must not be null.
+     * @return The added {@link LayerGroupInfo} after outbound resolution.
+     * @throws NullPointerException if {@code layerGroup} is null.
+     */
     @Override
     public LayerGroupInfo add(LayerGroupInfo layerGroup) {
         return resolveOutbound(super.add(resolveInbound(layerGroup)));
     }
 
+    /**
+     * Retrieves a layer group by ID, applying the outbound resolver.
+     *
+     * @param id The unique identifier; must not be null.
+     * @return The resolved {@link LayerGroupInfo}, or null if not found.
+     * @throws NullPointerException if {@code id} is null.
+     */
     @Override
     public LayerGroupInfo getLayerGroup(String id) {
         return resolveOutbound(super.getLayerGroup(id));
     }
 
+    /**
+     * Retrieves a layer group by name, applying the outbound resolver.
+     *
+     * @param name The name; must not be null.
+     * @return The resolved {@link LayerGroupInfo}, or null if not found.
+     * @throws NullPointerException if {@code name} is null.
+     */
     @Override
     public LayerGroupInfo getLayerGroupByName(String name) {
         return resolveOutbound(super.getLayerGroupByName(name));
     }
 
+    /**
+     * Retrieves a layer group by name and workspace, applying the outbound resolver.
+     *
+     * @param workspace The workspace; may be null.
+     * @param name      The name; must not be null.
+     * @return The resolved {@link LayerGroupInfo}, or null if not found.
+     * @throws NullPointerException if {@code name} is null.
+     */
     @Override
     public LayerGroupInfo getLayerGroupByName(WorkspaceInfo workspace, String name) {
         return resolveOutbound(super.getLayerGroupByName(workspace, name));
     }
 
+    /**
+     * Retrieves all layer groups, applying the outbound resolver.
+     *
+     * @return A list of resolved {@link LayerGroupInfo} objects.
+     */
     @Override
     public List<LayerGroupInfo> getLayerGroups() {
         return resolveOutbound(super.getLayerGroups());
     }
 
+    /**
+     * Retrieves layer groups by workspace, applying the outbound resolver.
+     *
+     * @param workspace The workspace; may be null.
+     * @return A list of resolved {@link LayerGroupInfo} objects.
+     */
     @Override
     public List<LayerGroupInfo> getLayerGroupsByWorkspace(WorkspaceInfo workspace) {
         return resolveOutbound(super.getLayerGroupsByWorkspace(workspace));
     }
 
+    /**
+     * Adds a namespace after applying the inbound resolver, resolving the result outbound.
+     *
+     * @param namespace The {@link NamespaceInfo} to add; must not be null.
+     * @return The added {@link NamespaceInfo} after outbound resolution.
+     * @throws NullPointerException if {@code namespace} is null.
+     */
     @Override
     public NamespaceInfo add(NamespaceInfo namespace) {
         return resolveOutbound(super.add(resolveInbound(namespace)));
     }
 
+    /**
+     * Retrieves the default namespace, applying the outbound resolver.
+     *
+     * @return The resolved {@link NamespaceInfo}, or null if not set.
+     */
     @Override
     public NamespaceInfo getDefaultNamespace() {
         return resolveOutbound(super.getDefaultNamespace());
     }
 
+    /**
+     * Sets the default namespace after applying the inbound resolver.
+     *
+     * @param defaultNamespace The {@link NamespaceInfo} to set as default; may be null.
+     */
     @Override
     public void setDefaultNamespace(NamespaceInfo defaultNamespace) {
         super.setDefaultNamespace(resolveInbound(defaultNamespace));
     }
 
+    /**
+     * Retrieves a namespace by ID, applying the outbound resolver.
+     *
+     * @param id The unique identifier; must not be null.
+     * @return The resolved {@link NamespaceInfo}, or null if not found.
+     * @throws NullPointerException if {@code id} is null.
+     */
     @Override
     public NamespaceInfo getNamespace(String id) {
         return resolveOutbound(super.getNamespace(id));
     }
 
+    /**
+     * Retrieves a namespace by prefix, applying the outbound resolver.
+     *
+     * @param prefix The prefix; must not be null.
+     * @return The resolved {@link NamespaceInfo}, or null if not found.
+     * @throws NullPointerException if {@code prefix} is null.
+     */
     @Override
     public NamespaceInfo getNamespaceByPrefix(String prefix) {
         return resolveOutbound(super.getNamespaceByPrefix(prefix));
     }
 
+    /**
+     * Retrieves a namespace by URI, applying the outbound resolver.
+     *
+     * @param uri The URI; must not be null.
+     * @return The resolved {@link NamespaceInfo}, or null if not found.
+     * @throws NullPointerException if {@code uri} is null.
+     */
     @Override
     public NamespaceInfo getNamespaceByURI(String uri) {
         return resolveOutbound(super.getNamespaceByURI(uri));
     }
 
+    /**
+     * Retrieves all namespaces, applying the outbound resolver.
+     *
+     * @return A list of resolved {@link NamespaceInfo} objects.
+     */
     @Override
     public List<NamespaceInfo> getNamespaces() {
         return resolveOutbound(super.getNamespaces());
     }
 
+    /**
+     * Adds a workspace after applying the inbound resolver, resolving the result outbound.
+     *
+     * @param workspace The {@link WorkspaceInfo} to add; must not be null.
+     * @return The added {@link WorkspaceInfo} after outbound resolution.
+     * @throws NullPointerException if {@code workspace} is null.
+     */
     @Override
     public WorkspaceInfo add(WorkspaceInfo workspace) {
         return resolveOutbound(super.add(resolveInbound(workspace)));
     }
 
+    /**
+     * Retrieves the default workspace, applying the outbound resolver.
+     *
+     * @return The resolved {@link WorkspaceInfo}, or null if not set.
+     */
     @Override
     public WorkspaceInfo getDefaultWorkspace() {
         return resolveOutbound(super.getDefaultWorkspace());
     }
 
+    /**
+     * Sets the default workspace after applying the inbound resolver.
+     *
+     * @param workspace The {@link WorkspaceInfo} to set as default; may be null.
+     */
     @Override
     public void setDefaultWorkspace(WorkspaceInfo workspace) {
         super.setDefaultWorkspace(resolveInbound(workspace));
     }
 
+    /**
+     * Sets the default data store for a workspace, applying the inbound resolver to inputs.
+     *
+     * @param workspace The workspace; must not be null.
+     * @param store     The {@link DataStoreInfo} to set; may be null.
+     * @throws NullPointerException if {@code workspace} is null.
+     */
     @Override
     public void setDefaultDataStore(WorkspaceInfo workspace, DataStoreInfo store) {
         super.setDefaultDataStore(resolveInbound(workspace), resolveInbound(store));
     }
 
+    /**
+     * Retrieves a workspace by ID, applying the outbound resolver.
+     *
+     * @param id The unique identifier; must not be null.
+     * @return The resolved {@link WorkspaceInfo}, or null if not found.
+     * @throws NullPointerException if {@code id} is null.
+     */
     @Override
     public WorkspaceInfo getWorkspace(String id) {
         return resolveOutbound(super.getWorkspace(id));
     }
 
+    /**
+     * Retrieves a workspace by name, applying the outbound resolver.
+     *
+     * @param name The name; must not be null.
+     * @return The resolved {@link WorkspaceInfo}, or null if not found.
+     * @throws NullPointerException if {@code name} is null.
+     */
     @Override
     public WorkspaceInfo getWorkspaceByName(String name) {
         return resolveOutbound(super.getWorkspaceByName(name));
     }
 
+    /**
+     * Retrieves all workspaces, applying the outbound resolver.
+     *
+     * @return A list of resolved {@link WorkspaceInfo} objects.
+     */
     @Override
     public List<WorkspaceInfo> getWorkspaces() {
         return resolveOutbound(super.getWorkspaces());
     }
 
+    /**
+     * Adds a style after applying the inbound resolver, resolving the result outbound.
+     *
+     * @param style The {@link StyleInfo} to add; must not be null.
+     * @return The added {@link StyleInfo} after outbound resolution.
+     * @throws NullPointerException if {@code style} is null.
+     */
     @Override
     public StyleInfo add(StyleInfo style) {
         return resolveOutbound(super.add(resolveInbound(style)));
     }
 
+    /**
+     * Retrieves a style by ID, applying the outbound resolver.
+     *
+     * @param id The unique identifier; must not be null.
+     * @return The resolved {@link StyleInfo}, or null if not found.
+     * @throws NullPointerException if {@code id} is null.
+     */
     @Override
     public StyleInfo getStyle(String id) {
         return resolveOutbound(super.getStyle(id));
     }
 
+    /**
+     * Retrieves a style by name, applying the outbound resolver.
+     *
+     * @param name The name; must not be null.
+     * @return The resolved {@link StyleInfo}, or null if not found.
+     * @throws NullPointerException if {@code name} is null.
+     */
     @Override
     public StyleInfo getStyleByName(String name) {
         return resolveOutbound(super.getStyleByName(name));
     }
 
+    /**
+     * Retrieves a style by name and workspace, applying the outbound resolver.
+     *
+     * @param workspace The workspace; may be null.
+     * @param name      The name; must not be null.
+     * @return The resolved {@link StyleInfo}, or null if not found.
+     * @throws NullPointerException if {@code name} is null.
+     */
     @Override
     public StyleInfo getStyleByName(WorkspaceInfo workspace, String name) {
         return resolveOutbound(super.getStyleByName(workspace, name));
     }
 
+    /**
+     * Retrieves all styles, applying the outbound resolver.
+     *
+     * @return A list of resolved {@link StyleInfo} objects.
+     */
     @Override
     public List<StyleInfo> getStyles() {
         return resolveOutbound(super.getStyles());
     }
 
+    /**
+     * Retrieves styles by workspace, applying the outbound resolver.
+     *
+     * @param workspace The workspace; may be null.
+     * @return A list of resolved {@link StyleInfo} objects.
+     */
     @Override
     public List<StyleInfo> getStylesByWorkspace(WorkspaceInfo workspace) {
         return resolveOutbound(super.getStylesByWorkspace(workspace));
     }
 
     /**
-     * @deprecated as per {@link ExtendedCatalogFacade#save(WorkspaceInfo)} use {@link
-     *     #update(CatalogInfo, Patch)} instead
+     * Saves a workspace after applying the inbound resolver (deprecated).
+     *
+     * <p>Resolves the input workspace inbound before delegating to the underlying facade’s deprecated
+     * {@link ExtendedCatalogFacade#save(WorkspaceInfo)} method.
+     *
+     * @param info The {@link WorkspaceInfo} to save; must not be null.
+     * @throws NullPointerException if {@code info} is null.
+     * @deprecated since 1.0, for removal; use {@link #update(CatalogInfo, Patch)} instead.
      */
     @Deprecated(since = "1.0", forRemoval = true)
     @Override
@@ -423,8 +932,11 @@ public class ResolvingCatalogFacadeDecorator extends ForwardingExtendedCatalogFa
     }
 
     /**
-     * @deprecated as per {@link ExtendedCatalogFacade#save(NamespaceInfo)} use {@link
-     *     #update(CatalogInfo, Patch)} instead
+     * Saves a namespace after applying the inbound resolver (deprecated).
+     *
+     * @param info The {@link NamespaceInfo} to save; must not be null.
+     * @throws NullPointerException if {@code info} is null.
+     * @deprecated since 1.0, for removal; use {@link #update(CatalogInfo, Patch)} instead.
      */
     @Deprecated(since = "1.0", forRemoval = true)
     @Override
@@ -433,8 +945,11 @@ public class ResolvingCatalogFacadeDecorator extends ForwardingExtendedCatalogFa
     }
 
     /**
-     * @deprecated as per {@link ExtendedCatalogFacade#save(StoreInfo)} use {@link
-     *     #update(CatalogInfo, Patch)} instead
+     * Saves a store after applying the inbound resolver (deprecated).
+     *
+     * @param info The {@link StoreInfo} to save; must not be null.
+     * @throws NullPointerException if {@code info} is null.
+     * @deprecated since 1.0, for removal; use {@link #update(CatalogInfo, Patch)} instead.
      */
     @Deprecated(since = "1.0", forRemoval = true)
     @Override
@@ -443,8 +958,11 @@ public class ResolvingCatalogFacadeDecorator extends ForwardingExtendedCatalogFa
     }
 
     /**
-     * @deprecated as per {@link ExtendedCatalogFacade#save(ResourceInfo)} use {@link
-     *     #update(CatalogInfo, Patch)} instead
+     * Saves a resource after applying the inbound resolver (deprecated).
+     *
+     * @param info The {@link ResourceInfo} to save; must not be null.
+     * @throws NullPointerException if {@code info} is null.
+     * @deprecated since 1.0, for removal; use {@link #update(CatalogInfo, Patch)} instead.
      */
     @Deprecated(since = "1.0", forRemoval = true)
     @Override
@@ -453,8 +971,11 @@ public class ResolvingCatalogFacadeDecorator extends ForwardingExtendedCatalogFa
     }
 
     /**
-     * @deprecated as per {@link ExtendedCatalogFacade#save(LayerInfo)} use {@link
-     *     #update(CatalogInfo, Patch)} instead
+     * Saves a layer after applying the inbound resolver (deprecated).
+     *
+     * @param info The {@link LayerInfo} to save; must not be null.
+     * @throws NullPointerException if {@code info} is null.
+     * @deprecated since 1.0, for removal; use {@link #update(CatalogInfo, Patch)} instead.
      */
     @Deprecated(since = "1.0", forRemoval = true)
     @Override
@@ -463,8 +984,11 @@ public class ResolvingCatalogFacadeDecorator extends ForwardingExtendedCatalogFa
     }
 
     /**
-     * @deprecated as per {@link ExtendedCatalogFacade#save(LayerGroupInfo)} use {@link
-     *     #update(CatalogInfo, Patch)} instead
+     * Saves a layer group after applying the inbound resolver (deprecated).
+     *
+     * @param info The {@link LayerGroupInfo} to save; must not be null.
+     * @throws NullPointerException if {@code info} is null.
+     * @deprecated since 1.0, for removal; use {@link #update(CatalogInfo, Patch)} instead.
      */
     @Deprecated(since = "1.0", forRemoval = true)
     @Override
@@ -473,8 +997,11 @@ public class ResolvingCatalogFacadeDecorator extends ForwardingExtendedCatalogFa
     }
 
     /**
-     * @deprecated as per {@link ExtendedCatalogFacade#save(StyleInfo)} use {@link
-     *     #update(CatalogInfo, Patch)} instead
+     * Saves a style after applying the inbound resolver (deprecated).
+     *
+     * @param info The {@link StyleInfo} to save; must not be null.
+     * @throws NullPointerException if {@code info} is null.
+     * @deprecated since 1.0, for removal; use {@link #update(CatalogInfo, Patch)} instead.
      */
     @Deprecated(since = "1.0", forRemoval = true)
     @Override
@@ -483,8 +1010,11 @@ public class ResolvingCatalogFacadeDecorator extends ForwardingExtendedCatalogFa
     }
 
     /**
-     * @deprecated as per {@link ExtendedCatalogFacade#save(MapInfo)} use {@link
-     *     #update(CatalogInfo, Patch)} instead
+     * Saves a map after applying the inbound resolver (deprecated).
+     *
+     * @param info The {@link MapInfo} to save; must not be null.
+     * @throws NullPointerException if {@code info} is null.
+     * @deprecated since 1.0, for removal; use {@link #update(CatalogInfo, Patch)} instead.
      */
     @Deprecated(since = "1.0", forRemoval = true)
     @Override
@@ -492,48 +1022,109 @@ public class ResolvingCatalogFacadeDecorator extends ForwardingExtendedCatalogFa
         super.save(resolveInbound(info));
     }
 
+    /**
+     * Removes a workspace after applying the inbound resolver.
+     *
+     * @param info The {@link WorkspaceInfo} to remove; must not be null.
+     * @throws NullPointerException if {@code info} is null.
+     */
     @Override
     public void remove(WorkspaceInfo info) {
         super.remove(resolveInbound(info));
     }
 
+    /**
+     * Removes a namespace after applying the inbound resolver.
+     *
+     * @param info The {@link NamespaceInfo} to remove; must not be null.
+     * @throws NullPointerException if {@code info} is null.
+     */
     @Override
     public void remove(NamespaceInfo info) {
         super.remove(resolveInbound(info));
     }
 
+    /**
+     * Removes a store after applying the inbound resolver.
+     *
+     * @param info The {@link StoreInfo} to remove; must not be null.
+     * @throws NullPointerException if {@code info} is null.
+     */
     @Override
     public void remove(StoreInfo info) {
         super.remove(resolveInbound(info));
     }
 
+    /**
+     * Removes a resource after applying the inbound resolver.
+     *
+     * @param info The {@link ResourceInfo} to remove; must not be null.
+     * @throws NullPointerException if {@code info} is null.
+     */
     @Override
     public void remove(ResourceInfo info) {
         super.remove(resolveInbound(info));
     }
 
+    /**
+     * Removes a layer after applying the inbound resolver.
+     *
+     * @param info The {@link LayerInfo} to remove; must not be null.
+     * @throws NullPointerException if {@code info} is null.
+     */
     @Override
     public void remove(LayerInfo info) {
         super.remove(resolveInbound(info));
     }
 
+    /**
+     * Removes a layer group after applying the inbound resolver.
+     *
+     * @param info The {@link LayerGroupInfo} to remove; must not be null.
+     * @throws NullPointerException if {@code info} is null.
+     */
     @Override
     public void remove(LayerGroupInfo info) {
         super.remove(resolveInbound(info));
     }
 
+    /**
+     * Removes a style after applying the inbound resolver.
+     *
+     * @param info The {@link StyleInfo} to remove; must not be null.
+     * @throws NullPointerException if {@code info} is null.
+     */
     @Override
     public void remove(StyleInfo info) {
         super.remove(resolveInbound(info));
     }
 
+    /**
+     * Removes a map after applying the inbound resolver.
+     *
+     * @param info The {@link MapInfo} to remove; must not be null.
+     * @throws NullPointerException if {@code info} is null.
+     */
     @Override
     public void remove(MapInfo info) {
         super.remove(resolveInbound(info));
     }
 
     /**
-     * @deprecated as per {@link ExtendedCatalogFacade#list()} use {@link #query(Query)} instead
+     * Retrieves a list of catalog objects matching criteria, applying the outbound resolver (deprecated).
+     *
+     * <p>Delegates to the underlying facade’s deprecated {@link ExtendedCatalogFacade#list(Class, Filter, Integer, Integer, SortBy...)}
+     * method and transforms the result iterator with the outbound resolver.
+     *
+     * @param <T>       The type of {@link CatalogInfo}.
+     * @param of        The class of objects; must not be null.
+     * @param filter    The filter; must not be null.
+     * @param offset    The offset; may be null.
+     * @param count     The count; may be null.
+     * @param sortOrder The sort order; may be null.
+     * @return A {@link CloseableIterator} of resolved objects.
+     * @throws NullPointerException if {@code of} or {@code filter} is null.
+     * @deprecated since 1.0, for removal; use {@link #query(Query)} instead.
      */
     @Deprecated(since = "1.0", forRemoval = true)
     @Override
@@ -543,4 +1134,6 @@ public class ResolvingCatalogFacadeDecorator extends ForwardingExtendedCatalogFa
         final CloseableIterator<T> orig = asExtendedFacade().list(of, filter, offset, count, sortOrder);
         return CloseableIteratorAdapter.transform(orig, this::resolveOutbound);
     }
+
+    // </editor-fold>
 }

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/locking/LockingCatalog.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/locking/LockingCatalog.java
@@ -20,17 +20,31 @@ import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.CatalogPlugin;
 
 /**
- * A locking catalog, akin to {@link LockingCatalogFacade}, but at a higher level of granularity,
- * because a single catalog operation (e.g. save()), can imply multiple config changes (e.g. sets
- * the default workspace/namespace/datastore), and we want all those automatic batch operations to
- * run inside the same lock, which is not possible with {@link LockingCatalogFacade}.
+ * A locking {@link CatalogPlugin} that ensures cluster-wide catalog updates safety using a
+ * {@link GeoServerConfigurationLock}.
  *
- * <p>The consistency guarantees are the ones provided by the {@link GeoServerConfigurationLock},
- * whether it guarantees atomicity at the JVM or cluster-wide level.
+ * <p>This class enhances {@link CatalogPlugin} by overriding mutating methods to run within a
+ * {@link GeoServerConfigurationLock}, which in GeoServer Cloud is required to provide cluster-level
+ * locking. This offers higher granularity than {@link LockingCatalogFacade}, ensuring that batch
+ * operations (e.g., {@code save()} affecting multiple config changes like setting defaults) execute
+ * atomically under the same lock. The consistency guarantees depend on the lock’s scope, typically
+ * cluster-wide in GeoServer Cloud.
  *
- * <p>This {@link CatalogPlugin} implementation overrides all mutating methods to run inside a
- * cluster-wide lock. For instance, {@link #doAdd}, {@link #doSave}, {@link #doRemove}, and all the
- * {@code setDefault*} methods.
+ * <p>Key mutating methods overridden include {@link #doAdd}, {@link #doSave}, {@link #doRemove}, and
+ * default-setting methods like {@link #setDefaultWorkspace}. Locking can be enabled or disabled via
+ * {@link #enableLocking()} and {@link #disableLocking()}.
+ *
+ * <p>Example usage:
+ * <pre>
+ * GeoServerConfigurationLock lock = ...;
+ * LockingCatalog catalog = new LockingCatalog(lock);
+ * catalog.add(new WorkspaceInfoImpl()); // Runs within cluster-wide lock
+ * </pre>
+ *
+ * @since 1.0
+ * @see GeoServerConfigurationLock
+ * @see CatalogPlugin
+ * @see LockingCatalogFacade
  */
 @SuppressWarnings("serial")
 public class LockingCatalog extends CatalogPlugin {
@@ -38,24 +52,52 @@ public class LockingCatalog extends CatalogPlugin {
     private final transient GeoServerConfigurationLock configurationLock;
     private transient LockingSupport locking;
 
+    /**
+     * Constructs a locking catalog with a configuration lock.
+     *
+     * @param configurationLock The {@link GeoServerConfigurationLock} for cluster-wide safety; must not be null.
+     * @throws NullPointerException if {@code configurationLock} is null.
+     */
     public LockingCatalog(@NonNull GeoServerConfigurationLock configurationLock) {
         super();
         this.configurationLock = configurationLock;
         enableLocking();
     }
 
+    /**
+     * Constructs a locking catalog with a configuration lock and isolation option.
+     *
+     * @param configurationLock The {@link GeoServerConfigurationLock} for cluster-wide safety; must not be null.
+     * @param isolated Whether the catalog operates in isolated mode.
+     * @throws NullPointerException if {@code configurationLock} is null.
+     */
     public LockingCatalog(@NonNull GeoServerConfigurationLock configurationLock, boolean isolated) {
         super(isolated);
         this.configurationLock = configurationLock;
         enableLocking();
     }
 
+    /**
+     * Constructs a locking catalog with a configuration lock and custom facade.
+     *
+     * @param configurationLock The {@link GeoServerConfigurationLock} for cluster-wide safety; must not be null.
+     * @param facade The {@link CatalogFacade} to use; may be null.
+     * @throws NullPointerException if {@code configurationLock} is null.
+     */
     public LockingCatalog(@NonNull GeoServerConfigurationLock configurationLock, CatalogFacade facade) {
         super(facade);
         this.configurationLock = configurationLock;
         enableLocking();
     }
 
+    /**
+     * Constructs a locking catalog with a configuration lock, custom facade, and isolation option.
+     *
+     * @param configurationLock The {@link GeoServerConfigurationLock} for cluster-wide safety; must not be null.
+     * @param facade The {@link CatalogFacade} to use; may be null.
+     * @param isolated Whether the catalog operates in isolated mode.
+     * @throws NullPointerException if {@code configurationLock} is null.
+     */
     public LockingCatalog(
             @NonNull GeoServerConfigurationLock configurationLock, CatalogFacade facade, boolean isolated) {
         super(facade, isolated);
@@ -63,14 +105,24 @@ public class LockingCatalog extends CatalogPlugin {
         enableLocking();
     }
 
+    /**
+     * Enables locking for all mutating operations using the configured {@link GeoServerConfigurationLock}.
+     */
     public void enableLocking() {
         this.locking = LockingSupport.locking(configurationLock);
     }
 
+    /**
+     * Disables locking, bypassing the {@link GeoServerConfigurationLock} for mutating operations.
+     */
     public void disableLocking() {
         this.locking = LockingSupport.ignoringLocking();
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Runs within a cluster-wide write lock to ensure update safety across related config changes.
+     */
     @Override
     public void setDefaultDataStore(@NonNull WorkspaceInfo workspace, DataStoreInfo store) {
         locking.runInWriteLock(
@@ -78,6 +130,10 @@ public class LockingCatalog extends CatalogPlugin {
                 "setDefaultDataStore(%s, %s)".formatted(workspace.getName(), store == null ? "null" : store.getName()));
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Runs within a cluster-wide write lock to ensure update safety across related config changes.
+     */
     @Override
     public void setDefaultNamespace(NamespaceInfo defaultNamespace) {
         locking.runInWriteLock(
@@ -85,6 +141,10 @@ public class LockingCatalog extends CatalogPlugin {
                 "setDefaultNamespace(%s)".formatted(defaultNamespace == null ? "null" : defaultNamespace.getName()));
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Runs within a cluster-wide write lock to ensure update safety across related config changes.
+     */
     @Override
     public void setDefaultWorkspace(WorkspaceInfo defaultWorkspace) {
         locking.runInWriteLock(
@@ -92,24 +152,37 @@ public class LockingCatalog extends CatalogPlugin {
                 "setDefaultWorkspace(%s)".formatted(defaultWorkspace == null ? "null" : defaultWorkspace.getName()));
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     * <p>Runs within a cluster-wide write lock to ensure update safety for addition.
+     */
     protected @Override <T extends CatalogInfo> void doAdd(T info, UnaryOperator<T> inserter) {
         locking.runInWriteLock(() -> super.doAdd(info, inserter), "add(%s[%s])".formatted(typeOf(info), nameOf(info)));
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     * <p>Runs within a cluster-wide write lock to ensure update safety for saving.
+     */
     protected @Override <I extends CatalogInfo> void doSave(final I info) {
         locking.runInWriteLock(() -> super.doSave(info), "save(%s[%s])".formatted(typeOf(info), nameOf(info)));
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     * <p>Runs within a cluster-wide write lock to ensure update safety for removal.
+     */
     protected @Override <T extends CatalogInfo> void doRemove(T info, Class<T> type) {
         locking.runInWriteLock(
                 () -> super.doRemove(info, type), "remove(%s[%s])".formatted(typeOf(info), nameOf(info)));
     }
 
     /**
-     * Overrides to call {@code super.save(StoreInfo)) instead of {@code super.doSave()} because {@code CatalogPlugin} performs additional logic
+     * Overrides to call {@code super.save(StoreInfo)} instead of {@code super.doSave()} because
+     * {@code CatalogPlugin} performs additional logic.
+     * <p>Runs within a cluster-wide write lock to ensure update safety for saving store information.
+     *
+     * @param store The {@link StoreInfo} to save; must not be null.
      */
     @Override
     public void save(StoreInfo store) {

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/locking/LockingGeoServer.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/locking/LockingGeoServer.java
@@ -17,87 +17,172 @@ import org.geoserver.config.SettingsInfo;
 import org.geoserver.config.plugin.GeoServerImpl;
 
 /**
+ * A locking {@link GeoServerImpl} that ensures cluster-wide configuration updates safety using a
+ * {@link GeoServerConfigurationLock}.
+ *
+ * <p>This class enhances {@link GeoServerImpl} by overriding mutating methods to run within a
+ * {@link GeoServerConfigurationLock}, which in GeoServer Cloud is required to provide cluster-level
+ * locking. This ensures that configuration changes (e.g., adding or saving services, settings) are
+ * executed atomically across the cluster, preventing concurrent modification issues.
+ *
+ * <p>Key mutating methods overridden include {@link #setGlobal}, {@link #save}, {@link #add}, and
+ * {@link #remove} for various configuration objects. Locking can be enabled or disabled via
+ * {@link #enableLocking()} and {@link #disableLocking()}.
+ *
+ * <p>Example usage:
+ * <pre>
+ * GeoServerConfigurationLock lock = ...;
+ * LockingGeoServer geoServer = new LockingGeoServer(lock);
+ * geoServer.add(new SettingsInfoImpl()); // Runs within cluster-wide lock
+ * </pre>
+ *
  * @since 1.0
+ * @see GeoServerConfigurationLock
+ * @see GeoServerImpl
  */
 public class LockingGeoServer extends GeoServerImpl {
 
     private LockingSupport lockingSupport;
     private final GeoServerConfigurationLock configurationLock;
 
+    /**
+     * Constructs a locking GeoServer with a configuration lock.
+     *
+     * @param locking The {@link GeoServerConfigurationLock} for cluster-wide safety; must not be null.
+     * @throws NullPointerException if {@code locking} is null.
+     */
     public LockingGeoServer(@NonNull GeoServerConfigurationLock locking) {
         super();
         this.configurationLock = locking;
         enableLocking();
     }
 
+    /**
+     * Constructs a locking GeoServer with a configuration lock and custom facade.
+     *
+     * @param locking The {@link GeoServerConfigurationLock} for cluster-wide safety; must not be null.
+     * @param facade The {@link GeoServerFacade} to use; must not be null.
+     * @throws NullPointerException if {@code locking} or {@code facade} is null.
+     */
     public LockingGeoServer(@NonNull GeoServerConfigurationLock locking, @NonNull GeoServerFacade facade) {
         super(facade);
         this.configurationLock = locking;
         enableLocking();
     }
 
+    /**
+     * Enables locking for all mutating operations using the configured {@link GeoServerConfigurationLock}.
+     */
     public void enableLocking() {
         this.lockingSupport = LockingSupport.locking(configurationLock);
     }
 
+    /**
+     * Disables locking, bypassing the {@link GeoServerConfigurationLock} for mutating operations.
+     */
     public void disableLocking() {
         this.lockingSupport = LockingSupport.ignoringLocking();
     }
 
+    /**
+     * Returns the configuration lock used for cluster-wide safety.
+     *
+     * @return The {@link GeoServerConfigurationLock}; never null.
+     */
     public @NonNull GeoServerConfigurationLock getConfigurationLock() {
         return this.configurationLock;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Runs within a cluster-wide write lock to ensure update safety for global configuration.
+     */
     @Override
     public void setGlobal(GeoServerInfo global) {
         lockingSupport.runInWriteLock(() -> super.setGlobal(global), "setGlobal(%s)".formatted(nameOf(global)));
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Runs within a cluster-wide write lock to ensure update safety for global configuration.
+     */
     @Override
     public void save(GeoServerInfo geoServer) {
         lockingSupport.runInWriteLock(() -> super.save(geoServer), "save(%s)".formatted(nameOf(geoServer)));
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Runs within a cluster-wide write lock to ensure update safety for adding settings.
+     */
     @Override
     public void add(SettingsInfo settings) {
         lockingSupport.runInWriteLock(
                 () -> super.add(settings), "add(%s[%s])".formatted(typeOf(settings), nameOf(settings)));
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Runs within a cluster-wide write lock to ensure update safety for saving settings.
+     */
     @Override
     public void save(SettingsInfo settings) {
         lockingSupport.runInWriteLock(
                 () -> super.save(settings), "save(%s[%s])".formatted(typeOf(settings), nameOf(settings)));
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Runs within a cluster-wide write lock to ensure update safety for removing settings.
+     */
     @Override
     public void remove(SettingsInfo settings) {
         lockingSupport.runInWriteLock(
                 () -> super.remove(settings), "remove(%s[%s])".formatted(typeOf(settings), nameOf(settings)));
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Runs within a cluster-wide write lock to ensure update safety for logging configuration.
+     */
     @Override
     public void setLogging(LoggingInfo logging) {
         lockingSupport.runInWriteLock(() -> super.setLogging(logging), "setLogging(LoggingInfo)");
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Runs within a cluster-wide write lock to ensure update safety for saving logging configuration.
+     */
     @Override
     public void save(LoggingInfo logging) {
         lockingSupport.runInWriteLock(() -> super.save(logging), "save(LoggingInfo)");
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Runs within a cluster-wide write lock to ensure update safety for adding services.
+     */
     @Override
     public void add(ServiceInfo service) {
         lockingSupport.runInWriteLock(
                 () -> super.add(service), "add(%s[%s])".formatted(typeOf(service), nameOf(service)));
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Runs within a cluster-wide write lock to ensure update safety for removing services.
+     */
     @Override
     public void remove(ServiceInfo service) {
         lockingSupport.runInWriteLock(
                 () -> super.remove(service), "remove(%s[%s])".formatted(typeOf(service), nameOf(service)));
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Runs within a cluster-wide write lock to ensure update safety for saving services.
+     */
     @Override
     public void save(ServiceInfo service) {
         lockingSupport.runInWriteLock(

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/locking/LockingSupport.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/locking/LockingSupport.java
@@ -19,42 +19,85 @@ import org.geoserver.catalog.impl.ModificationProxy;
 import org.geoserver.config.SettingsInfo;
 import org.geoserver.ows.util.OwsUtils;
 
-/** */
+/**
+ * An abstract utility class providing support for cluster-wide locking of catalog and configuration operations.
+ *
+ * <p>This class defines a framework for executing actions within a {@link GeoServerConfigurationLock}, which in
+ * GeoServer Cloud ensures cluster-wide update safety. It offers two implementations: one that enforces locking
+ * ({@link Enabled}) and one that bypasses it ({@link Calling}). The locking variant uses a
+ * {@link GeoServerConfigurationLock} to manage write locks, supporting both direct execution and callable tasks
+ * with exception handling. Static methods provide utility functions for identifying {@link Info} objects.
+ *
+ * <p>Example usage:
+ * <pre>
+ * GeoServerConfigurationLock lock = ...;
+ * LockingSupport locking = LockingSupport.locking(lock);
+ * locking.runInWriteLock(() -> System.out.println("Locked action"), "example operation");
+ * </pre>
+ *
+ * @since 1.0
+ * @see GeoServerConfigurationLock
+ */
 @Slf4j(topic = "org.geoserver.cloud.catalog.locking")
 public abstract class LockingSupport {
 
+    /**
+     * Executes a {@link Runnable} action within a cluster-wide write lock.
+     *
+     * @param action The action to execute; must not be null.
+     * @param reason A descriptive reason for the lock, used for logging purposes; must not be null.
+     */
     public abstract void runInWriteLock(Runnable action, String reason);
 
+    /**
+     * Executes a {@link Callable} action within a cluster-wide write lock, handling specified exceptions.
+     *
+     * @param <V> The return type of the callable.
+     * @param <E> The exception type to handle.
+     * @param exceptionType The class of exception to catch and rethrow; must not be null.
+     * @param action The callable action to execute; must not be null.
+     * @param reason A descriptive reason for the lock, used for logging purposes; must not be null.
+     * @return The result of the callable action.
+     * @throws E if the action throws an exception of type {@code E}.
+     */
     public abstract <V, E extends Exception> V callInWriteLock(
             Class<E> exceptionType, Callable<V> action, String reason) throws E;
 
+    /**
+     * A locking implementation that uses a {@link GeoServerConfigurationLock} to ensure cluster-wide safety.
+     */
     @RequiredArgsConstructor
     private static class Enabled extends LockingSupport {
 
         private final @NonNull GeoServerConfigurationLock configurationLock;
 
+        /**
+         * Acquires a write lock or upgrades an existing read lock, logging the action.
+         *
+         * @param reason The reason for acquiring the lock, used in logs.
+         */
         private void lock(String reason) {
             final LockType currentLock = configurationLock.getCurrentLock();
             if (null == currentLock) {
-
                 log.debug(" Acquiring write lock during {}", reason);
                 configurationLock.lock(LockType.WRITE);
                 log.debug("  Acquired write lock during {}", reason);
-
             } else if (currentLock == LockType.WRITE) {
-
                 log.debug("Reentering write lock during {}", reason);
                 configurationLock.lock(LockType.WRITE);
                 log.debug(" Reentered write lock during {}", reason);
-
             } else if (currentLock == LockType.READ) {
-
                 log.debug(" Upgrading read lock to write lock during {}", reason);
                 configurationLock.tryUpgradeLock();
                 log.debug("  Upgraded to write lock during {}", reason);
             }
         }
 
+        /**
+         * Releases the write lock, logging the action and handling cases where no lock is held.
+         *
+         * @param reason The reason for releasing the lock, used in logs.
+         */
         private void unlock(String reason) {
             final LockType currentLock = configurationLock.getCurrentLock();
             if (null == currentLock) {
@@ -67,6 +110,10 @@ public abstract class LockingSupport {
             }
         }
 
+        /**
+         * {@inheritDoc}
+         * <p>Executes the action within a cluster-wide write lock, converting checked exceptions to runtime exceptions.
+         */
         public void runInWriteLock(Runnable action, String reason) {
             try {
                 callInWriteLock(
@@ -83,6 +130,10 @@ public abstract class LockingSupport {
             }
         }
 
+        /**
+         * {@inheritDoc}
+         * <p>Executes the callable within a cluster-wide write lock, handling specified exceptions and ensuring lock release.
+         */
         public <V, E extends Exception> V callInWriteLock(Class<E> exceptionType, Callable<V> action, String reason)
                 throws E {
             lock(reason);
@@ -97,17 +148,27 @@ public abstract class LockingSupport {
         }
     }
 
+    /**
+     * A non-locking implementation that executes actions without synchronization.
+     */
     private static class Calling extends LockingSupport {
 
+        /**
+         * {@inheritDoc}
+         * <p>Executes the action directly without acquiring a lock.
+         */
         @Override
         public void runInWriteLock(Runnable action, String reason) {
             action.run();
         }
 
+        /**
+         * {@inheritDoc}
+         * <p>Executes the callable directly without acquiring a lock, handling specified exceptions.
+         */
         @Override
         public <V, E extends Exception> V callInWriteLock(Class<E> exceptionType, Callable<V> action, String reason)
                 throws E {
-
             try {
                 return action.call();
             } catch (Exception e) {
@@ -117,6 +178,15 @@ public abstract class LockingSupport {
         }
     }
 
+    /**
+     * Extracts a the name property from an {@link Info} object.
+     *
+     * <p>For {@link SettingsInfo}, uses the workspace name if available; otherwise, retrieves the "name" or "prefix"
+     * property, falling back to the "id" or type name if unset.
+     *
+     * @param object The {@link Info} object; may be null.
+     * @return The extracted name, or null if {@code object} is null.
+     */
     public static String nameOf(Info object) {
         if (null == object) return null;
         if (object instanceof SettingsInfo settings) {
@@ -134,15 +204,33 @@ public abstract class LockingSupport {
         return null == name ? ConfigInfoType.valueOf(object).name() : name;
     }
 
+    /**
+     * Determines the {@link ConfigInfoType} of an {@link Info} object.
+     *
+     * @param object The {@link Info} object; may be null.
+     * @return The corresponding {@link ConfigInfoType}, or null if {@code object} is null.
+     */
     public static ConfigInfoType typeOf(Info object) {
         if (null == object) return null;
         return ConfigInfoType.valueOf(object);
     }
 
+    /**
+     * Creates a locking support instance that enforces cluster-wide safety.
+     *
+     * @param configurationLock The {@link GeoServerConfigurationLock} to use; must not be null.
+     * @return A locking-enabled {@link LockingSupport} instance.
+     * @throws NullPointerException if {@code configurationLock} is null.
+     */
     public static LockingSupport locking(@NonNull GeoServerConfigurationLock configurationLock) {
         return new Enabled(configurationLock);
     }
 
+    /**
+     * Creates a locking support instance that bypasses locking.
+     *
+     * @return A non-locking {@link LockingSupport} instance.
+     */
     public static LockingSupport ignoringLocking() {
         return new Calling();
     }

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/CatalogPropertyResolver.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/CatalogPropertyResolver.java
@@ -26,46 +26,117 @@ import org.geoserver.catalog.impl.StyleInfoImpl;
 import org.geoserver.catalog.plugin.forwarding.ResolvingCatalogFacadeDecorator;
 
 /**
- * {@link ResolvingCatalogFacadeDecorator#setObjectResolver resolving function} to set the {@link
- * Catalog} property on {@link CatalogInfo} objects that require it before returning them from the
- * facade.
+ * A {@link UnaryOperator} that sets the {@link Catalog} property on {@link CatalogInfo} objects requiring it.
  *
- * @see StoreInfo#getCatalog()
- * @see ResourceInfo#getCatalog()
- * @see StyleInfoImpl#getCatalog()
+ * <p>This utility class implements a resolver for use with {@link ResolvingCatalogFacadeDecorator#setOutboundResolver(UnaryOperator)},
+ * ensuring that {@link CatalogInfo} objects (e.g., {@link StoreInfo}, {@link ResourceInfo}, {@link StyleInfo})
+ * have their catalog reference set before being returned by a facade. It recursively processes nested references
+ * (e.g., styles in a {@link LayerInfo}, layers in a {@link LayerGroupInfo}) to maintain catalog consistency.
+ * The resolver uses a catalog supplier to provide the current catalog instance, supporting dynamic catalog access.
+ *
+ * <p>Key features:
+ * <ul>
+ *   <li><strong>Catalog Assignment:</strong> Sets the catalog on supported {@link CatalogInfo} types.</li>
+ *   <li><strong>Recursive Resolution:</strong> Handles nested structures like styles, layers, and group styles.</li>
+ *   <li><strong>Null Safety:</strong> Gracefully handles null inputs, returning null without modification.</li>
+ * </ul>
+ *
+ * <p>Example usage:
+ * <pre>
+ * Catalog catalog = ...;
+ * ResolvingCatalogFacadeDecorator facade = ...;
+ * UnaryOperator<CatalogInfo> resolver = CatalogPropertyResolver.of(catalog);
+ * facade.setOutboundResolver(resolver);
+ * </pre>
+ *
+ * @param <T> The type of {@link Info} to resolve (typically {@link CatalogInfo}).
+ * @since 1.0
+ * @see ResolvingCatalogFacadeDecorator
+ * @see ModificationProxy
  */
 public class CatalogPropertyResolver<T extends Info> implements UnaryOperator<T> {
 
     private final Supplier<Catalog> catalog;
 
+    /**
+     * Constructs a resolver with a fixed {@link Catalog} instance.
+     *
+     * @param catalog The {@link Catalog} to set on resolved objects; must not be null.
+     * @throws NullPointerException if {@code catalog} is null.
+     */
     public CatalogPropertyResolver(Catalog catalog) {
-        Objects.requireNonNull(catalog);
+        Objects.requireNonNull(catalog, "Catalog must not be null");
         this.catalog = () -> catalog;
     }
 
+    /**
+     * Constructs a resolver with a dynamic {@link Catalog} supplier.
+     *
+     * @param catalog A supplier providing the {@link Catalog}; must not be null.
+     * @throws NullPointerException if {@code catalog} is null.
+     */
     public CatalogPropertyResolver(@NonNull Supplier<Catalog> catalog) {
-        Objects.requireNonNull(catalog);
+        Objects.requireNonNull(catalog, "Catalog supplier must not be null");
         this.catalog = catalog;
     }
 
+    /**
+     * Retrieves the current {@link Catalog} instance from the supplier.
+     *
+     * @return The {@link Catalog}; never null.
+     */
     @NonNull
     protected Catalog catalog() {
         return catalog.get();
     }
 
+    /**
+     * Creates a resolver for a fixed {@link Catalog} instance.
+     *
+     * @param <I>     The type of {@link Info} to resolve.
+     * @param catalog The {@link Catalog} to use; must not be null.
+     * @return A new {@link CatalogPropertyResolver} instance.
+     * @throws NullPointerException if {@code catalog} is null.
+     */
     public static <I extends Info> CatalogPropertyResolver<I> of(Catalog catalog) {
         return new CatalogPropertyResolver<>(catalog);
     }
 
+    /**
+     * Creates a resolver for a dynamic {@link Catalog} supplier.
+     *
+     * @param <I>     The type of {@link Info} to resolve.
+     * @param catalog A supplier providing the {@link Catalog}; must not be null.
+     * @return A new {@link CatalogPropertyResolver} instance.
+     * @throws NullPointerException if {@code catalog} is null.
+     */
     public static <I extends Info> CatalogPropertyResolver<I> of(Supplier<Catalog> catalog) {
         return new CatalogPropertyResolver<>(catalog);
     }
 
+    /**
+     * Applies the resolver to an {@link Info} object, setting its catalog property if applicable.
+     *
+     * @param i The {@link Info} object to resolve; may be null.
+     * @return The resolved object with catalog set, or null if {@code i} is null.
+     */
     @Override
     public T apply(T i) {
         return resolve(i);
     }
 
+    /**
+     * Resolves an {@link Info} object by setting its catalog property and processing nested references.
+     *
+     * <p>Unwraps any {@link ModificationProxy} and dispatches to type-specific resolution methods for
+     * {@link StoreInfo}, {@link ResourceInfo}, {@link StyleInfo}, {@link PublishedInfo}, and
+     * {@link LayerGroupStyle}.
+     *
+     * @param <I> The type of {@link Info}.
+     * @param i   The object to resolve; may be null.
+     * @return The resolved object, or null if {@code i} is null.
+     */
+    @SuppressWarnings("unchecked")
     private <I> I resolve(I i) {
         i = null == i ? null : ModificationProxy.unwrap(i);
         if (i instanceof StoreInfo store) setCatalog(store);
@@ -76,21 +147,41 @@ public class CatalogPropertyResolver<T extends Info> implements UnaryOperator<T>
         return i;
     }
 
+    /**
+     * Resolves a collection by applying resolution to each element.
+     *
+     * @param list The collection to resolve; may be null (no action taken).
+     */
     private void resolve(Collection<?> list) {
         if (null != list) list.forEach(this::resolve);
     }
 
+    /**
+     * Sets the catalog on a {@link PublishedInfo} object, dispatching to specific types.
+     *
+     * @param i The {@link PublishedInfo} to process; must not be null.
+     */
     private void setCatalog(@NonNull PublishedInfo i) {
         if (i instanceof LayerInfo li) setCatalog(li);
         else if (i instanceof LayerGroupInfo lg) setCatalog(lg);
     }
 
+    /**
+     * Sets the catalog on a {@link LayerInfo} and resolves its nested references.
+     *
+     * @param i The {@link LayerInfo} to process; must not be null.
+     */
     private void setCatalog(@NonNull LayerInfo i) {
         resolve(i.getResource());
         resolve(i.getDefaultStyle());
         resolve(i.getStyles());
     }
 
+    /**
+     * Sets the catalog on a {@link LayerGroupInfo} and resolves its nested references.
+     *
+     * @param i The {@link LayerGroupInfo} to process; must not be null.
+     */
     private void setCatalog(@NonNull LayerGroupInfo i) {
         resolve(i.getRootLayer());
         resolve(i.getRootLayerStyle());
@@ -99,15 +190,30 @@ public class CatalogPropertyResolver<T extends Info> implements UnaryOperator<T>
         resolve(i.getLayerGroupStyles());
     }
 
+    /**
+     * Sets the catalog on a {@link LayerGroupStyle} and resolves its nested references.
+     *
+     * @param i The {@link LayerGroupStyle} to process; must not be null.
+     */
     private void setCatalog(@NonNull LayerGroupStyle i) {
         if (null != i.getLayers()) i.getLayers().forEach(this::setCatalog);
         if (null != i.getStyles()) i.getStyles().forEach(this::setCatalog);
     }
 
+    /**
+     * Sets the catalog on a {@link StoreInfo} if it’s a concrete implementation.
+     *
+     * @param i The {@link StoreInfo} to process; must not be null.
+     */
     private void setCatalog(@NonNull StoreInfo i) {
         if (i instanceof StoreInfoImpl store) store.setCatalog(catalog());
     }
 
+    /**
+     * Sets the catalog on a {@link ResourceInfo} and resolves its nested references.
+     *
+     * @param i The {@link ResourceInfo} to process; must not be null.
+     */
     private void setCatalog(@NonNull ResourceInfo i) {
         i.setCatalog(catalog());
         resolve(i.getStore());
@@ -116,6 +222,11 @@ public class CatalogPropertyResolver<T extends Info> implements UnaryOperator<T>
         }
     }
 
+    /**
+     * Sets the catalog on a {@link StyleInfo} if it’s a concrete implementation.
+     *
+     * @param i The {@link StyleInfo} to process; must not be null.
+     */
     private void setCatalog(@NonNull StyleInfo i) {
         if (i instanceof StyleInfoImpl style) style.setCatalog(catalog());
     }

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/CollectionPropertiesInitializer.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/CollectionPropertiesInitializer.java
@@ -10,15 +10,47 @@ import org.geoserver.catalog.plugin.forwarding.ResolvingCatalogFacadeDecorator;
 import org.geoserver.ows.util.OwsUtils;
 
 /**
- * {@link ResolvingCatalogFacadeDecorator#setObjectResolver resolving function} that returns the
- * incoming object decorated with a {@link ModificationProxy}
+ * A {@link UnaryOperator} that initializes null collection properties of objects to empty collections.
  *
- * @see OwsUtils#resolveCollections
+ * <p>This utility class provides a resolver for use with
+ * {@link ResolvingCatalogFacadeDecorator#setOutboundResolver(UnaryOperator)}, ensuring that collection
+ * properties (e.g., lists, sets) within an object are initialized to empty collections if null. It leverages
+ * {@link OwsUtils#resolveCollections(Object)} to perform the initialization, making objects safe for use
+ * in contexts where null collections are undesirable. The resolver is stateless and reusable via a
+ * singleton instance.
+ *
+ * <p>Key features:
+ * <ul>
+ *   <li><strong>Collection Initialization:</strong> Converts null collections to empty ones within the object.</li>
+ *   <li><strong>Null Safety:</strong> Returns null for null inputs without modification.</li>
+ *   <li><strong>Singleton Design:</strong> Provides a single, reusable instance via {@link #instance()}.</li>
+ * </ul>
+ *
+ * <p>Example usage:
+ * <pre>
+ * ResolvingCatalogFacadeDecorator facade = ...;
+ * UnaryOperator<Object> resolver = CollectionPropertiesInitializer.instance();
+ * facade.setOutboundResolver(resolver);
+ * </pre>
+ *
+ * @param <T> The type of object to process (typically {@link CatalogInfo} or other {@link ModificationProxy}-compatible types).
+ * @since 1.0
+ * @see OwsUtils#resolveCollections(Object)
+ * @see ResolvingCatalogFacadeDecorator
  */
 public class CollectionPropertiesInitializer<T> implements UnaryOperator<T> {
 
     private static final CollectionPropertiesInitializer<?> INSTANCE = new CollectionPropertiesInitializer<>();
 
+    /**
+     * Applies the resolver to initialize null collection properties of an object.
+     *
+     * <p>Uses {@link OwsUtils#resolveCollections(Object)} to ensure all null collection fields are set to
+     * empty collections. If the input is null, returns null without modification.
+     *
+     * @param value The object to process; may be null.
+     * @return The processed object with initialized collections, or null if {@code value} is null.
+     */
     @Override
     public T apply(T value) {
         if (value != null) {
@@ -27,6 +59,18 @@ public class CollectionPropertiesInitializer<T> implements UnaryOperator<T> {
         return value;
     }
 
+    /**
+     * Returns the singleton instance of this resolver.
+     *
+     * @param <T> The type of object to process.
+     * @return The singleton {@link CollectionPropertiesInitializer}; never null.
+     * @example Using the singleton instance:
+     *          <pre>
+     *          UnaryOperator<Object> resolver = CollectionPropertiesInitializer.instance();
+     *          Object obj = ...;
+     *          Object resolved = resolver.apply(obj);
+     *          </pre>
+     */
     @SuppressWarnings("unchecked")
     public static <T> CollectionPropertiesInitializer<T> instance() {
         return (CollectionPropertiesInitializer<T>) INSTANCE;

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/ModificationProxyDecorator.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/ModificationProxyDecorator.java
@@ -6,29 +6,103 @@ package org.geoserver.catalog.plugin.resolving;
 
 import java.util.function.UnaryOperator;
 import lombok.experimental.UtilityClass;
+import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.impl.ClassMappings;
 import org.geoserver.catalog.impl.ModificationProxy;
 import org.geoserver.catalog.impl.ProxyUtils;
-import org.geoserver.catalog.plugin.forwarding.ResolvingCatalogFacadeDecorator;
 
 /**
- * {@link ResolvingCatalogFacadeDecorator#setObjectResolver resolving function} that returns the
- * incoming object decorated with a {@link ModificationProxy}
+ * A utility class providing {@link UnaryOperator} functions to wrap or unwrap objects with a
+ * {@link ModificationProxy} for use in resolving facades.
  *
- * @see ModificationProxy#create(Object, Class)
+ * <p>This class offers factory methods to create operators that either decorate objects with a
+ * {@link ModificationProxy} ({@link #wrap()}) or remove such proxies ({@link #unwrap()}). These operators
+ * are designed for use with {@link ResolvingCatalogFacade#setOutboundResolver(UnaryOperator)} or
+ * {@link ResolvingCatalogFacade#setInboundResolver(UnaryOperator)}, enabling modification tracking or
+ * proxy removal in catalog operations. The wrapping preserves object state changes, while unwrapping
+ * retrieves the underlying instance.
+ *
+ * <p>Key features:
+ * <ul>
+ *   <li><strong>Proxy Wrapping:</strong> {@link #wrap()} adds a {@link ModificationProxy} to objects if
+ *       not already proxied, ensuring type safety via {@link ClassMappings}.</li>
+ *   <li><strong>Proxy Unwrapping:</strong> {@link #unwrap()} removes {@link ModificationProxy} wrappers,
+ *       returning the raw object or null if the input is null.</li>
+ *   <li><strong>Null Safety:</strong> Both operators handle null inputs gracefully, returning null as
+ *       appropriate.</li>
+ * </ul>
+ *
+ * <p>Example usage in a resolving facade:
+ * <pre>
+ * {@code
+ * ResolvingCatalogFacade facade = ...;
+ * facade.setOutboundResolver(ModificationProxyDecorator.wrap());
+ * facade.setInboundResolver(ModificationProxyDecorator.unwrap());
+ * }
+ * </pre>
+ * This configures the facade to wrap outbound {@link CatalogInfo} objects in a {@link ModificationProxy}
+ * and unwrap inbound objects.
+ *
+ * @since 1.0
+ * @see ModificationProxy
+ * @see ResolvingCatalogFacade
  */
 @UtilityClass
 public class ModificationProxyDecorator {
 
+    /**
+     * Returns a {@link UnaryOperator} that wraps objects in a {@link ModificationProxy}.
+     *
+     * <p>The operator applies {@link #wrap(Object)} to each input, adding a proxy if the object isn’t
+     * already proxied, or returning it unchanged if it is or if null.
+     *
+     * @param <T> The type of object to wrap (typically a {@link CatalogInfo} subtype).
+     * @return A {@link UnaryOperator} for wrapping objects; never null.
+     * @example Using the wrap operator:
+     *          <pre>
+     *          UnaryOperator<CatalogInfo> wrapper = ModificationProxyDecorator.wrap();
+     *          CatalogInfo info = ...;
+     *          CatalogInfo proxied = wrapper.apply(info);
+     *          </pre>
+     */
     public static <T> UnaryOperator<T> wrap() {
         return ModificationProxyDecorator::wrap;
     }
 
+    /**
+     * Returns a {@link UnaryOperator} that unwraps objects from a {@link ModificationProxy}.
+     *
+     * <p>The operator applies {@link #unwrap(Object)} to each input, removing any {@link ModificationProxy}
+     * wrapper or returning null if the input is null.
+     *
+     * @param <T> The type of object to unwrap (typically a {@link CatalogInfo} subtype).
+     * @return A {@link UnaryOperator} for unwrapping objects; never null.
+     * @example Using the unwrap operator:
+     *          <pre>
+     *          UnaryOperator<CatalogInfo> unwrapper = ModificationProxyDecorator.unwrap();
+     *          CatalogInfo proxied = ...;
+     *          CatalogInfo raw = unwrapper.apply(proxied);
+     *          </pre>
+     */
     public static <T> UnaryOperator<T> unwrap() {
         return ModificationProxyDecorator::unwrap;
     }
 
+    /**
+     * Wraps an object in a {@link ModificationProxy} if it isn’t already proxied.
+     *
+     * <p>Checks if the input is non-null and not already a {@link ModificationProxy}. If so, it determines
+     * the appropriate catalog interface via {@link ClassMappings} and creates a proxy using
+     * {@link ModificationProxy#create(Object, Class)}. Returns null if the input is null, or the original
+     * object if already proxied.
+     *
+     * @param <T>  The type of object to wrap (typically a {@link CatalogInfo} subtype).
+     * @param info The object to wrap; may be null.
+     * @return The wrapped object, or null if {@code info} is null.
+     * @throws IllegalArgumentException if {@code info} is non-null but its type cannot be mapped to a
+     *                                  {@link CatalogInfo} subtype (e.g., an unrecognized proxy).
+     */
     @SuppressWarnings("unchecked")
     public static <T> T wrap(T info) {
         if (info != null && null == ProxyUtils.handler(info, ModificationProxy.class)) {
@@ -44,6 +118,16 @@ public class ModificationProxyDecorator {
         return info;
     }
 
+    /**
+     * Unwraps an object from a {@link ModificationProxy}, returning the underlying instance.
+     *
+     * <p>If the input is null, returns null. Otherwise, uses {@link ModificationProxy#unwrap(Object)} to
+     * remove any proxy wrapper and return the raw object.
+     *
+     * @param <T> The type of object to unwrap (typically a {@link CatalogInfo} subtype).
+     * @param i   The object to unwrap; may be null.
+     * @return The unwrapped object, or null if {@code i} is null.
+     */
     public static <T> T unwrap(T i) {
         return i == null ? null : ModificationProxy.unwrap(i);
     }

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/ResolvingCatalogInfoRepository.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/ResolvingCatalogInfoRepository.java
@@ -9,7 +9,40 @@ import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository;
 
 /**
+ * An abstract base class for catalog info repositories that support resolving {@link CatalogInfo} objects
+ * with configurable inbound and outbound transformations.
+ *
+ * <p>This class combines the data access functionality of {@link CatalogInfoRepository} with the resolving
+ * capabilities of {@link ResolvingFacade}, enabling concrete implementations to manage {@link CatalogInfo}
+ * persistence while applying custom transformations (e.g., proxy resolution, property initialization) to
+ * objects entering and leaving the repository. It uses a {@link ResolvingFacadeSupport} instance to handle
+ * the resolution logic, with default identity resolvers that can be customized via
+ * {@link #setOutboundResolver(UnaryOperator)} and {@link #setInboundResolver(UnaryOperator)}.
+ *
+ * <p>Key aspects:
+ * <ul>
+ *   <li><strong>Resolution Support:</strong> Provides methods to set and apply inbound/outbound resolvers
+ *       for {@link CatalogInfo} objects.</li>
+ *   <li><strong>Repository Base:</strong> Serves as a foundation for type-specific repositories (e.g.,
+ *       for {@link org.geoserver.catalog.StoreInfo}), delegating CRUD operations to subclasses.</li>
+ * </ul>
+ *
+ * <p>Subclasses must implement the {@link CatalogInfoRepository} methods (e.g., {@code add}, {@code findById})
+ * and ensure resolved objects are processed appropriately using {@link #resolveInbound(CatalogInfo)} for
+ * inputs and {@link #resolveOutbound(CatalogInfo)} for outputs.
+ *
+ * <p>Example usage:
+ * <pre>
+ * ResolvingCatalogInfoRepository<StoreInfo> repo = ...;
+ * repo.setOutboundResolver(CatalogPropertyResolver.of(catalog));
+ * StoreInfo store = repo.findById("id", StoreInfo.class); // Returns resolved object
+ * </pre>
+ *
+ * @param <T> The specific type of {@link CatalogInfo} this repository manages.
  * @since 1.4
+ * @see CatalogInfoRepository
+ * @see ResolvingFacade
+ * @see ResolvingFacadeSupport
  */
 public abstract class ResolvingCatalogInfoRepository<T extends CatalogInfo>
         implements ResolvingFacade<T>, CatalogInfoRepository<T> {
@@ -17,37 +50,58 @@ public abstract class ResolvingCatalogInfoRepository<T extends CatalogInfo>
     private final ResolvingFacadeSupport<T> resolver;
 
     /**
-     * @param template
+     * Constructs a new resolving repository with default identity resolvers.
+     *
+     * <p>Initializes the internal {@link ResolvingFacadeSupport} to manage inbound and outbound resolution
+     * with no transformations unless explicitly set.
      */
     protected ResolvingCatalogInfoRepository() {
         this.resolver = new ResolvingFacadeSupport<>();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void setOutboundResolver(UnaryOperator<T> resolvingFunction) {
         resolver.setOutboundResolver(resolvingFunction);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public UnaryOperator<T> getOutboundResolver() {
         return resolver.getOutboundResolver();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void setInboundResolver(UnaryOperator<T> resolvingFunction) {
         resolver.setInboundResolver(resolvingFunction);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public UnaryOperator<T> getInboundResolver() {
         return resolver.getInboundResolver();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public <C extends T> C resolveOutbound(C info) {
         return resolver.resolveOutbound(info);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public <C extends T> C resolveInbound(C info) {
         return resolver.resolveInbound(info);

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/ResolvingFacadeSupport.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/ResolvingFacadeSupport.java
@@ -9,56 +9,132 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.UnaryOperator;
 
-/** */
+/**
+ * A utility implementation of {@link ResolvingFacade} for managing inbound and outbound resolution of generic objects.
+ *
+ * <p>This class provides a concrete support mechanism for applying {@link UnaryOperator} functions to objects
+ * of type {@code T}, both when received (inbound) and before they are returned (outbound). It maintains two
+ * resolvers—{@code outboundResolver} and {@code inboundResolver}—defaulting to the identity function
+ * ({@link UnaryOperator#identity()}), and allows customization via {@link #setOutboundResolver(UnaryOperator)}
+ * and {@link #setInboundResolver(UnaryOperator)}. It’s designed to simplify the integration of resolution
+ * logic into facades or repositories, such as {@link ResolvingCatalogFacadeDecorator}.
+ *
+ * <p>Key aspects:
+ * <ul>
+ *   <li><strong>Resolver Management:</strong> Holds and applies configurable inbound and outbound resolvers.</li>
+ *   <li><strong>List Support:</strong> Includes a helper method to resolve lists of objects outbound.</li>
+ * </ul>
+ *
+ * <p>Example usage:
+ * <pre>
+ * <code>
+ * ResolvingFacadeSupport<CatalogInfo> support = new ResolvingFacadeSupport<>();
+ * support.setOutboundResolver(info -> { &lt;custom logic&gt;... return info; });
+ * CatalogInfo resolved = support.resolveOutbound(info);
+ * </code>
+ * </pre>
+ *
+ * @param <T> The type of objects to resolve (e.g., {@link CatalogInfo}).
+ * @since 1.0
+ * @see ResolvingFacade
+ * @see UnaryOperator
+ */
 public class ResolvingFacadeSupport<T> implements ResolvingFacade<T> {
 
     private UnaryOperator<T> outboundResolver = UnaryOperator.identity();
     private UnaryOperator<T> inboundResolver = UnaryOperator.identity();
 
+    /**
+     * {@inheritDoc}
+     * @throws NullPointerException if {@code resolvingFunction} is null.
+     */
     @Override
     public void setOutboundResolver(UnaryOperator<T> resolvingFunction) {
-        Objects.requireNonNull(resolvingFunction);
+        Objects.requireNonNull(resolvingFunction, "Outbound resolving function must not be null");
         this.outboundResolver = resolvingFunction;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Returns the current outbound resolver, defaulting to {@link UnaryOperator#identity()}.
+     */
     @Override
     public UnaryOperator<T> getOutboundResolver() {
         return this.outboundResolver;
     }
 
+    /**
+     * {@inheritDoc}
+     * @throws NullPointerException if {@code resolvingFunction} is null.
+     */
     @Override
     public void setInboundResolver(UnaryOperator<T> resolvingFunction) {
-        Objects.requireNonNull(resolvingFunction);
+        Objects.requireNonNull(resolvingFunction, "Inbound resolving function must not be null");
         this.inboundResolver = resolvingFunction;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Returns the current inbound resolver, defaulting to {@link UnaryOperator#identity()}.
+     */
     @Override
     public UnaryOperator<T> getInboundResolver() {
         return this.inboundResolver;
     }
 
+    /**
+     * Provides the outbound resolver as a type-safe {@link UnaryOperator} for a specific subtype.
+     *
+     * @param <I> The subtype of {@code T}.
+     * @return The outbound resolver cast to the subtype; never null.
+     */
     @SuppressWarnings("unchecked")
     public <I extends T> UnaryOperator<I> outbound() {
         return (UnaryOperator<I>) outboundResolver;
     }
 
+    /**
+     * Provides the inbound resolver as a type-safe {@link UnaryOperator} for a specific subtype.
+     *
+     * @param <I> The subtype of {@code T}.
+     * @return The inbound resolver cast to the subtype; never null.
+     */
     @SuppressWarnings("unchecked")
     public <I extends T> UnaryOperator<I> inbound() {
         return (UnaryOperator<I>) inboundResolver;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Applies the outbound resolver to the input object.
+     */
     @Override
     public <C extends T> C resolveOutbound(C info) {
         UnaryOperator<C> outboundResolve = outbound();
         return outboundResolve.apply(info);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Applies the inbound resolver to the input object.
+     */
     @Override
     public <C extends T> C resolveInbound(C info) {
         UnaryOperator<C> inboundResolve = inbound();
         return inboundResolve.apply(info);
     }
 
+    /**
+     * Resolves a list of objects using the outbound resolver.
+     *
+     * <p>Transforms each element in the list via {@link #resolveOutbound(Object)}, preserving order and
+     * allowing null results.
+     *
+     * @param <C>  The subtype of {@code T}.
+     * @param info The list to resolve; must not be null.
+     * @return A new list with resolved elements.
+     * @throws NullPointerException if {@code info} is null.
+     */
     protected <C extends T> List<C> resolveOutbound(List<C> info) {
         return Lists.transform(info, this::resolveOutbound);
     }

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/ResolvingProxyResolver.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/ResolvingProxyResolver.java
@@ -9,6 +9,7 @@ import java.lang.reflect.Proxy;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
@@ -35,17 +36,40 @@ import org.geoserver.config.ServiceInfo;
 import org.geoserver.config.SettingsInfo;
 
 /**
- * {@link ResolvingCatalogFacadeDecorator#setObjectResolver resolving function} that resolves {@link
- * CatalogInfo} properties that are proxied through {@link ResolvingProxy} before returning the
- * object from the facade.
+ * A {@link UnaryOperator} that resolves {@link ResolvingProxy} references within {@link CatalogInfo} objects.
  *
- * <p>When resolving object references from a stream of objects, it's convenient to use the {@link
- * #memoizing() memoizing} supplier, which will keep a local cache during the lifetime of the stream
- * to avoid querying the catalog over repeated occurrences. Note though, this may not be necessary
- * at if the catalog can do very fast id lookups. For example, if it has its own caching mechanism
- * or is a purely in-memory catalog.
+ * <p>This utility resolves proxied properties in {@link CatalogInfo} objects (e.g., {@link StoreInfo#getWorkspace()},
+ * {@link ResourceInfo#getNamespace()}) by fetching actual instances from a supplied {@link Catalog}, suitable
+ * for use with {@link ResolvingCatalogFacadeDecorator#setOutboundResolver(UnaryOperator)}. It processes both top-level
+ * proxies and nested references recursively, with configurable behavior for unresolved proxies via a
+ * {@link BiConsumer} callback. A memoizing variant is available via {@link #memoizing()} for efficient stream
+ * processing.
  *
+ * <p>Key features:
+ * <ul>
+ *   <li><strong>Proxy Resolution:</strong> Replaces {@link ResolvingProxy} instances with catalog objects.</li>
+ *   <li><strong>Recursive Handling:</strong> Resolves nested references in complex types (e.g., {@link LayerGroupInfo}).</li>
+ *   <li><strong>Configurable Failure:</strong> Allows customization of unresolved proxy handling.</li>
+ *   <li><strong>Memoization Option:</strong> Offers a caching variant for repeated lookups.</li>
+ * </ul>
+ *
+ * <p>Example usage:
+ * <pre>
+ * Catalog catalog = ...;
+ * ResolvingProxyResolver<CatalogInfo> resolver = ResolvingProxyResolver.of(catalog);
+ * ResolvingCatalogFacadeDecorator facade = ...;
+ * facade.setOutboundResolver(resolver);
+ * </pre>
+ *
+ * <p>When resolving object references from a stream of objects, it’s convenient to use the {@link #memoizing()}
+ * supplier, which will keep a local cache during the lifetime of the stream to avoid querying the catalog over
+ * repeated occurrences. Note though, this may not be necessary if the catalog can do very fast id lookups—for
+ * example, if it has its own caching mechanism or is a purely in-memory catalog.
+ *
+ * @param <T> The type of object to resolve (typically {@link CatalogInfo} or its subtypes).
+ * @since 1.0
  * @see ResolvingProxy
+ * @see ResolvingCatalogFacadeDecorator
  */
 @Slf4j(topic = "org.geoserver.catalog.plugin.resolving")
 public class ResolvingProxyResolver<T> implements UnaryOperator<T> {
@@ -55,6 +79,14 @@ public class ResolvingProxyResolver<T> implements UnaryOperator<T> {
 
     private BiConsumer<CatalogInfo, ResolvingProxy> onNotFound;
 
+    /**
+     * Constructs a resolver with a catalog supplier and default not-found behavior.
+     *
+     * <p>Uses a logging warning as the default action for unresolved proxies.
+     *
+     * @param catalog The supplier of the {@link Catalog} for resolution; must not be null.
+     * @throws NullPointerException if {@code catalog} is null.
+     */
     private ResolvingProxyResolver(@NonNull Supplier<Catalog> catalog) {
         this(
                 catalog,
@@ -62,23 +94,59 @@ public class ResolvingProxyResolver<T> implements UnaryOperator<T> {
                         .formatted(info.getId())));
     }
 
+    /**
+     * Constructs a resolver with a catalog supplier and custom not-found behavior.
+     *
+     * @param catalog   The supplier of the {@link Catalog} for resolution; must not be null.
+     * @param onNotFound The action to take when a proxy cannot be resolved; must not be null.
+     * @throws NullPointerException if {@code catalog} or {@code onNotFound} is null.
+     */
     private ResolvingProxyResolver(
             @NonNull Supplier<Catalog> catalog, @NonNull BiConsumer<CatalogInfo, ResolvingProxy> onNotFound) {
+        Objects.requireNonNull(catalog, "Catalog supplier must not be null");
+        Objects.requireNonNull(onNotFound, "onNotFound consumer must not be null");
         this.catalog = catalog;
         this.onNotFound = onNotFound;
         this.proxyUtils = new ProxyUtils(catalog, Optional.empty());
     }
 
+    /**
+     * Creates a resolver with a fixed catalog and custom not-found behavior.
+     *
+     * @param <I>        The type of {@link Info} to resolve.
+     * @param catalog    The {@link Catalog} to use; must not be null.
+     * @param onNotFound The action for unresolved proxies; must not be null.
+     * @return A new {@link ResolvingProxyResolver} instance.
+     * @throws NullPointerException if {@code catalog} or {@code onNotFound} is null.
+     */
     public static <I extends Info> ResolvingProxyResolver<I> of(
             Catalog catalog, BiConsumer<CatalogInfo, ResolvingProxy> onNotFound) {
         return new ResolvingProxyResolver<>(() -> catalog, onNotFound);
     }
 
+    /**
+     * Creates a resolver with a catalog supplier and custom not-found behavior.
+     *
+     * @param <I>        The type of {@link Info} to resolve.
+     * @param catalog    The supplier of the {@link Catalog}; must not be null.
+     * @param onNotFound The action for unresolved proxies; must not be null.
+     * @return A new {@link ResolvingProxyResolver} instance.
+     * @throws NullPointerException if {@code catalog} or {@code onNotFound} is null.
+     */
     public static <I extends Info> ResolvingProxyResolver<I> of(
             Supplier<Catalog> catalog, BiConsumer<CatalogInfo, ResolvingProxy> onNotFound) {
         return new ResolvingProxyResolver<>(catalog, onNotFound);
     }
 
+    /**
+     * Creates a resolver with a fixed catalog and configurable failure on not found.
+     *
+     * @param <I>           The type of {@link Info} to resolve.
+     * @param catalog       The {@link Catalog} to use; must not be null.
+     * @param errorOnNotFound If true, throws an exception on unresolved proxies; if false, logs a warning.
+     * @return A new {@link ResolvingProxyResolver} instance.
+     * @throws NullPointerException if {@code catalog} is null.
+     */
     public static <I extends Info> ResolvingProxyResolver<I> of(Catalog catalog, boolean errorOnNotFound) {
         if (errorOnNotFound)
             return ResolvingProxyResolver.of(catalog, (proxiedInfo, proxy) -> {
@@ -87,29 +155,78 @@ public class ResolvingProxyResolver<T> implements UnaryOperator<T> {
         return ResolvingProxyResolver.of(catalog);
     }
 
+    /**
+     * Creates a resolver with a fixed catalog and default not-found behavior.
+     *
+     * @param <I>     The type of {@link Info} to resolve.
+     * @param catalog The {@link Catalog} to use; must not be null.
+     * @return A new {@link ResolvingProxyResolver} instance.
+     * @throws NullPointerException if {@code catalog} is null.
+     */
     public static <I extends Info> ResolvingProxyResolver<I> of(Catalog catalog) {
         return new ResolvingProxyResolver<>(() -> catalog);
     }
 
+    /**
+     * Creates a resolver with a catalog supplier and default not-found behavior.
+     *
+     * @param <I>     The type of {@link Info} to resolve.
+     * @param catalog The supplier of the {@link Catalog}; must not be null.
+     * @return A new {@link ResolvingProxyResolver} instance.
+     * @throws NullPointerException if {@code catalog} is null.
+     */
     public static <I extends Info> ResolvingProxyResolver<I> of(Supplier<Catalog> catalog) {
         return new ResolvingProxyResolver<>(catalog);
     }
 
+    /**
+     * Creates a memoizing version of this resolver.
+     *
+     * <p>The memoizing variant caches resolved objects by ID to optimize repeated lookups, useful for streams.
+     *
+     * @param <I> The type of {@link Info} to resolve.
+     * @return A memoizing {@link ResolvingProxyResolver}.
+     */
     @SuppressWarnings("unchecked")
     public <I extends Info> ResolvingProxyResolver<I> memoizing() {
         return (ResolvingProxyResolver<I>) new MemoizingProxyResolver(catalog, onNotFound);
     }
 
+    /**
+     * Configures the action for unresolved proxies.
+     *
+     * @param onNotFound The action to take when a proxy cannot be resolved; must not be null.
+     * @return This resolver instance for chaining.
+     * @throws NullPointerException if {@code onNotFound} is null.
+     */
     public ResolvingProxyResolver<T> onNotFound(BiConsumer<CatalogInfo, ResolvingProxy> onNotFound) {
+        Objects.requireNonNull(onNotFound, "onNotFound consumer must not be null");
         this.onNotFound = onNotFound;
         return this;
     }
 
+    /**
+     * Applies the resolver to process an object, resolving any {@link ResolvingProxy} references.
+     *
+     * @param info The object to resolve; may be null.
+     * @return The resolved object, or null if {@code info} is null.
+     */
     @Override
     public T apply(T info) {
         return resolve(info);
     }
 
+    /**
+     * Resolves an object, handling top-level and nested {@link ResolvingProxy} references.
+     *
+     * <p>If the object is a {@link ResolvingProxy}, resolves it via the catalog; otherwise, processes nested
+     * references based on type (e.g., {@link LayerInfo}, {@link StoreInfo}). Unresolved proxies trigger the
+     * configured {@code onNotFound} action, defaulting to keeping the proxy if no exception is thrown.
+     *
+     * @param <I>  The type of object to resolve.
+     * @param orig The object to resolve; may be null.
+     * @return The resolved object, or {@code orig} if unresolved and allowed by {@code onNotFound}.
+     */
     @SuppressWarnings("unchecked")
     public <I> I resolve(final I orig) {
         if (orig == null) {
@@ -150,18 +267,43 @@ public class ResolvingProxyResolver<T> implements UnaryOperator<T> {
         return orig;
     }
 
+    /**
+     * Resolves a {@link Patch} using internal utilities.
+     *
+     * @param patch The {@link Patch} to resolve; must not be null.
+     * @return The resolved {@link Patch}.
+     */
     private Patch resolveInternal(Patch patch) {
         return proxyUtils.resolve(patch);
     }
 
+    /**
+     * Performs the actual proxy resolution using {@link ProxyUtils}.
+     *
+     * @param <I>  The type of {@link Info}.
+     * @param orig The proxy object to resolve; must not be null.
+     * @return The resolved object, or null if not found.
+     */
     protected <I extends Info> I doResolveProxy(final I orig) {
         return proxyUtils.resolve(orig);
     }
 
+    /**
+     * Checks if an object is a {@link ResolvingProxy}.
+     *
+     * @param unresolved The {@link CatalogInfo} to check; may be null.
+     * @return {@code true} if it’s a {@link ResolvingProxy}, {@code false} otherwise.
+     */
     protected boolean isResolvingProxy(final CatalogInfo unresolved) {
         return getResolvingProxy(unresolved) != null;
     }
 
+    /**
+     * Retrieves the {@link ResolvingProxy} handler if present.
+     *
+     * @param unresolved The {@link Info} to check; may be null.
+     * @return The {@link ResolvingProxy} handler, or null if not a proxy or not a {@link ResolvingProxy}.
+     */
     protected ResolvingProxy getResolvingProxy(final Info unresolved) {
         if (unresolved != null) {
             boolean isProxy = Proxy.isProxyClass(unresolved.getClass());
@@ -175,6 +317,13 @@ public class ResolvingProxyResolver<T> implements UnaryOperator<T> {
         return null;
     }
 
+    /**
+     * Resolves nested references in a {@link PublishedInfo} polymorphically.
+     *
+     * @param <P>       The type of {@link PublishedInfo}.
+     * @param published The {@link PublishedInfo} to resolve; must not be null.
+     * @return The resolved {@link PublishedInfo}.
+     */
     @SuppressWarnings("unchecked")
     protected <P extends PublishedInfo> P resolveInternal(P published) {
         if (published instanceof LayerInfo layer) return (P) resolveInternal(layer);
@@ -184,6 +333,12 @@ public class ResolvingProxyResolver<T> implements UnaryOperator<T> {
         return published;
     }
 
+    /**
+     * Resolves nested references in a {@link LayerInfo}.
+     *
+     * @param layer The {@link LayerInfo} to resolve; must not be null.
+     * @return The resolved {@link LayerInfo}.
+     */
     protected LayerInfo resolveInternal(LayerInfo layer) {
         if (isResolvingProxy(layer.getResource())) layer.setResource(resolve(layer.getResource()));
 
@@ -191,17 +346,20 @@ public class ResolvingProxyResolver<T> implements UnaryOperator<T> {
 
         final boolean hasProxiedStyles = layer.getStyles().stream().anyMatch(this::isResolvingProxy);
         if (hasProxiedStyles) {
-
-            LinkedHashSet<StyleInfo> resolvedStyles;
-            resolvedStyles =
+            LinkedHashSet<StyleInfo> resolvedStyles =
                     layer.getStyles().stream().map(this::resolve).collect(Collectors.toCollection(LinkedHashSet::new));
-
             layer.getStyles().clear();
             layer.getStyles().addAll(resolvedStyles);
         }
         return layer;
     }
 
+    /**
+     * Resolves nested references in a {@link LayerGroupInfo}.
+     *
+     * @param lg The {@link LayerGroupInfo} to resolve; must not be null.
+     * @return The resolved {@link LayerGroupInfo}.
+     */
     protected LayerGroupInfo resolveInternal(LayerGroupInfo lg) {
         for (int i = 0; i < lg.getLayers().size(); i++) {
             PublishedInfo l = lg.getLayers().get(i);
@@ -222,6 +380,12 @@ public class ResolvingProxyResolver<T> implements UnaryOperator<T> {
         return lg;
     }
 
+    /**
+     * Resolves nested references in a {@link StyleInfo}.
+     *
+     * @param style The {@link StyleInfo} to resolve; must not be null.
+     * @return The resolved {@link StyleInfo}.
+     */
     protected StyleInfo resolveInternal(StyleInfo style) {
         // resolve the workspace
         WorkspaceInfo ws = style.getWorkspace();
@@ -231,6 +395,12 @@ public class ResolvingProxyResolver<T> implements UnaryOperator<T> {
         return style;
     }
 
+    /**
+     * Resolves nested references in a {@link StoreInfo}.
+     *
+     * @param store The {@link StoreInfo} to resolve; must not be null.
+     * @return The resolved {@link StoreInfo}.
+     */
     protected StoreInfo resolveInternal(StoreInfo store) {
         // resolve the workspace
         WorkspaceInfo ws = store.getWorkspace();
@@ -240,16 +410,34 @@ public class ResolvingProxyResolver<T> implements UnaryOperator<T> {
         return store;
     }
 
+    /**
+     * Resolves nested references in a {@link SettingsInfo}.
+     *
+     * @param settings The {@link SettingsInfo} to resolve; must not be null.
+     * @return The resolved {@link SettingsInfo}.
+     */
     protected SettingsInfo resolveInternal(SettingsInfo settings) {
         settings.setWorkspace(resolve(settings.getWorkspace()));
         return settings;
     }
 
+    /**
+     * Resolves nested references in a {@link ServiceInfo}.
+     *
+     * @param service The {@link ServiceInfo} to resolve; must not be null.
+     * @return The resolved {@link ServiceInfo}.
+     */
     protected ServiceInfo resolveInternal(ServiceInfo service) {
         service.setWorkspace(resolve(service.getWorkspace()));
         return service;
     }
 
+    /**
+     * Resolves nested references in a {@link ResourceInfo}.
+     *
+     * @param resource The {@link ResourceInfo} to resolve; must not be null.
+     * @return The resolved {@link ResourceInfo}.
+     */
     protected ResourceInfo resolveInternal(ResourceInfo resource) {
         // resolve the store
         StoreInfo store = resource.getStore();
@@ -265,15 +453,31 @@ public class ResolvingProxyResolver<T> implements UnaryOperator<T> {
         return resource;
     }
 
+    /**
+     * A memoizing variant of {@link ResolvingProxyResolver} that caches resolved objects.
+     */
     private static class MemoizingProxyResolver extends ResolvingProxyResolver<Info> {
 
         private Map<String, Info> resolvedById = new ConcurrentHashMap<>();
 
+        /**
+         * Constructs a memoizing resolver with a catalog supplier and not-found behavior.
+         *
+         * @param catalog    The supplier of the {@link Catalog}; must not be null.
+         * @param onNotFound The action for unresolved proxies; must not be null.
+         */
         public MemoizingProxyResolver(
                 @NonNull Supplier<Catalog> catalog, BiConsumer<CatalogInfo, ResolvingProxy> onNotFound) {
             super(catalog, onNotFound);
         }
 
+        /**
+         * Resolves a proxy, using the cache to avoid repeated lookups.
+         *
+         * @param <I>  The type of {@link Info}.
+         * @param orig The proxy object to resolve; must not be null.
+         * @return The resolved object, or null if not found.
+         */
         @SuppressWarnings("unchecked")
         protected @Override <I extends Info> I doResolveProxy(final I orig) {
             String id = orig.getId();
@@ -287,6 +491,13 @@ public class ResolvingProxyResolver<T> implements UnaryOperator<T> {
             return resolved;
         }
 
+        /**
+         * Computes and caches the resolved object if absent.
+         *
+         * @param <I>  The type of {@link Info}.
+         * @param orig The proxy object to resolve; must not be null.
+         * @return The resolved object.
+         */
         @SuppressWarnings("unchecked")
         private <I extends Info> I computeIfAbsent(final I orig) {
             return (I) resolvedById.computeIfAbsent(orig.getId(), key -> super.doResolveProxy(orig));


### PR DESCRIPTION
* Update and expand Javadoc across multiple classes for improved clarity and guidance
* Detailed descriptions added to CatalogFacadeExtensionAdapter, CatalogInfoRepository interfaces, and related holder and repository classes
* Enhanced usage examples and API details for forwarding decorators (e.g. ForwardingCatalog, ForwardingCatalogFacade, and their repository counterparts)
* Improve resolving framework documentation and behavior
* Added comprehensive Javadoc for ResolvingCatalogFacadeDecorator, CatalogPropertyResolver, ResolvingProxyResolver, and supporting utility classes
* Clarified inbound/outbound resolution pipelines, null safety, and proxy handling with examples
* Refine locking support for cluster-wide configuration updates
* Updated LockingCatalog, LockingGeoServer, and LockingSupport with enhanced documentation explaining lock granularity and usage in GeoServer Cloud
* General code cleanup and comment reformatting to standardize documentation across the catalog plugin module