### PR TITLE
pgconfig: Fix startup error off an empty database

### DIFF
--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/security/GeoServerSecurityConfiguration.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/security/GeoServerSecurityConfiguration.java
@@ -9,11 +9,14 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+import org.geoserver.GeoServerConfigurationLock;
 import org.geoserver.cloud.autoconfigure.security.ConditionalOnGeoServerSecurityEnabled;
 import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.cloud.event.security.SecurityConfigChanged;
 import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.platform.config.UpdateSequence;
+import org.geoserver.security.CloudGeoServerSecurityFilterChainProxy;
+import org.geoserver.security.GeoServerSecurityFilterChainProxy;
 import org.geoserver.security.GeoServerSecurityManager;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
@@ -22,6 +25,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Lazy;
 
 /**
  * Loads geoserver security bean definitions from {@code
@@ -48,7 +52,7 @@ public class GeoServerSecurityConfiguration {
 
     /** */
     public static final String APPLICATION_SECURITY_CONTEXT_FILTER =
-            "classpath*:/applicationSecurityContext.xml#name=^(?!authenticationManager).*$";
+            "classpath*:/applicationSecurityContext.xml#name=^(?!authenticationManager|filterChainProxy).*$";
 
     private @Value("${geoserver.security.enabled:#{null}}") Boolean enabled;
 
@@ -61,17 +65,24 @@ public class GeoServerSecurityConfiguration {
         return new EnvironmentAdminAuthenticationProvider();
     }
 
+    @Bean
+    GeoServerSecurityFilterChainProxy filterChainProxy(GeoServerSecurityManager sm) {
+        return new CloudGeoServerSecurityFilterChainProxy(sm);
+    }
+
     /**
      * Override the {@code authenticationManager} bean defined in {@code gs-main}'s {@code
      * applicationSecurityContext.xml} with a version that notifies other services of any security
      * configuration change, and listens to remote events from other services in order to {@link
      * GeoServerSecurityManager#reload() reload} the config.
+     * @param lock
      *
      * @return {@link CloudGeoServerSecurityManager}
      */
     @Bean(name = {"authenticationManager", "geoServerSecurityManager"})
     @DependsOn({"extensions"})
     CloudGeoServerSecurityManager cloudAuthenticationManager( //
+            @Lazy GeoServerConfigurationLock lock,
             GeoServerDataDirectory dataDir, //
             ApplicationEventPublisher localContextPublisher, //
             UpdateSequence updateSequence, //
@@ -81,6 +92,6 @@ public class GeoServerSecurityConfiguration {
         Consumer<SecurityConfigChanged> publisher = localContextPublisher::publishEvent;
         Supplier<Long> updateSequenceIncrementor = updateSequence::nextValue;
 
-        return new CloudGeoServerSecurityManager(dataDir, publisher, updateSequenceIncrementor, List.of(envAuth));
+        return new CloudGeoServerSecurityManager(lock, dataDir, publisher, updateSequenceIncrementor, List.of(envAuth));
     }
 }

--- a/src/catalog/backends/common/src/main/java/org/geoserver/security/CloudGeoServerSecurityFilterChainProxy.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/security/CloudGeoServerSecurityFilterChainProxy.java
@@ -1,0 +1,25 @@
+/*
+ * (c) 2025 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.security;
+
+/**
+ * Overriddes {@link GeoServerSecurityFilterChainProxy#destroy()} to be resilient.
+ * <p>
+ * This class is in package {@code org.geoserver.security} to get access to the package private fields from the superclass
+ */
+public class CloudGeoServerSecurityFilterChainProxy extends GeoServerSecurityFilterChainProxy {
+
+    public CloudGeoServerSecurityFilterChainProxy(GeoServerSecurityManager securityManager) {
+        super(securityManager);
+    }
+
+    @Override
+    public void destroy() {
+        if (super.proxy != null) proxy.destroy();
+
+        // do some cleanup
+        if (super.securityManager != null) securityManager.removeListener(this);
+    }
+}


### PR DESCRIPTION
Grab a global lock (through `GeoServerConfigurationLock`) during `GeoServerSecurityManager.reload()` to avoid multiple pods trying to upgrade the security config at the same time.

Started happening after upgrading from 2.26.x to 2.27.x
