### PR TITLE
pgconfig: Fix TileLayer initialization with GWC defaults

### DIFF
--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigTileLayerCatalogAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigTileLayerCatalogAutoConfiguration.java
@@ -75,9 +75,10 @@ public class PgconfigTileLayerCatalogAutoConfiguration {
             GridSetBroker gridsetBroker,
             TileLayerInfoRepository repository,
             ApplicationEventPublisher eventPublisher,
-            @Qualifier("rawCatalog") Catalog catalog) {
+            @Qualifier("rawCatalog") Catalog catalog,
+            GWCConfigPersister defaultsProvider) {
 
-        var config = new PgconfigTileLayerCatalog(repository, gridsetBroker, () -> catalog);
+        var config = new PgconfigTileLayerCatalog(repository, gridsetBroker, () -> catalog, defaultsProvider);
         Consumer<TileLayerEvent> gwcEventPublisher = eventPublisher::publishEvent;
         return new GeoServerTileLayerConfiguration(config, gwcEventPublisher);
     }

--- a/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/GeoServerTileLayerInfoMapper.java
+++ b/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/GeoServerTileLayerInfoMapper.java
@@ -41,6 +41,9 @@ interface GeoServerTileLayerInfoMapper {
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "name", ignore = true)
     @Mapping(target = "autoCacheStyles", ignore = true)
+    // watch out GeoServerTileLayerInfoImpl.setMetaTilingX/Y asserts the arg is > 0
+    @Mapping(target = "metaTilingX", conditionExpression = "java(info.getMetaTilingX() > 0)")
+    @Mapping(target = "metaTilingY", conditionExpression = "java(info.getMetaTilingY() > 0)")
     GeoServerTileLayerInfoImpl map(TileLayerInfo info);
 
     @AfterMapping

--- a/src/gwc/backends/pgconfig/src/test/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigTileLayerCatalogIT.java
+++ b/src/gwc/backends/pgconfig/src/test/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigTileLayerCatalogIT.java
@@ -5,6 +5,8 @@
 package org.geoserver.cloud.gwc.backend.pgconfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +26,8 @@ import org.geoserver.catalog.plugin.CatalogPlugin;
 import org.geoserver.cloud.backend.pgconfig.PgconfigBackendBuilder;
 import org.geoserver.cloud.backend.pgconfig.support.PgConfigTestContainer;
 import org.geoserver.config.plugin.GeoServerImpl;
+import org.geoserver.gwc.config.GWCConfig;
+import org.geoserver.gwc.config.GWCConfigPersister;
 import org.geoserver.gwc.layer.GeoServerTileLayer;
 import org.geoserver.ows.LocalWorkspace;
 import org.geowebcache.grid.GridSetBroker;
@@ -55,7 +59,10 @@ class PgconfigTileLayerCatalogIT {
         GeoServerImpl geoServer = backendBuilder.createGeoServer(catalog);
         support = new TileLayerMocking(catalog, geoServer);
         GridSetBroker gridsets = support.getGridsets();
-        tlCatalog = new PgconfigTileLayerCatalog(container.getDataSource(), gridsets, () -> catalog);
+        GWCConfigPersister defaultsProvider = mock(GWCConfigPersister.class);
+        GWCConfig defaults = new GWCConfig();
+        when(defaultsProvider.getConfig()).thenReturn(defaults);
+        tlCatalog = new PgconfigTileLayerCatalog(container.getDataSource(), gridsets, () -> catalog, defaultsProvider);
     }
 
     @AfterEach

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/repository/CloudCatalogConfiguration.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/repository/CloudCatalogConfiguration.java
@@ -92,7 +92,7 @@ public class CloudCatalogConfiguration extends CatalogConfiguration {
         setMissingConfig(info, infoDefaults);
     }
 
-    private void setMissingConfig(GeoServerTileLayerInfo info, GeoServerTileLayerInfo defaults) {
+    public static void setMissingConfig(GeoServerTileLayerInfo info, GeoServerTileLayerInfo defaults) {
 
         String blobStoreId = defaults.getBlobStoreId();
         Set<WarningType> cacheWarningSkips = defaults.getCacheWarningSkips();


### PR DESCRIPTION
Modified `PgconfigTileLayerCatalog` to initialize thae unconfigured `GeoServerTileLayer` properties with the default values from `GWCConfig`.