### PR TITLE
Upgrade maven plugins ahead of Spring Boot 3 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -344,7 +344,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.2</version>
           <configuration>
             <!-- Default configuration for all JAR files -->
             <excludes>
@@ -370,27 +370,27 @@
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
-          <version>2.44.3</version>
+          <version>3.0.0</version>
         </plugin>
         <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>4.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>flatten-maven-plugin</artifactId>
-          <version>1.5.0</version>
+          <version>1.7.3</version>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.11</version>
+          <version>0.8.14</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.6.2</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -403,7 +403,7 @@
           <skip>${spotless.skip}</skip>
           <java>
             <palantirJavaFormat>
-              <version>2.61.0</version>
+              <version>2.74.0</version>
             </palantirJavaFormat>
           </java>
           <upToDateChecking>

--- a/src/apps/infrastructure/gateway/pom.xml
+++ b/src/apps/infrastructure/gateway/pom.xml
@@ -215,7 +215,7 @@
       <plugin>
         <groupId>com.github.ekryd.sortpom</groupId>
         <artifactId>sortpom-maven-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>4.0.0</version>
         <configuration>
           <encoding>UTF-8</encoding>
           <keepBlankLines>true</keepBlankLines>
@@ -237,11 +237,11 @@
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.43.0</version>
+        <version>3.0.0</version>
         <configuration>
           <java>
             <palantirJavaFormat>
-              <version>2.50.0</version>
+              <version>2.74.0</version>
             </palantirJavaFormat>
           </java>
           <upToDateChecking>

--- a/src/apps/pom.xml
+++ b/src/apps/pom.xml
@@ -20,7 +20,7 @@
       <plugin>
         <groupId>io.github.git-commit-id</groupId>
         <artifactId>git-commit-id-maven-plugin</artifactId>
-        <version>7.0.0</version>
+        <version>9.0.2</version>
         <configuration>
           <failOnNoGitDirectory>false</failOnNoGitDirectory>
           <generateGitPropertiesFile>true</generateGitPropertiesFile>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1120,7 +1120,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.11.0</version>
+          <version>3.14.1</version>
           <inherited>true</inherited>
           <configuration>
             <release>21</release>
@@ -1160,7 +1160,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.2.1</version>
+          <version>3.5.4</version>
           <inherited>true</inherited>
           <executions>
             <execution>
@@ -1179,7 +1179,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.2.1</version>
+          <version>3.5.4</version>
           <inherited>true</inherited>
           <configuration>
             <reuseForks>false</reuseForks>
@@ -1190,22 +1190,22 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.2</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>3.6.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.2</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.18.0</version>
+          <version>2.19.1</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/src/starters/observability-spring-boot-3/pom.xml
+++ b/src/starters/observability-spring-boot-3/pom.xml
@@ -106,7 +106,7 @@
       <plugin>
         <groupId>com.github.ekryd.sortpom</groupId>
         <artifactId>sortpom-maven-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>4.0.0</version>
         <configuration>
           <encoding>UTF-8</encoding>
           <keepBlankLines>true</keepBlankLines>
@@ -128,11 +128,11 @@
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.43.0</version>
+        <version>3.0.0</version>
         <configuration>
           <java>
             <palantirJavaFormat>
-              <version>2.50.0</version>
+              <version>2.74.0</version>
             </palantirJavaFormat>
           </java>
           <upToDateChecking>

--- a/src/starters/spring-boot3/pom.xml
+++ b/src/starters/spring-boot3/pom.xml
@@ -53,7 +53,7 @@
       <plugin>
         <groupId>com.github.ekryd.sortpom</groupId>
         <artifactId>sortpom-maven-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>4.0.0</version>
         <configuration>
           <encoding>UTF-8</encoding>
           <keepBlankLines>true</keepBlankLines>
@@ -75,11 +75,11 @@
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.43.0</version>
+        <version>3.0.0</version>
         <configuration>
           <java>
             <palantirJavaFormat>
-              <version>2.50.0</version>
+              <version>2.74.0</version>
             </palantirJavaFormat>
           </java>
           <upToDateChecking>


### PR DESCRIPTION
```
    com.diffplug.spotless:spotless-maven-plugin ....... 2.43.0 -> 3.0.0
    com.github.ekryd.sortpom:sortpom-maven-plugin ...... 3.3.0 -> 4.0.0
    io.github.git-commit-id:git-commit-id-maven-plugin . 7.0.0 -> 9.0.2
    maven-compiler-plugin ............................ 3.11.0 -> 3.14.1
    maven-enforcer-plugin .............................. 3.5.0 -> 3.6.2
    maven-surefire-plugin .............................. 3.2.1 -> 3.5.4
    maven-failsafe-plugin .............................. 3.2.1 -> 3.5.4
    maven-jar-plugin ................................... 3.3.0 -> 3.2.0
    org.codehaus.mojo:build-helper-maven-plugin ........ 3.4.0 -> 3.6.1
    org.codehaus.mojo:exec-maven-plugin ................ 3.1.0 -> 3.6.2
    org.codehaus.mojo:flatten-maven-plugin ............. 1.5.0 -> 1.7.3
    org.codehaus.mojo:versions-maven-plugin .......... 2.18.0 -> 2.19.1
    org.jacoco:jacoco-maven-plugin ................... 0.8.11 -> 0.8.14
```