### PR TITLE
Upgrade GeoServer to 2.27.2-SNAPSHOT

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -27,11 +27,12 @@
     <spring.version>5.3.39</spring.version>
     <spring.security.version>5.8.16</spring.security.version>
     <tomcat.version>9.0.104</tomcat.version>
-    <jackson.version>2.18.2</jackson.version>
+    <jackson.version>2.19.0</jackson.version>
     <gs.version>2.27.1-SNAPSHOT</gs.version>
     <gt.version>33-SNAPSHOT</gt.version>
+    <wicket.version>9.21.0</wicket.version>
     <acl.version>2.3.2</acl.version>
-    <postgresql.version>42.7.5</postgresql.version>
+    <postgresql.version>42.7.7</postgresql.version>
     <!-- Same netty.version used by geoserver for COG and GWC Azure plugin -->
     <netty.version>4.1.113.Final</netty.version>
     <lombok.version>1.18.30</lombok.version>
@@ -1273,7 +1274,7 @@
           <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.4.0-jre</version>
+            <version>33.4.8-jre</version>
           </dependency>
           <dependency>
             <groupId>com.google.guava</groupId>
@@ -1283,7 +1284,7 @@
           <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.9.4</version>
+            <version>1.11.0</version>
           </dependency>
           <dependency>
             <groupId>commons-collections</groupId>
@@ -1308,12 +1309,12 @@
           <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.2</version>
+            <version>1.3.5</version>
           </dependency>
           <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.16.1</version>
+            <version>2.19.0</version>
           </dependency>
           <dependency>
             <groupId>org.apache.commons</groupId>
@@ -1353,12 +1354,12 @@
           <dependency>
             <groupId>org.apache.wicket</groupId>
             <artifactId>wicket-core</artifactId>
-            <version>9.20.0</version>
+            <version>${wicket.version}</version>
           </dependency>
           <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <version>1.4.20</version>
+            <version>1.4.21</version>
           </dependency>
           <dependency>
             <groupId>com.fasterxml.woodstox</groupId>
@@ -1410,7 +1411,7 @@
         which provides runtime scope; however gs-auth has a compile time dependency-->
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>
-            <version>2.5.0</version>
+            <version>2.5.2</version>
             <scope>compile</scope>
           </dependency>
         </dependencies>
@@ -1464,7 +1465,7 @@
             <!-- actually to get rid of its com.squareup.okio:okio:2.8.0 dependency -->
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.10.0</version>
+            <version>4.12.0</version>
           </dependency>
           <dependency>
             <groupId>org.jssqlite-jdbcon</groupId>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -28,7 +28,7 @@
     <spring.security.version>5.8.16</spring.security.version>
     <tomcat.version>9.0.104</tomcat.version>
     <jackson.version>2.19.0</jackson.version>
-    <gs.version>2.27.1-SNAPSHOT</gs.version>
+    <gs.version>2.27.2-SNAPSHOT</gs.version>
     <gt.version>33-SNAPSHOT</gt.version>
     <wicket.version>9.21.0</wicket.version>
     <acl.version>2.3.2</acl.version>


### PR DESCRIPTION
Upgrade dependencies to match upstream GeoServer

Upgrade jackson from 2.18.2 to 2.19.0
Upgrade commons-io from 2.18.0 to 2.19.0
Upgrade guava from 33.4.0 to 33.4.8
Upgrade commons-beanutils from 1.10.1 to 1.11.0
Upgrade postgresql from 42.7.5 to 42.7.6

Dependency convergence upgrades:

Upgrade wicket from 9.20.0 to 9.20.1
Upgrade commons-logging from 1.2 to 1.3.5
Upgrade xstream from 1.4.20 to 1.4.21
Upgrade json-smart from 2.5.0 to 2.5.2
Upgrade okhttp from 4.10.0 to 4.12.0