### PR TITLE
Fix encoding of default styles in LayerGroups with pgconfig

### DIFF
--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgconfigLayerGroupRepository.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgconfigLayerGroupRepository.java
@@ -5,12 +5,16 @@
 
 package org.geoserver.cloud.backend.pgconfig.catalog.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import lombok.NonNull;
 import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.ResolvingProxy;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.LayerGroupRepository;
+import org.geoserver.catalog.plugin.resolving.ProxyUtils;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 
@@ -84,5 +88,27 @@ public class PgconfigLayerGroupRepository extends PgconfigPublishedInfoRepositor
                 """
                         .formatted(getQueryTable());
         return super.queryForStream(sql, workspace.getId());
+    }
+
+    @Override
+    protected String encode(LayerGroupInfo info) {
+        if (info != null) {
+            // beware default styles may come as ResolvingProxy("") from the rest API instead of null
+            List<StyleInfo> styles =
+                    info.getStyles().stream().map(this::sanitizeResolvingProxy).toList();
+            info.getStyles().clear();
+            info.getStyles().addAll(styles);
+        }
+        return super.encode(info);
+    }
+
+    private StyleInfo sanitizeResolvingProxy(StyleInfo s) {
+        if (ProxyUtils.isResolvingProxy(s)) {
+            String ref = ResolvingProxy.getRef(s);
+            if (null == ref) {
+                return null;
+            }
+        }
+        return s;
     }
 }

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModuleTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModuleTest.java
@@ -383,7 +383,7 @@ public abstract class GeoServerCatalogModuleTest {
     }
 
     @Test
-    void testLayerGroup() {
+    void testLayerGroupLayerGroupStyle() {
         LayerGroupInfo lg = data.layerGroup1;
         lg.setTitle("LG Title");
         lg.setAbstract("LG abstract");
@@ -406,6 +406,18 @@ public abstract class GeoServerCatalogModuleTest {
 
         lg.setLayerGroupStyles(Arrays.asList(lgs));
 
+        catalogInfoRoundtripTest(lg);
+    }
+
+    @Test
+    void testLayerGroupDefaultStyles() {
+        LayerGroupInfo lg = data.layerGroup1;
+
+        assertThat(lg.getLayers()).isNotEmpty();
+        lg.getStyles().clear();
+        for (int i = 0; i < lg.getLayers().size(); i++) {
+            lg.getStyles().add(null);
+        }
         catalogInfoRoundtripTest(lg);
     }
 

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/ResolvingProxyResolver.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/ResolvingProxyResolver.java
@@ -35,6 +35,7 @@ import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.catalog.plugin.forwarding.ResolvingCatalogFacadeDecorator;
 import org.geoserver.config.ServiceInfo;
 import org.geoserver.config.SettingsInfo;
+import org.springframework.util.StringUtils;
 
 /**
  * A {@link UnaryOperator} that resolves {@link ResolvingProxy} references within {@link CatalogInfo} objects.
@@ -394,9 +395,14 @@ public class ResolvingProxyResolver<T> implements UnaryOperator<T> {
 
         for (int i = 0; i < lg.getStyles().size(); i++) {
             StyleInfo s = lg.getStyles().get(i);
-            if (s != null) {
-                lg.getStyles().set(i, resolve(s));
+            ResolvingProxy proxy = org.geoserver.catalog.impl.ProxyUtils.handler(s, ResolvingProxy.class);
+            StyleInfo resolved = s;
+            if (proxy != null && !StringUtils.hasLength(proxy.getRef())) {
+                resolved = null;
+            } else if (s != null) {
+                resolved = resolve(s);
             }
+            lg.getStyles().set(i, resolved);
         }
         lg.setWorkspace(resolve(lg.getWorkspace()));
         lg.setRootLayer(resolve(lg.getRootLayer()));


### PR DESCRIPTION
When a LayerGroup is created through the REST API with default styles (i.e. `null` values), it gets `ResolvingProxy` instances with an empty string as `ref`, instead of a `null` value.

This patch adds some guards around creating and resolving these ill-formed LayerGroups when using the pgconfig backend. Probably for data directort the XStream persister takes that into account, but our JSON serializers didn't.