### PR TITLE
Add AWS credential chain authentication support for GeoParquet S3

### DIFF
--- a/src/apps/base-images/geoserver/src/main/java/org/geoserver/cloud/InstallDuckDBExtensions.java
+++ b/src/apps/base-images/geoserver/src/main/java/org/geoserver/cloud/InstallDuckDBExtensions.java
@@ -49,6 +49,9 @@ public class InstallDuckDBExtensions {
 
                 stmt.execute("INSTALL spatial;");
                 System.out.println("Spatial extension installed");
+
+                stmt.execute("INSTALL aws;");
+                System.out.println("AWS extension installed");
             }
 
             System.out.println("All extensions successfully installed to " + System.getenv("HOME") + "/.duckdb");


### PR DESCRIPTION
Pre-installs the `aws` duckdb extension an incorporates:

[GEOT-7847] Add AWS credential chain authentication support for GeoParquet S3 access 
[GEOS-12007] Add AWS credential chain authentication UI and documentation for GeoParquet