### PR TITLE
Exclude xml-apis:xml-apis:jar:1.0.b2 transitive dependency from gs-app-schema

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -764,6 +764,12 @@
         <groupId>org.geoserver.extension</groupId>
         <artifactId>gs-app-schema-core</artifactId>
         <version>${gs.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.geoserver.community</groupId>


### PR DESCRIPTION
Comes transitive from jdom2, it's not required since ages