### PR TITLE
Add JSON serialization backward compatiblity tests

### DIFF
--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/GeoServer.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/GeoServer.java
@@ -5,6 +5,8 @@
 
 package org.geoserver.jackson.databind.config.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -17,6 +19,9 @@ import org.geoserver.jackson.databind.catalog.dto.MetadataMapDto;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @JsonTypeName("GeoServerInfo")
+// for backwards compatiblility, xmlExternalEntitiesEnabled removed in 2.28.0, might be present in a config JSON
+// document from an earler version
+@JsonIgnoreProperties("xmlExternalEntitiesEnabled")
 public class GeoServer extends ConfigInfoDto {
     public enum ResourceErrorHandling {
         OGC_EXCEPTION_REPORT,
@@ -30,7 +35,10 @@ public class GeoServer extends ConfigInfoDto {
     }
 
     private Settings settings;
+
+    @JsonAlias({"jai", "JAI"})
     private ImageProcessingInfoDto imageProcessing;
+
     private CoverageAccess coverageAccess;
     private MetadataMapDto metadata;
     private long updateSequence;
@@ -40,7 +48,6 @@ public class GeoServer extends ConfigInfoDto {
     private Boolean globalServices;
     private Boolean useHeadersProxyURL;
     private Integer xmlPostRequestLogBufferSize;
-    private Boolean xmlExternalEntitiesEnabled;
     private String lockProviderName;
     private WebUIMode webUIMode;
     private Boolean allowStoredQueriesPerWorkspace;

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/GeoServerConfigMapper.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/GeoServerConfigMapper.java
@@ -113,6 +113,8 @@ public interface GeoServerConfigMapper {
 
     @Mapping(target = "id", ignore = true) // set by factory method
     @Mapping(target = "clientProperties", ignore = true)
+    @Mapping(target = "useHeadersProxyURL", ignore = true) // deprecated
+    @Mapping(target = "xmlExternalEntitiesEnabled", ignore = true) // deprecated
     GeoServerInfo toInfo(GeoServer dto);
 
     GeoServer toDto(GeoServerInfo info);

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/config/GeoServerConfigModuleTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/config/GeoServerConfigModuleTest.java
@@ -49,7 +49,7 @@ public abstract class GeoServerConfigModuleTest {
         }
     }
 
-    private ObjectMapper objectMapper;
+    protected ObjectMapper objectMapper;
 
     private Catalog catalog;
     private CatalogTestData testData;

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/config/GeoSeververConfigModuleJsonTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/config/GeoSeververConfigModuleJsonTest.java
@@ -5,8 +5,13 @@
 
 package org.geoserver.jackson.databind.config;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.geoserver.config.GeoServerInfo;
 import org.geotools.jackson.databind.util.ObjectMapperUtil;
+import org.junit.jupiter.api.Test;
 
 /**
  * @since 1.0
@@ -15,5 +20,73 @@ class GeoSeververConfigModuleJsonTest extends GeoServerConfigModuleTest {
 
     protected @Override ObjectMapper newObjectMapper() {
         return ObjectMapperUtil.newObjectMapper();
+    }
+
+    /**
+     * Test backward compatibility: verify that old JSON documents with "jai" field
+     * can be deserialized to the new "imageProcessing" field
+     */
+    @Test
+    void geoServerInfo_backwardCompatibility_jaiField() throws Exception {
+        // JSON with old "jai" field name (pre-2.28.0 format)
+        String oldFormatJson =
+                """
+                {
+                  "@type": "GeoServerInfo",
+                  "id": "test-id",
+                  "jai": {
+                    "allowInterpolation": true,
+                    "recycling": false,
+                    "tilePriority": 5,
+                    "tileThreads": 7,
+                    "memoryCapacity": 0.5,
+                    "memoryThreshold": 0.75,
+                    "pngEncoderType": "PNGJ"
+                  },
+                  "updateSequence": 123,
+                  "featureTypeCacheSize": 100,
+                  "globalServices": true,
+                  "trailingSlashMatch": false
+                }
+                """;
+
+        GeoServerInfo decoded = objectMapper.readValue(oldFormatJson, GeoServerInfo.class);
+
+        // Verify that the old "jai" field was correctly mapped to imageProcessing
+        assertEquals("test-id", decoded.getId());
+        var imageProcessing = decoded.getImageProcessing();
+
+        // Verify the imageProcessing object was deserialized correctly
+        assertNotNull(imageProcessing, "imageProcessing should not be null");
+        assertEquals(5, imageProcessing.getTilePriority());
+        assertEquals(7, imageProcessing.getTileThreads());
+        assertEquals(0.5, imageProcessing.getMemoryCapacity(), 0.001);
+        assertEquals(0.75, imageProcessing.getMemoryThreshold(), 0.001);
+    }
+
+    /**
+     * Test backward compatibility: verify that old JSON documents with "xmlExternalEntitiesEnabled" field
+     * can be deserialized though the propery has been deprecated in 2.28.0
+     */
+    @Test
+    void geoServerInfo_backwardCompatibility_xmlExternalEntitiesEnabled() throws Exception {
+        // JSON with old "jai" field name (pre-2.28.0 format)
+        String oldFormatJson =
+                """
+                {
+                  "@type": "GeoServerInfo",
+                  "id": "test-id",
+                  "updateSequence": 123,
+                  "featureTypeCacheSize": 100,
+                  "globalServices": true,
+                  "trailingSlashMatch": false,
+                  "xmlExternalEntitiesEnabled": true
+                }
+                """;
+
+        GeoServerInfo decoded = objectMapper.readValue(oldFormatJson, GeoServerInfo.class);
+        assertEquals("test-id", decoded.getId());
+        assertEquals(123, decoded.getUpdateSequence());
+        assertEquals(100, decoded.getFeatureTypeCacheSize());
     }
 }


### PR DESCRIPTION
GeoServerInfo.jai -> GeoServerInfo.imageProcessing: add an alias for `jai`
GeoServerInfo.xmlExternalEntitiesEnabled: deprecated, removed from DTO