### PR TITLE
Fix error with cascaded wms style

### DIFF
--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/CatalogPropertyResolver.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/CatalogPropertyResolver.java
@@ -247,7 +247,14 @@ public class CatalogPropertyResolver<T extends Info> implements UnaryOperator<T>
      */
     private void setCatalog(@NonNull StyleInfo i) {
         if (i instanceof StyleInfoImpl style) {
-            style.setCatalog(catalog());
+            /*
+             * When the style is remote (null id), StyleInfoImpl.getSLD() will check for a null catalog and return null.
+             * Otherwise it'll call ResourcePool.getStyle(StyleInfo) and fail
+             */
+            boolean isRemoteStyle = null == style.getId();
+            if (!isRemoteStyle) {
+                style.setCatalog(catalog());
+            }
         }
     }
 }


### PR DESCRIPTION
CatalogPropertyResolver sets the StyleInfo's Catalog property, but StyleInfoImpl expects the catalog to be null for remote WMS styles, otherwise StyleInfoImpl.getSLD() fails without short-circuiting to return null.