### PR TITLE
Implement connection parameters serialization for complex objects

### DIFF
--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/ConnectionParameters.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/ConnectionParameters.java
@@ -1,0 +1,55 @@
+/*
+ * (c) 2025 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.jackson.databind.catalog;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Specialized map class for store connection parameters.
+ *
+ * <p>
+ * This class extends LinkedHashMap to provide a concrete type for store connection parameters.
+ * The specialized type allows us to register custom serializers and deserializers specifically
+ * for connection parameters without affecting other Map&lt;String, Object&gt; instances.
+ * </p>
+ */
+public class ConnectionParameters extends LinkedHashMap<String, Object> {
+
+    private static final long serialVersionUID = 1L;
+
+    public ConnectionParameters() {
+        super();
+    }
+
+    public ConnectionParameters(Map<String, ?> map) {
+        super(map);
+    }
+
+    /**
+     * Convert from a Map&lt;String, Serializable&gt; to ConnectionParameters.
+     *
+     * @param params the source map
+     * @return a new ConnectionParameters instance
+     */
+    public static ConnectionParameters fromSerializableMap(Map<String, Serializable> params) {
+        if (params == null) return null;
+        return new ConnectionParameters(params);
+    }
+
+    /**
+     * Convert to a Map&lt;String, Serializable&gt;.
+     *
+     * @return a new Map containing the same entries
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public Map<String, Serializable> toSerializableMap() {
+        Map result = new HashMap<>();
+        result.putAll(this);
+        return result;
+    }
+}

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/ConnectionParametersDeserializer.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/ConnectionParametersDeserializer.java
@@ -1,0 +1,66 @@
+/*
+ * (c) 2025 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.jackson.databind.catalog;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import org.geotools.jackson.databind.filter.dto.Literal;
+
+/**
+ * Custom deserializer for Store connection parameters.
+ *
+ * <p>
+ * This deserializer handles Literal objects in the map, extracting their values.
+ * </p>
+ */
+public class ConnectionParametersDeserializer extends JsonDeserializer<ConnectionParameters> {
+
+    @Override
+    public ConnectionParameters deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        ConnectionParameters result = new ConnectionParameters();
+
+        if (p.currentToken() != JsonToken.START_OBJECT) {
+            throw new IOException("Expected START_OBJECT token, got " + p.currentToken());
+        }
+
+        // Read all fields in the object
+        while (p.nextToken() != JsonToken.END_OBJECT) {
+            String fieldName = p.currentName();
+            p.nextToken(); // Move to the value
+
+            // Read the value
+            Object value = readValue(p, ctxt);
+
+            // If it's a Literal, unwrap it
+            if (value instanceof Literal literal) {
+                result.put(fieldName, literal.getValue());
+            } else {
+                result.put(fieldName, value);
+            }
+        }
+
+        return result;
+    }
+
+    private Object readValue(JsonParser p, DeserializationContext ctxt) throws IOException {
+        // For object values, try to parse as Literal
+        if (p.currentToken() == JsonToken.START_OBJECT) {
+            try {
+                // Try to deserialize as a Literal
+                return ctxt.readValue(p, Literal.class);
+            } catch (Exception e) {
+                // If Literal deserialization fails, fall back to basic deserialization
+                // for simple types like Map
+                return ctxt.readValue(p, Object.class);
+            }
+        }
+
+        // For arrays, strings, numbers, booleans, null - deserialize as is
+        return ctxt.readValue(p, Object.class);
+    }
+}

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/ConnectionParametersSerializer.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/ConnectionParametersSerializer.java
@@ -1,0 +1,92 @@
+/*
+ * (c) 2025 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.jackson.databind.catalog;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.Map;
+import org.geotools.jackson.databind.filter.dto.Literal;
+
+/**
+ * Custom serializer for Store connection parameters.
+ *
+ * <p>
+ * This serializer handles complex types like ReferencedEnvelope by wrapping them in a Literal.
+ * </p>
+ */
+public class ConnectionParametersSerializer extends JsonSerializer<ConnectionParameters> {
+
+    @Override
+    public Class<ConnectionParameters> handledType() {
+        return ConnectionParameters.class;
+    }
+
+    @Override
+    public void serialize(ConnectionParameters value, JsonGenerator gen, SerializerProvider serializers)
+            throws IOException {
+
+        if (value == null) {
+            gen.writeNull();
+            return;
+        }
+
+        gen.writeStartObject();
+        for (Map.Entry<String, Object> entry : value.entrySet()) {
+            String key = entry.getKey();
+            Object val = entry.getValue();
+
+            if (val == null) {
+                gen.writeNullField(key);
+            } else if (shouldConvertToString(val)) {
+                // Values like URI, URL, File, Path should be serialized as strings
+                gen.writeStringField(key, val.toString());
+            } else if (shouldWrapAsLiteral(val)) {
+                // Complex type, wrap in Literal
+                Literal literal = Literal.valueOf(val);
+                gen.writeObjectField(key, literal);
+            } else {
+                // Primitive type
+                gen.writeObjectField(key, val);
+            }
+        }
+        gen.writeEndObject();
+    }
+
+    /**
+     * Determine if a value should be converted to a String.
+     *
+     * <p>
+     * Common types like URI, URL, File, and Path should be serialized as strings
+     * since DataAccessFactory.Param.lookUp() will convert them back to the proper type.
+     * </p>
+     */
+    private boolean shouldConvertToString(Object value) {
+        return value instanceof URI || value instanceof URL || value instanceof File || value instanceof Path;
+    }
+
+    /**
+     * Determine if a value should be wrapped in a Literal.
+     */
+    private boolean shouldWrapAsLiteral(Object value) {
+        if (value == null) return false;
+
+        // Basic types don't need to be wrapped
+        if (value instanceof String) return false;
+        if (value instanceof Number) return false;
+        if (value instanceof Boolean) return false;
+
+        // Types that are converted to strings don't need to be wrapped
+        if (shouldConvertToString(value)) return false;
+
+        // Complex types need to be wrapped
+        return true;
+    }
+}

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModule.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModule.java
@@ -156,6 +156,10 @@ public class GeoServerCatalogModule extends SimpleModule {
                 GridGeometryDto.class,
                 VALUE_MAPPER::dtoToGridGeometry2D);
 
+        // Register custom serializer/deserializer for ConnectionParameters class
+        super.addSerializer(new ConnectionParametersSerializer());
+        super.addDeserializer(ConnectionParameters.class, new ConnectionParametersDeserializer());
+
         addMapperSerializer(Query.class, VALUE_MAPPER::queryToDto, QueryDto.class, VALUE_MAPPER::dtoToQuery);
 
         addMapperSerializer(

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Store.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/Store.java
@@ -5,8 +5,6 @@
 package org.geoserver.jackson.databind.catalog.dto;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
-import java.io.Serializable;
-import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -25,7 +23,7 @@ public abstract class Store extends CatalogInfoDto {
     private String description;
     private String type;
     private boolean enabled;
-    private Map<String, Serializable> connectionParameters;
+    private org.geoserver.jackson.databind.catalog.ConnectionParameters connectionParameters;
     private MetadataMapDto metadata;
 
     /**

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/mapper/StoreMapper.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/mapper/StoreMapper.java
@@ -4,12 +4,16 @@
  */
 package org.geoserver.jackson.databind.catalog.mapper;
 
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import lombok.Generated;
 import org.geoserver.catalog.CoverageStoreInfo;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.WMSStoreInfo;
 import org.geoserver.catalog.WMTSStoreInfo;
+import org.geoserver.jackson.databind.catalog.ConnectionParameters;
 import org.geoserver.jackson.databind.catalog.dto.CoverageStore;
 import org.geoserver.jackson.databind.catalog.dto.DataStore;
 import org.geoserver.jackson.databind.catalog.dto.Store;
@@ -22,7 +26,6 @@ import org.mapstruct.Mapping;
 @Mapper(config = CatalogInfoMapperConfig.class)
 @AnnotateWith(value = Generated.class)
 public interface StoreMapper {
-
     default Store map(StoreInfo o) {
         if (o == null) return null;
         if (o instanceof DataStoreInfo ds) return map(ds);
@@ -43,27 +46,51 @@ public interface StoreMapper {
         throw new IllegalArgumentException("Unknown Store type: " + o);
     }
 
+    /**
+     * Convert ConnectionParameters to a standard Serializable map for StoreInfo.
+     */
+    default Map<String, Serializable> connectionParamsFromDto(ConnectionParameters params) {
+        if (params == null) return new LinkedHashMap<>();
+        return params.toSerializableMap();
+    }
+
+    /**
+     * Convert a standard Serializable map to ConnectionParameters for Store DTO.
+     */
+    default ConnectionParameters connectionParamsToDto(Map<String, Serializable> params) {
+        if (params == null) return new ConnectionParameters();
+        return new ConnectionParameters(params);
+    }
+
     @Mapping(target = "error", ignore = true)
     @Mapping(target = "catalog", ignore = true)
+    @Mapping(target = "connectionParameters", expression = "java(connectionParamsFromDto(o.getConnectionParameters()))")
     DataStoreInfo map(DataStore o);
 
+    @Mapping(target = "connectionParameters", expression = "java(connectionParamsToDto(o.getConnectionParameters()))")
     DataStore map(DataStoreInfo o);
 
     @Mapping(target = "error", ignore = true)
     @Mapping(target = "catalog", ignore = true)
+    @Mapping(target = "connectionParameters", expression = "java(connectionParamsFromDto(o.getConnectionParameters()))")
     CoverageStoreInfo map(CoverageStore o);
 
+    @Mapping(target = "connectionParameters", expression = "java(connectionParamsToDto(o.getConnectionParameters()))")
     CoverageStore map(CoverageStoreInfo o);
 
     @Mapping(target = "error", ignore = true)
     @Mapping(target = "catalog", ignore = true)
+    @Mapping(target = "connectionParameters", expression = "java(connectionParamsFromDto(o.getConnectionParameters()))")
     WMSStoreInfo map(WMSStore o);
 
+    @Mapping(target = "connectionParameters", expression = "java(connectionParamsToDto(o.getConnectionParameters()))")
     WMSStore map(WMSStoreInfo o);
 
     @Mapping(target = "error", ignore = true)
     @Mapping(target = "catalog", ignore = true)
+    @Mapping(target = "connectionParameters", expression = "java(connectionParamsFromDto(o.getConnectionParameters()))")
     WMTSStoreInfo map(WMTSStore o);
 
+    @Mapping(target = "connectionParameters", expression = "java(connectionParamsToDto(o.getConnectionParameters()))")
     WMTSStore map(WMTSStoreInfo o);
 }

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/ConnectionParametersSerializerTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/ConnectionParametersSerializerTest.java
@@ -1,0 +1,247 @@
+/*
+ * (c) 2025 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.jackson.databind.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.jackson.databind.filter.GeoToolsFilterModule;
+import org.geotools.jackson.databind.filter.dto.Literal;
+import org.geotools.jackson.databind.geojson.GeoToolsGeoJsonModule;
+import org.geotools.referencing.CRS;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ConnectionParameters} serialization and deserialization.
+ */
+class ConnectionParametersSerializerTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new GeoServerCatalogModule());
+        objectMapper.registerModule(new GeoToolsGeoJsonModule());
+        objectMapper.registerModule(new GeoToolsFilterModule());
+    }
+
+    @Test
+    void testSimpleTypesNotWrapped() throws IOException {
+        ConnectionParameters params = new ConnectionParameters();
+        params.put("string", "test");
+        params.put("integer", 123);
+        params.put("double", 123.456);
+        params.put("boolean", true);
+        params.put("null", null);
+
+        // Serialize
+        String json = objectMapper.writeValueAsString(params);
+
+        // Deserialize
+        ConnectionParameters result = objectMapper.readValue(json, ConnectionParameters.class);
+
+        // Verify
+        assertEquals(5, result.size());
+        assertEquals("test", result.get("string"));
+        assertEquals(123, result.get("integer"));
+        assertEquals(123.456, result.get("double"));
+        assertEquals(true, result.get("boolean"));
+        assertEquals(null, result.get("null"));
+    }
+
+    @Test
+    void testReferencedEnvelopeWrappedInLiteral() throws Exception {
+        // Create a ReferencedEnvelope
+        ReferencedEnvelope envelope = new ReferencedEnvelope(-180, 180, -90, 90, CRS.decode("EPSG:4326", true));
+
+        // Create test params
+        ConnectionParameters params = new ConnectionParameters();
+        params.put("bbox", envelope);
+        params.put("name", "testEnvelope");
+
+        // Serialize
+        String json = objectMapper.writeValueAsString(params);
+
+        // Verify JSON contains Literal structure
+        assertTrue(json.contains("Literal"));
+
+        // Deserialize
+        ConnectionParameters result = objectMapper.readValue(json, ConnectionParameters.class);
+
+        // Verify
+        assertEquals(2, result.size());
+        assertEquals("testEnvelope", result.get("name"));
+
+        Object bbox = result.get("bbox");
+        assertNotNull(bbox);
+        assertInstanceOf(ReferencedEnvelope.class, bbox);
+
+        ReferencedEnvelope resultEnvelope = (ReferencedEnvelope) bbox;
+        assertEquals(envelope.getMinX(), resultEnvelope.getMinX(), 1e-8);
+        assertEquals(envelope.getMaxX(), resultEnvelope.getMaxX(), 1e-8);
+        assertEquals(envelope.getMinY(), resultEnvelope.getMinY(), 1e-8);
+        assertEquals(envelope.getMaxY(), resultEnvelope.getMaxY(), 1e-8);
+        assertTrue(CRS.equalsIgnoreMetadata(
+                envelope.getCoordinateReferenceSystem(), resultEnvelope.getCoordinateReferenceSystem()));
+    }
+
+    @Test
+    void testMixedSimpleAndComplexTypes() throws Exception {
+        // Create a ReferencedEnvelope
+        ReferencedEnvelope envelope = new ReferencedEnvelope(-180, 180, -90, 90, CRS.decode("EPSG:4326", true));
+
+        // Create test params with mix of simple and complex types
+        ConnectionParameters params = new ConnectionParameters();
+        params.put("bbox", envelope);
+        params.put("name", "testMixed");
+        params.put("count", 42);
+        params.put("enabled", true);
+
+        // Serialize
+        String json = objectMapper.writeValueAsString(params);
+
+        // Deserialize
+        ConnectionParameters result = objectMapper.readValue(json, ConnectionParameters.class);
+
+        // Verify
+        assertEquals(4, result.size());
+        assertEquals("testMixed", result.get("name"));
+        assertEquals(42, result.get("count"));
+        assertEquals(true, result.get("enabled"));
+
+        Object bbox = result.get("bbox");
+        assertNotNull(bbox);
+        assertInstanceOf(ReferencedEnvelope.class, bbox);
+
+        ReferencedEnvelope resultEnvelope = (ReferencedEnvelope) bbox;
+        assertEquals(envelope.getMinX(), resultEnvelope.getMinX(), 1e-8);
+        assertEquals(envelope.getMaxX(), resultEnvelope.getMaxX(), 1e-8);
+        assertEquals(envelope.getMinY(), resultEnvelope.getMinY(), 1e-8);
+        assertEquals(envelope.getMaxY(), resultEnvelope.getMaxY(), 1e-8);
+    }
+
+    @Test
+    void testAlreadyWrappedLiteral() throws Exception {
+        // Create a ReferencedEnvelope already wrapped in a Literal
+        ReferencedEnvelope envelope = new ReferencedEnvelope(-180, 180, -90, 90, CRS.decode("EPSG:4326", true));
+        Literal literal = Literal.valueOf(envelope);
+
+        // Create test params
+        ConnectionParameters params = new ConnectionParameters();
+        params.put("bbox", literal);
+        params.put("name", "testLiteral");
+
+        // Serialize
+        String json = objectMapper.writeValueAsString(params);
+
+        // Deserialize
+        ConnectionParameters result = objectMapper.readValue(json, ConnectionParameters.class);
+
+        // Verify
+        assertEquals(2, result.size());
+        assertEquals("testLiteral", result.get("name"));
+
+        Object bbox = result.get("bbox");
+        assertNotNull(bbox);
+        assertInstanceOf(ReferencedEnvelope.class, bbox);
+
+        ReferencedEnvelope resultEnvelope = (ReferencedEnvelope) bbox;
+        assertEquals(envelope.getMinX(), resultEnvelope.getMinX(), 1e-8);
+        assertEquals(envelope.getMaxX(), resultEnvelope.getMaxX(), 1e-8);
+        assertEquals(envelope.getMinY(), resultEnvelope.getMinY(), 1e-8);
+        assertEquals(envelope.getMaxY(), resultEnvelope.getMaxY(), 1e-8);
+    }
+
+    @Test
+    void testMapConversion() {
+        // Create a ReferencedEnvelope
+        ReferencedEnvelope envelope = null;
+        try {
+            envelope = new ReferencedEnvelope(-180, 180, -90, 90, CRS.decode("EPSG:4326", true));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        // Test the conversion methods
+        ConnectionParameters params = new ConnectionParameters();
+        params.put("bbox", envelope);
+        params.put("name", "testConversion");
+        params.put("count", 42);
+
+        // Convert to serializable map
+        var serializableMap = params.toSerializableMap();
+
+        // Convert back
+        ConnectionParameters roundTrip = ConnectionParameters.fromSerializableMap(serializableMap);
+
+        // Verify
+        assertEquals(3, roundTrip.size());
+        assertEquals("testConversion", roundTrip.get("name"));
+        assertEquals(42, roundTrip.get("count"));
+
+        Object bbox = roundTrip.get("bbox");
+        assertNotNull(bbox);
+        assertInstanceOf(ReferencedEnvelope.class, bbox);
+    }
+
+    @Test
+    void testPathUriUrlFileAsStrings() throws Exception {
+        // Create test parameters with various path-related types
+        ConnectionParameters params = new ConnectionParameters();
+
+        // Add different path types
+        File file = new File("/tmp/testfile.txt");
+        URI uri = new URI("http://example.com/data");
+        URL url = new URL("http://example.com/data.json");
+        Path path = Paths.get("/tmp/testpath");
+
+        params.put("file", file);
+        params.put("uri", uri);
+        params.put("url", url);
+        params.put("path", path);
+
+        // Also add a primitive type for comparison
+        params.put("name", "testPaths");
+
+        // Serialize
+        String json = objectMapper.writeValueAsString(params);
+
+        // Verify values are serialized as strings, not wrapped in Literal
+        assertTrue(json.contains("\"file\":\"/tmp/testfile.txt\""));
+        assertTrue(json.contains("\"uri\":\"http://example.com/data\""));
+        assertTrue(json.contains("\"url\":\"http://example.com/data.json\""));
+        assertTrue(json.contains("\"path\":\"/tmp/testpath\""));
+        assertTrue(json.contains("\"name\":\"testPaths\""));
+
+        // Verify literals aren't used for these types
+        assertFalse(json.contains("\"file\":{\"@type\":\"Literal\""));
+
+        // Deserialize
+        ConnectionParameters result = objectMapper.readValue(json, ConnectionParameters.class);
+
+        // Verify
+        assertEquals(5, result.size());
+        assertEquals("testPaths", result.get("name"));
+
+        // Note: After deserialization, all path-related types are strings
+        assertEquals("/tmp/testfile.txt", result.get("file"));
+        assertEquals("http://example.com/data", result.get("uri"));
+        assertEquals("http://example.com/data.json", result.get("url"));
+        assertEquals("/tmp/testpath", result.get("path"));
+    }
+}

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModuleTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModuleTest.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.jackson.databind.catalog;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,6 +23,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.geoserver.catalog.AttributeTypeInfo;
 import org.geoserver.catalog.AuthorityURLInfo;
@@ -32,6 +34,7 @@ import org.geoserver.catalog.CatalogTestData;
 import org.geoserver.catalog.CoverageDimensionInfo;
 import org.geoserver.catalog.CoverageStoreInfo;
 import org.geoserver.catalog.DataLinkInfo;
+import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.DimensionInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.Info;
@@ -78,12 +81,12 @@ import org.geotools.coverage.grid.GeneralGridEnvelope;
 import org.geotools.coverage.grid.GridGeometry2D;
 import org.geotools.data.DataUtilities;
 import org.geotools.factory.CommonFactoryFinder;
-import org.geotools.feature.SchemaException;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.jdbc.VirtualTable;
 import org.geotools.measure.Measure;
 import org.geotools.referencing.CRS;
+import org.geotools.util.Converters;
 import org.geotools.util.NumberRange;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeAll;
@@ -92,8 +95,9 @@ import org.junit.jupiter.api.Test;
 import si.uom.SI;
 
 /**
- * Verifies that all {@link CatalogInfo} can be sent over the wire and parsed back using jackson,
- * thanks to {@link GeoServerCatalogModule} jackcon-databind module
+ * Verifies that all {@link CatalogInfo} can be sent over the wire and parsed
+ * back using jackson, thanks to {@link GeoServerCatalogModule} jackcon-databind
+ * module
  */
 @Slf4j
 public abstract class GeoServerCatalogModuleTest {
@@ -129,8 +133,14 @@ public abstract class GeoServerCatalogModuleTest {
 
     protected abstract ObjectMapper newObjectMapper();
 
-    @SuppressWarnings("unchecked")
-    private <T extends CatalogInfo> T catalogInfoRoundtripTest(final T orig) throws JsonProcessingException {
+    private <T extends CatalogInfo> T catalogInfoRoundtripTest(final T orig) {
+        boolean assertEquals = true;
+        return catalogInfoRoundtripTest(orig, assertEquals);
+    }
+
+    @SneakyThrows(JsonProcessingException.class)
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private <T extends CatalogInfo> T catalogInfoRoundtripTest(final T orig, boolean assertEquals) {
         ObjectWriter writer = objectMapper.writer();
         writer = writer.withDefaultPrettyPrinter();
 
@@ -151,8 +161,8 @@ public abstract class GeoServerCatalogModuleTest {
         if (orig instanceof ResourceInfo) assertNotNull(objectMapper.readValue(encoded, ResourceInfo.class));
         if (orig instanceof PublishedInfo) assertNotNull(objectMapper.readValue(encoded, PublishedInfo.class));
 
-        // This is the client code's responsibility, the Deserializer returns "resolving proxy"
-        // proxies for Info references
+        // This is the client code's responsibility, the Deserializer returns "resolving proxy"  proxies for Info
+        // references
         decoded = proxyResolver.resolve(decoded);
 
         if (Proxy.isProxyClass(orig.getClass())) {
@@ -160,15 +170,30 @@ public abstract class GeoServerCatalogModuleTest {
             proxy.commit();
             unproxied = (T) proxy.getProxyObject();
         }
+        if (assertEquals) {
+            if (unproxied instanceof DataStoreInfo store1) {
+                DataStoreInfo store2 = (DataStoreInfo) decoded;
+                Map params1 = store1.getConnectionParameters();
+                Map params2 = store2.getConnectionParameters();
+                // Convert to the orig map's class. It'll be done by Param.resolve() in real life
+                assertThat(params1.keySet()).isEqualTo(params2.keySet());
+                params1.forEach((k, v) -> {
+                    if (v != null) {
+                        Object converted = Converters.convert(params2.get(k), v.getClass());
+                        params2.put(k, converted);
+                    }
+                });
+            }
 
-        data.assertEqualsLenientConnectionParameters(unproxied, decoded);
+            assertEquals(unproxied, decoded);
+        }
         data.assertInternationalStringPropertiesEqual(unproxied, decoded);
 
         return decoded;
     }
 
     @Test
-    void testWorkspace() throws Exception {
+    void testWorkspace() {
         catalogInfoRoundtripTest(data.workspaceA);
 
         data.workspaceB.setIsolated(true);
@@ -178,7 +203,7 @@ public abstract class GeoServerCatalogModuleTest {
     }
 
     @Test
-    void testNamespace() throws Exception {
+    void testNamespace() {
         catalogInfoRoundtripTest(data.namespaceA);
 
         data.namespaceB.setIsolated(true);
@@ -188,19 +213,85 @@ public abstract class GeoServerCatalogModuleTest {
     }
 
     @Test
-    void testDataStore() throws Exception {
+    void testDataStore() {
         catalogInfoRoundtripTest(data.dataStoreA);
         catalogInfoRoundtripTest(data.dataStoreB);
         catalogInfoRoundtripTest(data.dataStoreC);
     }
 
     @Test
-    void testCoverageStore() throws Exception {
+    void storeParameterScalars() {
+        testStoreConnectionParameter(Integer.valueOf(101));
+        testStoreConnectionParameter(Double.valueOf(101.1));
+        testStoreConnectionParameter(Boolean.TRUE);
+        testStoreConnectionParameter(Boolean.FALSE);
+        testStoreConnectionParameter("String value");
+    }
+
+    @Test
+    void storeParameterPrimitives() {
+        testStoreConnectionParameter(Byte.valueOf((byte) 10));
+        testStoreConnectionParameter(Short.valueOf((short) 101));
+        testStoreConnectionParameter(Integer.valueOf(101));
+        testStoreConnectionParameter(Long.valueOf(101));
+        testStoreConnectionParameter(Float.valueOf(101.1f));
+        testStoreConnectionParameter(Double.valueOf(101.1));
+        testStoreConnectionParameter("String value");
+    }
+
+    @Test
+    @SneakyThrows
+    void storeParameterCoordinateReferenceSystem() {
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:4326", true);
+
+        testStoreConnectionParameter(crs);
+
+        crs = CRS.decode("EPSG:3857", true);
+        testStoreConnectionParameter(crs);
+    }
+
+    @Test
+    @SneakyThrows
+    void storeParameterReferencedEnvelope() {
+        CoordinateReferenceSystem crs;
+        ReferencedEnvelope bbox;
+
+        crs = CRS.decode("EPSG:4326", true);
+        bbox = new ReferencedEnvelope(-180, 180, -90, 90, crs);
+        testStoreConnectionParameter(bbox);
+
+        crs = CRS.decode("EPSG:3857", true);
+        bbox = new ReferencedEnvelope(-20037508.34, -20048966.1, 20037508.34, 20048966.1, crs);
+        testStoreConnectionParameter(bbox);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void testStoreConnectionParameter(Object value) {
+        DataStoreInfo store = data.dataStoreA;
+        store.getConnectionParameters().clear();
+        Class<?> type = value.getClass();
+        String key = "test-key-for-%s".formatted(type.getName());
+        Map expected = store.getConnectionParameters();
+        expected.put(key, value);
+        final boolean assertEquals = false;
+        DataStoreInfo decoded = catalogInfoRoundtripTest(store, assertEquals);
+
+        Map<String, Serializable> actual = decoded.getConnectionParameters();
+
+        assertThat(actual.keySet()).isEqualTo(expected.keySet());
+
+        Object roundtripped = actual.get(key);
+        Object converted = Converters.convert(roundtripped, value.getClass());
+        assertThat(converted).isEqualTo(value);
+    }
+
+    @Test
+    void testCoverageStore() {
         catalogInfoRoundtripTest(data.coverageStoreA);
     }
 
     @Test
-    void testCoverageStore_COG() throws Exception {
+    void testCoverageStore_COG() {
         CoverageStoreInfo store = data.coverageStoreA;
         CogSettingsStore cogSettings = new CogSettingsStore();
         cogSettings.setRangeReaderSettings(RangeReaderType.Azure);
@@ -214,17 +305,17 @@ public abstract class GeoServerCatalogModuleTest {
     }
 
     @Test
-    void testWmsStore() throws Exception {
+    void testWmsStore() {
         catalogInfoRoundtripTest(data.wmsStoreA);
     }
 
     @Test
-    void testWmtsStore() throws Exception {
+    void testWmtsStore() {
         catalogInfoRoundtripTest(data.wmtsStoreA);
     }
 
     @Test
-    void testFeatureType() throws Exception {
+    void testFeatureType() {
         KeywordInfo k = new Keyword("value");
         k.setLanguage("es");
         FeatureTypeInfo ft = data.featureTypeA;
@@ -242,7 +333,8 @@ public abstract class GeoServerCatalogModuleTest {
         catalogInfoRoundtripTest(ft);
     }
 
-    private List<AttributeTypeInfo> createTestAttributes(FeatureTypeInfo info) throws SchemaException {
+    @SneakyThrows
+    private List<AttributeTypeInfo> createTestAttributes(FeatureTypeInfo info) {
         String typeSpec =
                 "name:string,id:String,polygonProperty:Polygon:srid=32615,centroid:Point,url:java.net.URL,uuid:UUID";
         SimpleFeatureType ft = DataUtilities.createType("TestType", typeSpec);
@@ -261,22 +353,22 @@ public abstract class GeoServerCatalogModuleTest {
     }
 
     @Test
-    void testCoverage() throws Exception {
+    void testCoverage() {
         catalogInfoRoundtripTest(data.coverageA);
     }
 
     @Test
-    void testWmsLayer() throws Exception {
+    void testWmsLayer() {
         catalogInfoRoundtripTest(data.wmsLayerA);
     }
 
     @Test
-    void testWtmsLayer() throws Exception {
+    void testWtmsLayer() {
         catalogInfoRoundtripTest(data.wmtsLayerA);
     }
 
     @Test
-    void testLayer() throws Exception {
+    void testLayer() {
         LayerInfo layer = data.layerFeatureTypeA;
         layer.getStyles().add(data.style1);
         layer.getStyles().add(data.style2);
@@ -284,7 +376,7 @@ public abstract class GeoServerCatalogModuleTest {
     }
 
     @Test
-    void testLayerGroup() throws Exception {
+    void testLayerGroup() {
         LayerGroupInfo lg = data.layerGroup1;
         lg.setTitle("LG Title");
         lg.setAbstract("LG abstract");
@@ -311,13 +403,13 @@ public abstract class GeoServerCatalogModuleTest {
     }
 
     @Test
-    void testLayerGroupWorkspace() throws Exception {
+    void testLayerGroupWorkspace() {
         data.layerGroup1.setWorkspace(data.workspaceC);
         catalogInfoRoundtripTest(data.layerGroup1);
     }
 
     @Test
-    void testStyle() throws Exception {
+    void testStyle() {
         StyleInfo style1 = data.style1;
         style1.setFormatVersion(SLDHandler.VERSION_10);
         style1.setFormat(SLDHandler.FORMAT);
@@ -331,7 +423,7 @@ public abstract class GeoServerCatalogModuleTest {
     }
 
     @Test
-    void testStyleWorkspace() throws Exception {
+    void testStyleWorkspace() {
         data.style1.setWorkspace(data.workspaceA);
         data.style2.setWorkspace(data.workspaceB);
         catalogInfoRoundtripTest(data.style1);
@@ -354,7 +446,7 @@ public abstract class GeoServerCatalogModuleTest {
     }
 
     @Test
-    void testFilterWithInfoLiterals() throws JsonProcessingException {
+    void testFilterWithInfoLiterals() {
         testFilterLiteral(forceNonProxy(data.workspaceA));
         testFilterLiteral(forceNonProxy(data.namespaceA));
         testFilterLiteral(forceNonProxy(data.dataStoreA));
@@ -371,7 +463,7 @@ public abstract class GeoServerCatalogModuleTest {
     }
 
     @Test
-    void testFilterWithModificationProxyInfoLiterals() throws JsonProcessingException {
+    void testFilterWithModificationProxyInfoLiterals() {
         testFilterLiteral(forceModificationProxy(data.workspaceA));
         testFilterLiteral(forceModificationProxy(data.namespaceA));
         testFilterLiteral(forceModificationProxy(data.dataStoreA));
@@ -401,7 +493,8 @@ public abstract class GeoServerCatalogModuleTest {
         return ModificationProxy.unwrap(info);
     }
 
-    private <T> T testFilterLiteral(T value) throws JsonProcessingException {
+    @SneakyThrows
+    private <T> T testFilterLiteral(T value) {
         Class<? extends Object> expectedDecodedType = value.getClass();
         if (value instanceof Proxy) {
             T unwrap = ModificationProxy.unwrap(value);
@@ -411,12 +504,12 @@ public abstract class GeoServerCatalogModuleTest {
         return testFilterLiteral(value, expectedDecodedType);
     }
 
-    protected <T> T testFilterLiteral(T value, Class<? extends Object> expectedDecodedType)
-            throws JsonProcessingException {
+    protected <T> T testFilterLiteral(T value, Class<? extends Object> expectedDecodedType) {
         PropertyIsEqualTo filter = equals("literalTestProp", value);
         PropertyIsEqualTo decodedFilter = roundTrip(filter, Filter.class);
         assertEquals(filter.getExpression1(), decodedFilter.getExpression1());
-        // can't trust the equals() implementation on the provided object, make some basic checks
+        // can't trust the equals() implementation on the provided object, make some
+        // basic checks
         // and return the decoded object
         Literal decodedExp = (Literal) decodedFilter.getExpression2();
         Object decodedValue = decodedExp.getValue();
@@ -444,7 +537,8 @@ public abstract class GeoServerCatalogModuleTest {
         return ff.equals(ff.property(propertyName), ff.literal(literal));
     }
 
-    private <T> T roundTrip(T orig, Class<? super T> clazz) throws JsonProcessingException {
+    @SneakyThrows(JsonProcessingException.class)
+    private <T> T roundTrip(T orig, Class<? super T> clazz) {
         ObjectWriter writer = objectMapper.writer();
         writer = writer.withDefaultPrettyPrinter();
         String encoded = writer.writeValueAsString(orig);
@@ -456,7 +550,7 @@ public abstract class GeoServerCatalogModuleTest {
     }
 
     @Test
-    void testValueKeywordInfo() throws JsonProcessingException {
+    void testValueKeywordInfo() {
         KeywordInfo keyword = new org.geoserver.catalog.Keyword("value");
         keyword.setLanguage("en");
         keyword.setVocabulary("bad");
@@ -466,50 +560,54 @@ public abstract class GeoServerCatalogModuleTest {
     }
 
     @Test
-    void testValueCoordinateReferenceSystemGeographicLatLon() throws Exception {
+    @SneakyThrows
+    void testValueCoordinateReferenceSystemGeographicLatLon() {
         CoordinateReferenceSystem wgs84LatLon = CRS.decode("EPSG:4326", false);
         testValueCoordinateReferenceSystem(wgs84LatLon);
     }
 
     @Test
-    void testValueCoordinateReferenceSystemGeographicLonLat() throws Exception {
+    @SneakyThrows
+    void testValueCoordinateReferenceSystemGeographicLonLat() {
         CoordinateReferenceSystem wgs84LonLat = CRS.decode("EPSG:4326", true);
         testValueCoordinateReferenceSystem(wgs84LonLat);
     }
 
     @Test
-    void testValueCoordinateReferenceSystemProjected() throws Exception {
+    @SneakyThrows
+    void testValueCoordinateReferenceSystemProjected() {
         CoordinateReferenceSystem webMercator = CRS.decode("EPSG:3857", true);
         testValueCoordinateReferenceSystem(webMercator);
     }
 
     @Test
-    void testValueCoordinateReferenceSystemCustomCRS() throws Exception {
+    @SneakyThrows
+    void testValueCoordinateReferenceSystemCustomCRS() {
         String customWKT =
                 """
-			PROJCS[ "UTM Zone 10, Northern Hemisphere",
-			  GEOGCS["GRS 1980(IUGG, 1980)",
-			    DATUM["unknown",
-			       SPHEROID["GRS80",6378137,298.257222101],
-			       TOWGS84[0,0,0,0,0,0,0]
-			    ],
-			    PRIMEM["Greenwich",0],
-			    UNIT["degree",0.0174532925199433]
-			  ],
-			  PROJECTION["Transverse_Mercator"],
-			  PARAMETER["latitude_of_origin",0],
-			  PARAMETER["central_meridian",-123],
-			  PARAMETER["scale_factor",0.9996],
-			  PARAMETER["false_easting",1640419.947506562],
-			  PARAMETER["false_northing",0],
-			  UNIT["Foot (International)",0.3048]
-			]""";
+                PROJCS[ "UTM Zone 10, Northern Hemisphere",
+                  GEOGCS["GRS 1980(IUGG, 1980)",
+                    DATUM["unknown",
+                       SPHEROID["GRS80",6378137,298.257222101],
+                       TOWGS84[0,0,0,0,0,0,0]
+                    ],
+                    PRIMEM["Greenwich",0],
+                    UNIT["degree",0.0174532925199433]
+                  ],
+                  PROJECTION["Transverse_Mercator"],
+                  PARAMETER["latitude_of_origin",0],
+                  PARAMETER["central_meridian",-123],
+                  PARAMETER["scale_factor",0.9996],
+                  PARAMETER["false_easting",1640419.947506562],
+                  PARAMETER["false_northing",0],
+                  UNIT["Foot (International)",0.3048]
+                ]""";
 
         CoordinateReferenceSystem crs = CRS.parseWKT(customWKT);
         testValueCoordinateReferenceSystem(crs);
     }
 
-    private void testValueCoordinateReferenceSystem(CoordinateReferenceSystem crs) throws Exception {
+    private void testValueCoordinateReferenceSystem(CoordinateReferenceSystem crs) {
         CoordinateReferenceSystem decoded = roundTrip(crs, CoordinateReferenceSystem.class);
         assertTrue(CRS.equalsIgnoreMetadata(crs, decoded));
         decoded = testFilterLiteral(crs);
@@ -517,16 +615,17 @@ public abstract class GeoServerCatalogModuleTest {
     }
 
     /**
-     * Does not perform equals check, for value types that don't implement {@link
-     * Object#equals(Object)} or have misbehaving implementations
+     * Does not perform equals check, for value types that don't implement
+     * {@link Object#equals(Object)} or have misbehaving implementations
      */
-    private <T> T testValue(final T value, Class<T> type) throws Exception {
+    private <T> T testValue(final T value, Class<T> type) {
         T decoded = roundTrip(value, type);
+        assertNotNull(decoded);
         decoded = testFilterLiteral(value);
         return decoded;
     }
 
-    private <T> void testValueWithEquals(final T value, Class<T> type) throws Exception {
+    private <T> void testValueWithEquals(final T value, Class<T> type) {
         T decoded = roundTrip(value, type);
         assertEquals(value, decoded);
         decoded = testFilterLiteral(value);
@@ -534,20 +633,21 @@ public abstract class GeoServerCatalogModuleTest {
     }
 
     @Test
-    void testValueNumberRange() throws Exception {
+    void testValueNumberRange() {
         testValueWithEquals(NumberRange.create(Double.MIN_VALUE, 0d), NumberRange.class);
         testValueWithEquals(NumberRange.create(0L, false, Long.MAX_VALUE, true), NumberRange.class);
         testValueWithEquals(NumberRange.create(Integer.MIN_VALUE, true, Integer.MAX_VALUE, false), NumberRange.class);
     }
 
     @Test
-    void testValueMeasure() throws Exception {
+    void testValueMeasure() {
         testValueWithEquals(new Measure(1000, SI.METRE), Measure.class);
         testValueWithEquals(new Measure(.75, SI.RADIAN_PER_SECOND), Measure.class);
     }
 
     @Test
-    void testValueReferencedEnvelope() throws Exception {
+    @SneakyThrows
+    void testValueReferencedEnvelope() {
         CoordinateReferenceSystem wgs84LatLon = CRS.decode("EPSG:4326", false);
         CoordinateReferenceSystem wgs84LonLat = CRS.decode("EPSG:4326", true);
 
@@ -556,7 +656,8 @@ public abstract class GeoServerCatalogModuleTest {
     }
 
     @Test
-    void testValueGridGeometry2D() throws Exception {
+    @SneakyThrows
+    void testValueGridGeometry2D() {
         CoordinateReferenceSystem crs = CRS.decode("EPSG:4326", true);
         ReferencedEnvelope env = new ReferencedEnvelope(-180, 180, -90, 90, crs);
         GridEnvelope range = new GeneralGridEnvelope(new int[] {0, 0}, new int[] {1024, 768});
@@ -565,7 +666,7 @@ public abstract class GeoServerCatalogModuleTest {
     }
 
     @Test
-    void testValueAuthorityURLInfo() throws Exception {
+    void testValueAuthorityURLInfo() {
         AuthorityURL info = new AuthorityURL();
         info.setHref("href");
         info.setName("name");
@@ -573,13 +674,13 @@ public abstract class GeoServerCatalogModuleTest {
     }
 
     @Test
-    void testValueCoverageDimensionInfo() throws Exception {
+    void testValueCoverageDimensionInfo() {
         CoverageDimensionInfo cdi = data.faker().coverageDimensionInfo();
         testValueWithEquals(cdi, CoverageDimensionInfo.class);
     }
 
     @Test
-    void testValueDimensionInfo() throws Exception {
+    void testValueDimensionInfo() {
         DimensionInfo di = data.faker().dimensionInfo();
 
         // bad equals implementation on DimensionInfoImpl
@@ -601,19 +702,19 @@ public abstract class GeoServerCatalogModuleTest {
     }
 
     @Test
-    void testValueDataLinkInfo() throws Exception {
+    void testValueDataLinkInfo() {
         DataLinkInfo dl = data.faker().dataLinkInfo();
         testValueWithEquals(dl, DataLinkInfo.class);
     }
 
     @Test
-    void testValueLayerIdentifierInfo() throws Exception {
+    void testValueLayerIdentifierInfo() {
         org.geoserver.catalog.impl.LayerIdentifier li = data.faker().layerIdentifierInfo();
         testValueWithEquals(li, LayerIdentifierInfo.class);
     }
 
     @Test
-    void testValueLegendInfo() throws Exception {
+    void testValueLegendInfo() {
         LegendInfoImpl l = new LegendInfoImpl();
         l.setFormat("format");
         l.setHeight(10);
@@ -630,18 +731,18 @@ public abstract class GeoServerCatalogModuleTest {
     }
 
     @Test
-    void testValueMetadataLinkInfo() throws Exception {
+    void testValueMetadataLinkInfo() {
         testValueWithEquals(data.faker().metadataLink(), MetadataLinkInfo.class);
     }
 
     @Test
-    void testValueVirtualTable() throws Exception {
+    void testValueVirtualTable() {
         VirtualTable vt = new VirtualTable("testvt", "select * from test;", true);
         testValueWithEquals(vt, VirtualTable.class);
     }
 
     @Test
-    void testValueMetadataMap() throws Exception {
+    void testValueMetadataMap() {
         MetadataMap mdm = new MetadataMap();
         mdm.put("k1", "v1");
         mdm.put("k2", "v2");


### PR DESCRIPTION
- Create dedicated ConnectionParameters type to avoid interfering with generic maps
- Add custom serializer/deserializer specific to ConnectionParameters
- Convert URI, URL, File, and Path objects to strings instead of wrapping in Literals
- Maintain ReferencedEnvelope and other complex types wrapped in Literals
- Add comprehensive tests for all scenarios