### PR TITLE
Fix 403 errors in REST API when using pgconfig backend

### DIFF
--- a/src/apps/geoserver/restconfig/pom.xml
+++ b/src/apps/geoserver/restconfig/pom.xml
@@ -34,6 +34,11 @@
       <groupId>org.geoserver</groupId>
       <artifactId>gs-restconfig-wmts</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationDataDirectoryIT.java
+++ b/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationDataDirectoryIT.java
@@ -1,0 +1,32 @@
+/*
+ * (c) 2025 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.restconfig;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles({"test", "datadir"})
+public class RestConfigApplicationDataDirectoryIT extends RestConfigApplicationTest {
+
+    static @TempDir Path datadir;
+
+    @DynamicPropertySource
+    static void setUpDataDir(DynamicPropertyRegistry registry) throws IOException {
+        var gwcdir = datadir.resolve("gwc");
+        if (!Files.exists(gwcdir)) {
+            Files.createDirectory(gwcdir);
+        }
+        registry.add("geoserver.backend.data-directory.location", datadir::toAbsolutePath);
+        registry.add("gwc.cache-directory", gwcdir::toAbsolutePath);
+    }
+}

--- a/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationPgconfigIT.java
+++ b/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationPgconfigIT.java
@@ -1,0 +1,46 @@
+/*
+ * (c) 2025 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.restconfig;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles({"test", "pgconfigjndi"})
+@Testcontainers(disabledWithoutDocker = true)
+class RestConfigApplicationPgconfigIT extends RestConfigApplicationTest {
+
+    @Container
+    static PostgreSQLContainer<?> container = new PostgreSQLContainer<>("postgres:15");
+
+    /**
+     * Contribute the following properties defined in the {@literal pgconfigjndi}
+     * spring profile
+     *
+     * <ul>
+     * <li>pgconfig.host
+     * <li>pgconfig.port
+     * <li>pgconfig.database
+     * <li>pgconfig.schema
+     * <li>pgconfig.username
+     * <li>pgconfig.password
+     * </ul>
+     */
+    @DynamicPropertySource
+    static void setUpDataDir(DynamicPropertyRegistry registry) {
+        registry.add("pgconfig.host", container::getHost);
+        registry.add("pgconfig.port", () -> container.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT));
+        registry.add("pgconfig.database", container::getDatabaseName);
+        registry.add("pgconfig.schema", () -> "pgconfigtestschema");
+        registry.add("pgconfig.username", container::getUsername);
+        registry.add("pgconfig.password", container::getPassword);
+    }
+}

--- a/src/apps/geoserver/restconfig/src/test/resources/bootstrap-test.yml
+++ b/src/apps/geoserver/restconfig/src/test/resources/bootstrap-test.yml
@@ -11,15 +11,54 @@ eureka.client.enabled: false
 
 geoserver:
   acl.enabled: false
-  backend:
-    data-directory:
-      enabled: true
-      location: # to be set by the test class
+  extension:
+    security:
+      gateway-shared-auth:
+        enabled: true
+        auto: true
 
 logging:
   level:
     root: warn
     org.geoserver.platform: error
-    org.geoserver.cloud: info
-    org.geoserver.cloud.config.factory: info
+    org.geoserver.security: error
+    org.geoserver.cloud: warn
+    org.geoserver.cloud.config.factory: warn
     org.springframework.test: error
+    org.geoserver.cloud.security.gateway.sharedauth: info
+
+---
+spring.config.activate.on-profile: datadir
+geoserver:
+  backend:
+    data-directory:
+      enabled: true
+      location: # to be set by the test class
+
+---
+spring.config.activate.on-profile: pgconfigjndi
+
+geoserver:
+  backend:
+    pgconfig:
+      enabled: true
+      initialize: true
+      schema: ${pgconfig.schema}
+      create-schema: true
+      datasource:
+        jndi-name: java:comp/env/jdbc/pgconfig
+
+jndi:
+  datasources:
+    pgconfig:
+      enabled: true
+      schema: ${pgconfig.schema}
+      wait-for-it: true
+      wait-timeout: 10
+      url: jdbc:postgresql://${pgconfig.host}:${pgconfig.port}/${pgconfig.database}
+      username: ${pgconfig.username}
+      password: ${pgconfig.password}
+      maximum-pool-size: 10
+      minimum-idle: 0
+      connection-timeout: 2500
+      idle-timeout: 60000

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResource.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResource.java
@@ -8,10 +8,12 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.time.Instant;
 import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.ToString;
 import org.geoserver.platform.resource.Paths;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.platform.resource.ResourceListener;
@@ -19,8 +21,10 @@ import org.geoserver.platform.resource.ResourceListener;
 /**
  * @since 1.4
  */
-@EqualsAndHashCode(exclude = {"store"})
+@EqualsAndHashCode(exclude = {"store", "lastChecked"})
+@ToString(exclude = "store")
 class PgconfigResource implements Resource {
+
     @Getter
     long id;
 
@@ -28,9 +32,14 @@ class PgconfigResource implements Resource {
     long parentId;
 
     Resource.Type type;
+
     String path;
+
     long lastmodified;
+
     private PgconfigResourceStore store;
+
+    Instant lastChecked;
 
     PgconfigResource(
             @NonNull PgconfigResourceStore store,
@@ -45,9 +54,21 @@ class PgconfigResource implements Resource {
         this.type = type;
         this.path = path;
         this.lastmodified = lastmodified;
+        lastChecked = Instant.now();
     }
 
-    /** Undefined type factory method */
+    /**
+     * Factory method to create an undefined resource.
+     *
+     * <p>
+     * Creates a PgconfigResource with Type.UNDEFINED and UNDEFINED_ID for both
+     * id and parentId. This is used when a resource doesn't exist in the database.
+     * </p>
+     *
+     * @param store the resource store
+     * @param path the path for the undefined resource
+     * @return a new PgconfigResource instance with Type.UNDEFINED
+     */
     static PgconfigResource undefined(@NonNull PgconfigResourceStore store, @NonNull String path) {
         return new PgconfigResource(
                 store,
@@ -58,6 +79,18 @@ class PgconfigResource implements Resource {
                 0L);
     }
 
+    /**
+     * Copies all state from another PgconfigResource into this one.
+     *
+     * <p>
+     * This is used by the {@link PgconfigResourceStore#updateState} method to update a resource
+     * with the latest information from the database. It's particularly important for maintaining
+     * consistency of long-lived resource references that are held by other components.
+     * </p>
+     *
+     * @param other the resource whose state should be copied to this resource
+     * @see PgconfigResourceStore#updateState
+     */
     void copy(PgconfigResource other) {
         this.id = other.id;
         this.parentId = other.parentId;
@@ -103,11 +136,6 @@ class PgconfigResource implements Resource {
     }
 
     @Override
-    public long lastmodified() {
-        return lastmodified;
-    }
-
-    @Override
     public PgconfigResource parent() {
         return store.getParent(this);
     }
@@ -128,7 +156,44 @@ class PgconfigResource implements Resource {
 
     @Override
     public Type getType() {
+        updateState();
         return type;
+    }
+
+    @Override
+    public long lastmodified() {
+        updateState();
+        return lastmodified;
+    }
+
+    /**
+     * Updates the resource state if it's been held for longer than a threshold.
+     *
+     * <p>
+     * This method is critical for compatibility with GeoServer components that hold
+     * resource references as instance variables, such as AbstractAccessRuleDAO and RESTAccessRuleDAO.
+     * Since pgconfig resources are backed by database entries, long-lived references can become stale.
+     * </p>
+     *
+     * <p>
+     * By refreshing the state periodically when getType() or lastmodified() are called,
+     * we ensure that these long-lived references remain valid even if the underlying resource
+     * has been modified in the database by another process or service instance.
+     * </p>
+     *
+     * <p>
+     * This prevents issues such as 403 errors when REST resources appear to be missing
+     * because a stale resource reference doesn't reflect the current state in the database.
+     * </p>
+     *
+     * @see #getType()
+     * @see #lastmodified()
+     */
+    private void updateState() {
+        if (lastChecked.plusMillis(500).isBefore(Instant.now())) {
+            store.updateState(this);
+            lastChecked = Instant.now();
+        }
     }
 
     @Override
@@ -143,39 +208,100 @@ class PgconfigResource implements Resource {
 
     @Override
     public void addListener(ResourceListener listener) {
-        // TODO Auto-generated method stub
+        // no-op
     }
 
     @Override
     public void removeListener(ResourceListener listener) {
-        // TODO Auto-generated method stub
+        // no-op
     }
 
-    public String parentPath() {
-        return Paths.parent(path());
-    }
-
+    /**
+     * Returns a string representation of this resource, which is its path.
+     *
+     * @return the path of this resource
+     */
     @Override
     public String toString() {
         return path;
     }
 
+    /**
+     * Gets the path of the parent resource.
+     *
+     * <p>
+     * This is a convenience method that calls {@link Paths#parent(String)}
+     * on the result of {@link #path()}.
+     * </p>
+     *
+     * @return the parent path, or null if this is the root resource
+     */
+    public String parentPath() {
+        return Paths.parent(path());
+    }
+
+    /**
+     * Creates this resource as a directory, including any necessary parent directories.
+     *
+     * <p>
+     * This is a convenience method that delegates to {@link PgconfigResourceStore#mkdirs(PgconfigResource)}.
+     * </p>
+     *
+     * @return this resource, updated with the database ID of the created directory
+     */
     public PgconfigResource mkdirs() {
         return store.mkdirs(this);
     }
 
+    /**
+     * Checks if this resource exists in the database.
+     *
+     * <p>
+     * A resource exists if its ID is not {@link PgconfigResourceStore#UNDEFINED_ID}.
+     * </p>
+     *
+     * @return true if the resource exists, false otherwise
+     */
     public boolean exists() {
         return id != PgconfigResourceStore.UNDEFINED_ID;
     }
 
+    /**
+     * Checks if this resource is a file.
+     *
+     * <p>
+     * A resource is a file if its type is {@link Type#RESOURCE}.
+     * </p>
+     *
+     * @return true if the resource is a file, false otherwise
+     */
     public boolean isFile() {
         return getType() == Type.RESOURCE;
     }
 
+    /**
+     * Checks if this resource is a directory.
+     *
+     * <p>
+     * A resource is a directory if its type is {@link Type#DIRECTORY}.
+     * </p>
+     *
+     * @return true if the resource is a directory, false otherwise
+     */
     public boolean isDirectory() {
         return getType() == Type.DIRECTORY;
     }
 
+    /**
+     * Checks if this resource is undefined.
+     *
+     * <p>
+     * A resource is undefined if its type is {@link Type#UNDEFINED},
+     * which typically means it doesn't exist in the database.
+     * </p>
+     *
+     * @return true if the resource is undefined, false otherwise
+     */
     public boolean isUndefined() {
         return getType() == Type.UNDEFINED;
     }

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceStoreUpdateStateTest.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceStoreUpdateStateTest.java
@@ -1,0 +1,140 @@
+/*
+ * (c) 2025 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.backend.pgconfig.resource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.geoserver.platform.resource.Resource.Type;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Tests for the updateState method in PgconfigResourceStore.
+ *
+ * <p>
+ * This method is responsible for refreshing the state of a PgconfigResource
+ * from the database, which is critical for long-lived resource references.
+ * </p>
+ */
+@ExtendWith(MockitoExtension.class)
+class PgconfigResourceStoreUpdateStateTest {
+
+    private PgconfigResourceStore store;
+
+    @BeforeEach
+    void setup() {
+        store = mock(PgconfigResourceStore.class);
+    }
+
+    /**
+     * Test that updateState correctly updates a resource's state when it exists in
+     * the database.
+     */
+    @Test
+    void testUpdateStateExistingResource() {
+        // Create a resource with initial state
+        PgconfigResource resource =
+                new PgconfigResource(store, 1L, 0L, Type.RESOURCE, "security/rest.properties", 123456L);
+
+        // Create an updated resource that would come from the database
+        PgconfigResource updatedResource =
+                new PgconfigResource(store, 2L, 0L, Type.DIRECTORY, "security/rest.properties", 789012L);
+
+        // Direct test of copy method
+        resource.copy(updatedResource);
+
+        // Verify the resource was updated
+        assertEquals(2L, resource.getId());
+        assertEquals(0L, resource.getParentId());
+        assertEquals(Type.DIRECTORY, resource.getType());
+        assertEquals("security/rest.properties", resource.path());
+        assertEquals(789012L, resource.lastmodified());
+    }
+
+    /**
+     * Test that a resource can be marked as undefined when it no longer exists in
+     * the database.
+     */
+    @Test
+    void testMarkResourceAsUndefined() {
+        // Create a resource with initial state
+        PgconfigResource resource =
+                new PgconfigResource(store, 1L, 0L, Type.RESOURCE, "security/rest.properties", 123456L);
+
+        // Mark as undefined (this simulates what updateState would do)
+        resource.type = Type.UNDEFINED;
+        resource.id = PgconfigResourceStore.UNDEFINED_ID;
+        resource.parentId = PgconfigResourceStore.UNDEFINED_ID;
+
+        // Verify the resource was marked undefined
+        assertEquals(Type.UNDEFINED, resource.getType());
+        assertEquals(PgconfigResourceStore.UNDEFINED_ID, resource.getId());
+        assertEquals(PgconfigResourceStore.UNDEFINED_ID, resource.getParentId());
+        assertFalse(resource.exists());
+        assertTrue(resource.isUndefined());
+    }
+
+    /**
+     * Test that a resource can transition through different states.
+     */
+    @Test
+    void testResourceStateTransitions() {
+        // Create a PgconfigResource (undefined)
+        PgconfigResource resource = new PgconfigResource(
+                store,
+                PgconfigResourceStore.UNDEFINED_ID,
+                PgconfigResourceStore.UNDEFINED_ID,
+                Type.UNDEFINED,
+                "security/rest.properties",
+                0L);
+
+        // Initially, this should be an undefined resource
+        assertTrue(resource.isUndefined());
+        assertFalse(resource.exists());
+
+        // Create a file resource for transition 1: undefined -> file
+        PgconfigResource fileResource = new PgconfigResource(
+                store, 1L, 0L, Type.RESOURCE, "security/rest.properties", System.currentTimeMillis());
+
+        // Update to file state
+        resource.copy(fileResource);
+
+        // Verify the resource is now a file
+        assertTrue(resource.exists());
+        assertTrue(resource.isFile());
+        assertFalse(resource.isUndefined());
+        assertEquals(1L, resource.getId());
+
+        // Create a directory resource for transition 2: file -> directory
+        PgconfigResource dirResource = new PgconfigResource(
+                store, 1L, 0L, Type.DIRECTORY, "security/rest.properties", System.currentTimeMillis());
+
+        // Update to directory state
+        resource.copy(dirResource);
+
+        // Verify the resource is now a directory
+        assertTrue(resource.exists());
+        assertTrue(resource.isDirectory());
+        assertFalse(resource.isFile());
+        assertEquals(1L, resource.getId());
+
+        // Transition 3: directory -> undefined (deleted)
+        resource.type = Type.UNDEFINED;
+        resource.id = PgconfigResourceStore.UNDEFINED_ID;
+        resource.parentId = PgconfigResourceStore.UNDEFINED_ID;
+
+        // Verify the resource is undefined
+        assertEquals(Type.UNDEFINED, resource.getType());
+        assertEquals(PgconfigResourceStore.UNDEFINED_ID, resource.getId());
+        assertEquals(PgconfigResourceStore.UNDEFINED_ID, resource.getParentId());
+        assertFalse(resource.exists());
+        assertTrue(resource.isUndefined());
+    }
+}

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceUpdateStateTest.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceUpdateStateTest.java
@@ -1,0 +1,167 @@
+/*
+ * (c) 2025 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.backend.pgconfig.resource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.Instant;
+import org.geoserver.platform.resource.Resource.Type;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Tests for the updateState mechanism in PgconfigResource.
+ *
+ * <p>
+ * This mechanism is critical for compatibility with components like
+ * AbstractAccessRuleDAO and RESTAccessRuleDAO that hold resource references as
+ * instance variables, which can become stale in database-backed resource
+ * implementations.
+ * </p>
+ */
+@ExtendWith(MockitoExtension.class)
+class PgconfigResourceUpdateStateTest {
+
+    @Mock
+    private PgconfigResourceStore store;
+
+    private PgconfigResource resource;
+
+    @BeforeEach
+    void setup() {
+        resource = new PgconfigResource(store, 1L, 0L, Type.RESOURCE, "security/rest.properties", 123456L);
+    }
+
+    /**
+     * Test that getType() triggers updateState when sufficient time has passed.
+     */
+    @Test
+    void testGetTypeUpdatesState() {
+        // Set lastChecked to a time in the past to force update
+        resource.lastChecked = Instant.now().minusSeconds(10);
+
+        // Call getType which should trigger updateState
+        resource.getType();
+
+        // Verify updateState was called
+        verify(store).updateState(resource);
+    }
+
+    /**
+     * Test that lastmodified() triggers updateState when sufficient time has
+     * passed.
+     */
+    @Test
+    void testLastModifiedUpdatesState() {
+        // Set lastChecked to a time in the past to force update
+        resource.lastChecked = Instant.now().minusSeconds(10);
+
+        // Call lastmodified which should trigger updateState
+        resource.lastmodified();
+
+        // Verify updateState was called
+        verify(store).updateState(resource);
+    }
+
+    /**
+     * Test that multiple rapid calls to getType() only trigger updateState once.
+     */
+    @Test
+    void testUpdateStateNotCalledRepeatedly() {
+        // Set lastChecked to a time in the past to force update
+        resource.lastChecked = Instant.now().minusSeconds(10);
+
+        // First call should trigger updateState
+        resource.getType();
+
+        // Second call should not trigger updateState again
+        resource.getType();
+
+        // Verify updateState was called only once
+        verify(store, times(1)).updateState(resource);
+    }
+
+    /**
+     * Test that a resource's state is properly updated from the database.
+     */
+    @Test
+    void testStateIsProperlyUpdated() {
+        // Create a mock store that updates the resource on updateState
+        PgconfigResourceStore mockStore = mock(PgconfigResourceStore.class);
+
+        // Create a resource with initial state
+        resource = new PgconfigResource(mockStore, 1L, 0L, Type.RESOURCE, "security/rest.properties", 123456L);
+
+        // Create an "updated" resource to simulate what the DB would return
+        PgconfigResource updatedResource =
+                new PgconfigResource(mockStore, 2L, 0L, Type.DIRECTORY, "security/rest.properties", 789012L);
+
+        // Make updateState copy the updated resource's state to our test resource
+        // Use doAnswer instead of when for void methods
+        doAnswer(invocation -> {
+                    PgconfigResource r = invocation.getArgument(0);
+                    r.copy(updatedResource);
+                    return null;
+                })
+                .when(mockStore)
+                .updateState(any());
+
+        // Set lastChecked to a time in the past
+        resource.lastChecked = Instant.now().minusSeconds(10);
+
+        // Call getType which should trigger updateState
+        Type type = resource.getType();
+
+        // Verify that the resource was updated with new state
+        assertEquals(Type.DIRECTORY, type);
+        assertEquals(2L, resource.getId());
+        assertEquals(789012L, resource.lastmodified());
+    }
+
+    /**
+     * Test that updateState can handle the case where a resource no longer exists.
+     */
+    @Test
+    void testUpdateStateHandlesDeletedResource() {
+        // Create a mock store that marks the resource as undefined on updateState
+        PgconfigResourceStore mockStore = mock(PgconfigResourceStore.class);
+
+        // Create a resource with initial state
+        resource = new PgconfigResource(mockStore, 1L, 0L, Type.RESOURCE, "security/rest.properties", 123456L);
+
+        // Make updateState set the resource type to UNDEFINED
+        // Use doAnswer instead of when for void methods
+        doAnswer(invocation -> {
+                    PgconfigResource r = invocation.getArgument(0);
+                    r.type = Type.UNDEFINED;
+                    r.id = PgconfigResourceStore.UNDEFINED_ID;
+                    return null;
+                })
+                .when(mockStore)
+                .updateState(any());
+
+        // Set lastChecked to a time in the past
+        resource.lastChecked = Instant.now().minusSeconds(10);
+
+        // Call getType which should trigger updateState
+        Type type = resource.getType();
+
+        // Verify that the resource was marked as undefined
+        assertEquals(Type.UNDEFINED, type);
+        assertEquals(PgconfigResourceStore.UNDEFINED_ID, resource.getId());
+        assertFalse(resource.exists());
+        assertTrue(resource.isUndefined());
+    }
+}

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/security/SecurityManagerReloaded.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/security/SecurityManagerReloaded.java
@@ -1,0 +1,40 @@
+/*
+ * (c) 2025 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.event.security;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * Event fired after a {@link GeoServerSecurityManager} has successfully completed its reload
+ * process.
+ *
+ * <p>This event indicates that the security manager has fully initialized or reloaded its
+ * configuration, and it's safe to make further security configuration changes.
+ *
+ * @since 1.9
+ */
+@ToString(callSuper = true)
+public class SecurityManagerReloaded extends ApplicationEvent {
+
+    private static final long serialVersionUID = 1L;
+
+    /** The update sequence at the time this event was created. */
+    private final @Getter long updateSequence;
+
+    /**
+     * Creates a new {@code SecurityManagerReloaded} event.
+     *
+     * @param source the security manager that fired this event
+     * @param updateSequence the update sequence at the time this event was created
+     */
+    public SecurityManagerReloaded(@NonNull Object source, long updateSequence) {
+        super(source);
+        this.updateSequence = updateSequence;
+    }
+}

--- a/src/extensions/security/gateway-shared-auth/pom.xml
+++ b/src/extensions/security/gateway-shared-auth/pom.xml
@@ -20,6 +20,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <!-- for SecurityManagerReloaded -->
+      <groupId>org.geoserver.cloud.catalog</groupId>
+      <artifactId>gs-cloud-catalog-events</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-sec-core</artifactId>
       <scope>provided</scope>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1001,6 +1001,11 @@
                 <goal>integration-test</goal>
                 <goal>verify</goal>
               </goals>
+              <configuration>
+                <forkCount>2</forkCount>
+                <reuseForks>false</reuseForks>
+                <trimStackTrace>false</trimStackTrace>
+              </configuration>
             </execution>
           </executions>
         </plugin>


### PR DESCRIPTION
The REST API was failing with 403 forbidden errors when using the PostgreSQL configuration backend. This fix addresses two key issues:

1. Improved gateway-shared-auth initialization timing to wait for security manager reload completion before modifying the security filter chain
2. Added state refreshing mechanism for PgconfigResource objects to ensure REST security components have up-to-date resource access