### PR TITLE
Skip imagemosaic acceptance tests for pgconfig

### DIFF
--- a/.github/workflows/sonarcloud-fork-pr.yaml
+++ b/.github/workflows/sonarcloud-fork-pr.yaml
@@ -58,6 +58,7 @@ jobs:
         -Dcoverage \
         -Dsonar.projectKey=geoserver_geoserver-cloud \
         -Dsonar.organization=geoserver \
+        -Dsonar.scanner.skipJreProvisioning=true \
         -Dmaven.javadoc.skip=true \
         -ntp \
         -T1C

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -60,6 +60,7 @@ jobs:
         -Dcoverage \
         -Dsonar.projectKey=geoserver_geoserver-cloud \
         -Dsonar.organization=geoserver \
+        -Dsonar.scanner.skipJreProvisioning=true \
         -Dmaven.javadoc.skip=true \
         -ntp \
         -T1C

--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ start-acceptance-tests-pgconfig:
 
 .PHONY: run-acceptance-tests-pgconfig
 run-acceptance-tests-pgconfig:
-	(cd compose/ && ./acceptance_pgconfig run --rm -T acceptance bash -c 'until [ -f /tmp/healthcheck ]; do echo "Waiting for /tmp/healthcheck to be available..."; sleep 5; done && pytest . -vvv --color=yes')
+	(cd compose/ && ./acceptance_pgconfig run --rm -T acceptance bash -c 'until [ -f /tmp/healthcheck ]; do echo "Waiting for /tmp/healthcheck to be available..."; sleep 5; done && pytest . -vvv --color=yes --ignore=tests/test_imagemosaic.py --ignore=tests/test_imagemosaic_cog.py')
 
 .PHONY: clean-acceptance-tests-pgconfig
 clean-acceptance-tests-pgconfig:


### PR DESCRIPTION
While we should revisit how or whether imagemosaics with file based index should work for pgconfig, it doesn't make sense to keep it making all builds fail.