### PR TITLE
Spring Boot 3 compatible control-flow extension property initialization

### DIFF
--- a/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ConditionalOnControlFlow.java
+++ b/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ConditionalOnControlFlow.java
@@ -13,6 +13,34 @@ import java.lang.annotation.Target;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
+/**
+ * Composite conditional annotation for the GeoServer Control-Flow extension.
+ *
+ * <p>Beans annotated with this condition are only created when both conditions are met:
+ *
+ * <ul>
+ *   <li>The {@code org.geoserver.flow.ControlFlowConfigurator} class is present on the classpath
+ *       (i.e., the {@code gs-control-flow} dependency is available)
+ *   <li>The property {@code geoserver.extension.control-flow.enabled} is {@code true} (which is
+ *       the default if not specified)
+ * </ul>
+ *
+ * <p>The extension can be disabled by setting:
+ *
+ * <pre>{@code
+ * geoserver.extension.control-flow.enabled=false
+ * }</pre>
+ *
+ * <p>Or using the shorthand environment variable:
+ *
+ * <pre>{@code
+ * CONTROL_FLOW=false
+ * }</pre>
+ *
+ * @see ControlFlowAutoConfiguration
+ * @see ControlFlowConfigurationProperties#ENABLED_PROPERTY
+ * @since 2.28.1.1
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Documented

--- a/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowAppContextInitializer.java
+++ b/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowAppContextInitializer.java
@@ -7,8 +7,40 @@ package org.geoserver.cloud.autoconfigure.extensions.controlflow;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 
+/**
+ * Application context initializer that sets the {@code cpu.cores} system property.
+ *
+ * <p>This initializer runs early in the Spring Boot startup lifecycle, before configuration
+ * properties are bound. It sets the {@code cpu.cores} system property to the value returned by
+ * {@link Runtime#availableProcessors()}, which reflects the number of CPU cores available to the
+ * JVM (respecting container CPU limits).
+ *
+ * <p>This property enables dynamic configuration of Control-Flow limits based on available CPU
+ * resources using SpEL expressions:
+ *
+ * <pre>{@code
+ * geoserver:
+ *   extension:
+ *     control-flow:
+ *       properties:
+ *         '[ows.global]': "${cpu.cores} * 2"
+ *         '[ows.wms.getmap]': "${cpu.cores}"
+ * }</pre>
+ *
+ * <p>The initializer is registered via {@code META-INF/spring.factories} and runs automatically
+ * during application startup.
+ *
+ * @see ControlFlowConfigurationProperties
+ * @see ExpressionEvaluator
+ * @since 2.28.1.1
+ */
 public class ControlFlowAppContextInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
+    /**
+     * Initializes the {@code cpu.cores} system property if not already set.
+     *
+     * @param applicationContext the application context (not used, but required by interface)
+     */
     @Override
     public void initialize(ConfigurableApplicationContext applicationContext) {
         String cores = System.getProperty("cpu.cores");

--- a/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowAutoConfiguration.java
+++ b/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowAutoConfiguration.java
@@ -23,6 +23,48 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+/**
+ * Auto-configuration for the GeoServer Control-Flow extension.
+ *
+ * <p>The Control-Flow extension throttles incoming requests to prevent server overload and ensure
+ * fair resource distribution. It queues excess requests rather than rejecting them, helping achieve
+ * optimal throughput and preventing OutOfMemoryErrors.
+ *
+ * <p>This configuration supports two mutually exclusive modes:
+ *
+ * <ul>
+ *   <li><b>Externalized Configuration</b> (default): Uses Spring Boot properties with SpEL
+ *       expression support for dynamic limits based on CPU cores
+ *   <li><b>Data Directory Configuration</b>: Uses the traditional {@code control-flow.properties}
+ *       file from the GeoServer data directory
+ * </ul>
+ *
+ * <p>The mode is controlled by {@code geoserver.extension.control-flow.use-properties-file}:
+ *
+ * <pre>{@code
+ * # Externalized config (default)
+ * geoserver.extension.control-flow.use-properties-file=false
+ *
+ * # Data directory config
+ * geoserver.extension.control-flow.use-properties-file=true
+ * }</pre>
+ *
+ * <p>Beans registered by this configuration:
+ *
+ * <ul>
+ *   <li>{@link ControlFlowCallback} - Dispatcher callback that enforces flow control rules
+ *   <li>{@link ControlFlowConfigurator} - Reads and parses configuration
+ *   <li>{@link FlowControllerProvider} - Provides flow controllers based on configuration
+ *   <li>{@link IpBlacklistFilter} - Filters requests from blacklisted IP addresses
+ *   <li>{@link ControlModuleStatus} - Reports extension status for the REST API
+ * </ul>
+ *
+ * @see ControlFlowConfigurationProperties
+ * @see ConditionalOnControlFlow
+ * @see <a href="https://docs.geoserver.org/main/en/user/extensions/controlflow/index.html">
+ *     GeoServer Control Flow Documentation</a>
+ * @since 2.28.1.1
+ */
 @AutoConfiguration
 @Import({
     ControlFlowAutoConfiguration.Enabled.class,

--- a/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowConfigurationProperties.java
+++ b/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowConfigurationProperties.java
@@ -6,20 +6,47 @@ package org.geoserver.cloud.autoconfigure.extensions.controlflow;
 
 import java.util.Properties;
 import lombok.Data;
-import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.env.Environment;
 
+/**
+ * Configuration properties for the GeoServer Control-Flow extension.
+ *
+ * <p>This class binds properties under the {@code geoserver.extension.control-flow} prefix and
+ * supports dynamic property resolution using Spring Environment placeholders and SpEL expressions.
+ * <p>
+ * {@link #resolvedProperties()} is used to obtain the final property values.
+ *
+ * <p>Example configuration in {@code application.yml}:
+ *
+ * <pre>{@code
+ * geoserver:
+ *   extension:
+ *     control-flow:
+ *       enabled: true
+ *       use-properties-file: false
+ *       properties:
+ *         ows.global: "${CONTROL_FLOW_GLOBAL_LIMIT:100}"
+ *         user: "#{${MAX_USERS:10} * 2}"
+ * }</pre>
+ *
+ * @see ControlFlowAutoConfiguration
+ * @since 2.27.0
+ */
 @Data
 @ConfigurationProperties(prefix = "geoserver.extension.control-flow")
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.extensions.controlflow")
 class ControlFlowConfigurationProperties {
 
+    /** Property name for enabling/disabling the control-flow extension. */
     static final String ENABLED_PROPERTY = "geoserver.extension.control-flow.enabled";
+
+    /** Property name for using the legacy properties file configuration. */
     static final String USE_PROPERTIES_FILE = "geoserver.extension.control-flow.use-properties-file";
 
-    private final @NonNull ExpressionEvaluator evaluator;
+    private ExpressionEvaluator evaluator;
     private Properties resolved;
 
     /**
@@ -39,10 +66,28 @@ class ControlFlowConfigurationProperties {
      */
     private Properties properties = new Properties();
 
-    ControlFlowConfigurationProperties(Environment environment) {
+    /**
+     * Initializes the expression evaluator with the Spring Environment.
+     *
+     * @param environment the Spring Environment for resolving placeholders and SpEL expressions
+     */
+    @Autowired
+    void setEnvironment(Environment environment) {
         this.evaluator = new ExpressionEvaluator(environment);
     }
 
+    /**
+     * Returns the control-flow properties with all placeholders and SpEL expressions resolved.
+     *
+     * <p>Property values can contain:
+     *
+     * <ul>
+     *   <li>Environment placeholders: {@code ${VAR_NAME:default}}
+     *   <li>SpEL expressions: {@code #{expression}}
+     * </ul>
+     *
+     * @return a new Properties instance with all values resolved
+     */
     public Properties resolvedProperties() {
         if (resolved == null) {
             resolved = new Properties();
@@ -55,6 +100,12 @@ class ControlFlowConfigurationProperties {
         return resolved;
     }
 
+    /**
+     * Resolves placeholders and evaluates SpEL expressions in the given value.
+     *
+     * @param value the property value potentially containing placeholders or expressions
+     * @return the resolved value
+     */
     private String resolve(final String value) {
         String resolvedValue = evaluator.resolvePlaceholders(value);
         try {

--- a/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ExpressionEvaluator.java
+++ b/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ExpressionEvaluator.java
@@ -12,6 +12,41 @@ import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 
+/**
+ * Evaluates property placeholders and SpEL expressions in Control-Flow configuration values.
+ *
+ * <p>This class provides a two-stage resolution process for configuration values:
+ *
+ * <ol>
+ *   <li><b>Placeholder resolution</b>: Resolves {@code ${property:default}} placeholders using the
+ *       Spring {@link Environment}, including system properties like {@code ${cpu.cores}}
+ *   <li><b>SpEL evaluation</b>: Evaluates the result as a SpEL expression to support arithmetic
+ *       operations like {@code "4 * 2"} -> {@code "8"}
+ * </ol>
+ *
+ * <p>Example resolution flow:
+ *
+ * <pre>{@code
+ * Input:    "${cpu.cores} * 2"
+ * Step 1:   "4 * 2"         (placeholder resolved, assuming 4 cores)
+ * Step 2:   "8"             (SpEL evaluated)
+ * }</pre>
+ *
+ * <p>This enables dynamic configuration based on container resources:
+ *
+ * <pre>{@code
+ * geoserver:
+ *   extension:
+ *     control-flow:
+ *       properties:
+ *         '[ows.global]': "${cpu.cores} * 2"
+ *         '[ows.wms.getmap]': "${cpu.cores}"
+ * }</pre>
+ *
+ * @see ControlFlowConfigurationProperties#resolvedProperties()
+ * @see ControlFlowAppContextInitializer
+ * @since 2.28.1.1
+ */
 @RequiredArgsConstructor
 class ExpressionEvaluator {
 
@@ -19,14 +54,34 @@ class ExpressionEvaluator {
 
     private final ExpressionParser parser = new SpelExpressionParser();
 
-    // Use a standard context, we don't need access to Spring beans within the SpEL
-    // itself
+    // Use a standard context, we don't need access to Spring beans within the SpEL itself
     private final StandardEvaluationContext context = new StandardEvaluationContext();
 
+    /**
+     * Resolves property placeholders in the given string.
+     *
+     * <p>Placeholders follow the format {@code ${property:default}} and are resolved against the
+     * Spring Environment, which includes system properties, environment variables, and application
+     * configuration.
+     *
+     * @param expressionString the string containing placeholders to resolve
+     * @return the string with all placeholders resolved
+     */
     public String resolvePlaceholders(String expressionString) {
         return environment.resolvePlaceholders(expressionString);
     }
 
+    /**
+     * Evaluates the given string as a SpEL expression.
+     *
+     * <p>This is typically called after {@link #resolvePlaceholders(String)} to evaluate arithmetic
+     * expressions like {@code "4 * 2"}.
+     *
+     * @param expressionString the SpEL expression to evaluate
+     * @return the result of evaluating the expression as a String
+     * @throws org.springframework.expression.EvaluationException if the expression cannot be
+     *     evaluated
+     */
     public String evaluateExpressions(String expressionString) {
         Expression exp = parser.parseExpression(expressionString);
         return exp.getValue(context, String.class);


### PR DESCRIPTION
Add `@Autowired setEnvironment(Environment environment)` to `ControlFlowConfigurationProperties` to initialize the expression evaluator.

Improve extension documentation.