### PR TITLE
Create output-formats starter module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,11 @@
       </dependency>
       <dependency>
         <groupId>org.geoserver.cloud</groupId>
+        <artifactId>gs-cloud-starter-output-formats</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.cloud</groupId>
         <artifactId>gs-cloud-starter-extensions</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/src/starters/extensions/pom.xml
+++ b/src/starters/extensions/pom.xml
@@ -23,9 +23,10 @@
       <groupId>org.geoserver.cloud.extensions</groupId>
       <artifactId>gs-cloud-extension-mapbox-styling</artifactId>
     </dependency>
+    <!-- Output format extensions -->
     <dependency>
-      <groupId>org.geoserver.cloud.extensions</groupId>
-      <artifactId>gs-cloud-extension-vector-tiles</artifactId>
+      <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-starter-output-formats</artifactId>
     </dependency>
     <!-- Security starter (includes all security extensions) -->
     <dependency>

--- a/src/starters/output-formats/README.md
+++ b/src/starters/output-formats/README.md
@@ -1,0 +1,39 @@
+# GeoServer Cloud Output Formats Starter
+
+This starter module provides a convenient way to include all output format extensions in your GeoServer Cloud applications.
+
+## Included Extensions
+
+This starter includes the following output format extensions:
+
+- **Vector Tiles**: Provides support for various vector tile formats:
+  - Mapbox Vector Tiles
+  - GeoJSON Vector Tiles
+  - TopoJSON Vector Tiles
+
+## Usage
+
+To include all output format extensions in your GeoServer Cloud application, add the following dependency to your pom.xml:
+
+```xml
+<dependency>
+  <groupId>org.geoserver.cloud</groupId>
+  <artifactId>gs-cloud-starter-output-formats</artifactId>
+</dependency>
+```
+
+## Configuration
+
+These extensions can be configured in your application's configuration using the following properties:
+
+```yaml
+geoserver:
+  extension:
+    vector-tiles:
+      enabled: true  # Enable/disable vector tiles support
+      mapbox: true   # Enable Mapbox vector tiles format
+      geojson: true  # Enable GeoJSON vector tiles format
+      topojson: true # Enable TopoJSON vector tiles format
+```
+
+All formats are enabled by default.

--- a/src/starters/output-formats/pom.xml
+++ b/src/starters/output-formats/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.geoserver.cloud</groupId>
+    <artifactId>gs-cloud-starters</artifactId>
+    <version>${revision}</version>
+  </parent>
+  <artifactId>gs-cloud-starter-output-formats</artifactId>
+  <packaging>jar</packaging>
+  <description>Spring Boot starter for GeoServer Cloud output format extensions</description>
+  <dependencies>
+    <!-- Base dependencies -->
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-starter-webmvc</artifactId>
+    </dependency>
+    
+    <!-- Output format extensions -->
+    <dependency>
+      <groupId>org.geoserver.cloud.extensions</groupId>
+      <artifactId>gs-cloud-extension-vector-tiles</artifactId>
+    </dependency>
+    
+    <!-- Additional output formats can be added here as they are developed -->
+  </dependencies>
+</project>

--- a/src/starters/pom.xml
+++ b/src/starters/pom.xml
@@ -15,6 +15,7 @@
     <module>catalog-backend</module>
     <module>data-formats</module>
     <module>event-bus</module>
+    <module>output-formats</module>
     <module>extensions</module>
     <module>webmvc</module>
     <module>security</module>


### PR DESCRIPTION
- Add new starter module for output format extensions
- Move vector-tiles dependency to the output-formats starter
- Include the output-formats starter in the extensions starter
- Update dependency management in parent pom
- Add comprehensive README with usage instructions

This change improves modularity by creating a dedicated starter for output format extensions, which can be expanded in the future with additional output formats.