### PR TITLE
Stop log flooding for "Cannot find 6 /accessDenied.html"

### DIFF
--- a/src/apps/geoserver/gwc/src/main/resources/META-INF/accessDenied.html
+++ b/src/apps/geoserver/gwc/src/main/resources/META-INF/accessDenied.html
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>GeoServer: Access Denied</title>
+</head>
+<body>
+    <h1>GeoServer: Access Denied</h1>
+    <p><b>Sorry, you do not have permission to view this page.</b></p>
+    <p>Click <a href="web">here</a> to go back to the Welcome Page.</p>
+</body>
+</html>

--- a/src/apps/geoserver/restconfig/src/main/resources/META-INF/accessDenied.html
+++ b/src/apps/geoserver/restconfig/src/main/resources/META-INF/accessDenied.html
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>GeoServer: Access Denied</title>
+</head>
+<body>
+    <h1>GeoServer: Access Denied</h1>
+    <p><b>Sorry, you do not have permission to view this page.</b></p>
+    <p>Click <a href="web">here</a> to go back to the Welcome Page.</p>
+</body>
+</html>

--- a/src/apps/geoserver/wcs/src/main/resources/META-INF/accessDenied.html
+++ b/src/apps/geoserver/wcs/src/main/resources/META-INF/accessDenied.html
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>GeoServer: Access Denied</title>
+</head>
+<body>
+    <h1>GeoServer: Access Denied</h1>
+    <p><b>Sorry, you do not have permission to view this page.</b></p>
+    <p>Click <a href="web">here</a> to go back to the Welcome Page.</p>
+</body>
+</html>

--- a/src/apps/geoserver/webui/src/main/resources/META-INF/resources/accessDenied.html
+++ b/src/apps/geoserver/webui/src/main/resources/META-INF/resources/accessDenied.html
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>GeoServer: Access Denied</title>
+</head>
+<body>
+    <h1>GeoServer: Access Denied</h1>
+    <p><b>Sorry, you do not have permission to view this page.</b></p>
+    <p>Click <a href="web">here</a> to go back to the Welcome Page.</p>
+</body>
+</html>

--- a/src/apps/geoserver/wfs/src/main/resources/META-INF/resources/accessDenied.html
+++ b/src/apps/geoserver/wfs/src/main/resources/META-INF/resources/accessDenied.html
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>GeoServer: Access Denied</title>
+</head>
+<body>
+    <h1>GeoServer: Access Denied</h1>
+    <p><b>Sorry, you do not have permission to view this page.</b></p>
+    <p>Click <a href="web">here</a> to go back to the Welcome Page.</p>
+</body>
+</html>

--- a/src/apps/geoserver/wms/src/main/resources/META-INF/resources/accessDenied.html
+++ b/src/apps/geoserver/wms/src/main/resources/META-INF/resources/accessDenied.html
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>GeoServer: Access Denied</title>
+</head>
+<body>
+    <h1>GeoServer: Access Denied</h1>
+    <p><b>Sorry, you do not have permission to view this page.</b></p>
+    <p>Click <a href="web">here</a> to go back to the Welcome Page.</p>
+</body>
+</html>

--- a/src/apps/geoserver/wps/src/main/resources/META-INF/accessDenied.html
+++ b/src/apps/geoserver/wps/src/main/resources/META-INF/accessDenied.html
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>GeoServer: Access Denied</title>
+</head>
+<body>
+    <h1>GeoServer: Access Denied</h1>
+    <p><b>Sorry, you do not have permission to view this page.</b></p>
+    <p>Click <a href="web">here</a> to go back to the Welcome Page.</p>
+</body>
+</html>


### PR DESCRIPTION
Copy upstream's `src/web/app/src/main/webapp/accessDenied.html` to `src/main/resources/META-INF/resources/` (default location for static files) to stop log flooding with `WARNING Cannot find /accessDenied.html` from
`GeoServerExceptionTranslationFilter.initializeFromConfig()`.