### PR TITLE
Replace FilteringXmlBeanDefinitionReader with new @ImportFilteredResource annotation in configuration classes

### DIFF
--- a/src/apps/geoserver/wcs/src/main/java/org/geoserver/cloud/wcs/WcsApplicationConfiguration.java
+++ b/src/apps/geoserver/wcs/src/main/java/org/geoserver/cloud/wcs/WcsApplicationConfiguration.java
@@ -5,22 +5,19 @@
 package org.geoserver.cloud.wcs;
 
 import org.geoserver.catalog.Catalog;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.cloud.virtualservice.VirtualServiceVerifier;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 @Configuration
-@ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = { //
-            "jar:gs-wcs-.*!/applicationContext.xml", //
-            "jar:gs-wcs1_0-.*!/applicationContext.xml", //
-            "jar:gs-wcs1_1-.*!/applicationContext.xml", //
-            "jar:gs-wcs2_0-.*!/applicationContext.xml" //
-        })
+@ImportFilteredResource({ //
+    "jar:gs-wcs-.*!/applicationContext.xml", //
+    "jar:gs-wcs1_0-.*!/applicationContext.xml", //
+    "jar:gs-wcs1_1-.*!/applicationContext.xml", //
+    "jar:gs-wcs2_0-.*!/applicationContext.xml" //
+})
 public class WcsApplicationConfiguration {
 
     @Bean

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebCoreConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebCoreConfiguration.java
@@ -5,22 +5,19 @@
 package org.geoserver.cloud.autoconfigure.web.core;
 
 import org.apache.wicket.protocol.http.WicketServlet;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.web.GeoServerBasePage;
 import org.geoserver.web.GeoServerWicketServlet;
 import org.geoserver.web.HeaderContribution;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 @Configuration(proxyBeanMethods = true)
-@ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = { //
-            "jar:gs-web-core-.*!/applicationContext.xml#name=" + WebCoreConfiguration.EXCLUDED_BEANS_PATTERN, //
-            "jar:gs-web-rest-.*!/applicationContext.xml" //
-        })
+@ImportFilteredResource({
+    "jar:gs-web-core-.*!/applicationContext.xml#name=" + WebCoreConfiguration.EXCLUDED_BEANS_PATTERN, //
+    "jar:gs-web-rest-.*!/applicationContext.xml" //
+})
 public class WebCoreConfiguration {
 
     static final String EXCLUDED_BEANS_PATTERN = "^(?!logsPage).*$";

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/DemoRequestsConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/DemoRequestsConfiguration.java
@@ -5,11 +5,10 @@
 package org.geoserver.cloud.autoconfigure.web.demo;
 
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 @Configuration
 @ConditionalOnClass(name = "org.geoserver.web.demo.SRSListPage")
@@ -18,9 +17,7 @@ import org.springframework.context.annotation.ImportResource;
         name = "demo-requests",
         havingValue = "true",
         matchIfMissing = true)
-@ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=demoRequests"})
+@ImportFilteredResource("jar:gs-web-demo-.*!/applicationContext.xml#name=demoRequests")
 public class DemoRequestsConfiguration extends AbstractWebUIAutoConfiguration {
 
     static final String CONFIG_PREFIX = DemosAutoConfiguration.CONFIG_PREFIX + ".demo-requests";

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/LayerPreviewConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/LayerPreviewConfiguration.java
@@ -8,12 +8,11 @@ import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration
 import org.geoserver.cloud.autoconfigure.web.demo.LayerPreviewConfiguration.GmlCommonFormatsConfiguration;
 import org.geoserver.cloud.autoconfigure.web.demo.LayerPreviewConfiguration.KmlCommonFormatsConfiguration;
 import org.geoserver.cloud.autoconfigure.web.demo.LayerPreviewConfiguration.OpenLayersCommonFormatsConfiguration;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.ImportResource;
 
 @Configuration
 @ConditionalOnClass(name = "org.geoserver.web.demo.MapPreviewPage")
@@ -22,9 +21,7 @@ import org.springframework.context.annotation.ImportResource;
         name = "enabled",
         havingValue = "true",
         matchIfMissing = true)
-@ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=layerListDemo2"})
+@ImportFilteredResource("jar:gs-web-demo-.*!/applicationContext.xml#name=layerListDemo2")
 @Import({
     OpenLayersCommonFormatsConfiguration.class,
     GmlCommonFormatsConfiguration.class,
@@ -46,9 +43,7 @@ public class LayerPreviewConfiguration extends AbstractWebUIAutoConfiguration {
             name = "open-layers",
             havingValue = "true",
             matchIfMissing = true)
-    @ImportResource( //
-            reader = FilteringXmlBeanDefinitionReader.class, //
-            locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=openLayersPreview"})
+    @ImportFilteredResource("jar:gs-web-demo-.*!/applicationContext.xml#name=openLayersPreview")
     public class OpenLayersCommonFormatsConfiguration extends AbstractWebUIAutoConfiguration {
 
         static final String CONFIG_PREFIX = LayerPreviewConfiguration.COMMON_FORMATS_PREFIX + ".open-layers";
@@ -65,9 +60,7 @@ public class LayerPreviewConfiguration extends AbstractWebUIAutoConfiguration {
             name = "gml",
             havingValue = "true",
             matchIfMissing = true)
-    @ImportResource( //
-            reader = FilteringXmlBeanDefinitionReader.class, //
-            locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=gMLPreview"})
+    @ImportFilteredResource("jar:gs-web-demo-.*!/applicationContext.xml#name=gMLPreview")
     public class GmlCommonFormatsConfiguration extends AbstractWebUIAutoConfiguration {
 
         static final String CONFIG_PREFIX = LayerPreviewConfiguration.COMMON_FORMATS_PREFIX + ".gml";
@@ -84,9 +77,7 @@ public class LayerPreviewConfiguration extends AbstractWebUIAutoConfiguration {
             name = "kml",
             havingValue = "true",
             matchIfMissing = true)
-    @ImportResource( //
-            reader = FilteringXmlBeanDefinitionReader.class, //
-            locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=kMLPreview"})
+    @ImportFilteredResource("jar:gs-web-demo-.*!/applicationContext.xml#name=kMLPreview")
     public class KmlCommonFormatsConfiguration extends AbstractWebUIAutoConfiguration {
 
         static final String CONFIG_PREFIX = LayerPreviewConfiguration.COMMON_FORMATS_PREFIX + ".kml";

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/ReprojectionConsoleConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/ReprojectionConsoleConfiguration.java
@@ -5,11 +5,10 @@
 package org.geoserver.cloud.autoconfigure.web.demo;
 
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 @Configuration
 @ConditionalOnClass(name = "org.geoserver.web.demo.SRSListPage")
@@ -18,9 +17,7 @@ import org.springframework.context.annotation.ImportResource;
         name = "reprojection-console",
         havingValue = "true",
         matchIfMissing = true)
-@ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=reprojectionConsole"})
+@ImportFilteredResource("jar:gs-web-demo-.*!/applicationContext.xml#name=reprojectionConsole")
 public class ReprojectionConsoleConfiguration extends AbstractWebUIAutoConfiguration {
 
     static final String CONFIG_PREFIX = DemosAutoConfiguration.CONFIG_PREFIX + ".reprojection-console";

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/SrsListConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/SrsListConfiguration.java
@@ -5,11 +5,10 @@
 package org.geoserver.cloud.autoconfigure.web.demo;
 
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 @Configuration
 @ConditionalOnClass(name = "org.geoserver.web.demo.SRSListPage")
@@ -18,9 +17,7 @@ import org.springframework.context.annotation.ImportResource;
         name = "srs-list",
         havingValue = "true",
         matchIfMissing = true)
-@ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=srsList"})
+@ImportFilteredResource("jar:gs-web-demo-.*!/applicationContext.xml#name=srsList")
 public class SrsListConfiguration extends AbstractWebUIAutoConfiguration {
 
     static final String CONFIG_PREFIX = DemosAutoConfiguration.CONFIG_PREFIX + ".srs-list";

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/WcsRequestBuilderConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/WcsRequestBuilderConfiguration.java
@@ -5,11 +5,10 @@
 package org.geoserver.cloud.autoconfigure.web.demo;
 
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 @Configuration(proxyBeanMethods = true)
 @ConditionalOnClass(name = "org.geoserver.wcs.web.demo.WCSRequestBuilder")
@@ -18,12 +17,7 @@ import org.springframework.context.annotation.ImportResource;
         name = "wcs-request-builder",
         havingValue = "true",
         matchIfMissing = true)
-@ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = { //
-            "jar:gs-web-wcs-.*!/applicationContext.xml#name=wcsRequestBuilder"
-        } //
-        )
+@ImportFilteredResource("jar:gs-web-wcs-.*!/applicationContext.xml#name=wcsRequestBuilder")
 public class WcsRequestBuilderConfiguration extends AbstractWebUIAutoConfiguration {
 
     static final String CONFIG_PREFIX = DemosAutoConfiguration.CONFIG_PREFIX + ".wcs-request-builder";

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/WpsRequestBuilderConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/demo/WpsRequestBuilderConfiguration.java
@@ -5,11 +5,10 @@
 package org.geoserver.cloud.autoconfigure.web.demo;
 
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 @Configuration(proxyBeanMethods = true)
 @ConditionalOnClass(name = "org.geoserver.wps.web.WPSRequestBuilder")
@@ -18,9 +17,7 @@ import org.springframework.context.annotation.ImportResource;
         name = "wps-request-builder",
         havingValue = "true",
         matchIfMissing = true)
-@ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = "jar:gs-web-wps-.*!/applicationContext.xml#name=wpsRequestBuilder")
+@ImportFilteredResource("jar:gs-web-wps-.*!/applicationContext.xml#name=wpsRequestBuilder")
 public class WpsRequestBuilderConfiguration extends AbstractWebUIAutoConfiguration {
 
     static final String CONFIG_PREFIX = DemosAutoConfiguration.CONFIG_PREFIX + ".wps-request-builder";

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/extension/importer/ImporterConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/extension/importer/ImporterConfiguration.java
@@ -4,16 +4,12 @@
  */
 package org.geoserver.cloud.autoconfigure.web.extension.importer;
 
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 @Configuration(proxyBeanMethods = true)
-@ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = { //
-            "jar:gs-importer-core-.*!/applicationContext.xml", //
-            "jar:gs-importer-web-.*!/applicationContext.xml" //
-        } //
-        )
+@ImportFilteredResource({
+    "jar:gs-importer-core-.*!/applicationContext.xml",
+    "jar:gs-importer-web-.*!/applicationContext.xml"
+})
 public class ImporterConfiguration {}

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/security/SecurityConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/security/SecurityConfiguration.java
@@ -12,24 +12,20 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.security.filter.GeoServerLogoutFilter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 @Configuration(proxyBeanMethods = true)
-@ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = { //
-            "jar:gs-web-sec-core-.*!/applicationContext.xml", //
-            "jar:gs-web-sec-jdbc-.*!/applicationContext.xml", //
-            "jar:gs-web-sec-ldap-.*!/applicationContext.xml" //
-        } //
-        )
+@ImportFilteredResource({
+    "jar:gs-web-sec-core-.*!/applicationContext.xml",
+    "jar:gs-web-sec-jdbc-.*!/applicationContext.xml",
+    "jar:gs-web-sec-ldap-.*!/applicationContext.xml"
+})
 public class SecurityConfiguration {
 
     @Bean

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/tools/CatalogBulkLoadToolConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/tools/CatalogBulkLoadToolConfiguration.java
@@ -5,11 +5,10 @@
 package org.geoserver.cloud.autoconfigure.web.tools;
 
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 @Configuration
 @ConditionalOnClass(name = "org.geoserver.web.catalogstresstool.CatalogStressTester")
@@ -18,9 +17,7 @@ import org.springframework.context.annotation.ImportResource;
         name = "catalog-bulk-load",
         havingValue = "true",
         matchIfMissing = true)
-@ImportResource(
-        reader = FilteringXmlBeanDefinitionReader.class,
-        locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=CatalogStresser"})
+@ImportFilteredResource("jar:gs-web-demo-.*!/applicationContext.xml#name=CatalogStresser")
 public class CatalogBulkLoadToolConfiguration extends AbstractWebUIAutoConfiguration {
 
     static final String CONFIG_PREFIX = ToolsAutoConfiguration.CONFIG_PREFIX + ".catalog-bulk-load";

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/tools/ReprojectionConsoleConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/tools/ReprojectionConsoleConfiguration.java
@@ -5,11 +5,10 @@
 package org.geoserver.cloud.autoconfigure.web.tools;
 
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 @Configuration
 @ConditionalOnClass(name = "org.geoserver.web.catalogstresstool.CatalogStressTester")
@@ -18,9 +17,7 @@ import org.springframework.context.annotation.ImportResource;
         name = "reprojection-console",
         havingValue = "true",
         matchIfMissing = true)
-@ImportResource(
-        reader = FilteringXmlBeanDefinitionReader.class,
-        locations = {"jar:gs-web-demo-.*!/applicationContext.xml#name=reprojectionConsole"})
+@ImportFilteredResource("jar:gs-web-demo-.*!/applicationContext.xml#name=reprojectionConsole")
 public class ReprojectionConsoleConfiguration extends AbstractWebUIAutoConfiguration {
 
     static final String CONFIG_PREFIX = ToolsAutoConfiguration.CONFIG_PREFIX + ".reprojection-console";

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/tools/ResourceBrowserConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/tools/ResourceBrowserConfiguration.java
@@ -5,11 +5,10 @@
 package org.geoserver.cloud.autoconfigure.web.tools;
 
 import org.geoserver.cloud.autoconfigure.web.core.AbstractWebUIAutoConfiguration;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 /**
  * Configuration to enable the <a href=
@@ -25,9 +24,7 @@ import org.springframework.context.annotation.ImportResource;
         name = "resource-browser",
         havingValue = "true",
         matchIfMissing = true)
-@ImportResource(
-        reader = FilteringXmlBeanDefinitionReader.class,
-        locations = {"jar:gs-web-resource-.*!/applicationContext.xml"})
+@ImportFilteredResource("jar:gs-web-resource-.*!/applicationContext.xml")
 public class ResourceBrowserConfiguration extends AbstractWebUIAutoConfiguration {
 
     static final String CONFIG_PREFIX = ToolsAutoConfiguration.CONFIG_PREFIX + ".resource-browser";

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/wcs/WcsConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/wcs/WcsConfiguration.java
@@ -4,20 +4,16 @@
  */
 package org.geoserver.cloud.autoconfigure.web.wcs;
 
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 @Configuration(proxyBeanMethods = true)
-@ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = { //
-            "jar:gs-wcs-.*!/applicationContext.xml", //
-            "jar:gs-wcs1_0-.*!/applicationContext.xml", //
-            "jar:gs-wcs1_1-.*!/applicationContext.xml", //
-            "jar:gs-wcs2_0-.*!/applicationContext.xml", //
-            // exclude wcs request builder, the DemosAutoConfiguration takes care of it
-            "jar:gs-web-wcs-.*!/applicationContext.xml#name=^(?!wcsRequestBuilder).*$"
-        } //
-        )
+@ImportFilteredResource({
+    "jar:gs-wcs-.*!/applicationContext.xml",
+    "jar:gs-wcs1_0-.*!/applicationContext.xml",
+    "jar:gs-wcs1_1-.*!/applicationContext.xml",
+    "jar:gs-wcs2_0-.*!/applicationContext.xml",
+    // exclude wcs request builder, the DemosAutoConfiguration takes care of it
+    "jar:gs-web-wcs-.*!/applicationContext.xml#name=^(?!wcsRequestBuilder).*$"
+})
 public class WcsConfiguration {}

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/wfs/WfsConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/wfs/WfsConfiguration.java
@@ -4,18 +4,14 @@
  */
 package org.geoserver.cloud.autoconfigure.web.wfs;
 
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 @Configuration(proxyBeanMethods = true)
-@ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = { //
-            "jar:gs-web-wfs-.*!/applicationContext.xml", //
-            "jar:gs-wfs-.*!/applicationContext.xml",
-            "jar:gs-flatgeobuf-.*!/applicationContext.xml#name=.*",
-            "jar:gs-dxf-core-.*!/applicationContext.xml#name=.*"
-        } //
-        )
+@ImportFilteredResource({
+    "jar:gs-web-wfs-.*!/applicationContext.xml",
+    "jar:gs-wfs-.*!/applicationContext.xml",
+    "jar:gs-flatgeobuf-.*!/applicationContext.xml#name=.*",
+    "jar:gs-dxf-core-.*!/applicationContext.xml#name=.*"
+})
 public class WfsConfiguration {}

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/wms/WmsConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/wms/WmsConfiguration.java
@@ -4,18 +4,15 @@
  */
 package org.geoserver.cloud.autoconfigure.web.wms;
 
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 @Configuration(proxyBeanMethods = true)
-@ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {
-            "jar:gs-web-wms-.*!/applicationContext.xml", //
-            "jar:gs-wms-.*!/applicationContext.xml#name=" + WmsConfiguration.WMS_BEANS_REGEX, //
-            "jar:gs-wfs-.*!/applicationContext.xml#name=" + WmsConfiguration.WFS_BEANS_REGEX
-        })
+@ImportFilteredResource({
+    "jar:gs-web-wms-.*!/applicationContext.xml",
+    "jar:gs-wms-.*!/applicationContext.xml#name=" + WmsConfiguration.WMS_BEANS_REGEX,
+    "jar:gs-wfs-.*!/applicationContext.xml#name=" + WmsConfiguration.WFS_BEANS_REGEX
+})
 public class WmsConfiguration {
 
     static final String WFS_BEANS_REGEX =

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/wps/WpsConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/wps/WpsConfiguration.java
@@ -4,19 +4,16 @@
  */
 package org.geoserver.cloud.autoconfigure.web.wps;
 
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 @Configuration(proxyBeanMethods = true)
-@ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {
-            // exclude wpsRequestBuilder, DemosAutoConfiguration takes care of it
-            "jar:gs-web-wps-.*!/applicationContext.xml#name=^(?!wpsRequestBuilder).*$",
-            "jar:gs-wps-.*!/applicationContext.xml",
-            "jar:gs-wcs-.*!/applicationContext.xml",
-            "jar:gs-dxf-core-.*!/applicationContext.xml#name=.*",
-            "jar:gs-dxf-wps-.*!/applicationContext.xml#name=.*"
-        })
+@ImportFilteredResource({
+    // exclude wpsRequestBuilder, DemosAutoConfiguration takes care of it
+    "jar:gs-web-wps-.*!/applicationContext.xml#name=^(?!wpsRequestBuilder).*$",
+    "jar:gs-wps-.*!/applicationContext.xml",
+    "jar:gs-wcs-.*!/applicationContext.xml",
+    "jar:gs-dxf-core-.*!/applicationContext.xml#name=.*",
+    "jar:gs-dxf-wps-.*!/applicationContext.xml#name=.*"
+})
 public class WpsConfiguration {}

--- a/src/apps/geoserver/wfs/src/main/java/org/geoserver/cloud/wfs/config/WfsAutoConfiguration.java
+++ b/src/apps/geoserver/wfs/src/main/java/org/geoserver/cloud/wfs/config/WfsAutoConfiguration.java
@@ -6,22 +6,18 @@ package org.geoserver.cloud.wfs.config;
 
 import org.geoserver.catalog.Catalog;
 import org.geoserver.cloud.autoconfigure.core.GeoServerWebMvcMainAutoConfiguration;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.cloud.virtualservice.VirtualServiceVerifier;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ImportResource;
 
 @AutoConfiguration(after = GeoServerWebMvcMainAutoConfiguration.class)
-@ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {
-            "jar:gs-wfs-.*!/applicationContext.xml#name=.*",
-            "jar:gs-flatgeobuf-.*!/applicationContext.xml#name=.*",
-            "jar:gs-dxf-core-.*!/applicationContext.xml#name=.*"
-        } //
-        )
+@ImportFilteredResource({
+    "jar:gs-wfs-.*!/applicationContext.xml#name=.*",
+    "jar:gs-flatgeobuf-.*!/applicationContext.xml#name=.*",
+    "jar:gs-dxf-core-.*!/applicationContext.xml#name=.*"
+})
 public class WfsAutoConfiguration {
 
     @Bean

--- a/src/apps/geoserver/wms/src/main/java/org/geoserver/cloud/autoconfigure/wms/KMLAutoConfiguration.java
+++ b/src/apps/geoserver/wms/src/main/java/org/geoserver/cloud/autoconfigure/wms/KMLAutoConfiguration.java
@@ -4,7 +4,7 @@
  */
 package org.geoserver.cloud.autoconfigure.wms;
 
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.cloud.wms.controller.kml.KMLIconsController;
 import org.geoserver.cloud.wms.controller.kml.KMLReflectorController;
 import org.geoserver.community.mbstyle.MBStyleHandler;
@@ -15,7 +15,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 /**
  * @since 1.0
@@ -23,9 +22,7 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(name = "geoserver.wms.kml.enabled", havingValue = "true", matchIfMissing = true)
 @ConditionalOnClass(MBStyleHandler.class)
-@ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {"jar:gs-kml-.*!/applicationContext.xml#name=^(?!WFSKMLOutputFormat|kmlURLMapping).*$"})
+@ImportFilteredResource("jar:gs-kml-.*!/applicationContext.xml#name=^(?!WFSKMLOutputFormat|kmlURLMapping).*$")
 public class KMLAutoConfiguration {
 
     @Bean

--- a/src/apps/geoserver/wms/src/main/java/org/geoserver/cloud/autoconfigure/wms/WmsApplicationAutoConfiguration.java
+++ b/src/apps/geoserver/wms/src/main/java/org/geoserver/cloud/autoconfigure/wms/WmsApplicationAutoConfiguration.java
@@ -7,7 +7,7 @@ package org.geoserver.cloud.autoconfigure.wms;
 import java.util.List;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.cloud.autoconfigure.gwc.integration.WMSIntegrationAutoConfiguration;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.cloud.virtualservice.VirtualServiceVerifier;
 import org.geoserver.cloud.wms.app.StatusCodeWmsExceptionHandler;
 import org.geoserver.cloud.wms.controller.GetMapReflectorController;
@@ -27,18 +27,15 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ImportResource;
 import org.springframework.core.env.PropertyResolver;
 
 // auto-configure before GWC's wms-integration to avoid it precluding to load beans from
 // jar:gs-wms-.*
 @AutoConfiguration(before = WMSIntegrationAutoConfiguration.class)
-@ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = { //
-            "jar:gs-wms-.*!/applicationContext.xml#name=" + WmsApplicationAutoConfiguration.WMS_BEANS_BLACKLIST, //
-            "jar:gs-wfs-.*!/applicationContext.xml#name=" + WmsApplicationAutoConfiguration.WFS_BEANS_WHITELIST //
-        })
+@ImportFilteredResource({
+    "jar:gs-wms-.*!/applicationContext.xml#name=" + WmsApplicationAutoConfiguration.WMS_BEANS_BLACKLIST,
+    "jar:gs-wfs-.*!/applicationContext.xml#name=" + WmsApplicationAutoConfiguration.WFS_BEANS_WHITELIST
+})
 public class WmsApplicationAutoConfiguration {
 
     static final String WFS_BEANS_WHITELIST =

--- a/src/apps/geoserver/wps/src/main/java/org/geoserver/cloud/wps/WpsApplicationConfiguration.java
+++ b/src/apps/geoserver/wps/src/main/java/org/geoserver/cloud/wps/WpsApplicationConfiguration.java
@@ -5,26 +5,23 @@
 package org.geoserver.cloud.wps;
 
 import org.geoserver.catalog.Catalog;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.cloud.virtualservice.VirtualServiceVerifier;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 @Configuration
-@ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = { //
-            "jar:gs-wps-.*!/applicationContext.xml", //
-            "jar:gs-wcs-.*!/applicationContext.xml", //
-            "jar:gs-wcs1_0-.*!/applicationContext.xml", //
-            "jar:gs-wcs1_1-.*!/applicationContext.xml", //
-            "jar:gs-wcs2_0-.*!/applicationContext.xml", //
-            "jar:gs-wfs-.*!/applicationContext.xml#name=^(?!wfsInsertElementHandler|wfsUpdateElementHandler|wfsDeleteElementHandler|wfsReplaceElementHandler).*$", //
-            "jar:gs-dxf-core-.*!/applicationContext.xml#name=.*",
-            "jar:gs-dxf-wps-.*!/applicationContext.xml#name=.*"
-        })
+@ImportFilteredResource({
+    "jar:gs-wps-.*!/applicationContext.xml",
+    "jar:gs-wcs-.*!/applicationContext.xml",
+    "jar:gs-wcs1_0-.*!/applicationContext.xml",
+    "jar:gs-wcs1_1-.*!/applicationContext.xml",
+    "jar:gs-wcs2_0-.*!/applicationContext.xml",
+    "jar:gs-wfs-.*!/applicationContext.xml#name=^(?!wfsInsertElementHandler|wfsUpdateElementHandler|wfsDeleteElementHandler|wfsReplaceElementHandler).*$",
+    "jar:gs-dxf-core-.*!/applicationContext.xml#name=.*",
+    "jar:gs-dxf-wps-.*!/applicationContext.xml#name=.*"
+})
 public class WpsApplicationConfiguration {
 
     @Bean

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/security/GeoServerSecurityConfiguration.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/security/GeoServerSecurityConfiguration.java
@@ -10,7 +10,7 @@ import java.util.function.Supplier;
 import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.geoserver.cloud.autoconfigure.security.ConditionalOnGeoServerSecurityEnabled;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.cloud.event.security.SecurityConfigChanged;
 import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.platform.config.UpdateSequence;
@@ -22,7 +22,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
-import org.springframework.context.annotation.ImportResource;
 
 /**
  * Loads geoserver security bean definitions from {@code
@@ -40,10 +39,9 @@ import org.springframework.context.annotation.ImportResource;
  * this configuration. Defaults to {@code true}.
  */
 @Configuration
-@ImportResource(
-        reader = FilteringXmlBeanDefinitionReader.class, //
+@ImportFilteredResource(
         // exclude authenticationManager from applicationSecurityContext.xml
-        locations = {GeoServerSecurityConfiguration.APPLICATION_SECURITY_CONTEXT_FILTER})
+        GeoServerSecurityConfiguration.APPLICATION_SECURITY_CONTEXT_FILTER)
 @Slf4j(topic = "org.geoserver.cloud.config.security")
 @ConditionalOnGeoServerSecurityEnabled
 public class GeoServerSecurityConfiguration {

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/WMTSIntegrationAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/WMTSIntegrationAutoConfiguration.java
@@ -7,11 +7,10 @@ package org.geoserver.cloud.autoconfigure.gwc.integration;
 import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnWMTSIntegrationEnabled;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geowebcache.service.wmts.WMTSService;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.context.annotation.ImportResource;
 
 /**
  * @since 1.0
@@ -19,9 +18,7 @@ import org.springframework.context.annotation.ImportResource;
 @AutoConfiguration
 @ConditionalOnWMTSIntegrationEnabled
 @ConditionalOnClass(WMTSService.class)
-@ImportResource(
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {"jar:gs-gwc-[0-9]+.*!/geowebcache-geoserver-wmts-integration.xml"})
+@ImportFilteredResource("jar:gs-gwc-[0-9]+.*!/geowebcache-geoserver-wmts-integration.xml")
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.integration")
 public class WMTSIntegrationAutoConfiguration {
 

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/web/gwc/GeoServerWebUIAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/web/gwc/GeoServerWebUIAutoConfiguration.java
@@ -8,13 +8,12 @@ import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoServerWebUIEnabled;
 import org.geoserver.cloud.autoconfigure.gwc.GoServerWebUIConfigurationProperties;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.config.GeoServer;
 import org.geoserver.gwc.GWC;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 /**
  * Auto configuration to enabled GWC Wicket Web UI components.
@@ -32,13 +31,8 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration
 @ConditionalOnGeoServerWebUIEnabled
 @EnableConfigurationProperties(GoServerWebUIConfigurationProperties.class)
-@ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class,
-        locations = {
-            "jar:gs-web-gwc-.*!/applicationContext.xml#name=^(?!"
-                    + GeoServerWebUIAutoConfiguration.EXCLUDED_BEANS
-                    + ").*$"
-        })
+@ImportFilteredResource(
+        "jar:gs-web-gwc-.*!/applicationContext.xml#name=^(?!" + GeoServerWebUIAutoConfiguration.EXCLUDED_BEANS + ").*$")
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.web.gwc")
 public class GeoServerWebUIAutoConfiguration {
 

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/DiskQuotaConfiguration.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/DiskQuotaConfiguration.java
@@ -4,7 +4,7 @@
  */
 package org.geoserver.cloud.gwc.config.core;
 
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.gwc.config.GeoserverXMLResourceProvider;
 import org.geowebcache.config.ConfigurationException;
 import org.geowebcache.diskquota.DiskQuotaMonitor;
@@ -13,15 +13,12 @@ import org.geowebcache.storage.DefaultStorageFinder;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 /**
  * @since 1.0
  */
 @Configuration(proxyBeanMethods = false)
-@ImportResource(
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {"jar:gs-gwc-[0-9]+.*!/geowebcache-diskquota-context.xml#name=^(?!DiskQuotaConfigLoader).*$"})
+@ImportFilteredResource("jar:gs-gwc-[0-9]+.*!/geowebcache-diskquota-context.xml#name=^(?!DiskQuotaConfigLoader).*$")
 public class DiskQuotaConfiguration {
 
     static {

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/GeoServerIntegrationConfiguration.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/GeoServerIntegrationConfiguration.java
@@ -6,7 +6,7 @@ package org.geoserver.cloud.gwc.config.core;
 
 import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.cloud.gwc.event.ConfigChangeEvent;
 import org.geoserver.config.util.XStreamPersisterFactory;
 import org.geoserver.gwc.config.CloudGwcConfigPersister;
@@ -15,16 +15,13 @@ import org.geoserver.platform.GeoServerResourceLoader;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 /**
  * @since 1.0
  * @see DefaultTileLayerCatalogConfiguration
  */
 @Configuration(proxyBeanMethods = true)
-@ImportResource(
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {GeoServerIntegrationConfiguration.GS_INTEGRATION_INCLUDES})
+@ImportFilteredResource(GeoServerIntegrationConfiguration.GS_INTEGRATION_INCLUDES)
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.core")
 public class GeoServerIntegrationConfiguration {
 

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/GeoWebCacheCoreConfiguration.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/GeoWebCacheCoreConfiguration.java
@@ -21,7 +21,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import lombok.extern.slf4j.Slf4j;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.cloud.gwc.repository.CloudDefaultStorageFinder;
 import org.geoserver.cloud.gwc.repository.CloudGwcXmlConfiguration;
 import org.geoserver.cloud.gwc.repository.CloudXMLResourceProvider;
@@ -44,7 +44,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 import org.springframework.core.env.Environment;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
@@ -53,11 +52,8 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
  */
 @Configuration(proxyBeanMethods = true)
 @EnableConfigurationProperties(GeoWebCacheConfigurationProperties.class)
-@ImportResource(
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {
-            "jar:gs-gwc-[0-9]+.*!/geowebcache-core-context.xml#name=^(?!gwcXmlConfig|gwcDefaultStorageFinder|metastoreRemover).*$"
-        })
+@ImportFilteredResource(
+        "jar:gs-gwc-[0-9]+.*!/geowebcache-core-context.xml#name=^(?!gwcXmlConfig|gwcDefaultStorageFinder|metastoreRemover).*$")
 @Slf4j(topic = "org.geoserver.cloud.gwc.config.core")
 public class GeoWebCacheCoreConfiguration {
 

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/WebMapServiceMinimalConfiguration.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/WebMapServiceMinimalConfiguration.java
@@ -5,7 +5,7 @@
 package org.geoserver.cloud.gwc.config.core;
 
 import java.util.List;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.config.GeoServer;
 import org.geoserver.gwc.layer.GeoServerTileLayer;
 import org.geoserver.platform.Service;
@@ -19,7 +19,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
-import org.springframework.context.annotation.ImportResource;
 
 /**
  * Configuration to create a minimal {@link WebMapService} bean, may it not exist, to be used by
@@ -28,12 +27,10 @@ import org.springframework.context.annotation.ImportResource;
  * @since 1.0
  */
 @Configuration
-@ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = { //
-            WebMapServiceMinimalConfiguration.GS_WMS_INCLUDES, //
-            WebMapServiceMinimalConfiguration.GS_WFS_INCLUDES //
-        })
+@ImportFilteredResource({
+    WebMapServiceMinimalConfiguration.GS_WMS_INCLUDES,
+    WebMapServiceMinimalConfiguration.GS_WFS_INCLUDES
+})
 public class WebMapServiceMinimalConfiguration {
 
     /**

--- a/src/gwc/services/src/main/java/org/geoserver/cloud/gwc/config/services/GoogleMapsConfiguration.java
+++ b/src/gwc/services/src/main/java/org/geoserver/cloud/gwc/config/services/GoogleMapsConfiguration.java
@@ -4,13 +4,12 @@
  */
 package org.geoserver.cloud.gwc.config.services;
 
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geowebcache.service.gmaps.GMapsConverter;
 import org.gwc.web.gmaps.GoogleMapsController;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 /**
  * @since 1.0
@@ -18,7 +17,5 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(GMapsConverter.class)
 @ComponentScan(basePackageClasses = GoogleMapsController.class)
-@ImportResource(
-        reader = FilteringXmlBeanDefinitionReader.class,
-        locations = "jar:gs-gwc-[0-9]+.*!/geowebcache-gmaps-context.xml#name=gwcServiceGMapsTarget")
+@ImportFilteredResource("jar:gs-gwc-[0-9]+.*!/geowebcache-gmaps-context.xml#name=gwcServiceGMapsTarget")
 public class GoogleMapsConfiguration {}

--- a/src/gwc/services/src/main/java/org/geoserver/cloud/gwc/config/services/KMLConfiguration.java
+++ b/src/gwc/services/src/main/java/org/geoserver/cloud/gwc/config/services/KMLConfiguration.java
@@ -4,13 +4,12 @@
  */
 package org.geoserver.cloud.gwc.config.services;
 
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geowebcache.service.kml.KMLService;
 import org.gwc.web.kml.KMLController;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 /**
  * @since 1.0
@@ -18,7 +17,5 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(KMLService.class)
 @ComponentScan(basePackageClasses = KMLController.class)
-@ImportResource(
-        reader = FilteringXmlBeanDefinitionReader.class,
-        locations = "jar:gs-gwc-[0-9]+.*!/geowebcache-kmlservice-context.xml#name=gwcServiceKMLTarget")
+@ImportFilteredResource("jar:gs-gwc-[0-9]+.*!/geowebcache-kmlservice-context.xml#name=gwcServiceKMLTarget")
 public class KMLConfiguration {}

--- a/src/gwc/services/src/main/java/org/geoserver/cloud/gwc/config/services/MGMapsConfiguration.java
+++ b/src/gwc/services/src/main/java/org/geoserver/cloud/gwc/config/services/MGMapsConfiguration.java
@@ -4,13 +4,12 @@
  */
 package org.geoserver.cloud.gwc.config.services;
 
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geowebcache.service.mgmaps.MGMapsConverter;
 import org.gwc.web.mgmaps.MGMapsController;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 /**
  * @since 1.0
@@ -18,7 +17,5 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(MGMapsConverter.class)
 @ComponentScan(basePackageClasses = MGMapsController.class)
-@ImportResource(
-        reader = FilteringXmlBeanDefinitionReader.class,
-        locations = "jar:gs-gwc-[0-9]+.*!/geowebcache-gmaps-context.xml#name=gwcServiceMGMapsTarget")
+@ImportFilteredResource("jar:gs-gwc-[0-9]+.*!/geowebcache-gmaps-context.xml#name=gwcServiceMGMapsTarget")
 public class MGMapsConfiguration {}

--- a/src/gwc/services/src/main/java/org/geoserver/cloud/gwc/config/services/TileMapServiceConfiguration.java
+++ b/src/gwc/services/src/main/java/org/geoserver/cloud/gwc/config/services/TileMapServiceConfiguration.java
@@ -4,13 +4,12 @@
  */
 package org.geoserver.cloud.gwc.config.services;
 
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geowebcache.service.tms.TMSService;
 import org.gwc.web.tms.TMSController;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 /**
  * @since 1.0
@@ -18,7 +17,5 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(TMSService.class)
 @ComponentScan(basePackageClasses = TMSController.class)
-@ImportResource(
-        reader = FilteringXmlBeanDefinitionReader.class,
-        locations = "jar:gs-gwc-[0-9]+.*!/geowebcache-tmsservice-context.xml")
+@ImportFilteredResource("jar:gs-gwc-[0-9]+.*!/geowebcache-tmsservice-context.xml")
 public class TileMapServiceConfiguration {}

--- a/src/gwc/services/src/main/java/org/geoserver/cloud/gwc/config/services/WebMapServiceConfiguration.java
+++ b/src/gwc/services/src/main/java/org/geoserver/cloud/gwc/config/services/WebMapServiceConfiguration.java
@@ -4,13 +4,12 @@
  */
 package org.geoserver.cloud.gwc.config.services;
 
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geowebcache.service.wms.WMSService;
 import org.gwc.web.wms.WMSController;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 /**
  * @since 1.0
@@ -18,7 +17,5 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(WMSService.class)
 @ComponentScan(basePackageClasses = WMSController.class)
-@ImportResource(
-        reader = FilteringXmlBeanDefinitionReader.class,
-        locations = "jar:gs-gwc-[0-9]+.*!/geowebcache-wmsservice-context.xml")
+@ImportFilteredResource("jar:gs-gwc-[0-9]+.*!/geowebcache-wmsservice-context.xml")
 public class WebMapServiceConfiguration {}

--- a/src/gwc/services/src/main/java/org/geoserver/cloud/gwc/config/services/WebMapTileServiceConfiguration.java
+++ b/src/gwc/services/src/main/java/org/geoserver/cloud/gwc/config/services/WebMapTileServiceConfiguration.java
@@ -4,13 +4,12 @@
  */
 package org.geoserver.cloud.gwc.config.services;
 
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geowebcache.service.wmts.WMTSService;
 import org.gwc.web.wmts.WMTSController;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 /**
  * @since 1.0
@@ -18,7 +17,5 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(WMTSService.class)
 @ComponentScan(basePackageClasses = WMTSController.class)
-@ImportResource(
-        reader = FilteringXmlBeanDefinitionReader.class,
-        locations = "jar:gs-gwc-[0-9]+.*!/geowebcache-wmtsservice-context.xml")
+@ImportFilteredResource("jar:gs-gwc-[0-9]+.*!/geowebcache-wmtsservice-context.xml")
 public class WebMapTileServiceConfiguration {}

--- a/src/library/spring-factory/src/main/java/org/geoserver/cloud/config/factory/ImportFilteredResource.java
+++ b/src/library/spring-factory/src/main/java/org/geoserver/cloud/config/factory/ImportFilteredResource.java
@@ -1,0 +1,96 @@
+package org.geoserver.cloud.config.factory;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.core.annotation.AliasFor;
+
+/**
+ * A composed annotation for importing Spring XML bean definitions using a filtered reader.
+ * <p>
+ * This annotation is meta-annotated with {@link ImportResource} and is intended to be used in place
+ * of the standard {@code @ImportResource} when you wish to apply filtering logic to the XML bean
+ * definitions. It customizes the default behavior by specifying
+ * {@link FilteringXmlBeanDefinitionReader} as the default reader. This reader allows you to append
+ * filtering criteria to the resource location, such as including or excluding beans based on a
+ * regular expression applied to the bean names.
+ * <p>
+ * For example, you can specify a location like:
+ * <pre class="code">
+ *   "jar:gs-main-.*!/applicationContext.xml#name=^(?!foo|bar).*$"
+ * </pre>
+ * to import only those beans whose names do not match "foo" or "bar". The filtering mechanism is
+ * implemented by {@link FilteringXmlBeanDefinitionReader}, which caches parsed XML documents and
+ * classpath resources to optimize resource loading.
+ * <p>
+ * Both the {@code reader} and {@code locations} attributes of this annotation are aliased to the
+ * corresponding attributes of {@link ImportResource} using {@link AliasFor}. This enables seamless
+ * integration with Spring's XML bean definition processing while adding the filtering capabilities.
+ * <p>
+ * <strong>Example usage:</strong>
+ * <pre class="code">
+ * &#64;Configuration
+ * &#64;ImportFilteredResource(
+ *     // Exclude beans named "foo" or "bar"
+ *     locations = "jar:gs-main-.*!/applicationContext.xml#name=^(?!foo|bar).*$"
+ * )
+ * public class AppConfig {
+ *     // Your bean definitions go here
+ * }
+ * </pre>
+ * <p>
+ * Refer to {@link FilteringXmlBeanDefinitionReader} for details on how the filtering is applied,
+ * including support for regular expression filters appended to the resource location. Note that the
+ * filtering logic currently applies to bean names (not aliases) and defers alias registration until
+ * after bean filtering.
+ *
+ * @see ImportResource
+ * @see FilteringXmlBeanDefinitionReader
+ * @since 1.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Documented
+@ImportResource
+public @interface ImportFilteredResource {
+
+    /**
+     * Alias for the {@code reader} attribute of {@link ImportResource}.
+     * <p>
+     * Defaults to {@link FilteringXmlBeanDefinitionReader}, which is a custom XML bean definition reader
+     * that applies filtering based on a regular expression. This reader allows you to append filtering
+     * criteria to the resource location (e.g., <code>#name=&lt;regex&gt;</code>) so that only beans
+     * matching the given pattern are registered.
+     *
+     * @return the class to use for reading and filtering XML bean definitions
+     */
+    @AliasFor(annotation = ImportResource.class, attribute = "reader")
+    Class<?> reader() default FilteringXmlBeanDefinitionReader.class;
+
+    /**
+     * Alias for the {@code locations} attribute of {@link ImportResource}.
+     * <p>
+     * This attribute serves as a shortcut so you don’t have to specify the attribute name
+     * explicitly. It is equivalent to {@link #locations()}.
+     *
+     * @return an array of resource location strings, optionally appended with filtering criteria
+     */
+    @AliasFor(annotation = ImportResource.class, attribute = "locations")
+    String[] value() default {};
+
+    /**
+     * Alias for the {@code locations} attribute of {@link ImportResource}.
+     * <p>
+     * Specifies one or more resource locations from which to import Spring bean definitions. When using
+     * {@link FilteringXmlBeanDefinitionReader}, the resource location may include a filtering fragment,
+     * for example, <code>applicationContext.xml#name=^(foo|bar|gml.*OutputFormat).*$</code>, to include or
+     * exclude beans based on their names.
+     *
+     * @return an array of resource location strings, optionally appended with filtering criteria
+     */
+    @AliasFor(annotation = ImportResource.class, attribute = "locations")
+    String[] locations() default {};
+}

--- a/src/starters/geonode/src/main/java/org/geoserver/cloud/autoconfigure/geonode/GeoNodeOAuth2AutoConfiguration.java
+++ b/src/starters/geonode/src/main/java/org/geoserver/cloud/autoconfigure/geonode/GeoNodeOAuth2AutoConfiguration.java
@@ -5,21 +5,19 @@
 package org.geoserver.cloud.autoconfigure.geonode;
 
 import lombok.extern.slf4j.Slf4j;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.ImportResource;
 
 /**
  * @since 1.9
  */
 @AutoConfiguration
 @ComponentScan(basePackages = "org.geoserver.security.oauth2")
-@ImportResource(
+@ImportFilteredResource(
         // gs-sec-oauth2-geonode is all what's needed, gs-sec-oauth2-core and gs-sec-oauth2-web are
         // transitive but not required for this specific functionality
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {"jar:gs-sec-oauth2-geonode-.*!/applicationContext.xml"})
+        "jar:gs-sec-oauth2-geonode-.*!/applicationContext.xml")
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.geonode")
 public class GeoNodeOAuth2AutoConfiguration {
 

--- a/src/starters/raster-formats/src/main/java/org/geoserver/cloud/autoconfigure/cog/COGAutoConfiguration.java
+++ b/src/starters/raster-formats/src/main/java/org/geoserver/cloud/autoconfigure/cog/COGAutoConfiguration.java
@@ -4,18 +4,15 @@
  */
 package org.geoserver.cloud.autoconfigure.cog;
 
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.cog.CogSettings;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.context.annotation.ImportResource;
 
 /** Auto configuration to enable the COG (Cloud Optimized GeoTIFF) support as raster data format. */
 @AutoConfiguration
 @ConditionalOnClass({CogSettings.class})
-@ImportResource(
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {"jar:gs-cog-.*!/applicationContext.xml#name=" + COGAutoConfiguration.EXCLUDE_WEBUI_BEANS})
+@ImportFilteredResource("jar:gs-cog-.*!/applicationContext.xml#name=" + COGAutoConfiguration.EXCLUDE_WEBUI_BEANS)
 public class COGAutoConfiguration {
 
     static final String EXCLUDE_WEBUI_BEANS = "^(?!" + COGWebUIAutoConfiguration.WEBUI_BEAN_NAMES + ").*$";

--- a/src/starters/raster-formats/src/main/java/org/geoserver/cloud/autoconfigure/cog/COGWebUIAutoConfiguration.java
+++ b/src/starters/raster-formats/src/main/java/org/geoserver/cloud/autoconfigure/cog/COGWebUIAutoConfiguration.java
@@ -4,19 +4,16 @@
  */
 package org.geoserver.cloud.autoconfigure.cog;
 
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.web.GeoServerApplication;
 import org.geoserver.web.data.store.cog.panel.CogRasterEditPanel;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 /** Auto configuration to enable the COG customized store panel when the web-ui is present. */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass({GeoServerApplication.class, CogRasterEditPanel.class})
-@ImportResource(
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {"jar:gs-cog-.*!/applicationContext.xml#name=" + COGWebUIAutoConfiguration.INCLUDE_WEBUI_BEANS})
+@ImportFilteredResource("jar:gs-cog-.*!/applicationContext.xml#name=" + COGWebUIAutoConfiguration.INCLUDE_WEBUI_BEANS)
 public class COGWebUIAutoConfiguration {
 
     static final String WEBUI_BEAN_NAMES = "COGGeoTIFFExclusionFilter|CogGeotiffStorePanel|CogSettingsPanel";

--- a/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/AuthKeyAutoConfiguration.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/authzn/AuthKeyAutoConfiguration.java
@@ -6,7 +6,7 @@ package org.geoserver.cloud.autoconfigure.authzn;
 
 import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.platform.ModuleStatus;
 import org.geoserver.platform.ModuleStatusImpl;
 import org.geoserver.security.web.auth.AuthenticationFilterPanel;
@@ -16,7 +16,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.ImportResource;
 
 /**
  * @since 1.0
@@ -49,9 +48,7 @@ public class AuthKeyAutoConfiguration {
     }
 
     @ConditionalOnAuthKeyEnabled
-    @ImportResource(
-            reader = FilteringXmlBeanDefinitionReader.class,
-            locations = {Enabled.INCLUDE})
+    @ImportFilteredResource(Enabled.INCLUDE)
     static @Configuration class Enabled {
         static final String EXCLUDE = "authKeyExtension|" + WEB_UI_BEANS;
         static final String INCLUDE = "jar:gs-authkey-.*!/applicationContext.xml#name=^(?!" + EXCLUDE + ").*$";
@@ -63,9 +60,7 @@ public class AuthKeyAutoConfiguration {
 
     @ConditionalOnAuthKeyEnabled
     @ConditionalOnClass(AuthenticationFilterPanel.class)
-    @ImportResource(
-            reader = FilteringXmlBeanDefinitionReader.class,
-            locations = {WebUI.INCLUDE})
+    @ImportFilteredResource(WebUI.INCLUDE)
     static @Configuration class WebUI {
         static final String INCLUDE = "jar:gs-authkey-.*!/applicationContext.xml#name=^(" + WEB_UI_BEANS + ").*$";
     }

--- a/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/security/jdbc/JDBCSecurityAutoConfiguration.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/security/jdbc/JDBCSecurityAutoConfiguration.java
@@ -6,11 +6,10 @@ package org.geoserver.cloud.autoconfigure.security.jdbc;
 
 import org.geoserver.cloud.autoconfigure.security.ConditionalOnGeoServerSecurityEnabled;
 import org.geoserver.cloud.autoconfigure.security.GeoServerSecurityAutoConfiguration;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.ImportResource;
 
 /** {@link AutoConfiguration @AutoConfiguration} to enable {@code gs-sec-jdbc} */
 // run before GeoServerSecurityAutoConfiguration so the provider is available when
@@ -19,7 +18,5 @@ import org.springframework.context.annotation.ImportResource;
 @EnableConfigurationProperties(JDBCSecurityConfigProperties.class)
 @ConditionalOnGeoServerSecurityEnabled
 @ConditionalOnProperty(name = "geoserver.security.jdbc", havingValue = "true", matchIfMissing = true)
-@ImportResource(
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = "jar:gs-sec-jdbc-.*!/applicationContext.xml")
+@ImportFilteredResource("jar:gs-sec-jdbc-.*!/applicationContext.xml")
 public class JDBCSecurityAutoConfiguration {}

--- a/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/security/jdbc/JDBCSecurityWebUIAutoConfiguration.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/security/jdbc/JDBCSecurityWebUIAutoConfiguration.java
@@ -6,13 +6,12 @@ package org.geoserver.cloud.autoconfigure.security.jdbc;
 
 import org.geoserver.cloud.autoconfigure.security.ConditionalOnGeoServerSecurityEnabled;
 import org.geoserver.cloud.autoconfigure.security.GeoServerSecurityAutoConfiguration;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.security.web.auth.AuthenticationFilterPanelInfo;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.ImportResource;
 
 /**
  * {@link AutoConfiguration @AutoConfiguration} to enable {@code gs-web-sec-jdbc} when running with
@@ -25,7 +24,5 @@ import org.springframework.context.annotation.ImportResource;
 @ConditionalOnClass(AuthenticationFilterPanelInfo.class)
 @ConditionalOnGeoServerSecurityEnabled
 @ConditionalOnProperty(name = "geoserver.security.jdbc", havingValue = "true", matchIfMissing = true)
-@ImportResource(
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = "jar:gs-web-sec-jdbc-.*!/applicationContext.xml")
+@ImportFilteredResource("jar:gs-web-sec-jdbc-.*!/applicationContext.xml")
 public class JDBCSecurityWebUIAutoConfiguration {}

--- a/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/security/ldap/LDAPSecurityAutoConfiguration.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/security/ldap/LDAPSecurityAutoConfiguration.java
@@ -6,11 +6,10 @@ package org.geoserver.cloud.autoconfigure.security.ldap;
 
 import org.geoserver.cloud.autoconfigure.security.ConditionalOnGeoServerSecurityEnabled;
 import org.geoserver.cloud.autoconfigure.security.GeoServerSecurityAutoConfiguration;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.ImportResource;
 
 /** {@link AutoConfiguration @AutoConfiguration} to enable {@code gs-sec-ldap} */
 // run before GeoServerSecurityAutoConfiguration so the provider is available when
@@ -19,7 +18,5 @@ import org.springframework.context.annotation.ImportResource;
 @EnableConfigurationProperties(LDAPSecurityConfigProperties.class)
 @ConditionalOnGeoServerSecurityEnabled
 @ConditionalOnProperty(name = "geoserver.security.ldap", havingValue = "true", matchIfMissing = true)
-@ImportResource(
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = "jar:gs-sec-ldap-.*!/applicationContext.xml")
+@ImportFilteredResource("jar:gs-sec-ldap-.*!/applicationContext.xml")
 public class LDAPSecurityAutoConfiguration {}

--- a/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/security/ldap/LDAPSecurityWebUIAutoConfiguration.java
+++ b/src/starters/security/src/main/java/org/geoserver/cloud/autoconfigure/security/ldap/LDAPSecurityWebUIAutoConfiguration.java
@@ -6,13 +6,12 @@ package org.geoserver.cloud.autoconfigure.security.ldap;
 
 import org.geoserver.cloud.autoconfigure.security.ConditionalOnGeoServerSecurityEnabled;
 import org.geoserver.cloud.autoconfigure.security.GeoServerSecurityAutoConfiguration;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.security.web.auth.AuthenticationFilterPanelInfo;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.ImportResource;
 
 /**
  * {@link AutoConfiguration @AutoConfiguration} to enable {@code gs-web-sec-ldap} when running with
@@ -25,7 +24,5 @@ import org.springframework.context.annotation.ImportResource;
 @ConditionalOnClass(AuthenticationFilterPanelInfo.class)
 @ConditionalOnGeoServerSecurityEnabled
 @ConditionalOnProperty(name = "geoserver.security.ldap", havingValue = "true", matchIfMissing = true)
-@ImportResource(
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = "jar:gs-web-sec-ldap-.*!/applicationContext.xml")
+@ImportFilteredResource("jar:gs-web-sec-ldap-.*!/applicationContext.xml")
 public class LDAPSecurityWebUIAutoConfiguration {}

--- a/src/starters/webmvc/src/main/java/org/geoserver/cloud/config/main/GeoServerMainModuleConfiguration.java
+++ b/src/starters/webmvc/src/main/java/org/geoserver/cloud/config/main/GeoServerMainModuleConfiguration.java
@@ -5,9 +5,8 @@
 package org.geoserver.cloud.config.main;
 
 import org.geoserver.cloud.config.catalog.backend.core.GeoServerBackendConfigurer;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 /**
  * Loads bean definitions from {@code jar:gs-main-.*!/applicationContext.xml}, excluding the ones
@@ -54,11 +53,9 @@ import org.springframework.context.annotation.ImportResource;
  * </ul>
  */
 @Configuration(proxyBeanMethods = false)
-@ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
+@ImportFilteredResource( //
         // exclude beans
-        locations =
-                "jar:gs-main-.*!/applicationContext.xml#name=" + GeoServerMainModuleConfiguration.EXCLUDE_BEANS_REGEX)
+        "jar:gs-main-.*!/applicationContext.xml#name=" + GeoServerMainModuleConfiguration.EXCLUDE_BEANS_REGEX)
 public class GeoServerMainModuleConfiguration {
 
     private static final String UNUSED_BEAN_NAMES =

--- a/src/starters/wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/extensions/CssStylingConfiguration.java
+++ b/src/starters/wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/extensions/CssStylingConfiguration.java
@@ -5,7 +5,7 @@
 package org.geoserver.cloud.autoconfigure.wms.extensions;
 
 import org.apache.batik.svggen.StyleHandler;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.community.css.web.CssHandler;
 import org.geoserver.platform.ModuleStatus;
 import org.geoserver.platform.ModuleStatusImpl;
@@ -18,7 +18,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.ImportResource;
 
 /**
  * @since 1.0
@@ -31,9 +30,8 @@ class CssStylingConfiguration {
     @ConditionalOnBean(name = "sldHandler")
     @ConditionalOnProperty(name = "geoserver.styling.css.enabled", havingValue = "true", matchIfMissing = true)
     @ConditionalOnClass(CssHandler.class)
-    @ImportResource( //
-            reader = FilteringXmlBeanDefinitionReader.class, //
-            locations = {"jar:gs-css-.*!/applicationContext.xml"})
+    @ImportFilteredResource( //
+            "jar:gs-css-.*!/applicationContext.xml")
     static class Enabled {}
 
     /**

--- a/src/starters/wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/extensions/MapBoxStylingConfiguration.java
+++ b/src/starters/wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/extensions/MapBoxStylingConfiguration.java
@@ -4,7 +4,7 @@
  */
 package org.geoserver.cloud.autoconfigure.wms.extensions;
 
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.community.mbstyle.MBStyleHandler;
 import org.geoserver.platform.ModuleStatus;
 import org.geoserver.platform.ModuleStatusImpl;
@@ -16,7 +16,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.ImportResource;
 
 /**
  * @since 1.0
@@ -29,9 +28,8 @@ class MapBoxStylingConfiguration {
     @ConditionalOnBean(name = "sldHandler") // sldHandler is MBStyleHandler's constructor arg
     @ConditionalOnProperty(name = "geoserver.styling.mapbox.enabled", havingValue = "true", matchIfMissing = true)
     @ConditionalOnClass(MBStyleHandler.class)
-    @ImportResource( //
-            reader = FilteringXmlBeanDefinitionReader.class, //
-            locations = {"jar:gs-mbstyle-.*!/applicationContext.xml"})
+    @ImportFilteredResource( //
+            "jar:gs-mbstyle-.*!/applicationContext.xml")
     static class Enabled {}
 
     @Configuration

--- a/src/starters/wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/extensions/VectorTilesConfiguration.java
+++ b/src/starters/wms-extensions/src/main/java/org/geoserver/cloud/autoconfigure/wms/extensions/VectorTilesConfiguration.java
@@ -5,14 +5,13 @@
 package org.geoserver.cloud.autoconfigure.wms.extensions;
 
 import org.geoserver.cloud.autoconfigure.wms.extensions.WmsExtensionsConfigProperties.Wms.WmsOutputFormatsConfigProperties.VectorTilesConfigProperties;
-import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.wms.vector.VectorTileMapOutputFormat;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 
 /**
  * @since 1.0
@@ -20,9 +19,7 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(VectorTileMapOutputFormat.class)
 @EnableConfigurationProperties(WmsExtensionsConfigProperties.class)
-@ImportResource( //
-        reader = FilteringXmlBeanDefinitionReader.class, //
-        locations = {"jar:gs-vectortiles-.*!/applicationContext.xml#name=(VectorTilesExtension)"})
+@ImportFilteredResource("jar:gs-vectortiles-.*!/applicationContext.xml#name=(VectorTilesExtension)")
 class VectorTilesConfiguration {
 
     static final String PREFIX = "geoserver.wms.output-formats.vector-tiles";
@@ -36,26 +33,17 @@ class VectorTilesConfiguration {
     }
 
     @ConditionalOnProperty(prefix = PREFIX + ".mapbox", name = "enabled", havingValue = "true", matchIfMissing = true)
-    @ImportResource( //
-            reader = FilteringXmlBeanDefinitionReader.class, //
-            locations = {
-                "jar:gs-vectortiles-.*!/applicationContext.xml#name=(wmsMapBoxBuilderFactory|wmsMapBoxMapOutputFormat)"
-            })
+    @ImportFilteredResource(
+            "jar:gs-vectortiles-.*!/applicationContext.xml#name=(wmsMapBoxBuilderFactory|wmsMapBoxMapOutputFormat)")
     static @Configuration class MapBox {}
 
     @ConditionalOnProperty(prefix = PREFIX + ".geojson", name = "enabled", havingValue = "true", matchIfMissing = true)
-    @ImportResource( //
-            reader = FilteringXmlBeanDefinitionReader.class, //
-            locations = {
-                "jar:gs-vectortiles-.*!/applicationContext.xml#name=(wmsGeoJsonBuilderFactory|wmsGeoJsonMapOutputFormat)"
-            })
+    @ImportFilteredResource(
+            "jar:gs-vectortiles-.*!/applicationContext.xml#name=(wmsGeoJsonBuilderFactory|wmsGeoJsonMapOutputFormat)")
     static @Configuration class GeoJson {}
 
     @ConditionalOnProperty(prefix = PREFIX + ".topojson", name = "enabled", havingValue = "true", matchIfMissing = true)
-    @ImportResource( //
-            reader = FilteringXmlBeanDefinitionReader.class, //
-            locations = {
-                "jar:gs-vectortiles-.*!/applicationContext.xml#name=(wmsTopoJSONBuilderFactory|wmsTopoJSONMapOutputFormat)"
-            })
+    @ImportFilteredResource(
+            "jar:gs-vectortiles-.*!/applicationContext.xml#name=(wmsTopoJSONBuilderFactory|wmsTopoJSONMapOutputFormat)")
     static @Configuration class TopoJson {}
 }


### PR DESCRIPTION
This commit removes all direct references to `FilteringXmlBeanDefinitionReader` from the configuration classes and replaces them with the new composed annotation `ImportFilteredResource`. With this change, Spring XML bean definitions are imported using the filtering capabilities provided by `FilteringXmlBeanDefinitionReader`, while benefiting from the simplified configuration offered by ImportFilteredResource.

The update affects modules across WCS, WFS, WMS, WPS, web UI, security, GWC, and others, ensuring that resource locations (including jar-based URLs and filtering fragments) are handled consistently.

Changes include:
* Updating all `@ImportResource` annotations that used `FilteringXmlBeanDefinitionReader` to `@ImportFilteredResource`.
* Adjusting import statements accordingly across multiple packages and modules.
* Ensuring that any filtering fragments appended to resource locations continue to work as expected.

This refactor simplifies the configuration process while preserving the intended filtering behavior for bean registration.