### PR TITLE
feat: integrate geoserver app-schema extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,11 @@
       </dependency>
       <dependency>
         <groupId>org.geoserver.cloud</groupId>
+        <artifactId>gs-cloud-starter-extensions</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.cloud</groupId>
         <artifactId>gs-cloud-starter-wms-extensions</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/src/apps/geoserver/webui/pom.xml
+++ b/src/apps/geoserver/webui/pom.xml
@@ -15,6 +15,10 @@
   <dependencies>
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-starter-extensions</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-cloud-starter-wms-extensions</artifactId>
     </dependency>
     <dependency>
@@ -60,6 +64,10 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wcs2_0</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-app-schema-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.geoserver.extension</groupId>

--- a/src/apps/geoserver/wfs/pom.xml
+++ b/src/apps/geoserver/wfs/pom.xml
@@ -15,6 +15,10 @@
   <dependencies>
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-starter-extensions</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-cloud-starter-vector-formats</artifactId>
     </dependency>
     <dependency>
@@ -33,6 +37,10 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-dxf-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-app-schema-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -706,6 +706,11 @@
         <version>${gs.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.geoserver.extension</groupId>
+        <artifactId>gs-app-schema-core</artifactId>
+        <version>${gs.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.geoserver.community</groupId>
         <artifactId>gs-cog-core</artifactId>
         <version>${gs.version}</version>
@@ -871,6 +876,21 @@
       <dependency>
         <groupId>org.geotools</groupId>
         <artifactId>gt-wfs-ng</artifactId>
+        <version>${gt.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geotools</groupId>
+        <artifactId>gt-complex</artifactId>
+        <version>${gt.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geotools</groupId>
+        <artifactId>gt-app-schema</artifactId>
+        <version>${gt.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geotools</groupId>
+        <artifactId>gt-app-schema-resolver</artifactId>
         <version>${gt.version}</version>
       </dependency>
       <dependency>
@@ -1125,6 +1145,11 @@
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
             <version>3.2.2</version>
+          </dependency>
+          <dependency>
+            <groupId>commons-digester</groupId>
+            <artifactId>commons-digester</artifactId>
+            <version>1.7</version>
           </dependency>
           <dependency>
             <groupId>commons-lang</groupId>

--- a/src/starters/extensions/pom.xml
+++ b/src/starters/extensions/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.geoserver.cloud</groupId>
+    <artifactId>gs-cloud-starters</artifactId>
+    <version>${revision}</version>
+  </parent>
+  <artifactId>gs-cloud-starter-extensions</artifactId>
+  <packaging>jar</packaging>
+  <description>Curated list of supported extensions with auto configuration</description>
+  <dependencies>
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-spring-factory</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-starter-catalog-backend</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/starters/extensions/src/main/java/org/geoserver/cloud/autoconfigure/extensions/AppSchemaConfiguration.java
+++ b/src/starters/extensions/src/main/java/org/geoserver/cloud/autoconfigure/extensions/AppSchemaConfiguration.java
@@ -1,0 +1,65 @@
+/*
+ * (c) 2025 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions;
+
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
+import org.geoserver.platform.ModuleStatus;
+import org.geoserver.platform.ModuleStatusImpl;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * @since 1.0
+ */
+@Configuration
+@Import(
+        value = {
+            AppSchemaConfiguration.EnabledWebUI.class,
+            AppSchemaConfiguration.EnabledWFS.class,
+            AppSchemaConfiguration.Disabled.class
+        })
+class AppSchemaConfiguration {
+
+    @Configuration
+    @ConditionalOnBean(name = "geoServer")
+    @ConditionalOnClass(name = "org.geoserver.cloud.web.app.WebUIApplication")
+    @ConditionalOnProperty(name = "geoserver.extension.appschema.enabled", havingValue = "true", matchIfMissing = false)
+    @ImportFilteredResource("jar:gs-app-schema-core-.*!/applicationContext.xml#name=(appSchemaExtension)")
+    static class EnabledWebUI {}
+
+    @Configuration
+    @ConditionalOnClass(name = "org.geoserver.cloud.wfs.app.WfsApplication")
+    @ConditionalOnProperty(name = "geoserver.extension.appschema.enabled", havingValue = "true", matchIfMissing = false)
+    @ComponentScan(basePackages = "org.geoserver.complex")
+    static class EnabledWFS {}
+
+    @Configuration
+    @ConditionalOnBean(name = "geoServer")
+    @ConditionalOnProperty(
+            name = "geoserver.extension.appschema.enabled",
+            havingValue = "false",
+            matchIfMissing = false)
+    static class Disabled {
+
+        // the app-schema extension still works as the geotools is
+        // not using Spring and classes are still on classpath
+        // TODO "really" disable the geotools data factory SPI mechanism? if possible?
+
+        @Bean
+        ModuleStatus appSchemaDisabledModuleStatus() {
+            ModuleStatusImpl mod = new ModuleStatusImpl(
+                    "gs-app-schema-core", "App Schema Core Extension", "App Schema Core extension");
+            mod.setEnabled(false);
+            mod.setMessage(
+                    "App schema extension disabled through config property geoserver.extension.appschema.enabled=false");
+            return mod;
+        }
+    }
+}

--- a/src/starters/extensions/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ExtensionsAutoConfiguration.java
+++ b/src/starters/extensions/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ExtensionsAutoConfiguration.java
@@ -1,0 +1,24 @@
+/*
+ * (c) 2025 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions;
+
+import javax.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ *
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(ExtensionsConfigProperties.class)
+@Slf4j(topic = "org.geoserver.cloud.autoconfigure.extensions")
+@Import(value = {AppSchemaConfiguration.class})
+public class ExtensionsAutoConfiguration {
+    public @PostConstruct void log() {
+        log.info("Extensions configuration detected");
+    }
+}

--- a/src/starters/extensions/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ExtensionsConfigProperties.java
+++ b/src/starters/extensions/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ExtensionsConfigProperties.java
@@ -1,0 +1,38 @@
+/*
+ * (c) 2025 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for extensions.
+ *
+ * <p>Available properties:
+ *
+ * <pre>{@code
+ * geoserver:
+ *   extension:
+ *     appschema:
+ *       enabled: true
+ * }</pre>
+ *
+ * @since 1.0
+ */
+@ConfigurationProperties(prefix = "geoserver")
+public @Data class ExtensionsConfigProperties {
+
+    private Extension extension = new Extension();
+
+    public static @Data @NoArgsConstructor @AllArgsConstructor class EnabledProperty {
+        private boolean enabled;
+    }
+
+    public static @Data class Extension {
+        private EnabledProperty appschema = new EnabledProperty();
+    }
+}

--- a/src/starters/extensions/src/main/resources/META-INF/spring.factories
+++ b/src/starters/extensions/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.geoserver.cloud.autoconfigure.extensions.ExtensionsAutoConfiguration

--- a/src/starters/extensions/src/test/resources/logback-test.xml
+++ b/src/starters/extensions/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.springframework.test" level="WARN"/>
+    <logger name="org.springframework.boot.test" level="WARN"/>
+    <logger name="org.springframework.context" level="WARN"/>
+</configuration>

--- a/src/starters/pom.xml
+++ b/src/starters/pom.xml
@@ -13,6 +13,7 @@
     <module>spring-boot</module>
     <module>catalog-backend</module>
     <module>event-bus</module>
+    <module>extensions</module>
     <module>vector-formats</module>
     <module>raster-formats</module>
     <module>webmvc</module>


### PR DESCRIPTION
## Add support for GeoServer app-schema extension

This is currently a draft (but functional!)

Compared to https://github.com/geoserver/geoserver-cloud/pull/617 I tried to find a more centralized approach here by introducing a new `gs-cloud-starter-extensions` package in the starters package.

### Description
This draft PR introduces support for the GeoServer [app-schema extension](https://docs.geoserver.org/main/en/user/data/app-schema/index.html) within the geoserver-cloud project. The integration works as expected, allowing the use of app-schema/complex feature functionality.

However, **disabling** the extension remains a challenge (if we do not want to fully integrate it). The primary issue stems from the fact that GeoTools does not rely on Spring beans but instead uses the Java SPI plugin mechanism for loading components. So the classes are on the classPath and the extension will still work, even with `enabled=false` :-)

### Current Status
- ✅ App-schema extension **is functional** within geoserver-cloud.
- ⚠️ Disabling the extension is not yet fully handled due to SPI-based loading of geotools classes

Any feedback, suggestions, or alternative approaches are highly welcome!
