### PR TITLE
Fix acceptance tests startup

### DIFF
--- a/compose/acceptance_datadir
+++ b/compose/acceptance_datadir
@@ -3,6 +3,8 @@
 GSUID=$(id -u)
 GSGID=$(id -g)
 
+mkdir -p catalog-datadir
+
 GS_USER="$GSUID:$GSGID" \
 COMPOSE_PROJECT_NAME=gscloud-acceptance-datadir \
 docker compose \


### PR DESCRIPTION
The GitHub action is failing with:
```
Error response from daemon: failed to populate volume: error while mounting volume '/var/lib/docker/volumes/gscloud-acceptance-datadir_data_directory/_data': failed to mount local volume: mount /home/runner/work/geoserver-cloud/geoserver-cloud/compose/catalog-datadir:/var/lib/docker/volumes/gscloud-acceptance-datadir_data_directory/_data, flags: 0x1000: no such file or directory
```