### PR TITLE
Enhance geoserver base image with comprehensive starter dependencies

### DIFF
--- a/src/apps/base-images/geoserver/pom.xml
+++ b/src/apps/base-images/geoserver/pom.xml
@@ -13,9 +13,25 @@
       <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-cloud-spring-factory</artifactId>
     </dependency>
+    <!-- Base Spring Boot integration -->
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-spring-boot-starter</artifactId>
+    </dependency>
+    <!-- Spring Cloud integration -->
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-spring-cloud-starter</artifactId>
+    </dependency>
+    <!-- Web MVC functionality -->
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-cloud-starter-webmvc</artifactId>
+    </dependency>
+    <!-- Extensions and functionality -->
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-starter-extensions</artifactId>
     </dependency>
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
@@ -23,15 +39,7 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
-      <artifactId>gs-cloud-spring-cloud-starter</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.geoserver.cloud</groupId>
-      <artifactId>spring-boot-simplejndi</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.geoserver.cloud</groupId>
-      <artifactId>gs-cloud-starter-input-formats</artifactId>
+      <artifactId>gs-cloud-starter-observability</artifactId>
     </dependency>
     <dependency>
       <groupId>org.geoserver.cloud.apps</groupId>


### PR DESCRIPTION
Improve the Docker layer caching and image composition by:

1. Adding a more complete set of starter dependencies to the geoserver base image
2. Reorganizing dependencies with clear categorization (Boot, Cloud, WebMVC, Extensions)
3. Adding observability support and common extensions to the base image
4. Replacing individual dependencies with more comprehensive starters

These changes allow service-specific images to inherit more pre-built layers from the base image, improving build performance and reducing image sizes across all GeoServer service containers.