### PR TITLE
Fix loading of DXF and Flatgeobuf output format extensions

### DIFF
--- a/src/apps/geoserver/wfs/src/test/java/org/geoserver/cloud/wfs/app/WfsApplicationDataDirectoryIT.java
+++ b/src/apps/geoserver/wfs/src/test/java/org/geoserver/cloud/wfs/app/WfsApplicationDataDirectoryIT.java
@@ -13,7 +13,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
-@SpringBootTest(classes = WfsApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
+@SpringBootTest(classes = WfsApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT, args = "-Ddebug=true")
 @ActiveProfiles("datadir")
 class WfsApplicationDataDirectoryIT extends WfsApplicationTest {
 

--- a/src/apps/geoserver/wfs/src/test/java/org/geoserver/cloud/wfs/app/WfsApplicationTest.java
+++ b/src/apps/geoserver/wfs/src/test/java/org/geoserver/cloud/wfs/app/WfsApplicationTest.java
@@ -42,6 +42,22 @@ abstract class WfsApplicationTest {
         XmlAssert.assertThat(caps).withNamespaceContext(nscontext).hasXPath("/wfs:WFS_Capabilities");
     }
 
+    @Test
+    void wfsGetCapabilitiesOutputFormatsTest(@LocalServerPort int servicePort) {
+        String url = "http://localhost:%d/wfs?SERVICE=WFS&REQUEST=GETCAPABILITIES&VERSION=1.1.0".formatted(servicePort);
+        String caps = restTemplate.getForObject(url, String.class);
+
+        Map<String, String> nscontext =
+                Map.of("wfs", "http://www.opengis.net/wfs", "ows", "http://www.opengis.net/ows");
+        XmlAssert xmlAssert = XmlAssert.assertThat(caps).withNamespaceContext(nscontext);
+        xmlAssert.hasXPath(
+                "//ows:Operation[@name='GetFeature']/ows:Parameter[@name='outputFormat']/ows:Value[text()='DXF']");
+        xmlAssert.hasXPath(
+                "//ows:Operation[@name='GetFeature']/ows:Parameter[@name='outputFormat']/ows:Value[text()='DXF-ZIP']");
+        xmlAssert.hasXPath(
+                "//ows:Operation[@name='GetFeature']/ows:Parameter[@name='outputFormat']/ows:Value[text()='application/flatgeobuf']");
+    }
+
     /**
      * Tests the service-specific conditional annotations.
      *

--- a/src/extensions/output-formats/dxf/src/main/java/org/geoserver/cloud/autoconfigure/extensions/dxf/DxfAutoConfiguration.java
+++ b/src/extensions/output-formats/dxf/src/main/java/org/geoserver/cloud/autoconfigure/extensions/dxf/DxfAutoConfiguration.java
@@ -55,14 +55,6 @@ import org.springframework.context.annotation.Import;
 public class DxfAutoConfiguration {
 
     /**
-     * Logs that the DXF extension is enabled.
-     */
-    @PostConstruct
-    void log() {
-        log.info("DXF extension enabled for multiple services");
-    }
-
-    /**
      * Provides a ModuleStatus for the DXF extension.
      */
     @SuppressWarnings("java:S6830")
@@ -93,7 +85,12 @@ public class DxfAutoConfiguration {
     @ConditionalOnDxf
     @ConditionalOnGeoServerWFS
     @ImportFilteredResource("jar:gs-dxf-core-.*!/applicationContext.xml#name=.*")
-    public static class DxfOutputFormatConfiguration {}
+    public static class DxfOutputFormatConfiguration {
+        @PostConstruct
+        void log() {
+            log.info("DXF WFS output format extension enabled");
+        }
+    }
 
     /**
      * Configuration class that enables DXF in the WebUI service.
@@ -115,5 +112,10 @@ public class DxfAutoConfiguration {
     @ConditionalOnDxf
     @ConditionalOnGeoServerWebUI
     @ImportFilteredResource("jar:gs-dxf-core-.*!/applicationContext.xml#name=.*")
-    public static class WebUIConfiguration {}
+    public static class WebUIConfiguration {
+        @PostConstruct
+        void log() {
+            log.info("DXF WebUI output format extension enabled");
+        }
+    }
 }

--- a/src/extensions/output-formats/dxf/src/main/resources/META-INF/spring.factories
+++ b/src/extensions/output-formats/dxf/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.geoserver.cloud.autoconfigure.extensions.dxf.DxfAutoConfiguration

--- a/src/extensions/output-formats/dxf/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/extensions/output-formats/dxf/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.geoserver.cloud.autoconfigure.extensions.dxf.DxfAutoConfiguration

--- a/src/extensions/output-formats/flatgeobuf/pom.xml
+++ b/src/extensions/output-formats/flatgeobuf/pom.xml
@@ -19,7 +19,6 @@
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-flatgeobuf</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <!-- GeoServer WFS API (needed for conditional annotation) -->

--- a/src/extensions/output-formats/flatgeobuf/src/main/java/org/geoserver/cloud/autoconfigure/extensions/flatgeobuf/FlatGeobufAutoConfiguration.java
+++ b/src/extensions/output-formats/flatgeobuf/src/main/java/org/geoserver/cloud/autoconfigure/extensions/flatgeobuf/FlatGeobufAutoConfiguration.java
@@ -69,14 +69,6 @@ import org.springframework.context.annotation.Import;
 public class FlatGeobufAutoConfiguration {
 
     /**
-     * Logs that the FlatGeobuf extension is enabled.
-     */
-    @PostConstruct
-    void log() {
-        log.info("FlatGeobuf extension enabled for multiple services");
-    }
-
-    /**
      * Provides a ModuleStatus for the FlatGeobuf extension.
      */
     @Bean("flatGeobufExtension")
@@ -104,7 +96,12 @@ public class FlatGeobufAutoConfiguration {
     @ConditionalOnFlatGeobuf
     @ConditionalOnGeoServerWFS
     @ImportFilteredResource("jar:gs-flatgeobuf-.*!/applicationContext.xml#name=.*")
-    public static class FlatGeobufOutputFormatConfiguration {}
+    public static class FlatGeobufOutputFormatConfiguration {
+        @PostConstruct
+        void log() {
+            log.info("FlatGeobuf WFS output format enabled");
+        }
+    }
 
     /**
      * Configuration class that enables FlatGeobuf in the WebUI service.
@@ -126,5 +123,10 @@ public class FlatGeobufAutoConfiguration {
     @ConditionalOnFlatGeobuf
     @ConditionalOnGeoServerWebUI
     @ImportFilteredResource("jar:gs-flatgeobuf-.*!/applicationContext.xml#name=.*")
-    public static class WebUIConfiguration {}
+    public static class WebUIConfiguration {
+        @PostConstruct
+        void log() {
+            log.info("FlatGeobuf WebUI output format extension enabled");
+        }
+    }
 }


### PR DESCRIPTION
The DXF extension was missing the META-INF/spring.factories file.

The Flatgeobuf extension had it but the gs-flatgeobuf dependency was optional, despite it logged a message saying it was enabled.

---
Fixes #721
