### PR TITLE
ci: optimize GitHub Actions workflow by building Docker images once

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -90,9 +90,7 @@ jobs:
       # We're building the JARs ourselves in the previous step
       run: REPACKAGE=false make build-image
 
-    - name: Build acceptance tests docker image
-      run: |
-        make build-acceptance
+    # We'll build the acceptance test image in each matrix job instead
 
     - name: Save Docker images to cache
       run: |
@@ -139,10 +137,18 @@ jobs:
         export TAG=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
         echo "Using TAG: $TAG"
         
-        # Set environment variables
+        # Set environment variables for subsequent steps
         echo "REPOSITORY=geoservercloud" >> $GITHUB_ENV
         echo "ACL_REPOSITORY=geoservercloud" >> $GITHUB_ENV
         echo "TAG=$TAG" >> $GITHUB_ENV
+
+    - name: Build acceptance tests docker image
+      run: |
+        make build-acceptance
+        
+        # List all images after building
+        echo "Available Docker images:"
+        docker images
 
     - name: Install CI dependencies
       id: installci

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -80,10 +80,8 @@ jobs:
 
     - name: Build necessary JARs for Docker images
       run: |
-        # Only build the minimum necessary for Docker images
-        ./mvnw clean package -f src/apps/base-images -DskipTests -T4
-        ./mvnw clean package -f src/apps/infrastructure -DskipTests -T4
-        ./mvnw clean package -f src/apps/geoserver -DskipTests -T4
+        # Build all dependencies
+        ./mvnw clean install -DskipTests -T1C -Dfmt.skip -ntp
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -54,17 +54,66 @@ jobs:
       with:
         name: application-jars
         path: |
-           ./**/target/*-bin.jar
-           ./**/target/config/
+           ./src/apps/**/target/*-bin.jar
+           ./src/apps/**/target/config/
         retention-days: 1
-        compression-level: 0 # no compression
+        compression-level: 9 # maximum compression to reduce download time
 
-  acceptance:
-    name: Acceptance
+  build-images:
+    name: Build Docker Images
     if: github.repository == 'geoserver/geoserver-cloud'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
-    needs: test
+    timeout-minutes: 30
+    # This job runs in parallel with the test job
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Set up java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+        cache: 'maven'
+
+    - name: Build necessary JARs for Docker images
+      run: |
+        # Only build the minimum necessary for Docker images
+        ./mvnw clean package -f src/apps/base-images -DskipTests -T4
+        ./mvnw clean package -f src/apps/infrastructure -DskipTests -T4
+        ./mvnw clean package -f src/apps/geoserver -DskipTests -T4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build images
+      # We're building the JARs ourselves in the previous step
+      run: REPACKAGE=false make build-image
+
+    - name: Build acceptance tests docker image
+      run: |
+        make build-acceptance
+
+    - name: Save Docker images to cache
+      run: |
+        mkdir -p /tmp/docker-cache
+        docker save $(docker images -q) -o /tmp/docker-cache/images.tar
+      
+    - name: Upload Docker images cache
+      uses: actions/upload-artifact@v4
+      with:
+        name: docker-images
+        path: /tmp/docker-cache/images.tar
+        retention-days: 1
+
+  acceptance:
+    name: Acceptance - ${{ matrix.catalog }}
+    if: github.repository == 'geoserver/geoserver-cloud'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [test, build-images]
     strategy:
       fail-fast: false
       matrix:
@@ -76,19 +125,26 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Download application jar files
+    - name: Download Docker images
       uses: actions/download-artifact@v4
       with:
-        name: application-jars
-        path: .
+        name: docker-images
+        path: /tmp/docker-cache
 
-    - name: Build images
-      # REPACKAGE=false avoids to re-package the apps during build-image
-      run: REPACKAGE=false make build-image
-
-    - name: Build acceptance tests docker image
+    - name: Load Docker images
       run: |
-        make build-acceptance
+        docker load -i /tmp/docker-cache/images.tar
+
+    - name: Set environment variables for Docker Compose
+      run: |
+        # Get the project version (TAG) from pom.xml
+        export TAG=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        echo "Using TAG: $TAG"
+        
+        # Set environment variables
+        echo "REPOSITORY=geoservercloud" >> $GITHUB_ENV
+        echo "ACL_REPOSITORY=geoservercloud" >> $GITHUB_ENV
+        echo "TAG=$TAG" >> $GITHUB_ENV
 
     - name: Install CI dependencies
       id: installci
@@ -96,11 +152,17 @@ jobs:
 
     - name: Launch ${{ matrix.catalog }} acceptance tests docker composition
       id: start
+      env:
+        REPOSITORY: geoservercloud
+        ACL_REPOSITORY: geoservercloud
       run: |
         make start-acceptance-tests-${{ matrix.catalog }}
 
     - name: Run ${{ matrix.catalog }} acceptance tests
       id: acceptance
+      env:
+        REPOSITORY: geoservercloud
+        ACL_REPOSITORY: geoservercloud
       run: |
         make run-acceptance-tests-${{ matrix.catalog }}
 
@@ -110,5 +172,8 @@ jobs:
 
     - name: Cleanup acceptance tests
       if: always()
+      env:
+        REPOSITORY: geoservercloud
+        ACL_REPOSITORY: geoservercloud
       run: |
         make clean-acceptance-tests-${{ matrix.catalog }}


### PR DESCRIPTION
- Create separate build-images job that builds all Docker images and caches them
- Matrix acceptance tests now download and load images instead of rebuilding them
- Reduces CI run time by eliminating duplicate Docker builds
- Uses GitHub Actions artifacts to share images between jobs without external registry