### PR TITLE
Fix PgconfigResourceStore.save() undefined type bug and refactor to UPSERT

### DIFF
--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResource.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResource.java
@@ -92,7 +92,7 @@ class PgconfigResource implements Resource {
      * @param other the resource whose state should be copied to this resource
      * @see PgconfigResourceStore#updateState
      */
-    void copy(PgconfigResource other) {
+    void reset(PgconfigResource other) {
         this.id = other.id;
         this.parentId = other.parentId;
         this.type = other.type;

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceStoreUpdateStateTest.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceStoreUpdateStateTest.java
@@ -49,7 +49,7 @@ class PgconfigResourceStoreUpdateStateTest {
                 new PgconfigResource(store, 2L, 0L, Type.DIRECTORY, "security/rest.properties", 789012L);
 
         // Direct test of copy method
-        resource.copy(updatedResource);
+        resource.reset(updatedResource);
 
         // Verify the resource was updated
         assertEquals(2L, resource.getId());
@@ -105,7 +105,7 @@ class PgconfigResourceStoreUpdateStateTest {
                 store, 1L, 0L, Type.RESOURCE, "security/rest.properties", System.currentTimeMillis());
 
         // Update to file state
-        resource.copy(fileResource);
+        resource.reset(fileResource);
 
         // Verify the resource is now a file
         assertTrue(resource.exists());
@@ -118,7 +118,7 @@ class PgconfigResourceStoreUpdateStateTest {
                 store, 1L, 0L, Type.DIRECTORY, "security/rest.properties", System.currentTimeMillis());
 
         // Update to directory state
-        resource.copy(dirResource);
+        resource.reset(dirResource);
 
         // Verify the resource is now a directory
         assertTrue(resource.exists());

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceUpdateStateTest.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceUpdateStateTest.java
@@ -113,7 +113,7 @@ class PgconfigResourceUpdateStateTest {
         // Use doAnswer instead of when for void methods
         doAnswer(invocation -> {
                     PgconfigResource r = invocation.getArgument(0);
-                    r.copy(updatedResource);
+                    r.reset(updatedResource);
                     return null;
                 })
                 .when(mockStore)


### PR DESCRIPTION
Fixes critical bug where saving new resources failed with "Attempting to save
a resource of undefined type" error. This prevented GeoServer security
initialization when using pgconfig backend (e.g., saving master password file).

Root cause: save() called resource.isUndefined() which triggered getType(),
which called updateState() that reset the type to UNDEFINED before INSERT.

Solution:
- Access resource.type field directly instead of calling getType()
- Refactor save() to unified UPSERT (INSERT ... ON CONFLICT ... DO UPDATE)
- Add optional contents parameter for atomic content+metadata updates
- Use COALESCE to preserve existing content when contents is null

Related improvements:
- Simplify out() implementation to single save() call
- Fix move() to use direct UPDATE, preserving content and ID
- Rename copy() to reset() for clarity
- Add testWriteNewResource() covering the master password scenario
