### PR TITLE
Configure separate bind mount directories for development and acceptance tests

### DIFF
--- a/compose/.gitignore
+++ b/compose/.gitignore
@@ -1,1 +1,2 @@
 catalog-datadir/
+catalog-datadir_acceptance/

--- a/compose/acceptance_datadir
+++ b/compose/acceptance_datadir
@@ -3,9 +3,10 @@
 GSUID=$(id -u)
 GSGID=$(id -g)
 
-mkdir -p catalog-datadir
+mkdir -p catalog-datadir_acceptance
 
 GS_USER="$GSUID:$GSGID" \
+CATALOG_DATADIR_PATH="$PWD/catalog-datadir_acceptance" \
 COMPOSE_PROJECT_NAME=gscloud-acceptance-datadir \
 docker compose \
 -f compose.yml \

--- a/compose/catalog-datadir.yml
+++ b/compose/catalog-datadir.yml
@@ -12,7 +12,7 @@ volumes:
     driver_opts:
       type: none
       o: bind
-      device: $PWD/catalog-datadir
+      device: ${CATALOG_DATADIR_PATH:-$PWD/catalog-datadir}
 
 # Append the shared data directory to the geoserver_volumes anchor
 x-volume-mounts: &geoserver_volumes


### PR DESCRIPTION
Use separate bind mount directory for acceptance tests

Configure catalog-datadir bind mount path via environment variable to isolate acceptance test data from development data.

- catalog-datadir.yml: Use `${CATALOG_DATADIR_PATH:-$PWD/catalog-datadir}`
- acceptance_datadir: Use `catalog-datadir_acceptance directory`
- compose/.gitignore: Ignore `catalog-datadir_acceptance/`

This prevents acceptance tests from failing when the development datadir contains non-empty data, while preserving development data across runs.