### PR TITLE
Fix a bug preventing GlobalSettingsPage to be displayed

### DIFF
--- a/src/apps/geoserver/webui/src/test/java/org/geoserver/cloud/web/app/GlobalSettingsPageTest.java
+++ b/src/apps/geoserver/webui/src/test/java/org/geoserver/cloud/web/app/GlobalSettingsPageTest.java
@@ -1,0 +1,245 @@
+/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.web.app;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import org.apache.wicket.Component;
+import org.apache.wicket.markup.html.form.CheckBox;
+import org.apache.wicket.util.tester.FormTester;
+import org.apache.wicket.util.tester.TagTester;
+import org.apache.wicket.util.tester.WicketTester;
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.GeoServerInfo;
+import org.geoserver.web.GeoServerApplication;
+import org.geoserver.web.GeoServerHomePage;
+import org.geoserver.web.GeoServerLoginPage;
+import org.geoserver.web.admin.GlobalSettingsPage;
+import org.geoserver.web.wicket.Select2DropDownChoice;
+import org.geoserver.web.wicket.WicketHierarchyPrinter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+@SpringBootTest(
+        properties = {
+            "spring.cloud.bus.enabled: false",
+            "spring.cloud.config.enabled: false",
+            "spring.cloud.config.discovery.enabled: false",
+            "eureka.client.enabled: false"
+        })
+@ActiveProfiles("test") // see bootstrap-test.yml
+class GlobalSettingsPageTest {
+
+    private GeoServer gs;
+
+    private @Autowired GeoServerApplication app;
+    private WicketTester tester;
+
+    static @TempDir Path tmpdir;
+    static Path datadir;
+
+    @DynamicPropertySource
+    static void setUpDataDir(DynamicPropertyRegistry registry) throws IOException {
+        datadir = tmpdir.resolve("datadir");
+        Path gwcdir = datadir.resolve("gwc");
+        if (!Files.isDirectory(datadir)) {
+            datadir = Files.createDirectory(datadir);
+        }
+        if (!Files.isDirectory(gwcdir)) {
+            datadir = Files.createDirectory(gwcdir);
+        }
+        registry.add("geoserver.backend.data-directory.location", datadir::toAbsolutePath);
+        registry.add("gwc.cache-directory", gwcdir::toAbsolutePath);
+    }
+
+    static @BeforeAll void beforeAll() {
+        System.setProperty("wicket.configuration", "deployment");
+        // Disable CSRF protection for tests, since the test framework doesn't set the Referer
+        System.setProperty(GeoServerApplication.GEOSERVER_CSRF_DISABLED, "true");
+        // make sure that we check the english i18n when needed
+        Locale.setDefault(Locale.ENGLISH);
+    }
+
+    @BeforeEach
+    void setUpWicketTester() {
+        boolean init = true;
+        tester = new WicketTester(app, init);
+    }
+
+    @BeforeEach
+    void reset() {
+        gs = app.getGeoServer();
+        GeoServerInfo info = gs.getGlobal();
+        info.getSettings().setVerbose(false);
+        gs.save(info);
+    }
+
+    @AfterEach
+    void tearDownWicketTester() {
+        if (null != tester) {
+            tester.destroy();
+        }
+        logout();
+    }
+
+    void login() {
+        login("admin", "geoserver", "ROLE_ADMINISTRATOR");
+    }
+
+    void logout() {
+        login("anonymousUser", "", "ROLE_ANONYMOUS");
+    }
+
+    protected void login(String username, String password, String... roles) {
+        SecurityContextHolder.setContext(new SecurityContextImpl());
+        List<GrantedAuthority> l = new ArrayList<>();
+        for (String role : roles) {
+            l.add(new SimpleGrantedAuthority(role));
+        }
+
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken(username, password, l));
+    }
+
+    @SuppressWarnings("unused")
+    private void print(Component component) {
+        boolean dumpClass = true;
+        boolean dumpValue = false;
+        boolean dumpPath = true;
+        WicketHierarchyPrinter.print(component, dumpClass, dumpValue, dumpPath);
+    }
+
+    @Test
+    void testValues() {
+        GeoServerInfo info = gs.getGlobal();
+
+        login();
+        tester.startPage(GlobalSettingsPage.class);
+        tester.assertComponent("form:verbose", CheckBox.class);
+        tester.assertModelValue("form:verbose", info.getSettings().isVerbose());
+
+        tester.assertComponent(
+                "form:webAdminInterfaceSettingsFragment:loggedInUserDisplayMode", Select2DropDownChoice.class);
+        tester.assertModelValue(
+                "form:webAdminInterfaceSettingsFragment:loggedInUserDisplayMode",
+                info.getUserDetailsDisplaySettings().getLoggedInUserDisplayMode());
+        tester.assertComponent("form:webAdminInterfaceSettingsFragment:showProfileColumnsInUserList", CheckBox.class);
+        tester.assertModelValue(
+                "form:webAdminInterfaceSettingsFragment:showProfileColumnsInUserList",
+                info.getUserDetailsDisplaySettings().getShowProfileColumnsInUserList());
+        tester.assertComponent("form:webAdminInterfaceSettingsFragment:emailDisplayMode", Select2DropDownChoice.class);
+        tester.assertModelValue(
+                "form:webAdminInterfaceSettingsFragment:emailDisplayMode",
+                info.getUserDetailsDisplaySettings().getEmailDisplayMode());
+        tester.assertComponent("form:webAdminInterfaceSettingsFragment:revealEmailAtClick", CheckBox.class);
+        tester.assertModelValue(
+                "form:webAdminInterfaceSettingsFragment:revealEmailAtClick",
+                info.getUserDetailsDisplaySettings().getRevealEmailAtClick());
+        tester.assertComponent("form:webAdminInterfaceSettingsFragment:showCreatedTimeCols", CheckBox.class);
+        tester.assertModelValue(
+                "form:webAdminInterfaceSettingsFragment:showCreatedTimeCols",
+                info.getSettings().isShowCreatedTimeColumnsInAdminList());
+        tester.assertComponent("form:webAdminInterfaceSettingsFragment:showModifiedTimeCols", CheckBox.class);
+        tester.assertModelValue(
+                "form:webAdminInterfaceSettingsFragment:showModifiedTimeCols",
+                info.getSettings().isShowModifiedTimeColumnsInAdminList());
+        tester.assertComponent("form:webAdminInterfaceSettingsFragment:showModifiedByCols", CheckBox.class);
+        tester.assertModelValue(
+                "form:webAdminInterfaceSettingsFragment:showModifiedByCols",
+                info.getSettings().isShowModifiedUserInAdminList());
+
+        tester.assertComponent("form:trailingSlashMatch", CheckBox.class);
+        tester.assertModelValue("form:trailingSlashMatch", info.isTrailingSlashMatch());
+    }
+
+    @Test
+    void testSave() {
+        login();
+        tester.startPage(GlobalSettingsPage.class);
+        FormTester ft = tester.newFormTester("form");
+        ft.setValue("verbose", true);
+        ft.setValue("trailingSlashMatch", false);
+        ft.submit("submit");
+
+        tester.assertRenderedPage(GeoServerHomePage.class);
+        assertTrue(gs.getSettings().isVerbose());
+        assertFalse(gs.getGlobal().isTrailingSlashMatch());
+    }
+
+    @Test
+    void testApply() {
+        login();
+        tester.startPage(GlobalSettingsPage.class);
+        FormTester ft = tester.newFormTester("form");
+        ft.setValue("verbose", true);
+        ft.setValue("trailingSlashMatch", false);
+        ft.submit("apply");
+
+        tester.assertRenderedPage(GlobalSettingsPage.class);
+        assertTrue(gs.getSettings().isVerbose());
+        assertFalse(gs.getGlobal().isTrailingSlashMatch());
+    }
+
+    @Test
+    void testDefaultLocale() {
+        login();
+        tester.startPage(GlobalSettingsPage.class);
+        FormTester ft = tester.newFormTester("form");
+        ft.select("defaultLocale", 10);
+        ft.submit("submit");
+        assertNotNull(gs.getSettings().getDefaultLocale());
+    }
+
+    @Test
+    void testLoggedOut() {
+        logout();
+        tester.startPage(GlobalSettingsPage.class);
+        tester.assertRenderedPage(GeoServerLoginPage.class);
+    }
+
+    @Test
+    void testHiddenComponentsForGeoServerCloud() {
+        login();
+        tester.startPage(GlobalSettingsPage.class);
+        tester.assertRenderedPage(GlobalSettingsPage.class);
+        GlobalSettingsPage page = (GlobalSettingsPage) tester.getLastRenderedPage();
+        assertNotNull(page);
+        assertHidden("proxyBaseUrlContainer");
+        assertHidden("useHeadersProxyURL");
+        assertHidden("loggingSettingsContainer");
+        assertHidden("lockProviderContainer");
+        assertHidden("webUISettingsContainer");
+    }
+
+    protected void assertHidden(String id) {
+        TagTester tag = tester.getTagById(id);
+        String msg = "expected custom 'unused' css class to hide the %s form inputs in custom GlobalSettingsPage.html"
+                .formatted(id);
+        assertEquals("unused", tag.getAttribute("class"), msg);
+    }
+}

--- a/src/apps/geoserver/webui/src/test/java/org/geoserver/cloud/web/app/WebUIApplicationTest.java
+++ b/src/apps/geoserver/webui/src/test/java/org/geoserver/cloud/web/app/WebUIApplicationTest.java
@@ -6,7 +6,6 @@
 package org.geoserver.cloud.web.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
@@ -19,14 +18,12 @@ import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
-import org.apache.wicket.util.tester.TagTester;
 import org.apache.wicket.util.tester.WicketTester;
 import org.geoserver.cloud.autoconfigure.extensions.test.ConditionalTestAutoConfiguration;
+import org.geoserver.cloud.autoconfigure.web.core.WebUIContextInitializer;
 import org.geoserver.web.GeoServerApplication;
 import org.geoserver.web.GeoServerHomePage;
-import org.geoserver.web.GeoServerLoginPage;
 import org.geoserver.web.ServicesPanel;
-import org.geoserver.web.admin.GlobalSettingsPage;
 import org.geoserver.web.wicket.WicketHierarchyPrinter;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -143,27 +140,6 @@ class WebUIApplicationTest {
     }
 
     @Test
-    void GlobalSettingsPage_smoke_test_loggedout() {
-        logout();
-        tester.startPage(GlobalSettingsPage.class);
-        tester.assertRenderedPage(GeoServerLoginPage.class);
-    }
-
-    @Test
-    void GlobalSettingsPage_smoke_test() {
-        login();
-        tester.startPage(GlobalSettingsPage.class);
-        tester.assertRenderedPage(GlobalSettingsPage.class);
-        GlobalSettingsPage page = (GlobalSettingsPage) tester.getLastRenderedPage();
-        assertNotNull(page);
-        assertHidden("proxyBaseUrlContainer");
-        assertHidden("useHeadersProxyURL");
-        assertHidden("loggingSettingsContainer");
-        assertHidden("lockProviderContainer");
-        assertHidden("webUISettingsContainer");
-    }
-
-    @Test
     void GeoServerHomePage_smoke_test_service_links() {
         GeoServerHomePage page = tester.startPage(GeoServerHomePage.class);
         assertNotNull(page);
@@ -183,13 +159,6 @@ class WebUIApplicationTest {
 
         tester.assertComponent("serviceList:serviceDescriptions:4", ListItem.class);
         tester.assertComponent("serviceList:serviceDescriptions:4:links:0", ListItem.class);
-    }
-
-    protected void assertHidden(String id) {
-        TagTester tag = tester.getTagById(id);
-        String msg = "expected custom 'unused' css class to hide the %s form inputs in custom GlobalSettingsPage.html"
-                .formatted(id);
-        assertEquals("unused", tag.getAttribute("class"), msg);
     }
 
     /**

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/GeoServerConfigModule.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/GeoServerConfigModule.java
@@ -20,6 +20,7 @@ import org.geoserver.config.ImageProcessingInfo;
 import org.geoserver.config.LoggingInfo;
 import org.geoserver.config.ServiceInfo;
 import org.geoserver.config.SettingsInfo;
+import org.geoserver.config.UserDetailsDisplaySettingsInfo;
 import org.geoserver.gwc.wmts.WMTSInfo;
 import org.geoserver.jackson.databind.catalog.GeoServerCatalogModule;
 import org.geoserver.jackson.databind.catalog.dto.InfoDto;
@@ -28,6 +29,7 @@ import org.geoserver.jackson.databind.config.dto.CogSettingsStoreDto;
 import org.geoserver.jackson.databind.config.dto.Contact;
 import org.geoserver.jackson.databind.config.dto.CoverageAccess;
 import org.geoserver.jackson.databind.config.dto.GeoServer;
+import org.geoserver.jackson.databind.config.dto.GeoServer.UserDetailsDisplaySettings;
 import org.geoserver.jackson.databind.config.dto.ImageProcessingInfoDto;
 import org.geoserver.jackson.databind.config.dto.Logging;
 import org.geoserver.jackson.databind.config.dto.Service;
@@ -118,6 +120,12 @@ public class GeoServerConfigModule extends SimpleModule {
                 VALUE_MAPPER::imageProcessingInfo,
                 ImageProcessingInfoDto.class,
                 VALUE_MAPPER::imageProcessingInfo);
+
+        addMapperSerializer(
+                UserDetailsDisplaySettingsInfo.class,
+                VALUE_MAPPER::toDto,
+                UserDetailsDisplaySettings.class,
+                VALUE_MAPPER::toInfo);
 
         addMapperSerializer(ContactInfo.class, VALUE_MAPPER::contactInfo, Contact.class, VALUE_MAPPER::contactInfo);
 

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/GeoServer.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/GeoServer.java
@@ -20,9 +20,9 @@ import org.geoserver.jackson.databind.catalog.dto.MetadataMapDto;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @JsonTypeName("GeoServerInfo")
-// for backwards compatiblility, xmlExternalEntitiesEnabled removed in 2.28.0, might be present in a config JSON
-// document from an earler version
-@JsonIgnoreProperties("xmlExternalEntitiesEnabled")
+// for backwards compatiblility, xmlExternalEntitiesEnabled and useHeadersProxyURLremoved in 2.28.0, might be present in
+// a config JSON document from an earler version
+@JsonIgnoreProperties({"xmlExternalEntitiesEnabled", "useHeadersProxyURL"})
 public class GeoServer extends ConfigInfoDto {
     public enum ResourceErrorHandling {
         OGC_EXCEPTION_REPORT,
@@ -47,7 +47,6 @@ public class GeoServer extends ConfigInfoDto {
     private String adminPassword;
     private int featureTypeCacheSize;
     private Boolean globalServices;
-    private Boolean useHeadersProxyURL;
     private Integer xmlPostRequestLogBufferSize;
     private String lockProviderName;
     private WebUIMode webUIMode;
@@ -62,7 +61,7 @@ public class GeoServer extends ConfigInfoDto {
     /**
      * @since 2.28.1
      */
-    private UserDetailsDisplaySettings userDetailsDisplaySettings;
+    private UserDetailsDisplaySettings userDetailsDisplaySettings = new UserDetailsDisplaySettings();
 
     /**
      * DTO for {@link UserDetailsDisplaySettingsInfo}
@@ -87,9 +86,9 @@ public class GeoServer extends ConfigInfoDto {
 
         // ignoring String id, this is not an entity but a value object
 
-        LoggedInUserDisplayMode loggedInUserDisplayMode;
+        LoggedInUserDisplayMode loggedInUserDisplayMode = LoggedInUserDisplayMode.USERNAME;
         boolean showProfileColumnsInUserList;
-        EmailDisplayMode emailDisplayMode;
+        EmailDisplayMode emailDisplayMode = EmailDisplayMode.DOMAIN_ONLY;
         boolean revealEmailAtClick;
     }
 }

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/GeoServerConfigMapper.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/GeoServerConfigMapper.java
@@ -116,8 +116,15 @@ public interface GeoServerConfigMapper {
     @Mapping(target = "clientProperties", ignore = true)
     @Mapping(target = "useHeadersProxyURL", ignore = true) // deprecated
     @Mapping(target = "xmlExternalEntitiesEnabled", ignore = true) // deprecated
+    @Mapping(
+            target = "userDetailsDisplaySettings",
+            defaultExpression = "java(new org.geoserver.config.impl.UserDetailsDisplaySettingsInfoImpl())")
     GeoServerInfo toInfo(GeoServer dto);
 
+    @Mapping(
+            target = "userDetailsDisplaySettings",
+            defaultExpression =
+                    "java(new org.geoserver.jackson.databind.config.dto.GeoServer.UserDetailsDisplaySettings())")
     GeoServer toDto(GeoServerInfo info);
 
     UserDetailsDisplaySettingsInfo toInfo(GeoServer.UserDetailsDisplaySettings dto);

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/ObjectFacotries.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/mapper/ObjectFacotries.java
@@ -22,6 +22,7 @@ import org.geoserver.config.impl.LoggingInfoImpl;
 import org.geoserver.config.impl.SettingsInfoImpl;
 import org.geoserver.config.impl.UserDetailsDisplaySettingsInfoImpl;
 import org.geoserver.jackson.databind.config.dto.GeoServer;
+import org.geoserver.jackson.databind.config.dto.GeoServer.UserDetailsDisplaySettings;
 import org.geoserver.jackson.databind.config.dto.Logging;
 import org.geoserver.jackson.databind.config.dto.Settings;
 import org.geoserver.ows.util.OwsUtils;
@@ -67,5 +68,9 @@ public class ObjectFacotries {
 
     public @ObjectFactory UserDetailsDisplaySettingsInfo userDetailsDisplaySettings() {
         return new UserDetailsDisplaySettingsInfoImpl();
+    }
+
+    public @ObjectFactory UserDetailsDisplaySettings userDetailsDisplaySettingsDto() {
+        return new UserDetailsDisplaySettings();
     }
 }

--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/mapper/PatchMapper.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/mapper/PatchMapper.java
@@ -83,6 +83,9 @@ public abstract class PatchMapper {
             if (ProxyUtils.encodeByReference(info)) {
                 dto = (R) REFS.infoToReference(info);
             }
+            // note if info is a value object Info (i.e. can't have id) and still is a ModificationProxy, a Jackson
+            // serializer/deserializer must be registered against its interface (e.g. see GeoServerConfigModule
+            // registering de/serializer for UserDetailsDisplaySettings
         } else if (value instanceof Collection<?> c) {
             dto = (R) copyOf(c, this::valueToDto);
         } else if (value instanceof Map) {

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/PatchSerializationTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/PatchSerializationTest.java
@@ -62,10 +62,13 @@ import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.ImageProcessingInfo;
 import org.geoserver.config.ServiceInfo;
 import org.geoserver.config.SettingsInfo;
+import org.geoserver.config.UserDetailsDisplaySettingsInfo;
 import org.geoserver.config.impl.CoverageAccessInfoImpl;
+import org.geoserver.config.impl.UserDetailsDisplaySettingsInfoImpl;
 import org.geoserver.config.plugin.GeoServerImpl;
 import org.geoserver.jackson.databind.catalog.mapper.CatalogInfoMapper;
 import org.geoserver.jackson.databind.catalog.mapper.GeoServerValueObjectsMapper;
+import org.geoserver.jackson.databind.config.GeoServerConfigModule;
 import org.geoserver.jackson.databind.config.dto.mapper.GeoServerConfigMapper;
 import org.geoserver.ows.util.OwsUtils;
 import org.geoserver.platform.GeoServerExtensionsHelper;
@@ -464,6 +467,20 @@ public abstract class PatchSerializationTest {
     @Test
     void modificationProxy_geoserverInfo() throws Exception {
         testPatch("global", forceProxy(data.global, GeoServerInfo.class));
+    }
+
+    /**
+     * UserDetailsDisplaySettingsInfo is a value object, has no id, hence can't be
+     * encoded by reference, yet the webui is setting
+     * {@link GeoServerInfo#setUserDetailsDisplaySettings(UserDetailsDisplaySettingsInfo)}
+     * using a {@link ModificationProxy}
+     * <p>
+     * The solution is to ensure {@link GeoServerConfigModule} registers a de/serializer for the {@link UserDetailsDisplaySettingsInfo} interface
+     */
+    @Test
+    void modificationProxy_UserDetailsDisplaySettingsInfo() throws Exception {
+        UserDetailsDisplaySettingsInfo info = new UserDetailsDisplaySettingsInfoImpl();
+        testPatch("userDetailsDisplaySettingsInfo", forceProxy(info, UserDetailsDisplaySettingsInfo.class));
     }
 
     @Test


### PR DESCRIPTION
The introduction of UserDetailsDisplaySettingsInfo in 2.28.1 upstream broke the deserialization of GeoServerInfo's JSON from previous versions and wasn't caught by any test case.