### PR TITLE
Fix VirtualTableDTO

### DIFF
--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/VirtualTableDto.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/VirtualTableDto.java
@@ -5,8 +5,31 @@
 
 package org.geoserver.jackson.databind.catalog.dto;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.Data;
+import org.geoserver.jackson.databind.catalog.dto.VirtualTableDto.GeometryTypesDeserializer;
+import org.geoserver.jackson.databind.catalog.dto.VirtualTableDto.GeometryTypesSerializer;
 import org.geotools.jdbc.VirtualTable;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.MultiLineString;
+import org.locationtech.jts.geom.MultiPoint;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
 
 /** DTO type for {@link VirtualTable} */
 @Data
@@ -15,4 +38,87 @@ public class VirtualTableDto {
     private String name;
     private String sql;
     private boolean escapeSql;
+    private List<String> primaryKeyColumns;
+
+    @JsonSerialize(using = GeometryTypesSerializer.class)
+    @JsonDeserialize(using = GeometryTypesDeserializer.class)
+    private Map<String, Class<? extends Geometry>> geometryTypes;
+
+    private Map<String, Integer> nativeSrids;
+    private Map<String, Integer> dimensions;
+    private Map<String, VirtualTableParameterDto> parameters;
+
+    /**
+     * Custom serializer to convert geometry class types to string representation
+     */
+    public static class GeometryTypesSerializer extends JsonSerializer<Map<String, Class<? extends Geometry>>> {
+        @Override
+        public void serialize(
+                Map<String, Class<? extends Geometry>> value, JsonGenerator gen, SerializerProvider serializers)
+                throws IOException {
+            if (value == null) {
+                gen.writeNull();
+                return;
+            }
+
+            gen.writeStartObject();
+            for (Map.Entry<String, Class<? extends Geometry>> entry : value.entrySet()) {
+                gen.writeFieldName(entry.getKey());
+                if (entry.getValue() != null) {
+                    gen.writeString(entry.getValue().getSimpleName());
+                } else {
+                    gen.writeNull();
+                }
+            }
+            gen.writeEndObject();
+        }
+    }
+
+    /**
+     * Custom deserializer to convert string back to geometry class types
+     */
+    public static class GeometryTypesDeserializer extends JsonDeserializer<Map<String, Class<? extends Geometry>>> {
+        @Override
+        public Map<String, Class<? extends Geometry>> deserialize(JsonParser p, DeserializationContext ctxt)
+                throws IOException {
+            Map<String, String> stringMap = p.readValueAs(new TypeReference<Map<String, String>>() {});
+            if (stringMap == null) {
+                return null;
+            }
+
+            Map<String, Class<? extends Geometry>> result = new HashMap<>();
+            for (Map.Entry<String, String> entry : stringMap.entrySet()) {
+                String className = entry.getValue();
+                if (className != null) {
+                    Class<? extends Geometry> geometryClass = getGeometryClass(className);
+                    result.put(entry.getKey(), geometryClass);
+                } else {
+                    result.put(entry.getKey(), null);
+                }
+            }
+            return result;
+        }
+
+        private Class<? extends Geometry> getGeometryClass(String className) {
+            switch (className) {
+                case "Point":
+                    return Point.class;
+                case "LineString":
+                    return LineString.class;
+                case "Polygon":
+                    return Polygon.class;
+                case "MultiPoint":
+                    return MultiPoint.class;
+                case "MultiLineString":
+                    return MultiLineString.class;
+                case "MultiPolygon":
+                    return MultiPolygon.class;
+                case "GeometryCollection":
+                    return GeometryCollection.class;
+                case "Geometry":
+                default:
+                    return Geometry.class;
+            }
+        }
+    }
 }

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/VirtualTableParameterDto.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/catalog/dto/VirtualTableParameterDto.java
@@ -1,0 +1,21 @@
+/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.jackson.databind.catalog.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import org.geotools.jdbc.VirtualTableParameter;
+
+/** DTO type for {@link VirtualTableParameter} */
+@Data
+public class VirtualTableParameterDto {
+
+    private String name;
+    private String defaultValue;
+
+    @JsonProperty("regexpValidator")
+    private String validator; // Store as string for UI display
+}

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/VirtualTableSerializationTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/VirtualTableSerializationTest.java
@@ -1,0 +1,150 @@
+/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.jackson.databind.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import lombok.SneakyThrows;
+import org.geotools.jdbc.RegexpValidator;
+import org.geotools.jdbc.VirtualTable;
+import org.geotools.jdbc.VirtualTableParameter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
+
+/**
+ * Test to verify our VirtualTable serialization fixes work correctly
+ */
+public class VirtualTableSerializationTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setup() {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new GeoServerCatalogModule());
+    }
+
+    @Test
+    @SneakyThrows
+    void testVirtualTableWithValidatorsAndGeometryTypes() {
+        // Create a VirtualTable with validators and geometry types
+        VirtualTable originalVt = new VirtualTable("test_vt", "SELECT * FROM test_table", true);
+
+        // Set primary key columns
+        originalVt.setPrimaryKeyColumns(Arrays.asList("id", "name"));
+
+        // Add geometry metadata with different geometry types
+        originalVt.addGeometryMetadatata("geom_point", Point.class, 4326, 2);
+        originalVt.addGeometryMetadatata("geom_line", LineString.class, 4326, 2);
+        originalVt.addGeometryMetadatata("geom_poly", Polygon.class, 3857, 2);
+
+        // Add parameters with validators
+        VirtualTableParameter param1 = new VirtualTableParameter("param1", "default1");
+        param1.setValidator(new RegexpValidator("^[A-Za-z0-9]+$"));
+        originalVt.addParameter(param1);
+
+        VirtualTableParameter param2 = new VirtualTableParameter("param2", "default2");
+        param2.setValidator(new RegexpValidator("\\d{4}-\\d{2}-\\d{2}"));
+        originalVt.addParameter(param2);
+
+        // Serialize to JSON
+        String json = objectMapper.writeValueAsString(originalVt);
+        System.out.println("Serialized VirtualTable: " + json);
+
+        // Deserialize back
+        VirtualTable deserializedVt = objectMapper.readValue(json, VirtualTable.class);
+
+        // Verify basic properties
+        assertEquals(originalVt.getName(), deserializedVt.getName());
+        assertEquals(originalVt.getSql(), deserializedVt.getSql());
+        assertEquals(originalVt.isEscapeSql(), deserializedVt.isEscapeSql());
+        assertEquals(originalVt.getPrimaryKeyColumns(), deserializedVt.getPrimaryKeyColumns());
+
+        // Verify geometry types
+        assertEquals(originalVt.getGeometries(), deserializedVt.getGeometries());
+        assertEquals(Point.class, deserializedVt.getGeometryType("geom_point"));
+        assertEquals(LineString.class, deserializedVt.getGeometryType("geom_line"));
+        assertEquals(Polygon.class, deserializedVt.getGeometryType("geom_poly"));
+
+        // Verify SRIDs
+        assertEquals(4326, deserializedVt.getNativeSrid("geom_point"));
+        assertEquals(4326, deserializedVt.getNativeSrid("geom_line"));
+        assertEquals(3857, deserializedVt.getNativeSrid("geom_poly"));
+
+        // Verify parameters and validators
+        assertEquals(originalVt.getParameterNames(), deserializedVt.getParameterNames());
+
+        VirtualTableParameter deserializedParam1 = deserializedVt.getParameter("param1");
+        assertNotNull(deserializedParam1);
+        assertEquals("param1", deserializedParam1.getName());
+        assertEquals("default1", deserializedParam1.getDefaultValue());
+        assertNotNull(deserializedParam1.getValidator());
+        assertTrue(deserializedParam1.getValidator() instanceof RegexpValidator);
+
+        VirtualTableParameter deserializedParam2 = deserializedVt.getParameter("param2");
+        assertNotNull(deserializedParam2);
+        assertEquals("param2", deserializedParam2.getName());
+        assertEquals("default2", deserializedParam2.getDefaultValue());
+        assertNotNull(deserializedParam2.getValidator());
+        assertTrue(deserializedParam2.getValidator() instanceof RegexpValidator);
+
+        // Verify the validators work by checking their patterns
+        RegexpValidator validator1 = (RegexpValidator) deserializedParam1.getValidator();
+        RegexpValidator validator2 = (RegexpValidator) deserializedParam2.getValidator();
+
+        assertEquals("^[A-Za-z0-9]+$", validator1.getPattern().pattern());
+        assertEquals("\\d{4}-\\d{2}-\\d{2}", validator2.getPattern().pattern());
+
+        // Test that the validators actually work (validate() throws exception on invalid input)
+        try {
+            validator1.validate("test123");
+            // If we get here, validation passed
+        } catch (RuntimeException e) {
+            throw new AssertionError("Valid input 'test123' should not fail validation", e);
+        }
+
+        try {
+            validator2.validate("2023-12-25");
+            // If we get here, validation passed
+        } catch (RuntimeException e) {
+            throw new AssertionError("Valid input '2023-12-25' should not fail validation", e);
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void testVirtualTableWithNullValues() {
+        // Test with null geometry types and null validators
+        VirtualTable originalVt = new VirtualTable("test_null", "SELECT * FROM test", false);
+
+        // Add a parameter without validator (null validator)
+        VirtualTableParameter param = new VirtualTableParameter("no_validator", "default");
+        // param.setValidator(null); // This should be null by default
+        originalVt.addParameter(param);
+
+        // Serialize and deserialize
+        String json = objectMapper.writeValueAsString(originalVt);
+        VirtualTable deserializedVt = objectMapper.readValue(json, VirtualTable.class);
+
+        // Verify
+        assertEquals(originalVt.getName(), deserializedVt.getName());
+        assertEquals(originalVt.getSql(), deserializedVt.getSql());
+        assertEquals(originalVt.isEscapeSql(), deserializedVt.isEscapeSql());
+
+        VirtualTableParameter deserializedParam = deserializedVt.getParameter("no_validator");
+        assertNotNull(deserializedParam);
+        assertEquals("no_validator", deserializedParam.getName());
+        assertEquals("default", deserializedParam.getDefaultValue());
+        // The validator should be null or not set
+    }
+}


### PR DESCRIPTION
This PR adds the missing properties of VirtualTable to the Dto to allow pgconfig (and others) to define sql views.

This also solves the following known issues:
- [#633 - SQL views not saving correctly using pgconfig profile on GS Cloud](https://github.com/geoserver/geoserver-cloud/issues/633)
- [#516 - Sql view with viewparam](https://github.com/geoserver/geoserver-cloud/issues/516)

Please let us know if there are any changes need to be made for the PR to be accepted.
We also added a test file for the serialization.

Thank you in advance,
Webiks