### PR TITLE
Enable AWS S3 acceptance tests in CI

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -94,13 +94,19 @@ jobs:
 
     - name: Set up AWS credentials for acceptance tests
       run: |
-        mkdir -p compose/secrets/aws
-        cat > compose/secrets/aws/credentials << 'EOF'
+        if [ -n "${{ secrets.AWS_ACCESS_KEY_ID }}" ] && [ -n "${{ secrets.AWS_SECRET_ACCESS_KEY }}" ]; then
+          echo "AWS credentials available, creating credentials file"
+          mkdir -p compose/secrets/aws
+          cat > compose/secrets/aws/credentials << EOF
         [default]
         aws_access_key_id = ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws_secret_access_key = ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         EOF
-        chmod 600 compose/secrets/aws/credentials
+          chmod 600 compose/secrets/aws/credentials
+        else
+          echo "AWS credentials not available, skipping credentials file creation"
+          echo "S3 integration tests will be skipped"
+        fi
 
     - name: Launch ${{ matrix.catalog }} acceptance tests docker composition
       id: start

--- a/compose/acceptance.yml
+++ b/compose/acceptance.yml
@@ -34,6 +34,8 @@ services:
         limits:
           cpus: "1.0"
           memory: 512M
+    volumes:
+      - ./secrets/aws:/compose/secrets/aws:ro
 
   # For github CI
   rabbitmq:


### PR DESCRIPTION
Mount the AWS credential file where the tests in test_s3_credentials_chain.py expect it so that they run in the CI
Create the file only if the credentials are available