### PR TITLE
Fix conditional annotations for service availability and add integration tests

### DIFF
--- a/src/apps/geoserver/gwc/src/main/resources/bootstrap.yml
+++ b/src/apps/geoserver/gwc/src/main/resources/bootstrap.yml
@@ -18,7 +18,13 @@ gwc:
 # and usually loaded from gs-gwc.jar's application.properties.
 # This won't be the case since we declare spring.config.name=geoserver
 gwc.context.suffix: gwc
-geoserver.base-path: /gwc
+geoserver:
+  base-path: /gwc
+  service:
+    # Fixed per-service value to support conditional activation of extensions.
+    # This property is checked by @ConditionalOnGeoServerGWC
+    gwc:
+      enabled: true
 
 info:
   component: GeoWebcache

--- a/src/apps/geoserver/pom.xml
+++ b/src/apps/geoserver/pom.xml
@@ -29,6 +29,15 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <!-- For testing service conditional annotations -->
+        <groupId>org.geoserver.cloud.extensions</groupId>
+        <artifactId>gs-cloud-extensions-core</artifactId>
+        <version>${project.version}</version>
+        <classifier>tests</classifier>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -92,6 +101,14 @@
     <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-assertj3</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <!-- For testing service conditional annotations -->
+      <groupId>org.geoserver.cloud.extensions</groupId>
+      <artifactId>gs-cloud-extensions-core</artifactId>
+      <classifier>tests</classifier>
+      <type>test-jar</type>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/apps/geoserver/restconfig/src/main/resources/bootstrap.yml
+++ b/src/apps/geoserver/restconfig/src/main/resources/bootstrap.yml
@@ -7,7 +7,13 @@ server:
   forward-headers-strategy: framework
   servlet.context-path: /
 management.server.port: 8081
-geoserver.base-path: /rest
+geoserver:
+  base-path: /rest
+  service:
+    # Fixed per-service value to support conditional activation of extensions.
+    # This property is checked by @ConditionalOnGeoServerREST
+    restconfig:
+      enabled: true
 spring:
   config:
     import:

--- a/src/apps/geoserver/wcs/src/main/resources/bootstrap.yml
+++ b/src/apps/geoserver/wcs/src/main/resources/bootstrap.yml
@@ -7,7 +7,13 @@ server:
   forward-headers-strategy: framework
   servlet.context-path: /
 management.server.port: 8081
-geoserver.base-path: /wcs
+geoserver:
+  base-path: /wcs
+  service:
+    # Fixed per-service value to support conditional activation of extensions.
+    # This property is checked by @ConditionalOnGeoServerWCS
+    wcs:
+      enabled: true
 spring:
   config:
     import:

--- a/src/apps/geoserver/wcs/src/test/java/org/geoserver/cloud/wcs/WcsApplicationTest.java
+++ b/src/apps/geoserver/wcs/src/test/java/org/geoserver/cloud/wcs/WcsApplicationTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Path;
 import java.util.stream.Stream;
+import org.geoserver.cloud.autoconfigure.extensions.test.ConditionalTestAutoConfiguration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -177,5 +178,33 @@ class WcsApplicationTest {
 
     protected void expectBean(String name, Class<?> type) {
         assertThat(context.getBean(name)).isInstanceOf(type);
+    }
+
+    /**
+     * Tests the service-specific conditional annotations.
+     *
+     * <p>
+     * Verifies that only the WCS conditional bean is activated in this service,
+     * based on the geoserver.service.wcs.enabled=true property set in bootstrap.yml.
+     * This test relies on the ConditionalTestAutoConfiguration class from the
+     * extensions-core test-jar, which contains beans conditionally activated
+     * based on each GeoServer service type.
+     */
+    @Test
+    void testServiceConditionalAnnotations() {
+        // This should exist in WCS service
+        assertThat(context.containsBean("wcsConditionalBean")).isTrue();
+        if (context.containsBean("wcsConditionalBean")) {
+            ConditionalTestAutoConfiguration.ConditionalTestBean bean =
+                    context.getBean("wcsConditionalBean", ConditionalTestAutoConfiguration.ConditionalTestBean.class);
+            assertThat(bean.getServiceName()).isEqualTo("WCS");
+        }
+
+        // These should not exist in WCS service
+        assertThat(context.containsBean("wmsConditionalBean")).isFalse();
+        assertThat(context.containsBean("wfsConditionalBean")).isFalse();
+        assertThat(context.containsBean("wpsConditionalBean")).isFalse();
+        assertThat(context.containsBean("restConditionalBean")).isFalse();
+        assertThat(context.containsBean("webUiConditionalBean")).isFalse();
     }
 }

--- a/src/apps/geoserver/webui/src/main/resources/bootstrap.yml
+++ b/src/apps/geoserver/webui/src/main/resources/bootstrap.yml
@@ -13,7 +13,6 @@ server:
         name: JSESSIONID_${spring.application.name}
         http-only: true
 management.server.port: 8081
-geoserver.base-path: /web
 spring:
   config:
     import:
@@ -52,6 +51,12 @@ eureka.client:
   registry-fetch-interval-seconds: 10
 
 geoserver:
+  base-path: /web
+  service:
+    # Fixed per-service value to support conditional activation of extensions.
+    # This property is checked by @ConditionalOnGeoServerWebUI
+    webui:
+      enabled: true
   styling:
     css.enabled: true
   wms:

--- a/src/apps/geoserver/webui/src/test/java/org/geoserver/cloud/web/app/WebUIApplicationTest.java
+++ b/src/apps/geoserver/webui/src/test/java/org/geoserver/cloud/web/app/WebUIApplicationTest.java
@@ -21,6 +21,7 @@ import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.util.tester.TagTester;
 import org.apache.wicket.util.tester.WicketTester;
+import org.geoserver.cloud.autoconfigure.extensions.test.ConditionalTestAutoConfiguration;
 import org.geoserver.web.GeoServerApplication;
 import org.geoserver.web.GeoServerHomePage;
 import org.geoserver.web.GeoServerLoginPage;
@@ -191,5 +192,36 @@ class WebUIApplicationTest {
     @Test
     void homePageSelectionModeDefaultsToTEXT() {
         assertThat(System.getProperty("GeoServerHomePage.selectionMode")).isEqualTo("TEXT");
+    }
+
+    /**
+     * Tests the service-specific conditional annotations.
+     *
+     * <p>
+     * Verifies that only the WebUI conditional bean is activated in this service,
+     * based on the geoserver.service.webui.enabled=true property set in bootstrap.yml.
+     * This test relies on the ConditionalTestAutoConfiguration class from the
+     * extensions-core test-jar, which contains beans conditionally activated
+     * based on each GeoServer service type.
+     */
+    @Test
+    void testServiceConditionalAnnotations() {
+        // Access the application context through the app bean
+        var context = app.getApplicationContext();
+
+        // This should exist in WebUI service
+        assertThat(context.containsBean("webUiConditionalBean")).isTrue();
+        if (context.containsBean("webUiConditionalBean")) {
+            ConditionalTestAutoConfiguration.ConditionalTestBean bean =
+                    context.getBean("webUiConditionalBean", ConditionalTestAutoConfiguration.ConditionalTestBean.class);
+            assertThat(bean.getServiceName()).isEqualTo("WebUI");
+        }
+
+        // These should not exist in WebUI service
+        assertThat(context.containsBean("wfsConditionalBean")).isFalse();
+        assertThat(context.containsBean("wcsConditionalBean")).isFalse();
+        assertThat(context.containsBean("wmsConditionalBean")).isFalse();
+        assertThat(context.containsBean("wpsConditionalBean")).isFalse();
+        assertThat(context.containsBean("restConditionalBean")).isFalse();
     }
 }

--- a/src/apps/geoserver/wfs/src/main/resources/bootstrap.yml
+++ b/src/apps/geoserver/wfs/src/main/resources/bootstrap.yml
@@ -7,7 +7,13 @@ server:
   forward-headers-strategy: framework
   servlet.context-path: /
 management.server.port: 8081
-geoserver.base-path: /wfs
+geoserver:
+  base-path: /wfs
+  service:
+    # Fixed per-service value to support conditional activation of extensions.
+    # This property is checked by @ConditionalOnGeoServerWFS
+    wfs:
+      enabled: true
 spring:
   config:
     import:

--- a/src/apps/geoserver/wfs/src/test/java/org/geoserver/cloud/wfs/app/WfsApplicationTest.java
+++ b/src/apps/geoserver/wfs/src/test/java/org/geoserver/cloud/wfs/app/WfsApplicationTest.java
@@ -5,18 +5,26 @@
 
 package org.geoserver.cloud.wfs.app;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Map;
+import org.geoserver.cloud.autoconfigure.extensions.test.ConditionalTestAutoConfiguration;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.ApplicationContext;
 import org.xmlunit.assertj3.XmlAssert;
 
 @SpringBootTest(classes = WfsApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
 abstract class WfsApplicationTest {
 
     protected TestRestTemplate restTemplate = new TestRestTemplate("admin", "geoserver");
+
+    @Autowired
+    protected ApplicationContext context;
 
     @Test
     void owsGetCapabilitiesSmokeTest(@LocalServerPort int servicePort) {
@@ -32,5 +40,33 @@ abstract class WfsApplicationTest {
         String caps = restTemplate.getForObject(url, String.class);
         Map<String, String> nscontext = Map.of("wfs", "http://www.opengis.net/wfs");
         XmlAssert.assertThat(caps).withNamespaceContext(nscontext).hasXPath("/wfs:WFS_Capabilities");
+    }
+
+    /**
+     * Tests the service-specific conditional annotations.
+     *
+     * <p>
+     * Verifies that only the WFS conditional bean is activated in this service,
+     * based on the geoserver.service.wfs.enabled=true property set in bootstrap.yml.
+     * This test relies on the ConditionalTestAutoConfiguration class from the
+     * extensions-core test-jar, which contains beans conditionally activated
+     * based on each GeoServer service type.
+     */
+    @Test
+    void testServiceConditionalAnnotations() {
+        // This should exist in WFS service
+        assertThat(context.containsBean("wfsConditionalBean")).isTrue();
+        if (context.containsBean("wfsConditionalBean")) {
+            ConditionalTestAutoConfiguration.ConditionalTestBean bean =
+                    context.getBean("wfsConditionalBean", ConditionalTestAutoConfiguration.ConditionalTestBean.class);
+            assertThat(bean.getServiceName()).isEqualTo("WFS");
+        }
+
+        // These should not exist in WFS service
+        assertThat(context.containsBean("wmsConditionalBean")).isFalse();
+        assertThat(context.containsBean("wcsConditionalBean")).isFalse();
+        assertThat(context.containsBean("wpsConditionalBean")).isFalse();
+        assertThat(context.containsBean("restConditionalBean")).isFalse();
+        assertThat(context.containsBean("webUiConditionalBean")).isFalse();
     }
 }

--- a/src/apps/geoserver/wms/src/main/resources/bootstrap.yml
+++ b/src/apps/geoserver/wms/src/main/resources/bootstrap.yml
@@ -12,7 +12,13 @@ server:
     whitelabel:
       enabled: true
 management.server.port: 8081
-geoserver.base-path: /wms
+geoserver:
+  base-path: /wms
+  service:
+    # Fixed per-service value to support conditional activation of extensions.
+    # This property is checked by @ConditionalOnGeoServerWMS
+    wms:
+      enabled: true
 spring:
   config:
     import:

--- a/src/apps/geoserver/wms/src/test/java/org/geoserver/cloud/wms/app/WmsApplicationTest.java
+++ b/src/apps/geoserver/wms/src/test/java/org/geoserver/cloud/wms/app/WmsApplicationTest.java
@@ -7,6 +7,7 @@ package org.geoserver.cloud.wms.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.geoserver.cloud.autoconfigure.extensions.test.ConditionalTestAutoConfiguration;
 import org.geoserver.cloud.autoconfigure.gwc.integration.WMSIntegrationAutoConfiguration.ForwardGetMapToGwcAspect;
 import org.geoserver.cloud.virtualservice.VirtualServiceVerifier;
 import org.geoserver.cloud.wms.controller.GetMapReflectorController;
@@ -80,6 +81,34 @@ abstract class WmsApplicationTest {
     void testKmlIntegration() {
         expectBean("kmlIconsController", KMLIconsController.class);
         expectBean("kmlReflectorController", KMLReflectorController.class);
+    }
+
+    /**
+     * Tests the service-specific conditional annotations.
+     *
+     * <p>
+     * Verifies that only the WMS conditional bean is activated in this service,
+     * based on the geoserver.service.wms.enabled=true property set in bootstrap.yml.
+     * This test relies on the ConditionalTestAutoConfiguration class from the
+     * extensions-core test-jar, which contains beans conditionally activated
+     * based on each GeoServer service type.
+     */
+    @Test
+    void testServiceConditionalAnnotations() {
+        // This should exist in WMS service
+        assertThat(context.containsBean("wmsConditionalBean")).isTrue();
+        if (context.containsBean("wmsConditionalBean")) {
+            ConditionalTestAutoConfiguration.ConditionalTestBean bean =
+                    context.getBean("wmsConditionalBean", ConditionalTestAutoConfiguration.ConditionalTestBean.class);
+            assertThat(bean.getServiceName()).isEqualTo("WMS");
+        }
+
+        // These should not exist in WMS service
+        assertThat(context.containsBean("wfsConditionalBean")).isFalse();
+        assertThat(context.containsBean("wcsConditionalBean")).isFalse();
+        assertThat(context.containsBean("wpsConditionalBean")).isFalse();
+        assertThat(context.containsBean("restConditionalBean")).isFalse();
+        assertThat(context.containsBean("webUiConditionalBean")).isFalse();
     }
 
     protected void expectBean(String name, Class<?> type) {

--- a/src/apps/geoserver/wps/src/main/resources/bootstrap.yml
+++ b/src/apps/geoserver/wps/src/main/resources/bootstrap.yml
@@ -7,7 +7,13 @@ server:
   forward-headers-strategy: framework
   servlet.context-path: /
 management.server.port: 8081
-geoserver.base-path: /wps
+geoserver:
+  base-path: /wps
+  service:
+    # Fixed per-service value to support conditional activation of extensions.
+    # This property is checked by @ConditionalOnGeoServerWPS
+    wps:
+      enabled: true
 spring:
   config:
     import:

--- a/src/apps/geoserver/wps/src/test/java/org/geoserver/cloud/wps/WpsApplicationTest.java
+++ b/src/apps/geoserver/wps/src/test/java/org/geoserver/cloud/wps/WpsApplicationTest.java
@@ -5,14 +5,19 @@
 
 package org.geoserver.cloud.wps;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.nio.file.Path;
 import java.util.Map;
+import org.geoserver.cloud.autoconfigure.extensions.test.ConditionalTestAutoConfiguration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -23,6 +28,8 @@ import org.xmlunit.assertj3.XmlAssert;
 class WpsApplicationTest {
 
     static @TempDir Path datadir;
+
+    private @Autowired ConfigurableApplicationContext context;
 
     @DynamicPropertySource
     static void setUpDataDir(DynamicPropertyRegistry registry) {
@@ -47,5 +54,33 @@ class WpsApplicationTest {
         String caps = restTemplate.getForObject(url, String.class);
         Map<String, String> nscontext = Map.of("wps", "http://www.opengis.net/wps/1.0.0");
         XmlAssert.assertThat(caps).withNamespaceContext(nscontext).hasXPath("/wps:Capabilities");
+    }
+
+    /**
+     * Tests the service-specific conditional annotations.
+     *
+     * <p>
+     * Verifies that only the WPS conditional bean is activated in this service,
+     * based on the geoserver.service.wps.enabled=true property set in bootstrap.yml.
+     * This test relies on the ConditionalTestAutoConfiguration class from the
+     * extensions-core test-jar, which contains beans conditionally activated
+     * based on each GeoServer service type.
+     */
+    @Test
+    void testServiceConditionalAnnotations() {
+        // This should exist in WPS service
+        assertThat(context.containsBean("wpsConditionalBean")).isTrue();
+        if (context.containsBean("wpsConditionalBean")) {
+            ConditionalTestAutoConfiguration.ConditionalTestBean bean =
+                    context.getBean("wpsConditionalBean", ConditionalTestAutoConfiguration.ConditionalTestBean.class);
+            assertThat(bean.getServiceName()).isEqualTo("WPS");
+        }
+
+        // These should not exist in WPS service
+        assertThat(context.containsBean("wfsConditionalBean")).isFalse();
+        assertThat(context.containsBean("wcsConditionalBean")).isFalse();
+        assertThat(context.containsBean("wmsConditionalBean")).isFalse();
+        assertThat(context.containsBean("restConditionalBean")).isFalse();
+        assertThat(context.containsBean("webUiConditionalBean")).isFalse();
     }
 }

--- a/src/extensions/core/README.md
+++ b/src/extensions/core/README.md
@@ -7,40 +7,54 @@ This module provides common infrastructure for GeoServer Cloud extensions, inclu
 The extensions core module defines several conditional annotations that control when extension components should be activated. These annotations follow a consistent pattern:
 
 1. `@ConditionalOnClass` - Verifies that a specific GeoServer class is on the classpath
-2. `@ConditionalOnBean` - Checks for the presence of a named bean in the Spring context 
+2. `@ConditionalOnProperty` - Checks for the presence of a configuration property
 3. `@ConditionalOnGeoServer` - Base condition that verifies GeoServer core is available
 
 ### Conditional Annotation Mappings
 
-Each conditional annotation pairs a class check with a bean name check, ensuring both are satisfied:
+Each conditional annotation pairs a class check with a property check, ensuring both are satisfied:
 
-| Annotation | Class Condition | Bean Condition | Source JAR |
-|------------|----------------|----------------|------------|
-| `@ConditionalOnGeoServer` | `org.geoserver.config.GeoServer` | GeoServer bean | gs-main |
-| `@ConditionalOnGeoServerWMS` | `org.geoserver.wms.DefaultWebMapService` | wmsServiceTarget bean | gs-wms |
-| `@ConditionalOnGeoServerWFS` | `org.geoserver.wfs.DefaultWebFeatureService` | wfsServiceTarget bean | gs-wfs |
-| `@ConditionalOnGeoServerWCS` | `org.geoserver.wcs.responses.CoverageResponseDelegateFinder` | coverageResponseDelegateFactory bean | gs-wcs |
-| `@ConditionalOnGeoServerWPS` | `org.geoserver.wps.DefaultWebProcessingService` | wpsServiceTarget bean | gs-wps |
-| `@ConditionalOnGeoServerREST` | `org.geoserver.rest.security.RestConfigXStreamPersister` | restConfigXStreamPersister bean | gs-restconfig |
-| `@ConditionalOnGeoServerWebUI` | `org.geoserver.web.GeoServerApplication` | webApplication bean | gs-web-core |
+| Annotation | Class Condition | Property Condition | Source JAR |
+|------------|----------------|-------------------|------------|
+| `@ConditionalOnGeoServer` | `org.geoserver.config.GeoServer` | n/a | gs-main |
+| `@ConditionalOnGeoServerWMS` | `org.geoserver.wms.DefaultWebMapService` | `geoserver.service.wms.enabled=true` | gs-wms |
+| `@ConditionalOnGeoServerWFS` | `org.geoserver.wfs.DefaultWebFeatureService` | `geoserver.service.wfs.enabled=true` | gs-wfs |
+| `@ConditionalOnGeoServerWCS` | `org.geoserver.wcs.responses.CoverageResponseDelegateFinder` | `geoserver.service.wcs.enabled=true` | gs-wcs |
+| `@ConditionalOnGeoServerWPS` | `org.geoserver.wps.DefaultWebProcessingService` | `geoserver.service.wps.enabled=true` | gs-wps |
+| `@ConditionalOnGeoServerREST` | `org.geoserver.rest.security.RestConfigXStreamPersister` | `geoserver.service.restconfig.enabled=true` | gs-restconfig |
+| `@ConditionalOnGeoServerWebUI` | `org.geoserver.web.GeoServerApplication` | `geoserver.service.webui.enabled=true` | gs-web-core |
+
+These property conditions are set to `true` by default in each service's bootstrap configuration file, which ensures reliable detection of the service type during auto-configuration processing.
 
 ### Testing with Conditionals
 
-When writing tests for components that use these conditionals, you need to satisfy both the class and bean requirements. The recommended approach is to:
+When writing tests for components that use these conditionals, you need to satisfy both the class and property requirements. The recommended approach is to:
 
 1. Add the appropriate dependency with `<scope>test</scope>` to your module's pom.xml
 2. Use Spring's `ApplicationContextRunner` or `WebApplicationContextRunner` in tests
-3. Provide mock implementations of the required beans
+3. Set the required property values
 
 Example:
 
 ```java
-private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
+private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
         // @ConditionalOnGeoServer
         .withBean(GeoServer.class, () -> mock(GeoServer.class))
         // @ConditionalOnGeoServerWMS
-        .withBean("wmsServiceTarget", DefaultWebMapService.class, () -> mock(DefaultWebMapService.class))
+        .withPropertyValues("geoserver.service.wms.enabled=true")
         .withConfiguration(AutoConfigurations.of(YourAutoConfiguration.class));
+```
+
+For testing the class condition aspect, you can use `FilteredClassLoader` to verify conditional behavior when a class is not available:
+
+```java
+contextRunner
+    .withClassLoader(new FilteredClassLoader(RequiredClass.class))
+    .withPropertyValues("required.property=true")
+    .run(context -> {
+        // Component should not be created when class is unavailable
+        assertThat(context).doesNotHaveBean(YourComponent.class);
+    });
 ```
 
 ## Maven Dependencies

--- a/src/extensions/core/pom.xml
+++ b/src/extensions/core/pom.xml
@@ -57,9 +57,15 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-gwc</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
+    <!-- Test dependencies are inherited from parent POM -->
   </dependencies>
 </project>

--- a/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServer.java
+++ b/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServer.java
@@ -7,6 +7,7 @@ package org.geoserver.cloud.autoconfigure.extensions;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -43,10 +44,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
  *
  * @since 2.27.0
  */
-// original idea was conditional on bean but it's a can of worms with all the forcer spring initialization during
+// original idea was conditional on bean but it's a can of worms with all the forced spring initialization during
 // startup
 @ConditionalOnClass(GeoServer.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
+@Inherited
 @Documented
 public @interface ConditionalOnGeoServer {}

--- a/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerGWC.java
+++ b/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerGWC.java
@@ -15,24 +15,20 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 /**
  * Annotation that marks a component to be conditional on the application being
- * the GeoServer Web UI application (containing {@code org.geoserver.web.GeoServerApplication}).
+ * a GeoServer GWC (GeoWebCache) application.
  *
  * <p>
  * This annotation is used to selectively enable components that should only be active
- * in the GeoServer Web UI application, such as UI panels, page components, and related
- * configurations.
- *
- * <p>
- * The condition checks for:
+ * in GeoServer GWC applications. It verifies that:
  * <ul>
- *   <li>The presence of GeoServer core classes ({@link ConditionalOnGeoServer})</li>
- *   <li>The presence of the GeoServer Web UI application class</li>
- *   <li>The {@code geoserver.service.webui.enabled} property is set to {@code true}</li>
+ *   <li>The application has GeoServer core classes ({@link ConditionalOnGeoServer})</li>
+ *   <li>The GeoWebCache service class is available in the classpath</li>
+ *   <li>The {@code geoserver.service.gwc.enabled} property is set to {@code true}</li>
  * </ul>
  *
  * <p>
- * This conditional uses a property-based approach rather than relying solely on class presence
- * to avoid potential issues with bean initialization order during auto-configuration processing.
+ * This conditional uses a property-based approach rather than bean detection to avoid
+ * potential issues with bean initialization order during auto-configuration processing.
  * Each GeoServer service module is responsible for setting its corresponding
  * {@code geoserver.service.[service-name].enabled} property in its bootstrap configuration.
  *
@@ -40,21 +36,24 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
  * Usage example:
  * <pre>{@code
  * @Configuration
- * @ConditionalOnGeoServerWebUI
- * public class WebUISpecificConfiguration {
- *     // Configuration only activated in the Web UI application
+ * @ConditionalOnGeoServerWMS
+ * public class WmsSpecificConfiguration {
+ *     // Configuration only activated in WMS service
  * }
  * }</pre>
  *
  * @see ConditionalOnGeoServer
- * @see ConditionalOnGeoServerWebUIUnavailable
+ * @see ConditionalOnGeoServerWFS
+ * @see ConditionalOnGeoServerWCS
+ * @see ConditionalOnGeoServerWPS
+ * @see ConditionalOnGeoServerWebUI
+ * @see ConditionalOnGeoServerREST
  * @since 2.27.0
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Documented
 @ConditionalOnGeoServer
-// use string class name for optional dependencies
-@ConditionalOnClass(name = "org.geoserver.web.GeoServerApplication")
-@ConditionalOnProperty(name = "geoserver.service.webui.enabled", havingValue = "true", matchIfMissing = false)
-public @interface ConditionalOnGeoServerWebUI {}
+@ConditionalOnClass(org.geowebcache.GeoWebCache.class)
+@ConditionalOnProperty(name = "geoserver.service.gwc.enabled", havingValue = "true", matchIfMissing = false)
+public @interface ConditionalOnGeoServerGWC {}

--- a/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerREST.java
+++ b/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerREST.java
@@ -10,8 +10,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 /**
  * Annotation that marks a component to be conditional on the application being
@@ -27,8 +27,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
  * <ul>
  *   <li>The application has GeoServer core classes ({@link ConditionalOnGeoServer})</li>
  *   <li>The REST Configuration service class is available in the classpath</li>
- *   <li>The REST Configuration bean (restConfigXStreamPersister) is registered in the application context</li>
+ *   <li>The {@code geoserver.service.restconfig.enabled} property is set to {@code true}</li>
  * </ul>
+ *
+ * <p>
+ * This conditional uses a property-based approach rather than bean detection to avoid
+ * potential issues with bean initialization order during auto-configuration processing.
+ * Each GeoServer service module is responsible for setting its corresponding
+ * {@code geoserver.service.[service-name].enabled} property in its bootstrap configuration.
  *
  * <p>
  * Usage example:
@@ -45,6 +51,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
  * @see ConditionalOnGeoServerWFS
  * @see ConditionalOnGeoServerWCS
  * @see ConditionalOnGeoServerWPS
+ * @see ConditionalOnGeoServerWebUI
+ * @see ConditionalOnGeoServerGWC
  * @since 2.27.0
  */
 @Retention(RetentionPolicy.RUNTIME)
@@ -52,5 +60,5 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 @Documented
 @ConditionalOnGeoServer
 @ConditionalOnClass(org.geoserver.rest.security.RestConfigXStreamPersister.class)
-@ConditionalOnBean(name = "restConfigXStreamPersister")
+@ConditionalOnProperty(name = "geoserver.service.restconfig.enabled", havingValue = "true", matchIfMissing = false)
 public @interface ConditionalOnGeoServerREST {}

--- a/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWCS.java
+++ b/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWCS.java
@@ -10,8 +10,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 /**
  * Annotation that marks a component to be conditional on the application being
@@ -23,8 +23,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
  * <ul>
  *   <li>The application has GeoServer core classes ({@link ConditionalOnGeoServer})</li>
  *   <li>The WCS service class is available in the classpath</li>
- *   <li>The WCS service bean (coverageResponseDelegateFactory) is registered in the application context</li>
+ *   <li>The {@code geoserver.service.wcs.enabled} property is set to {@code true}</li>
  * </ul>
+ *
+ * <p>
+ * This conditional uses a property-based approach rather than bean detection to avoid
+ * potential issues with bean initialization order during auto-configuration processing.
+ * Each GeoServer service module is responsible for setting its corresponding
+ * {@code geoserver.service.[service-name].enabled} property in its bootstrap configuration.
  *
  * <p>
  * Usage example:
@@ -40,6 +46,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
  * @see ConditionalOnGeoServerWMS
  * @see ConditionalOnGeoServerWFS
  * @see ConditionalOnGeoServerWPS
+ * @see ConditionalOnGeoServerREST
+ * @see ConditionalOnGeoServerWebUI
+ * @see ConditionalOnGeoServerGWC
  * @since 2.27.0
  */
 @Retention(RetentionPolicy.RUNTIME)
@@ -47,5 +56,5 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 @Documented
 @ConditionalOnGeoServer
 @ConditionalOnClass(org.geoserver.wcs.responses.CoverageResponseDelegateFinder.class)
-@ConditionalOnBean(name = "coverageResponseDelegateFactory")
+@ConditionalOnProperty(name = "geoserver.service.wcs.enabled", havingValue = "true", matchIfMissing = false)
 public @interface ConditionalOnGeoServerWCS {}

--- a/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWFS.java
+++ b/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWFS.java
@@ -10,8 +10,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 /**
  * Annotation that marks a component to be conditional on the application being
@@ -23,8 +23,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
  * <ul>
  *   <li>The application has GeoServer core classes ({@link ConditionalOnGeoServer})</li>
  *   <li>The WFS service class is available in the classpath</li>
- *   <li>The WFS service bean is registered in the application context</li>
+ *   <li>The {@code geoserver.service.wfs.enabled} property is set to {@code true}</li>
  * </ul>
+ *
+ * <p>
+ * This conditional uses a property-based approach rather than bean detection to avoid
+ * potential issues with bean initialization order during auto-configuration processing.
+ * Each GeoServer service module is responsible for setting its corresponding
+ * {@code geoserver.service.[service-name].enabled} property in its bootstrap configuration.
  *
  * <p>
  * Usage example:
@@ -40,6 +46,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
  * @see ConditionalOnGeoServerWMS
  * @see ConditionalOnGeoServerWCS
  * @see ConditionalOnGeoServerWPS
+ * @see ConditionalOnGeoServerREST
+ * @see ConditionalOnGeoServerWebUI
+ * @see ConditionalOnGeoServerGWC
  * @since 2.27.0
  */
 @Retention(RetentionPolicy.RUNTIME)
@@ -47,5 +56,5 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 @Documented
 @ConditionalOnGeoServer
 @ConditionalOnClass(org.geoserver.wfs.DefaultWebFeatureService.class)
-@ConditionalOnBean(name = "wfsServiceTarget")
+@ConditionalOnProperty(name = "geoserver.service.wfs.enabled", havingValue = "true", matchIfMissing = false)
 public @interface ConditionalOnGeoServerWFS {}

--- a/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWMS.java
+++ b/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWMS.java
@@ -10,8 +10,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 /**
  * Annotation that marks a component to be conditional on the application being
@@ -23,8 +23,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
  * <ul>
  *   <li>The application has GeoServer core classes ({@link ConditionalOnGeoServer})</li>
  *   <li>The WMS service class is available in the classpath</li>
- *   <li>The WMS service bean is registered in the application context</li>
+ *   <li>The {@code geoserver.service.wms.enabled} property is set to {@code true}</li>
  * </ul>
+ *
+ * <p>
+ * This conditional uses a property-based approach rather than bean detection to avoid
+ * potential issues with bean initialization order during auto-configuration processing.
+ * Each GeoServer service module is responsible for setting its corresponding
+ * {@code geoserver.service.[service-name].enabled} property in its bootstrap configuration.
  *
  * <p>
  * Usage example:
@@ -40,6 +46,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
  * @see ConditionalOnGeoServerWFS
  * @see ConditionalOnGeoServerWCS
  * @see ConditionalOnGeoServerWPS
+ * @see ConditionalOnGeoServerREST
+ * @see ConditionalOnGeoServerWebUI
+ * @see ConditionalOnGeoServerGWC
  * @since 2.27.0
  */
 @Retention(RetentionPolicy.RUNTIME)
@@ -47,5 +56,5 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 @Documented
 @ConditionalOnGeoServer
 @ConditionalOnClass(org.geoserver.wms.DefaultWebMapService.class)
-@ConditionalOnBean(name = "wmsServiceTarget")
+@ConditionalOnProperty(name = "geoserver.service.wms.enabled", havingValue = "true", matchIfMissing = false)
 public @interface ConditionalOnGeoServerWMS {}

--- a/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWPS.java
+++ b/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWPS.java
@@ -10,8 +10,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 /**
  * Annotation that marks a component to be conditional on the application being
@@ -23,8 +23,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
  * <ul>
  *   <li>The application has GeoServer core classes ({@link ConditionalOnGeoServer})</li>
  *   <li>The WPS service class is available in the classpath</li>
- *   <li>The WPS service bean is registered in the application context</li>
+ *   <li>The {@code geoserver.service.wps.enabled} property is set to {@code true}</li>
  * </ul>
+ *
+ * <p>
+ * This conditional uses a property-based approach rather than bean detection to avoid
+ * potential issues with bean initialization order during auto-configuration processing.
+ * Each GeoServer service module is responsible for setting its corresponding
+ * {@code geoserver.service.[service-name].enabled} property in its bootstrap configuration.
  *
  * <p>
  * Usage example:
@@ -40,6 +46,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
  * @see ConditionalOnGeoServerWMS
  * @see ConditionalOnGeoServerWFS
  * @see ConditionalOnGeoServerWCS
+ * @see ConditionalOnGeoServerREST
+ * @see ConditionalOnGeoServerWebUI
+ * @see ConditionalOnGeoServerGWC
  * @since 2.27.0
  */
 @Retention(RetentionPolicy.RUNTIME)
@@ -47,5 +56,5 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 @Documented
 @ConditionalOnGeoServer
 @ConditionalOnClass(org.geoserver.wps.DefaultWebProcessingService.class)
-@ConditionalOnBean(name = "wpsServiceTarget")
+@ConditionalOnProperty(name = "geoserver.service.wps.enabled", havingValue = "true", matchIfMissing = false)
 public @interface ConditionalOnGeoServerWPS {}

--- a/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/AbstractConditionalTest.java
+++ b/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/AbstractConditionalTest.java
@@ -1,0 +1,52 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.autoconfigure.extensions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.impl.GeoServerImpl;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * Base test class for testing conditional annotations.
+ */
+public abstract class AbstractConditionalTest {
+
+    /**
+     * Creates and returns a new {@link ApplicationContextRunner} with basic GeoServer context.
+     */
+    protected ApplicationContextRunner createContextRunner() {
+        org.geoserver.config.GeoServer geoServer = new GeoServerImpl();
+        return new ApplicationContextRunner().withBean("geoServer", GeoServer.class, () -> geoServer);
+    }
+
+    /**
+     * Verifies that the condition properly activates based on the property.
+     *
+     * @param contextRunner The context runner
+     * @param conditionalProperty The property name to enable the condition
+     * @param conditionalBeanClass The class to register conditionally
+     */
+    protected void verifyConditionalActivation(
+            ApplicationContextRunner contextRunner, String conditionalProperty, Class<?> conditionalBeanClass) {
+
+        // Test without the property set - condition should not activate
+        contextRunner.run(context -> {
+            assertThat(context).doesNotHaveBean(conditionalBeanClass);
+        });
+
+        // Test with the property set to false - condition should not activate
+        contextRunner.withPropertyValues(conditionalProperty + "=false").run(context -> {
+            assertThat(context).doesNotHaveBean(conditionalBeanClass);
+        });
+
+        // Test with the property set to true - condition should activate
+        contextRunner.withPropertyValues(conditionalProperty + "=true").run(context -> {
+            assertThat(context).hasSingleBean(conditionalBeanClass);
+        });
+    }
+}

--- a/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerRESTTest.java
+++ b/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerRESTTest.java
@@ -1,0 +1,46 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.autoconfigure.extensions;
+
+import org.geoserver.rest.security.RestConfigXStreamPersister;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Tests for {@link ConditionalOnGeoServerREST}.
+ */
+class ConditionalOnGeoServerRESTTest extends AbstractConditionalTest {
+
+    // No setup needed
+
+    @Test
+    void testConditionalActivation() {
+        verifyConditionalActivation(
+                createContextRunner().withUserConfiguration(RestTestConfiguration.class),
+                "geoserver.service.restconfig.enabled",
+                ConditionalTestComponent.class);
+    }
+
+    @Configuration
+    static class RestTestConfiguration {
+        @Bean
+        RestConfigXStreamPersister restConfigXStreamPersister() {
+            return Mockito.mock(RestConfigXStreamPersister.class);
+        }
+
+        @Bean
+        @ConditionalOnGeoServerREST
+        ConditionalTestComponent conditionalComponent() {
+            return new ConditionalTestComponent();
+        }
+    }
+
+    static class ConditionalTestComponent {
+        // Simple component for testing conditional activation
+    }
+}

--- a/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWCSTest.java
+++ b/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWCSTest.java
@@ -1,0 +1,46 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.autoconfigure.extensions;
+
+import org.geoserver.wcs.responses.CoverageResponseDelegateFinder;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Tests for {@link ConditionalOnGeoServerWCS}.
+ */
+class ConditionalOnGeoServerWCSTest extends AbstractConditionalTest {
+
+    // No setup needed
+
+    @Test
+    void testConditionalActivation() {
+        verifyConditionalActivation(
+                createContextRunner().withUserConfiguration(WcsTestConfiguration.class),
+                "geoserver.service.wcs.enabled",
+                ConditionalTestComponent.class);
+    }
+
+    @Configuration
+    static class WcsTestConfiguration {
+        @Bean
+        CoverageResponseDelegateFinder coverageResponseDelegateFinder() {
+            return Mockito.mock(CoverageResponseDelegateFinder.class);
+        }
+
+        @Bean
+        @ConditionalOnGeoServerWCS
+        ConditionalTestComponent conditionalComponent() {
+            return new ConditionalTestComponent();
+        }
+    }
+
+    static class ConditionalTestComponent {
+        // Simple component for testing conditional activation
+    }
+}

--- a/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWFSTest.java
+++ b/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWFSTest.java
@@ -1,0 +1,46 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.autoconfigure.extensions;
+
+import org.geoserver.wfs.DefaultWebFeatureService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Tests for {@link ConditionalOnGeoServerWFS}.
+ */
+class ConditionalOnGeoServerWFSTest extends AbstractConditionalTest {
+
+    // No setup needed
+
+    @Test
+    void testConditionalActivation() {
+        verifyConditionalActivation(
+                createContextRunner().withUserConfiguration(WfsTestConfiguration.class),
+                "geoserver.service.wfs.enabled",
+                ConditionalTestComponent.class);
+    }
+
+    @Configuration
+    static class WfsTestConfiguration {
+        @Bean
+        DefaultWebFeatureService wfsService() {
+            return Mockito.mock(DefaultWebFeatureService.class);
+        }
+
+        @Bean
+        @ConditionalOnGeoServerWFS
+        ConditionalTestComponent conditionalComponent() {
+            return new ConditionalTestComponent();
+        }
+    }
+
+    static class ConditionalTestComponent {
+        // Simple component for testing conditional activation
+    }
+}

--- a/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWMSTest.java
+++ b/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWMSTest.java
@@ -1,0 +1,46 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.autoconfigure.extensions;
+
+import org.geoserver.wms.DefaultWebMapService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Tests for {@link ConditionalOnGeoServerWMS}.
+ */
+class ConditionalOnGeoServerWMSTest extends AbstractConditionalTest {
+
+    // No setup needed
+
+    @Test
+    void testConditionalActivation() {
+        verifyConditionalActivation(
+                createContextRunner().withUserConfiguration(WmsTestConfiguration.class),
+                "geoserver.service.wms.enabled",
+                ConditionalTestComponent.class);
+    }
+
+    @Configuration
+    static class WmsTestConfiguration {
+        @Bean
+        DefaultWebMapService wmsService() {
+            return Mockito.mock(DefaultWebMapService.class);
+        }
+
+        @Bean
+        @ConditionalOnGeoServerWMS
+        ConditionalTestComponent conditionalComponent() {
+            return new ConditionalTestComponent();
+        }
+    }
+
+    static class ConditionalTestComponent {
+        // Simple component for testing conditional activation
+    }
+}

--- a/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWPSTest.java
+++ b/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWPSTest.java
@@ -1,0 +1,46 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.autoconfigure.extensions;
+
+import org.geoserver.wps.DefaultWebProcessingService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Tests for {@link ConditionalOnGeoServerWPS}.
+ */
+class ConditionalOnGeoServerWPSTest extends AbstractConditionalTest {
+
+    // No setup needed
+
+    @Test
+    void testConditionalActivation() {
+        verifyConditionalActivation(
+                createContextRunner().withUserConfiguration(WpsTestConfiguration.class),
+                "geoserver.service.wps.enabled",
+                ConditionalTestComponent.class);
+    }
+
+    @Configuration
+    static class WpsTestConfiguration {
+        @Bean
+        DefaultWebProcessingService wpsService() {
+            return Mockito.mock(DefaultWebProcessingService.class);
+        }
+
+        @Bean
+        @ConditionalOnGeoServerWPS
+        ConditionalTestComponent conditionalComponent() {
+            return new ConditionalTestComponent();
+        }
+    }
+
+    static class ConditionalTestComponent {
+        // Simple component for testing conditional activation
+    }
+}

--- a/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWebUITest.java
+++ b/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWebUITest.java
@@ -1,0 +1,58 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.autoconfigure.extensions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.geoserver.web.GeoServerApplication;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Tests for {@link ConditionalOnGeoServerWebUI}.
+ */
+class ConditionalOnGeoServerWebUITest extends AbstractConditionalTest {
+
+    // No setup needed
+
+    @Test
+    void testConditionalActivation() {
+        // Test the property-based condition like other tests
+        verifyConditionalActivation(
+                createContextRunner().withUserConfiguration(WebUITestConfiguration.class),
+                "geoserver.service.webui.enabled",
+                ConditionalTestComponent.class);
+    }
+
+    @Test
+    void testConditionalActivationWithFilteredClassLoader() {
+        // Test with FilteredClassLoader to exclude GeoServerApplication
+        createContextRunner()
+                .withClassLoader(new FilteredClassLoader(GeoServerApplication.class))
+                .withUserConfiguration(WebUITestConfiguration.class)
+                .withPropertyValues("geoserver.service.webui.enabled=true")
+                .run(context -> {
+                    // Even with the property set to true, the bean should not be created
+                    // because the GeoServerApplication class is not available
+                    assertThat(context).doesNotHaveBean(ConditionalTestComponent.class);
+                });
+    }
+
+    @Configuration
+    static class WebUITestConfiguration {
+        @Bean
+        @ConditionalOnGeoServerWebUI
+        ConditionalTestComponent conditionalComponent() {
+            return new ConditionalTestComponent();
+        }
+    }
+
+    static class ConditionalTestComponent {
+        // Simple component for testing conditional activation
+    }
+}

--- a/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/test/ConditionalTestAutoConfiguration.java
+++ b/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/test/ConditionalTestAutoConfiguration.java
@@ -1,0 +1,124 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.autoconfigure.extensions.test;
+
+import org.geoserver.cloud.autoconfigure.extensions.ConditionalOnGeoServerREST;
+import org.geoserver.cloud.autoconfigure.extensions.ConditionalOnGeoServerWCS;
+import org.geoserver.cloud.autoconfigure.extensions.ConditionalOnGeoServerWFS;
+import org.geoserver.cloud.autoconfigure.extensions.ConditionalOnGeoServerWMS;
+import org.geoserver.cloud.autoconfigure.extensions.ConditionalOnGeoServerWPS;
+import org.geoserver.cloud.autoconfigure.extensions.ConditionalOnGeoServerWebUI;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Test auto-configuration that registers beans conditionally for each GeoServer service.
+ *
+ * <p>
+ * This auto-configuration is intended for testing the conditional annotations
+ * in each service application. It creates simple marker beans that should
+ * only be registered in their corresponding service context.
+ *
+ * <p>
+ * To use this in a service application test:
+ *
+ * <pre>
+ * &#64;SpringBootTest
+ * public class ConditionalActivationTest {
+ *
+ *   &#64;Autowired
+ *   private ApplicationContext context;
+ *
+ *   &#64;Test
+ *   void verifyOnlyRightConditionalBeanExists() {
+ *     // This should exist in this service
+ *     assertThat(context.containsBean("wmsConditionalBean")).isTrue();
+ *
+ *     // These should not exist in this service
+ *     assertThat(context.containsBean("wfsConditionalBean")).isFalse();
+ *     assertThat(context.containsBean("wcsConditionalBean")).isFalse();
+ *     // etc.
+ *   }
+ * }
+ * </pre>
+ */
+@AutoConfiguration
+public class ConditionalTestAutoConfiguration {
+
+    /**
+     * Bean that should only be created in WMS service applications.
+     */
+    @Bean("wmsConditionalBean")
+    @ConditionalOnGeoServerWMS
+    ConditionalTestBean wmsConditionalBean() {
+        return new ConditionalTestBean("WMS");
+    }
+
+    /**
+     * Bean that should only be created in WFS service applications.
+     */
+    @Bean("wfsConditionalBean")
+    @ConditionalOnGeoServerWFS
+    ConditionalTestBean wfsConditionalBean() {
+        return new ConditionalTestBean("WFS");
+    }
+
+    /**
+     * Bean that should only be created in WCS service applications.
+     */
+    @Bean("wcsConditionalBean")
+    @ConditionalOnGeoServerWCS
+    ConditionalTestBean wcsConditionalBean() {
+        return new ConditionalTestBean("WCS");
+    }
+
+    /**
+     * Bean that should only be created in WPS service applications.
+     */
+    @Bean("wpsConditionalBean")
+    @ConditionalOnGeoServerWPS
+    ConditionalTestBean wpsConditionalBean() {
+        return new ConditionalTestBean("WPS");
+    }
+
+    /**
+     * Bean that should only be created in REST service applications.
+     */
+    @Bean("restConditionalBean")
+    @ConditionalOnGeoServerREST
+    ConditionalTestBean restConditionalBean() {
+        return new ConditionalTestBean("REST");
+    }
+
+    /**
+     * Bean that should only be created in Web UI applications.
+     */
+    @Bean("webUiConditionalBean")
+    @ConditionalOnGeoServerWebUI
+    ConditionalTestBean webUiConditionalBean() {
+        return new ConditionalTestBean("WebUI");
+    }
+
+    /**
+     * Simple marker bean for conditional testing.
+     */
+    public static class ConditionalTestBean {
+        private final String serviceName;
+
+        public ConditionalTestBean(String serviceName) {
+            this.serviceName = serviceName;
+        }
+
+        public String getServiceName() {
+            return serviceName;
+        }
+
+        @Override
+        public String toString() {
+            return "ConditionalTestBean[" + serviceName + "]";
+        }
+    }
+}

--- a/src/extensions/core/src/test/resources/META-INF/spring.factories
+++ b/src/extensions/core/src/test/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.geoserver.cloud.autoconfigure.extensions.test.ConditionalTestAutoConfiguration

--- a/src/extensions/core/src/test/resources/logback-test.xml
+++ b/src/extensions/core/src/test/resources/logback-test.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    <root level="ERROR"/>
+</configuration>

--- a/src/extensions/css-styling/src/main/java/org/geoserver/cloud/autoconfigure/extensions/cssstyling/ConditionalOnCssStyling.java
+++ b/src/extensions/css-styling/src/main/java/org/geoserver/cloud/autoconfigure/extensions/cssstyling/ConditionalOnCssStyling.java
@@ -11,16 +11,19 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.geoserver.cloud.autoconfigure.extensions.ConditionalOnGeoServerWMS;
+import org.geoserver.cloud.autoconfigure.extensions.ConditionalOnGeoServer;
+import org.geoserver.community.css.web.CssHandler;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 /**
- * Composite annotation that combines conditions required for CSS styling support.
+ * Composite annotation that checks if CSS styling is enabled by configuration property.
  *
  * <p>
  * This conditional activates when:
  * <ul>
- *   <li>The GeoServer WMS module is available in the application context</li>
+ *   <li>GeoServer is available</li>
+ *   <li>The CssHandler class is on the classpath</li>
  *   <li>The geoserver.extension.css-styling.enabled property is true (the default)</li>
  * </ul>
  *
@@ -28,15 +31,17 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
  * This annotation can be used on configuration classes or bean methods to make them
  * conditional on CSS styling being enabled.
  *
- * @see ConditionalOnGeoServerWMS
  * @see ConditionalOnProperty
+ * @see ConditionalOnClass
+ * @see ConditionalOnGeoServer
  * @since 2.27.0
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Documented
 @Inherited
-@ConditionalOnGeoServerWMS
+@ConditionalOnGeoServer
+@ConditionalOnClass(CssHandler.class)
 @ConditionalOnProperty(
         name = "geoserver.extension.css-styling.enabled",
         havingValue = "true",

--- a/src/extensions/css-styling/src/main/java/org/geoserver/cloud/autoconfigure/extensions/cssstyling/CssStylingAutoConfiguration.java
+++ b/src/extensions/css-styling/src/main/java/org/geoserver/cloud/autoconfigure/extensions/cssstyling/CssStylingAutoConfiguration.java
@@ -16,8 +16,6 @@ import org.geotools.styling.css.CssParser;
 import org.geotools.util.Version;
 import org.geotools.util.factory.GeoTools;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -33,7 +31,6 @@ import org.springframework.context.annotation.Import;
  * allowing users to define map styles using CSS syntax instead of SLD. It will be activated
  * when the following conditions are met:
  * <ul>
- *   <li>The GeoServer WMS module is available</li>
  *   <li>The CSS handler classes are on the classpath</li>
  *   <li>The geoserver.extension.css-styling.enabled property is true (the default)</li>
  * </ul>
@@ -41,8 +38,8 @@ import org.springframework.context.annotation.Import;
  * <p>
  * The configuration consists of two inner classes:
  * <ul>
- *   <li>Enabled - Imports the CSS extension beans when extension is enabled</li>
- *   <li>Disabled - Provides a disabled module status when extension is disabled</li>
+ *   <li>Enabled - Imports the CSS extension when it's enabled</li>
+ *   <li>Disabled - Provides a disabled module status when extension is explicitly disabled</li>
  * </ul>
  *
  * @since 2.27.0
@@ -55,13 +52,10 @@ import org.springframework.context.annotation.Import;
 public class CssStylingAutoConfiguration {
 
     /**
-     * Configuration class that activates when the CSS styling extension is enabled.
-     * Imports all required beans from the CSS extension's application context.
+     * Configuration class that activates CSS styling extension when enabled.
      */
     @Configuration
     @ConditionalOnCssStyling
-    @ConditionalOnBean(name = "sldHandler")
-    @ConditionalOnClass(CssHandler.class)
     @ImportFilteredResource("jar:gs-css-.*!/applicationContext.xml")
     static class Enabled {
         @PostConstruct
@@ -79,7 +73,6 @@ public class CssStylingAutoConfiguration {
      * {@link ModuleStatus#isEnabled() == false}.
      */
     @Configuration
-    @ConditionalOnBean(name = "sldHandler")
     @ConditionalOnProperty(
             name = "geoserver.extension.css-styling.enabled",
             havingValue = "false",

--- a/src/extensions/mapbox-styling/src/main/java/org/geoserver/cloud/autoconfigure/extensions/mapboxstyling/ConditionalOnMapBoxStyling.java
+++ b/src/extensions/mapbox-styling/src/main/java/org/geoserver/cloud/autoconfigure/extensions/mapboxstyling/ConditionalOnMapBoxStyling.java
@@ -11,14 +11,17 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.geoserver.cloud.autoconfigure.extensions.ConditionalOnGeoServerWMS;
+import org.geoserver.cloud.autoconfigure.extensions.ConditionalOnGeoServer;
+import org.geoserver.community.mbstyle.MBStyleHandler;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Documented
 @Inherited
-@ConditionalOnGeoServerWMS
+@ConditionalOnGeoServer
+@ConditionalOnClass(MBStyleHandler.class)
 @ConditionalOnProperty(
         name = "geoserver.extension.mapbox-styling.enabled",
         havingValue = "true",

--- a/src/extensions/mapbox-styling/src/main/java/org/geoserver/cloud/autoconfigure/extensions/mapboxstyling/MapBoxStylingAutoConfiguration.java
+++ b/src/extensions/mapbox-styling/src/main/java/org/geoserver/cloud/autoconfigure/extensions/mapboxstyling/MapBoxStylingAutoConfiguration.java
@@ -14,7 +14,6 @@ import org.geoserver.platform.ModuleStatusImpl;
 import org.geotools.util.Version;
 import org.geotools.util.factory.GeoTools;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -23,8 +22,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 /**
- * Auto-configuration for MapBox Styling extension that provides a style handler for MapBox
- * stylesheets.
+ * Auto-configuration for MapBox Styling extension that provides a style handler
+ * for MapBox stylesheets.
  *
  * @since 2.27.0
  */
@@ -37,8 +36,6 @@ public class MapBoxStylingAutoConfiguration {
 
     @Configuration
     @ConditionalOnMapBoxStyling
-    @ConditionalOnBean(name = "sldHandler") // sldHandler is MBStyleHandler's constructor arg
-    @ConditionalOnClass(MBStyleHandler.class)
     @ImportFilteredResource("jar:gs-mbstyle-.*!/applicationContext.xml")
     static class Enabled {
         @PostConstruct
@@ -55,6 +52,7 @@ public class MapBoxStylingAutoConfiguration {
     @ConditionalOnClass(MBStyleHandler.class)
     static class Disabled {
 
+        @SuppressWarnings("java:S6830")
         @Bean(name = "MBStyleExtension")
         ModuleStatus mbStyleDisabledModuleStatus() {
             ModuleStatusImpl mod = new ModuleStatusImpl();

--- a/src/extensions/mapbox-styling/src/test/java/org/geoserver/cloud/autoconfigure/extensions/mapboxstyling/MapBoxStylingAutoConfigurationTest.java
+++ b/src/extensions/mapbox-styling/src/test/java/org/geoserver/cloud/autoconfigure/extensions/mapboxstyling/MapBoxStylingAutoConfigurationTest.java
@@ -6,15 +6,13 @@
 package org.geoserver.cloud.autoconfigure.extensions.mapboxstyling;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 import org.geoserver.catalog.SLDHandler;
 import org.geoserver.community.mbstyle.MBStyleHandler;
 import org.geoserver.config.GeoServer;
+import org.geoserver.config.impl.GeoServerImpl;
 import org.geoserver.platform.GeoServerExtensions;
-import org.geoserver.platform.ModuleStatusImpl;
-import org.geoserver.wms.DefaultWebMapService;
-import org.geoserver.wms.WMS;
+import org.geoserver.platform.ModuleStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -29,53 +27,36 @@ class MapBoxStylingAutoConfigurationTest {
 
     @BeforeEach
     void setup() {
-        // Create a mock GeoServer instance and WMS dependencies to satisfy @ConditionalOnGeoServerWMS
-        var mockGeoServer = mock(GeoServer.class);
-        var mockWMS = mock(WMS.class);
-        var mockWmsServiceTarget = mock(DefaultWebMapService.class);
-
         contextRunner = new ApplicationContextRunner()
                 .withBean("extensions", GeoServerExtensions.class)
-                .withBean("geoServer", GeoServer.class, () -> mockGeoServer)
-                .withBean("wmsServiceTarget", DefaultWebMapService.class, () -> mockWmsServiceTarget)
-                .withBean(WMS.class, () -> mockWMS)
+                .withBean("geoServer", GeoServer.class, GeoServerImpl::new)
+                .withBean("sldHandler", SLDHandler.class)
                 .withConfiguration(AutoConfigurations.of(MapBoxStylingAutoConfiguration.class));
     }
 
     @Test
-    void stylingHandler_no_config() {
-        contextRunner.withBean("sldHandler", SLDHandler.class).run(context -> assertThat(context)
-                .hasSingleBean(MBStyleHandler.class));
+    void testEnabledByDefault() {
+        contextRunner.run(context -> assertThat(context).hasNotFailed().hasSingleBean(MBStyleHandler.class));
     }
 
     @Test
-    void stylingHandler_enabled() {
+    void testEnabledExplicitly() {
         contextRunner
-                .withBean("sldHandler", SLDHandler.class)
                 .withPropertyValues("geoserver.extension.mapbox-styling.enabled=true")
-                .run(context -> assertThat(context).hasSingleBean(MBStyleHandler.class));
+                .run(context -> assertThat(context).hasNotFailed().hasSingleBean(MBStyleHandler.class));
     }
 
     @Test
-    void stylingHandler_disabled_registers_module_status() {
+    void testDisabledRegistersModuleStatus() {
         contextRunner
-                .withBean("sldHandler", SLDHandler.class)
                 .withPropertyValues("geoserver.extension.mapbox-styling.enabled=false")
                 .run(context -> {
-                    assertThat(context).doesNotHaveBean(MBStyleHandler.class);
-                    assertThat(context).hasBean("MBStyleExtension");
-                    assertThat(context).getBean("MBStyleExtension").isInstanceOf(ModuleStatusImpl.class);
-                });
-    }
-
-    @Test
-    void stylingHandler_conditional_on_sldHandler() {
-        contextRunner
-                .withPropertyValues("geoserver.extension.mapbox-styling.enabled=true")
-                .run(context -> {
-                    assertThat(context).doesNotHaveBean(SLDHandler.class);
-                    assertThat(context).doesNotHaveBean(MBStyleHandler.class);
-                    assertThat(context).doesNotHaveBean("MBStyleExtension");
+                    assertThat(context)
+                            .hasNotFailed()
+                            .doesNotHaveBean(MBStyleHandler.class)
+                            .hasBean("MBStyleExtension")
+                            .getBean("MBStyleExtension", ModuleStatus.class)
+                            .hasFieldOrPropertyWithValue("enabled", false);
                 });
     }
 }

--- a/src/extensions/output-formats/vector-tiles/README.md
+++ b/src/extensions/output-formats/vector-tiles/README.md
@@ -5,9 +5,10 @@ Auto-configuration for GeoServer Vector Tiles extension.
 ## Features
 
 This extension:
-- Provides auto-configuration for Vector Tiles output format support in GeoServer WMS
+- Provides auto-configuration for Vector Tiles output format support in multiple GeoServer services
 - Adds support for MapBox, GeoJSON, and TopoJSON vector tile formats
 - Conditionally enables or disables individual formats based on configuration properties
+- Serves as an example of a module required by multiple services (WMS, WebUI, and GWC)
 
 ## Configuration
 
@@ -30,28 +31,48 @@ The extension uses Spring Boot auto-configuration to conditionally register Vect
 - `VectorTilesAutoConfiguration`: Main auto-configuration class that controls the overall extension
 - `VectorTilesConfigProperties`: Configuration properties class with settings for each format
 - `ConditionalOnVectorTiles`: Conditional annotation for enabling the extension
+- Service-specific configurations:
+  - `WMSConfiguration`: Activates vector tiles formats in the WMS service
+  - `WebUIConfiguration`: Activates vector tiles formats in the Web UI for layer previews
+  - `GWCConfiguration`: Activates vector tiles formats in GeoWebCache for tile caching
 - Format-specific configurations:
   - `MapBoxConfiguration`: Configuration for MapBox vector tiles
   - `GeoJsonConfiguration`: Configuration for GeoJSON vector tiles
   - `TopoJsonConfiguration`: Configuration for TopoJSON vector tiles
 
 The extension registers each vector tile format when:
-1. GeoServer WMS is available in the application context
+1. The corresponding GeoServer service is available (WMS, WebUI, or GWC)
 2. The main extension is enabled (`geoserver.extension.vector-tiles.enabled=true`)
 3. The specific format is enabled (e.g., `geoserver.extension.vector-tiles.mapbox=true`)
 
-## Usage
+## Multi-Service Usage
 
-Once enabled, vector tiles can be requested from GeoServer WMS service using the appropriate output format:
+This extension demonstrates how a single module can be required by multiple GeoServer services:
 
+### WMS Service
+Vector tiles can be requested directly from the WMS service:
 - MapBox vector tiles: `format=application/vnd.mapbox-vector-tile`
 - GeoJSON vector tiles: `format=application/json;type=geojson`
 - TopoJSON vector tiles: `format=application/json;type=topojson`
 
-Example request:
+Example WMS request:
 ```
 http://localhost:8080/geoserver/wms?service=WMS&version=1.1.0&request=GetMap&layers=topp:states&styles=&bbox=-124.731,24.955,-66.97,49.371&width=780&height=330&srs=EPSG:4326&format=application/vnd.mapbox-vector-tile
 ```
+
+### Web UI Integration
+The Web UI service uses these formats to:
+- Display vector tiles in the Layer Preview page
+- Provide format options in the Layer Preview dropdown
+- Enable interactive vector tile viewing through OpenLayers
+
+### GeoWebCache Integration
+GWC can create and serve cached vector tiles:
+- Creates tile caches in vector formats (MapBox, GeoJSON, TopoJSON)
+- Serves cached vector tiles with improved performance
+- Supports the same formats as direct WMS requests
+
+This multi-service integration demonstrates how GeoServer Cloud's modular architecture allows extensions to be used across different services while maintaining separation of concerns.
 
 ## Related Documentation
 

--- a/src/extensions/output-formats/vector-tiles/pom.xml
+++ b/src/extensions/output-formats/vector-tiles/pom.xml
@@ -24,6 +24,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.geoserver.web</groupId>
+      <artifactId>gs-web-core</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>

--- a/src/extensions/output-formats/vector-tiles/src/main/java/org/geoserver/cloud/autoconfigure/extensions/vectortiles/ConditionalOnVectorTiles.java
+++ b/src/extensions/output-formats/vector-tiles/src/main/java/org/geoserver/cloud/autoconfigure/extensions/vectortiles/ConditionalOnVectorTiles.java
@@ -17,21 +17,30 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 /**
- * Composite annotation that combines conditions required for Vector Tiles extension support.
+ * Composite annotation that combines conditions required for Vector Tiles extension support
+ * across multiple GeoServer services.
  *
  * <p>
  * This conditional activates when:
  * <ul>
- *   <li>The GeoServer WMS module is available in the application context</li>
  *   <li>The VectorTileMapOutputFormat class is available on the classpath</li>
  *   <li>The geoserver.extension.vector-tiles.enabled property is true (the default)</li>
  * </ul>
  *
  * <p>
- * This annotation can be used on configuration classes or bean methods to make them
- * conditional on the Vector Tiles extension being enabled.
+ * This annotation is used as a base condition for enabling vector tiles support. It is
+ * designed to work in conjunction with service-specific conditions to enable vector tiles
+ * across multiple services (WMS, WebUI, GWC) in a consistent manner.
+ *
+ * <p>
+ * It provides a good example of how to create composable conditional annotations in
+ * GeoServer Cloud that can work with different service-specific conditions to enable
+ * functionality in multiple services while maintaining a single point of control for
+ * the extension's overall enabled/disabled state.
  *
  * @see ConditionalOnGeoServerWMS
+ * @see ConditionalOnGeoServerWebUI
+ * @see ConditionalOnGeoServerGWC
  * @see ConditionalOnClass
  * @see ConditionalOnProperty
  * @since 2.27.0
@@ -40,7 +49,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Documented
 @Inherited
-@ConditionalOnGeoServerWMS
 @ConditionalOnClass(VectorTileMapOutputFormat.class)
 @ConditionalOnProperty(name = "geoserver.extension.vector-tiles.enabled", havingValue = "true", matchIfMissing = true)
 public @interface ConditionalOnVectorTiles {}

--- a/src/extensions/output-formats/vector-tiles/src/main/java/org/geoserver/cloud/autoconfigure/extensions/vectortiles/VectorTilesAutoConfiguration.java
+++ b/src/extensions/output-formats/vector-tiles/src/main/java/org/geoserver/cloud/autoconfigure/extensions/vectortiles/VectorTilesAutoConfiguration.java
@@ -7,33 +7,49 @@ package org.geoserver.cloud.autoconfigure.extensions.vectortiles;
 
 import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+import org.geoserver.cloud.autoconfigure.extensions.ConditionalOnGeoServerGWC;
+import org.geoserver.cloud.autoconfigure.extensions.ConditionalOnGeoServerWMS;
+import org.geoserver.cloud.autoconfigure.extensions.ConditionalOnGeoServerWebUI;
 import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.platform.ModuleStatusImpl;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 /**
- * Auto-configuration for Vector Tiles WMS output formats extension.
+ * Auto-configuration for Vector Tiles extension across multiple GeoServer services.
  *
  * <p>
- * This auto-configuration enables the Vector Tiles extension in GeoServer Cloud,
- * allowing various vector tile formats to be used as WMS output formats. It is activated
- * when the following conditions are met:
+ * This auto-configuration enables the Vector Tiles extension in GeoServer
+ * Cloud, allowing various vector tile formats to be used across different GeoServer
+ * services (WMS, WebUI, and GWC). It serves as an example of a module that's required
+ * by multiple services.
+ *
+ * <p>
+ * It is activated when the following conditions are met:
  * <ul>
- *   <li>The GeoServer WMS module is available</li>
- *   <li>The required VectorTileMapOutputFormat classes are on the classpath</li>
- *   <li>The geoserver.extension.vector-tiles.enabled property is true (the default)</li>
+ * <li>One or more of the supported GeoServer services are available (WMS, WebUI, or GWC)</li>
+ * <li>The required VectorTileMapOutputFormat classes are on the classpath</li>
+ * <li>The geoserver.extension.vector-tiles.enabled property is true (the default)</li>
  * </ul>
  *
  * <p>
- * The configuration supports three vector tile formats, each of which can be individually
- * enabled or disabled:
+ * The configuration supports three vector tile formats, each of which can be
+ * individually enabled or disabled:
  * <ul>
- *   <li>MapBox - Controlled by geoserver.extension.vector-tiles.mapbox</li>
- *   <li>GeoJSON - Controlled by geoserver.extension.vector-tiles.geojson</li>
- *   <li>TopoJSON - Controlled by geoserver.extension.vector-tiles.topojson</li>
+ * <li>MapBox - Controlled by geoserver.extension.vector-tiles.mapbox</li>
+ * <li>GeoJSON - Controlled by geoserver.extension.vector-tiles.geojson</li>
+ * <li>TopoJSON - Controlled by geoserver.extension.vector-tiles.topojson</li>
+ * </ul>
+ *
+ * <p>
+ * Multi-service integration:
+ * <ul>
+ * <li>WMS - Vector tiles are offered as output formats for GetMap requests</li>
+ * <li>WebUI - Formats are available in the Layer Preview page</li>
+ * <li>GWC - Vector tiles can be cached and served through GeoWebCache</li>
  * </ul>
  *
  * @since 2.27.0
@@ -43,7 +59,11 @@ import org.springframework.context.annotation.Import;
 @ConditionalOnVectorTiles
 @EnableConfigurationProperties(VectorTilesConfigProperties.class)
 @ImportFilteredResource("jar:gs-vectortiles-.*!/applicationContext.xml#name=(VectorTilesExtension)")
-@Import({MapBoxConfiguration.class, GeoJsonConfiguration.class, TopoJsonConfiguration.class})
+@Import({
+    VectorTilesAutoConfiguration.WMSConfiguration.class,
+    VectorTilesAutoConfiguration.WebUIConfiguration.class,
+    VectorTilesAutoConfiguration.GWCConfiguration.class
+})
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.extensions.vectortiles")
 public class VectorTilesAutoConfiguration {
 
@@ -51,11 +71,12 @@ public class VectorTilesAutoConfiguration {
      * Constructor that configures the Vector Tiles extension.
      *
      * <p>
-     * Sets the enabled state of the Vector Tiles extension based on whether any
-     * of the vector tile formats are enabled.
+     * Sets the enabled state of the Vector Tiles extension based on whether any of
+     * the vector tile formats are enabled.
      *
      * @param extensionInfo The ModuleStatusImpl bean for the Vector Tiles extension
-     * @param config The configuration properties for the Vector Tiles extension
+     * @param config        The configuration properties for the Vector Tiles
+     *                      extension
      */
     @SuppressWarnings("java:S6830")
     public VectorTilesAutoConfiguration(
@@ -71,4 +92,38 @@ public class VectorTilesAutoConfiguration {
     void log() {
         log.info("Vector Tiles extension enabled");
     }
+
+    /**
+     * Configuration class that activates Vector Tiles formats for the WMS service.
+     *
+     * <p>This enables vector tile output formats for WMS GetMap requests,
+     * allowing clients to request map data in vectorized form instead of as raster images.
+     */
+    @Configuration
+    @ConditionalOnGeoServerWMS
+    @Import({MapBoxConfiguration.class, GeoJsonConfiguration.class, TopoJsonConfiguration.class})
+    static class WMSConfiguration {}
+
+    /**
+     * Configuration class that activates Vector Tiles formats for the WebUI service.
+     *
+     * <p>This enables vector tile formats in the Layer Preview interface,
+     * allowing users to test and visualize vector tiles directly in the GeoServer admin UI.
+     */
+    @Configuration
+    @ConditionalOnGeoServerWebUI
+    @Import({MapBoxConfiguration.class, GeoJsonConfiguration.class, TopoJsonConfiguration.class})
+    static class WebUIConfiguration {}
+
+    /**
+     * Configuration class that activates Vector Tiles formats for the GeoWebCache service.
+     *
+     * <p>This enables vector tile caching capabilities in GWC, allowing vector tiles
+     * to be pre-generated and served with improved performance. GWC can create
+     * tile caches in these vector formats and serve them directly.
+     */
+    @Configuration
+    @ConditionalOnGeoServerGWC
+    @Import({MapBoxConfiguration.class, GeoJsonConfiguration.class, TopoJsonConfiguration.class})
+    static class GWCConfiguration {}
 }

--- a/src/extensions/raster-formats/src/test/java/org/geotools/autoconfigure/rasterformats/GridFormatFactoryFilterProcessorTest.java
+++ b/src/extensions/raster-formats/src/test/java/org/geotools/autoconfigure/rasterformats/GridFormatFactoryFilterProcessorTest.java
@@ -35,8 +35,6 @@ class GridFormatFactoryFilterProcessorTest {
         config.setEnabled(true);
 
         Map<String, Boolean> formats = new HashMap<>();
-        formats.put("DisabledExampleFormat", false);
-        formats.put("EnabledExampleFormat", true);
         // Use actual format names that might exist
         formats.put("GeoTIFF", false);
         formats.put("ImageMosaic", false);
@@ -62,7 +60,7 @@ class GridFormatFactoryFilterProcessorTest {
 
         // Just check the number of formats in the configuration
         int configuredFormatsCount = config.getRasterFormats().size();
-        assertThat(configuredFormatsCount).isEqualTo(4);
+        assertThat(configuredFormatsCount).isEqualTo(2);
 
         // Check that the filter was installed - registry should be a FilteringFactoryCreator
         boolean filteringInstalled = checkFilterIsInstalled();

--- a/src/extensions/security/gateway-shared-auth/src/test/java/org/geoserver/cloud/autoconfigure/extensions/security/gateway/sharedauth/GatewaySharedAuthAutoConfigurationTest.java
+++ b/src/extensions/security/gateway-shared-auth/src/test/java/org/geoserver/cloud/autoconfigure/extensions/security/gateway/sharedauth/GatewaySharedAuthAutoConfigurationTest.java
@@ -56,7 +56,9 @@ class GatewaySharedAuthAutoConfigurationTest {
 
     @Test
     void testEnabledServerMode() {
-        runner.withPropertyValues("geoserver.extension.security.gateway-shared-auth.enabled=true")
+        runner.withPropertyValues(
+                        "geoserver.extension.security.gateway-shared-auth.enabled=true",
+                        "geoserver.service.webui.enabled=true")
                 .run(context -> {
                     assertThat(context)
                             .hasNotFailed()

--- a/src/extensions/security/geonode-oauth2/src/test/java/org/geoserver/cloud/autoconfigure/extensions/security/geonode/GeoNodeOAuth2WebUIAutoConfigurationTest.java
+++ b/src/extensions/security/geonode-oauth2/src/test/java/org/geoserver/cloud/autoconfigure/extensions/security/geonode/GeoNodeOAuth2WebUIAutoConfigurationTest.java
@@ -111,12 +111,14 @@ class GeoNodeOAuth2WebUIAutoConfigurationTest {
         FilteredClassLoader filteredClassLoader =
                 new FilteredClassLoader(GeoServerApplication.class, AuthenticationFilterPanelInfo.class);
 
-        runner.withClassLoader(filteredClassLoader).run(context -> assertThat(context)
-                .hasNotFailed()
-                .doesNotHaveBean("geoNodeOAuth2AuthPanelInfo")
-                .doesNotHaveBean("geonodeFormLoginButton"));
+        runner.withPropertyValues("geoserver.service.webui.enabled=true")
+                .withClassLoader(filteredClassLoader)
+                .run(context -> assertThat(context)
+                        .hasNotFailed()
+                        .doesNotHaveBean("geoNodeOAuth2AuthPanelInfo")
+                        .doesNotHaveBean("geonodeFormLoginButton"));
 
-        runner.run(context -> assertThat(context)
+        runner.withPropertyValues("geoserver.service.webui.enabled=true").run(context -> assertThat(context)
                 .hasNotFailed()
                 .hasBean("geoNodeOAuth2AuthPanelInfo")
                 .hasBean("geonodeFormLoginButton"));

--- a/src/extensions/vector-formats/src/test/java/org/geoserver/cloud/autoconfigure/vectorformats/graticule/GraticuleWebComponentsAutoConfigurationTest.java
+++ b/src/extensions/vector-formats/src/test/java/org/geoserver/cloud/autoconfigure/vectorformats/graticule/GraticuleWebComponentsAutoConfigurationTest.java
@@ -27,11 +27,16 @@ class GraticuleWebComponentsAutoConfigurationTest {
 
     @Test
     void testConditionalOnGeoServerWebUI() {
-        contextRunner.run(context -> assertThat(context).hasNotFailed().hasBean("graticuleStorePanel"));
+        contextRunner.run(context -> assertThat(context).hasNotFailed().doesNotHaveBean("graticuleStorePanel"));
 
         contextRunner
+                .withPropertyValues("geoserver.service.webui.enabled=true")
                 .withClassLoader(new FilteredClassLoader(GeoServerApplication.class))
                 .run(context -> assertThat(context).hasNotFailed().doesNotHaveBean("graticuleStorePanel"));
+
+        contextRunner
+                .withPropertyValues("geoserver.service.webui.enabled=true")
+                .run(context -> assertThat(context).hasNotFailed().hasBean("graticuleStorePanel"));
     }
 
     @Test


### PR DESCRIPTION
Refactors the service-specific conditional annotations to use `@ConditionalOnProperty` instead of `@ConditionalOnBean` for more reliable activation during the Spring Boot bootstrap phase. This property-based approach solves initialization order issues by checking for service properties (`geoserver.service.<type>.enabled`) instead of relying on bean presence.

Changes include:

- Change all six conditional annotations (WMS, WFS, WCS, WPS, REST, WebUI) to use `@ConditionalOnProperty`
- Update service `bootstrap.yml` files to explicitly set service-specific enabled properties
- Add comprehensive unit tests for each conditional annotation
- Add integration tests across all service applications to verify proper conditional bean activation
- Add `ConditionalTestAutoConfiguration` with test beans for each service type

This improves extension reliability by eliminating race conditions during auto-configuration and provides a more predictable activation mechanism for service-specific extensions.