### PR TITLE
Fix SonarCloud PR analysis for fork PRs

### DIFF
--- a/.github/workflows/sonarcloud-fork-pr.yaml
+++ b/.github/workflows/sonarcloud-fork-pr.yaml
@@ -49,6 +49,9 @@ jobs:
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
 
+    # For pull_request_target, we must explicitly pass PR parameters to SonarCloud
+    # since the scanner runs in the base repo context and can't auto-detect PR info.
+    # This enables PR analysis reports and PR decoration on GitHub.
     - name: Analyze with Sonar
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information
@@ -59,6 +62,9 @@ jobs:
         -Dsonar.projectKey=geoserver_geoserver-cloud \
         -Dsonar.organization=geoserver \
         -Dsonar.scanner.skipJreProvisioning=true \
+        -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} \
+        -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} \
+        -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }} \
         -Dmaven.javadoc.skip=true \
         -ntp \
         -T1C

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -2,6 +2,7 @@
 
 name: SonarCloud QA
 on:
+  workflow_dispatch:  # Allow manual trigger from GitHub Actions UI
   push:
     branches:
       - main


### PR DESCRIPTION
Add explicit sonar.pullrequest.* parameters to the fork PR workflow. When using pull_request_target, SonarCloud can't auto-detect PR info since the workflow runs in the base repository context.