### PR TITLE
Add servlet filter to hide disabled web UI components

### DIFF
--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebUIApplicationAutoConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebUIApplicationAutoConfiguration.java
@@ -15,12 +15,17 @@ import org.geoserver.cloud.autoconfigure.web.wfs.WfsAutoConfiguration;
 import org.geoserver.cloud.autoconfigure.web.wms.WmsAutoConfiguration;
 import org.geoserver.cloud.autoconfigure.web.wps.WpsAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
 
 @AutoConfiguration(after = {GeoServerWebMvcMainAutoConfiguration.class})
 @SuppressWarnings("java:S1118") // Suppress SonarLint warning, constructor needs to be public
+@EnableConfigurationProperties(WebUIConfigurationProperties.class)
 @Import({ //
     WebCoreConfiguration.class, // this one is mandatory
     SecurityAutoConfiguration.class,
@@ -37,5 +42,21 @@ public class WebUIApplicationAutoConfiguration {
     @Bean
     WebUIInitializer webUIDefaultsInitializer(Environment env) {
         return new WebUIInitializer(env);
+    }
+
+    /**
+     * A {@link WicketComponentFilter} that effectively hides pages (returns 404)
+     * for components that are disabled by {@link WebUIConfigurationProperties}
+     */
+    @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    FilterRegistrationBean<WicketComponentFilter> wicketComponentFilter(WebUIConfigurationProperties config) {
+
+        FilterRegistrationBean<WicketComponentFilter> registrationBean = new FilterRegistrationBean<>();
+
+        registrationBean.setFilter(new WicketComponentFilter(config));
+        registrationBean.addUrlPatterns("/web/*");
+
+        return registrationBean;
     }
 }

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebUIConfigurationProperties.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebUIConfigurationProperties.java
@@ -1,0 +1,339 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.autoconfigure.web.core;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+/**
+ * Configuration properties for GeoServer Web UI modules.
+ * Maps to all {@code @ConditionalOnProperty} conditions used in web-ui auto-configurations.
+ */
+@Data
+@ConfigurationProperties(prefix = "geoserver.web-ui")
+public class WebUIConfigurationProperties {
+
+    /**
+     * Basic component configuration with enabled flag.
+     */
+    @Data
+    public static class ComponentConfig {
+        /**
+         * Flag to enable/disable the component.
+         */
+        private boolean enabled = true;
+    }
+
+    /**
+     * File browser configuration.
+     */
+    @Data
+    public static class FileBrowserConfig {
+        /**
+         * Flag to hide the file system in the file browser.
+         */
+        private boolean hideFileSystem = false;
+    }
+
+    /**
+     * GeoWebCache UI configuration.
+     */
+    @Data
+    public static class GwcConfig {
+        /**
+         * Flag to enable/disable GWC UI.
+         */
+        private boolean enabled = true;
+
+        /**
+         * GWC capabilities configuration.
+         */
+        @NestedConfigurationProperty
+        private CapabilitiesConfig capabilities = new CapabilitiesConfig();
+
+        /**
+         * GWC capabilities configuration.
+         */
+        @Data
+        public static class CapabilitiesConfig {
+            /**
+             * Flag to enable/disable TMS capabilities.
+             */
+            private boolean tms = true;
+
+            /**
+             * Flag to enable/disable WMTS capabilities.
+             */
+            private boolean wmts = true;
+
+            /**
+             * Flag to enable/disable WMSC capabilities.
+             */
+            private boolean wmsc = true;
+        }
+    }
+
+    /**
+     * Security UI configuration.
+     * (Maps to {@code geoserver.web-ui.security}).
+     */
+    @NestedConfigurationProperty
+    private ComponentConfig security = new ComponentConfig();
+
+    /**
+     * WFS UI configuration.
+     * (Maps to {@code geoserver.web-ui.wfs}).
+     */
+    @NestedConfigurationProperty
+    private ComponentConfig wfs = new ComponentConfig();
+
+    /**
+     * WMS UI configuration.
+     * (Maps to {@code geoserver.web-ui.wms}).
+     */
+    @NestedConfigurationProperty
+    private ComponentConfig wms = new ComponentConfig();
+
+    /**
+     * WCS UI configuration.
+     * (Maps to {@code geoserver.web-ui.wcs}).
+     */
+    @NestedConfigurationProperty
+    private ComponentConfig wcs = new ComponentConfig();
+
+    /**
+     * WPS UI configuration.
+     * (Maps to {@code geoserver.web-ui.wps}).
+     */
+    @NestedConfigurationProperty
+    private ComponentConfig wps = new ComponentConfig();
+
+    /**
+     * GWC UI configuration.
+     * (Maps to {@code geoserver.web-ui.gwc}).
+     */
+    @NestedConfigurationProperty
+    private GwcConfig gwc = new GwcConfig();
+
+    /**
+     * ACL UI configuration.
+     * (Maps to {@code geoserver.web-ui.acl}).
+     */
+    @NestedConfigurationProperty
+    private ComponentConfig acl = new ComponentConfig();
+
+    /**
+     * File browser UI configuration.
+     * (Maps to {@code geoserver.web-ui.file-browser}).
+     */
+    @NestedConfigurationProperty
+    private FileBrowserConfig fileBrowser = new FileBrowserConfig();
+
+    /**
+     * Demos UI configuration.
+     */
+    @NestedConfigurationProperty
+    private Demos demos = new Demos();
+
+    /**
+     * Tools UI configuration.
+     */
+    @NestedConfigurationProperty
+    private Tools tools = new Tools();
+
+    /**
+     * Configuration for demo UI components.
+     */
+    @Data
+    public static class Demos {
+        /**
+         * Flag to enable/disable demos UI.
+         * (Maps to {@code geoserver.web-ui.demos.enabled}).
+         */
+        private boolean enabled = true;
+
+        /**
+         * Flag to enable/disable WPS request builder.
+         * (Maps to {@code geoserver.web-ui.demos.wps-request-builder}).
+         */
+        private boolean wpsRequestBuilder = true;
+
+        /**
+         * Flag to enable/disable WCS request builder.
+         * (Maps to {@code geoserver.web-ui.demos.wcs-request-builder}).
+         */
+        private boolean wcsRequestBuilder = true;
+
+        /**
+         * Flag to enable/disable demo requests.
+         * (Maps to {@code geoserver.web-ui.demos.demo-requests}).
+         */
+        private boolean demoRequests = true;
+
+        /**
+         * Flag to enable/disable SRS list.
+         * (Maps to {@code geoserver.web-ui.demos.srs-list}).
+         */
+        private boolean srsList = true;
+
+        /**
+         * Flag to enable/disable reprojection console.
+         * (Maps to {@code geoserver.web-ui.demos.reprojection-console}).
+         */
+        private boolean reprojectionConsole = true;
+
+        /**
+         * Layer preview configuration.
+         * (Maps to {@code geoserver.web-ui.demos.layer-preview-page}).
+         */
+        @NestedConfigurationProperty
+        private LayerPreviewPageConfig layerPreviewPage = new LayerPreviewPageConfig();
+
+        /**
+         * Configuration for layer preview page.
+         */
+        @Data
+        public static class LayerPreviewPageConfig {
+            /**
+             * Flag to enable/disable layer preview page.
+             * (Maps to {@code geoserver.web-ui.demos.layer-preview-page.enabled}).
+             */
+            private boolean enabled = true;
+
+            /**
+             * Layer preview common formats configuration.
+             * (Maps to {@code geoserver.web-ui.demos.layer-preview-page.common-formats}).
+             */
+            @NestedConfigurationProperty
+            private CommonFormatsConfig commonFormats = new CommonFormatsConfig();
+
+            /**
+             * Configuration for layer preview common formats.
+             */
+            @Data
+            public static class CommonFormatsConfig {
+                /**
+                 * Flag to enable/disable OpenLayers common format.
+                 * (Maps to {@code geoserver.web-ui.demos.layer-preview-page.common-formats.open-layers}).
+                 */
+                private boolean openLayers = true;
+
+                /**
+                 * Flag to enable/disable GML common format.
+                 * (Maps to {@code geoserver.web-ui.demos.layer-preview-page.common-formats.gml}).
+                 */
+                private boolean gml = true;
+
+                /**
+                 * Flag to enable/disable KML common format.
+                 * (Maps to {@code geoserver.web-ui.demos.layer-preview-page.common-formats.kml}).
+                 */
+                private boolean kml = true;
+            }
+        }
+    }
+
+    /**
+     * Configuration for tools UI components.
+     */
+    @Data
+    public static class Tools {
+        /**
+         * Flag to enable/disable tools UI.
+         * (Maps to {@code geoserver.web-ui.tools.enabled}).
+         */
+        private boolean enabled = true;
+
+        /**
+         * Flag to enable/disable resource browser.
+         * (Maps to {@code geoserver.web-ui.tools.resource-browser}).
+         */
+        private boolean resourceBrowser = true;
+
+        /**
+         * Flag to enable/disable catalog bulk load tool.
+         * (Maps to {@code geoserver.web-ui.tools.catalog-bulk-load}).
+         */
+        private boolean catalogBulkLoad = true;
+
+        /**
+         * Flag to enable/disable reprojection console.
+         * (Maps to {@code geoserver.web-ui.tools.reprojection-console}).
+         */
+        private boolean reprojectionConsole = true;
+    }
+
+    /**
+     * Returns whether the class name from a wicket bookmarkable page URL should be enabled or hidden. E.g. for {@code org.geoserver.wms.web.WMSAdminPage}
+     * from {@code /web/wicket/bookmarkable/org.geoserver.wms.web.WMSAdminPage?filter=false}, will return {@code false} if {@link #wms} is disabled.
+     */
+    public boolean enablePageClassUrl(String bookmarkablePageClassName) {
+        if (bookmarkablePageClassName == null || bookmarkablePageClassName.isBlank()) {
+            return true;
+        }
+
+        // Check the page class name to determine which component it belongs to
+        if (bookmarkablePageClassName.contains(".wms.web.")) {
+            return wms.isEnabled();
+        } else if (bookmarkablePageClassName.contains(".wfs.web.")) {
+            return wfs.isEnabled();
+        } else if (bookmarkablePageClassName.contains(".wcs.web.")) {
+            return wcs.isEnabled();
+        } else if (bookmarkablePageClassName.contains(".wps.web.")) {
+            return wps.isEnabled();
+        } else if (bookmarkablePageClassName.contains(".security.web.")) {
+            return security.isEnabled();
+        } else if (bookmarkablePageClassName.contains(".acl.web.")) {
+            return acl.isEnabled();
+        } else if (bookmarkablePageClassName.contains(".gwc.web.")) {
+            return gwc.isEnabled();
+        } else if (bookmarkablePageClassName.contains(".web.demo.")) {
+            if (!demos.isEnabled()) {
+                return false;
+            }
+
+            // Check specific demo pages
+            if (bookmarkablePageClassName.contains("LayerPreviewPage")) {
+                return demos.getLayerPreviewPage().isEnabled();
+            } else if (bookmarkablePageClassName.contains("DemoRequest")) {
+                return demos.isDemoRequests();
+            } else if (bookmarkablePageClassName.contains("SRSListPage")) {
+                return demos.isSrsList();
+            } else if (bookmarkablePageClassName.contains("ReprojectPage")) {
+                return demos.isReprojectionConsole();
+            } else if (bookmarkablePageClassName.contains("WCSRequestBuilder")) {
+                return demos.isWcsRequestBuilder();
+            } else if (bookmarkablePageClassName.contains("WPSRequestBuilder")) {
+                return demos.isWpsRequestBuilder();
+            }
+
+            // Default for other demo pages
+            return true;
+        } else if (bookmarkablePageClassName.contains(".web.resources.")
+                || bookmarkablePageClassName.contains(".web.catalogstresstool.")) {
+
+            if (!tools.isEnabled()) {
+                return false;
+            }
+
+            // Check specific tool pages
+            if (bookmarkablePageClassName.contains("PageResourceBrowser")) {
+                return tools.isResourceBrowser();
+            } else if (bookmarkablePageClassName.contains("CatalogStressTester")) {
+                return tools.isCatalogBulkLoad();
+            } else if (bookmarkablePageClassName.contains("ReprojectPage")) {
+                return tools.isReprojectionConsole();
+            }
+
+            // Default for other tool pages
+            return true;
+        }
+
+        // By default, allow access to other pages
+        return true;
+    }
+}

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WicketComponentFilter.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WicketComponentFilter.java
@@ -1,0 +1,151 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.web.core;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+
+/**
+ * A servlet filter that intercepts requests to Wicket bookmarkable pages and
+ * returns a 404 (Not Found) response when the requested page belongs to a
+ * component that has been disabled through configuration.
+ *
+ * <p>
+ * This filter examines incoming requests to {@code /web/wicket/bookmarkable/*}
+ * URLs, extracts the target page class name, and uses
+ * {@link WebUIConfigurationProperties} to determine if access to that page
+ * should be allowed based on the current configuration.
+ * </p>
+ *
+ * <p>
+ * Examples:
+ * </p>
+ * <ul>
+ * <li>If {@code geoserver.web-ui.wms=false}, accessing
+ * {@code /web/wicket/bookmarkable/org.geoserver.wms.web.WMSAdminPage} will
+ * result in a 404 response</li>
+ * <li>If {@code geoserver.web-ui.demos.layer-preview-page=false}, accessing
+ * {@code /web/wicket/bookmarkable/org.geoserver.web.demo.LayerPreviewPage} will
+ * result in a 404 response</li>
+ * </ul>
+ *
+ * <p>
+ * This filter allows site administrators to selectively disable UI components
+ * while maintaining a consistent user experience by hiding those components
+ * completely, rather than showing them but having them fail when accessed.
+ * </p>
+ */
+@RequiredArgsConstructor
+@NoArgsConstructor // For bean instantiation when registered manually
+public class WicketComponentFilter implements Filter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WicketComponentFilter.class);
+
+    /**
+     * Pattern to match bookmarkable page URLs. Handles both path formats:
+     * {@literal /web/wicket/bookmarkable/org.geoserver.wms.web.WMSAdminPage} or
+     * {@literal /geoserver/cloud/web/bookmarkable/org.geoserver.wms.web.WMSAdminPage}
+     */
+    private static final Pattern BOOKMARKABLE_URL_PATTERN =
+            Pattern.compile(".*/(?:web/wicket/bookmarkable|web/bookmarkable)/([^?/]+)(?:\\?.*)?$");
+
+    private @NonNull WebUIConfigurationProperties config;
+
+    /**
+     * Filters incoming HTTP requests to intercept and handle requests to disabled
+     * Wicket components.
+     *
+     * <p>
+     * The filter performs the following steps:
+     * </p>
+     * <ol>
+     * <li>Checks if the request is an HTTP request and if configuration is
+     * available</li>
+     * <li>For Wicket bookmarkable page requests, determines if the requested page
+     * belongs to a disabled component</li>
+     * <li>If the page should be hidden (belongs to a disabled component):
+     * <ul>
+     * <li>Returns an HTTP 404 (Not Found) response</li>
+     * <li>Sets the content type to text/plain</li>
+     * <li>Writes a simple "Page not found" message to the response</li>
+     * <li>Logs the blocked access at debug level</li>
+     * </ul>
+     * </li>
+     * <li>Otherwise, passes the request to the next filter in the chain</li>
+     * </ol>
+     *
+     * <p>
+     * This method ensures that disabled components are completely hidden from
+     * users, providing a consistent experience by returning the same status code
+     * that would be returned for any other non-existent resource.
+     * </p>
+     */
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        if (!(request instanceof HttpServletRequest) || config == null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        if (shouldHide(httpRequest)) {
+            // Return a 404 Not Found response
+            HttpServletResponse httpResponse = (HttpServletResponse) response;
+            httpResponse.setStatus(HttpStatus.NOT_FOUND.value());
+            httpResponse.setContentType("text/plain");
+            httpResponse.getWriter().println("Page not found");
+            LOGGER.debug("Blocked access to disabled component: {}", httpRequest.getRequestURI());
+        } else {
+            chain.doFilter(request, response);
+        }
+    }
+
+    private boolean shouldHide(HttpServletRequest request) {
+        String requestURI = request.getRequestURI();
+        String bookmarkablePageClassName = extractBookmarkablePageClassName(requestURI);
+        if (bookmarkablePageClassName != null) {
+            // Return true if the page should be hidden (when enablePageClassUrl returns
+            // false)
+            return !config.enablePageClassUrl(bookmarkablePageClassName);
+        }
+        // If not a bookmarkable page URL, don't hide it
+        return false;
+    }
+
+    /**
+     * Extracts the wicket bookmarkable page class name (e.g.
+     * {@code org.geoserver.wms.web.WMSAdminPage} from
+     * {@code /web/wicket/bookmarkable/org.geoserver.wms.web.WMSAdminPage?filter=false})
+     *
+     * @param requestURI the request URI
+     * @return the bookmarkable page class name, or null if the URI doesn't match
+     *         the pattern
+     */
+    private String extractBookmarkablePageClassName(String requestURI) {
+        if (requestURI != null) {
+            Matcher matcher = BOOKMARKABLE_URL_PATTERN.matcher(requestURI);
+            if (matcher.matches()) {
+                return matcher.group(1);
+            }
+        }
+        return null;
+    }
+}

--- a/src/apps/geoserver/webui/src/test/java/org/geoserver/cloud/autoconfigure/web/core/WicketComponentFilterTest.java
+++ b/src/apps/geoserver/webui/src/test/java/org/geoserver/cloud/autoconfigure/web/core/WicketComponentFilterTest.java
@@ -1,0 +1,149 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.web.core;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Test for {@link WicketComponentFilter}
+ */
+public class WicketComponentFilterTest {
+
+    private WicketComponentFilter filter;
+    private WebUIConfigurationProperties config;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private FilterChain chain;
+    private StringWriter responseWriter;
+
+    @Before
+    public void setUp() throws IOException {
+        config = new WebUIConfigurationProperties();
+        filter = new WicketComponentFilter(config);
+
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        chain = mock(FilterChain.class);
+
+        responseWriter = new StringWriter();
+        PrintWriter writer = new PrintWriter(responseWriter);
+        when(response.getWriter()).thenReturn(writer);
+    }
+
+    @Test
+    public void testNonBookmarkableUrl() throws ServletException, IOException {
+        when(request.getRequestURI()).thenReturn("/web/some/other/url");
+
+        filter.doFilter(request, response, chain);
+
+        // Should pass through to the filter chain
+        verify(chain).doFilter(request, response);
+        verify(response, never()).setStatus(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Test
+    public void testEnabledComponent() throws ServletException, IOException {
+        // WMS is enabled by default
+        assertTrue(config.getWms().isEnabled());
+
+        when(request.getRequestURI()).thenReturn("/web/wicket/bookmarkable/org.geoserver.wms.web.WMSAdminPage");
+
+        filter.doFilter(request, response, chain);
+
+        // Should pass through to the filter chain
+        verify(chain).doFilter(request, response);
+        verify(response, never()).setStatus(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Test
+    public void testEnabledComponentAlternativeUrlFormat() throws ServletException, IOException {
+        // WMS is enabled by default
+        assertTrue(config.getWms().isEnabled());
+
+        when(request.getRequestURI())
+                .thenReturn("/geoserver/cloud/web/bookmarkable/org.geoserver.wms.web.WMSAdminPage");
+
+        filter.doFilter(request, response, chain);
+
+        // Should pass through to the filter chain
+        verify(chain).doFilter(request, response);
+        verify(response, never()).setStatus(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Test
+    public void testDisabledComponent() throws ServletException, IOException {
+        // Disable WMS
+        config.getWms().setEnabled(false);
+        assertFalse(config.getWms().isEnabled());
+
+        when(request.getRequestURI()).thenReturn("/web/wicket/bookmarkable/org.geoserver.wms.web.WMSAdminPage");
+
+        filter.doFilter(request, response, chain);
+
+        // Should return 404 and not continue the chain
+        verify(response).setStatus(HttpStatus.NOT_FOUND.value());
+        verify(chain, never()).doFilter(request, response);
+    }
+
+    @Test
+    public void testDisabledNestedComponent() throws ServletException, IOException {
+        // Disable demo page layer preview
+        config.getDemos().getLayerPreviewPage().setEnabled(false);
+
+        when(request.getRequestURI()).thenReturn("/web/wicket/bookmarkable/org.geoserver.web.demo.LayerPreviewPage");
+
+        filter.doFilter(request, response, chain);
+
+        // Should return 404 and not continue the chain
+        verify(response).setStatus(HttpStatus.NOT_FOUND.value());
+        verify(chain, never()).doFilter(request, response);
+    }
+
+    @Test
+    public void testDisabledNestedComponentAlternativeUrlFormat() throws ServletException, IOException {
+        // Disable resource browser tool
+        config.getTools().setResourceBrowser(false);
+
+        when(request.getRequestURI())
+                .thenReturn("/geoserver/cloud/web/bookmarkable/org.geoserver.web.resources.PageResourceBrowser");
+
+        filter.doFilter(request, response, chain);
+
+        // Should return 404 and not continue the chain
+        verify(response).setStatus(HttpStatus.NOT_FOUND.value());
+        verify(chain, never()).doFilter(request, response);
+    }
+
+    @Test
+    public void testUrlsWithQueryParameters() throws ServletException, IOException {
+        // Disable WMS
+        config.getWms().setEnabled(false);
+
+        when(request.getRequestURI())
+                .thenReturn("/web/wicket/bookmarkable/org.geoserver.wms.web.WMSAdminPage?param=value");
+
+        filter.doFilter(request, response, chain);
+
+        // Should return 404 and not continue the chain
+        verify(response).setStatus(HttpStatus.NOT_FOUND.value());
+        verify(chain, never()).doFilter(request, response);
+    }
+}


### PR DESCRIPTION
Implemented a servlet filter that returns 404 (Not Found) response when attempting to access Wicket bookmarkable pages for components that have been disabled through configuration.

- Created WebUIConfigurationProperties class that maps to geoserver.web-ui.* configuration properties with a hierarchical structure
- Added WicketComponentFilter to intercept bookmarkable page requests and check if the component has been disabled through configuration
- Supports both URL formats: /web/wicket/bookmarkable/* and /geoserver/cloud/web/bookmarkable/*
- Added comprehensive unit tests and JavaDocs
- Configurable via application properties (e.g. geoserver.web-ui.wms.enabled=false)

This allows site administrators to selectively disable UI components while maintaining a consistent user experience by hiding those components completely, rather than showing them but having them fail when accessed.