### PR TITLE
Add backwards-compatibility tests for Jackson 2 JSON property naming

### DIFF
--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/BackwardsCompatibilityTestSupport.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/BackwardsCompatibilityTestSupport.java
@@ -1,0 +1,45 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.jackson.databind.catalog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.geotools.jackson.databind.util.ObjectMapperUtil;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Base class for backwards-compatibility tests that verify deserialization from known JSON text
+ * blocks produced by Jackson 2.
+ *
+ * <p>These tests ensure that JSON property names produced by Jackson 2's {@code
+ * legacyManglePropertyName} behavior (which lowercases leading uppercase characters in field names)
+ * are correctly deserialized. This is important for maintaining wire-format compatibility when
+ * upgrading to Jackson 3, which preserves field name casing.
+ */
+public abstract class BackwardsCompatibilityTestSupport {
+
+    protected ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = ObjectMapperUtil.newObjectMapper();
+    }
+
+    protected <T> T decode(String json, Class<T> type) throws Exception {
+        return objectMapper.readValue(json, type);
+    }
+
+    protected void assertFilterIsInclude(org.geotools.jackson.databind.filter.dto.Filter filter) {
+        assertThat(filter).isInstanceOf(org.geotools.jackson.databind.filter.dto.Filter.IncludeFilter.class);
+    }
+
+    protected void assertFilterIsNative(org.geotools.jackson.databind.filter.dto.Filter filter, String expectedNative) {
+        assertThat(filter).isInstanceOf(org.geotools.jackson.databind.filter.dto.Filter.NativeFilter.class);
+        assertThat(((org.geotools.jackson.databind.filter.dto.Filter.NativeFilter) filter).getNative())
+                .isEqualTo(expectedNative);
+    }
+}

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModuleBackwardsCompatibilityTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/GeoServerCatalogModuleBackwardsCompatibilityTest.java
@@ -1,0 +1,551 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.jackson.databind.catalog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.geoserver.catalog.CoverageInfo;
+import org.geoserver.catalog.CoverageStoreInfo;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WMSLayerInfo;
+import org.geoserver.catalog.WMSStoreInfo;
+import org.geoserver.catalog.WMTSLayerInfo;
+import org.geoserver.catalog.WMTSStoreInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geotools.jackson.databind.dto.CRS;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that JSON produced by Jackson 2's property naming convention (lowercase leading
+ * characters) can be deserialized correctly. These tests use hardcoded JSON text blocks with the
+ * Jackson 2 property names and the {@code @type} property for type discrimination.
+ *
+ * <p>Key Jackson 2 property name mappings tested:
+ *
+ * <ul>
+ *   <li>{@code CRS.WKT} &rarr; {@code "wkt"}
+ *   <li>{@code Resource.SRS} &rarr; {@code "srs"}
+ *   <li>{@code Resource.Abstract} &rarr; {@code "abstract"}
+ *   <li>{@code Namespace.URI} &rarr; {@code "uri"}
+ *   <li>{@code CoverageStore.URL} &rarr; {@code "url"}
+ *   <li>{@code Published.Abstract} &rarr; {@code "abstract"}
+ *   <li>{@code LayerGroupStyle.Abstract} &rarr; {@code "abstract"}
+ *   <li>{@code Filter.NativeFilter.Native} &rarr; {@code "native"}
+ * </ul>
+ */
+class GeoServerCatalogModuleBackwardsCompatibilityTest extends BackwardsCompatibilityTestSupport {
+
+    @Test
+    void testWorkspaceInfo() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "WorkspaceInfo",
+                  "id": "ws1",
+                  "name": "testWs",
+                  "isolated": false
+                }
+                """;
+        WorkspaceInfo ws = decode(json, WorkspaceInfo.class);
+        assertThat(ws.getName()).isEqualTo("testWs");
+        assertThat(ws.isIsolated()).isFalse();
+    }
+
+    @Test
+    void testNamespaceInfo_uri() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "NamespaceInfo",
+                  "id": "ns1",
+                  "name": "testNs",
+                  "uri": "http://test.namespace.com",
+                  "isolated": false
+                }
+                """;
+        NamespaceInfo ns = decode(json, NamespaceInfo.class);
+        assertThat(ns.getName()).isEqualTo("testNs");
+        assertThat(ns.getURI()).isEqualTo("http://test.namespace.com");
+        assertThat(ns.isIsolated()).isFalse();
+    }
+
+    @Test
+    void testDataStoreInfo() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "DataStoreInfo",
+                  "id": "ds1",
+                  "name": "testDs",
+                  "workspace": "ws1",
+                  "enabled": true,
+                  "connectionParameters": {},
+                  "disableOnConnFailure": false
+                }
+                """;
+        DataStoreInfo ds = decode(json, DataStoreInfo.class);
+        assertThat(ds.getName()).isEqualTo("testDs");
+        assertThat(ds.isEnabled()).isTrue();
+    }
+
+    @Test
+    void testCoverageStoreInfo_url() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "CoverageStoreInfo",
+                  "id": "cs1",
+                  "name": "testCs",
+                  "workspace": "ws1",
+                  "enabled": true,
+                  "connectionParameters": {},
+                  "disableOnConnFailure": false,
+                  "url": "file:///data/raster.tif"
+                }
+                """;
+        CoverageStoreInfo cs = decode(json, CoverageStoreInfo.class);
+        assertThat(cs.getName()).isEqualTo("testCs");
+        assertThat(cs.getURL()).isEqualTo("file:///data/raster.tif");
+    }
+
+    @Test
+    void testWMSStoreInfo() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "WMSStoreInfo",
+                  "id": "wmsst1",
+                  "name": "testWmsStore",
+                  "workspace": "ws1",
+                  "enabled": true,
+                  "connectionParameters": {},
+                  "disableOnConnFailure": false,
+                  "capabilitiesURL": "http://example.com/wms?service=WMS&version=1.1.1&request=GetCapabilities",
+                  "maxConnections": 6,
+                  "readTimeout": 60,
+                  "connectTimeout": 30
+                }
+                """;
+        WMSStoreInfo store = decode(json, WMSStoreInfo.class);
+        assertThat(store.getName()).isEqualTo("testWmsStore");
+    }
+
+    @Test
+    void testWMTSStoreInfo() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "WMTSStoreInfo",
+                  "id": "wmtsst1",
+                  "name": "testWmtsStore",
+                  "workspace": "ws1",
+                  "enabled": true,
+                  "connectionParameters": {},
+                  "disableOnConnFailure": false,
+                  "capabilitiesURL": "http://example.com/wmts?service=WMTS&request=GetCapabilities",
+                  "maxConnections": 6,
+                  "readTimeout": 60,
+                  "connectTimeout": 30
+                }
+                """;
+        WMTSStoreInfo store = decode(json, WMTSStoreInfo.class);
+        assertThat(store.getName()).isEqualTo("testWmtsStore");
+    }
+
+    @Test
+    void testFeatureTypeInfo_abstract_and_srs() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "FeatureTypeInfo",
+                  "id": "ft1",
+                  "name": "testFt",
+                  "namespace": "ns1",
+                  "store": "ds1",
+                  "nativeName": "test_table",
+                  "title": "Test Feature Type",
+                  "abstract": "A test feature type",
+                  "srs": "EPSG:4326",
+                  "enabled": true,
+                  "serviceConfiguration": false,
+                  "maxFeatures": 0,
+                  "numDecimals": 0,
+                  "padWithZeros": false,
+                  "forcedDecimal": false,
+                  "overridingServiceSRS": false,
+                  "skipNumberMatched": false,
+                  "circularArcPresent": false,
+                  "encodeMeasures": false
+                }
+                """;
+        FeatureTypeInfo ft = decode(json, FeatureTypeInfo.class);
+        assertThat(ft.getName()).isEqualTo("testFt");
+        assertThat(ft.getAbstract()).isEqualTo("A test feature type");
+        assertThat(ft.getSRS()).isEqualTo("EPSG:4326");
+    }
+
+    @Test
+    void testCoverageInfo_abstract_and_srs() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "CoverageInfo",
+                  "id": "cov1",
+                  "name": "testCoverage",
+                  "namespace": "ns1",
+                  "store": "cs1",
+                  "nativeName": "test_coverage",
+                  "title": "Test Coverage",
+                  "abstract": "A test coverage",
+                  "srs": "EPSG:4326",
+                  "enabled": true,
+                  "serviceConfiguration": false
+                }
+                """;
+        CoverageInfo c = decode(json, CoverageInfo.class);
+        assertThat(c.getName()).isEqualTo("testCoverage");
+        assertThat(c.getAbstract()).isEqualTo("A test coverage");
+        assertThat(c.getSRS()).isEqualTo("EPSG:4326");
+    }
+
+    @Test
+    void testWMSLayerInfo_abstract_and_srs() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "WMSLayerInfo",
+                  "id": "wmsl1",
+                  "name": "testWmsLayer",
+                  "namespace": "ns1",
+                  "store": "wmsst1",
+                  "nativeName": "remote_layer",
+                  "title": "Test WMS Layer",
+                  "abstract": "A remote WMS layer",
+                  "srs": "EPSG:4326",
+                  "enabled": true,
+                  "serviceConfiguration": false,
+                  "metadataBBoxRespected": false
+                }
+                """;
+        WMSLayerInfo layer = decode(json, WMSLayerInfo.class);
+        assertThat(layer.getName()).isEqualTo("testWmsLayer");
+        assertThat(layer.getAbstract()).isEqualTo("A remote WMS layer");
+        assertThat(layer.getSRS()).isEqualTo("EPSG:4326");
+    }
+
+    @Test
+    void testWMTSLayerInfo_abstract_and_srs() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "WMTSLayerInfo",
+                  "id": "wmtsl1",
+                  "name": "testWmtsLayer",
+                  "namespace": "ns1",
+                  "store": "wmtsst1",
+                  "nativeName": "remote_wmts_layer",
+                  "title": "Test WMTS Layer",
+                  "abstract": "A remote WMTS layer",
+                  "srs": "EPSG:4326",
+                  "enabled": true,
+                  "serviceConfiguration": false
+                }
+                """;
+        WMTSLayerInfo layer = decode(json, WMTSLayerInfo.class);
+        assertThat(layer.getName()).isEqualTo("testWmtsLayer");
+        assertThat(layer.getAbstract()).isEqualTo("A remote WMTS layer");
+        assertThat(layer.getSRS()).isEqualTo("EPSG:4326");
+    }
+
+    @Test
+    void testLayerInfo_abstract() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "LayerInfo",
+                  "id": "layer1",
+                  "name": "testLayer",
+                  "title": "Test Layer",
+                  "abstract": "A test layer",
+                  "enabled": true,
+                  "advertised": true,
+                  "resource": "ft1",
+                  "defaultStyle": "style1",
+                  "type": "VECTOR"
+                }
+                """;
+        LayerInfo layer = decode(json, LayerInfo.class);
+        assertThat(layer.getId()).isEqualTo("layer1");
+        assertThat(layer.getType()).isEqualTo(org.geoserver.catalog.PublishedType.VECTOR);
+    }
+
+    @Test
+    void testLayerGroupInfo_abstract_and_layerGroupStyleAbstract() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "LayerGroupInfo",
+                  "id": "lg1",
+                  "name": "testLayerGroup",
+                  "title": "Test LG",
+                  "abstract": "A test layer group",
+                  "enabled": true,
+                  "advertised": true,
+                  "mode": "SINGLE",
+                  "layers": ["layer1", "layer2"],
+                  "styles": ["style1", "style2"],
+                  "layerGroupStyles": [{
+                    "id": "lgs1",
+                    "title": "LGS Title",
+                    "abstract": "LGS Abstract",
+                    "layers": ["layer1"],
+                    "styles": ["style1"]
+                  }]
+                }
+                """;
+        LayerGroupInfo lg = decode(json, LayerGroupInfo.class);
+        assertThat(lg.getName()).isEqualTo("testLayerGroup");
+        assertThat(lg.getAbstract()).isEqualTo("A test layer group");
+        assertThat(lg.getLayerGroupStyles()).hasSize(1);
+        assertThat(lg.getLayerGroupStyles().get(0).getAbstract()).isEqualTo("LGS Abstract");
+    }
+
+    @Test
+    void testStyleInfo() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "StyleInfo",
+                  "id": "style1",
+                  "name": "testStyle",
+                  "format": "sld",
+                  "filename": "testStyle.sld"
+                }
+                """;
+        StyleInfo style = decode(json, StyleInfo.class);
+        assertThat(style.getName()).isEqualTo("testStyle");
+        assertThat(style.getFormat()).isEqualTo("sld");
+    }
+
+    @Test
+    void testCRS_wkt() throws Exception {
+        String json =
+                """
+                {
+                  "srs": "EPSG:4326",
+                  "wkt": "GEOGCS[\\"WGS 84\\"]"
+                }
+                """;
+        CRS crs = decode(json, CRS.class);
+        assertThat(crs.getSrs()).isEqualTo("EPSG:4326");
+        assertThat(crs.getWKT()).isEqualTo("GEOGCS[\"WGS 84\"]");
+    }
+
+    @Test
+    void testCRS_srsOnly() throws Exception {
+        String json = """
+                {
+                  "srs": "EPSG:3857"
+                }
+                """;
+        CRS crs = decode(json, CRS.class);
+        assertThat(crs.getSrs()).isEqualTo("EPSG:3857");
+    }
+
+    @Test
+    void testFeatureTypeInfo_with_nativeCRS() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "FeatureTypeInfo",
+                  "id": "ft2",
+                  "name": "testFt",
+                  "namespace": "ns1",
+                  "store": "ds1",
+                  "nativeName": "test_table",
+                  "title": "Test FT",
+                  "abstract": "Abstract text",
+                  "nativeCRS": {
+                    "srs": "EPSG:4326",
+                    "wkt": "GEOGCS[\\"WGS 84\\"]"
+                  },
+                  "srs": "EPSG:4326",
+                  "enabled": true,
+                  "serviceConfiguration": false,
+                  "maxFeatures": 0,
+                  "numDecimals": 0,
+                  "padWithZeros": false,
+                  "forcedDecimal": false,
+                  "overridingServiceSRS": false,
+                  "skipNumberMatched": false,
+                  "circularArcPresent": false,
+                  "encodeMeasures": false
+                }
+                """;
+        FeatureTypeInfo ft = decode(json, FeatureTypeInfo.class);
+        assertThat(ft.getAbstract()).isEqualTo("Abstract text");
+        assertThat(ft.getSRS()).isEqualTo("EPSG:4326");
+        assertThat(ft.getNativeCRS()).isNotNull();
+    }
+
+    @Test
+    void testFeatureTypeInfo_with_keywords_and_metadata() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "FeatureTypeInfo",
+                  "id": "ft3",
+                  "name": "testFt",
+                  "namespace": "ns1",
+                  "store": "ds1",
+                  "nativeName": "test_table",
+                  "title": "Test FT",
+                  "abstract": "My abstract",
+                  "keywords": [
+                    {"value": "keyword1", "language": "en"},
+                    {"value": "keyword2"}
+                  ],
+                  "srs": "EPSG:4326",
+                  "enabled": true,
+                  "serviceConfiguration": false,
+                  "metadata": {
+                    "MetadataMap": {
+                      "k1": {
+                        "Literal": {
+                          "type": "java.lang.String",
+                          "value": "v1"
+                        }
+                      }
+                    }
+                  },
+                  "maxFeatures": 0,
+                  "numDecimals": 0,
+                  "padWithZeros": false,
+                  "forcedDecimal": false,
+                  "overridingServiceSRS": false,
+                  "skipNumberMatched": false,
+                  "circularArcPresent": false,
+                  "encodeMeasures": false
+                }
+                """;
+        FeatureTypeInfo ft = decode(json, FeatureTypeInfo.class);
+        assertThat(ft.getAbstract()).isEqualTo("My abstract");
+        assertThat(ft.getKeywords()).hasSize(2);
+        assertThat(ft.getMetadata()).containsKey("k1");
+    }
+
+    @Test
+    void testNativeFilter_native() throws Exception {
+        String json =
+                """
+                {
+                  "NativeFilter": {
+                    "native": "SELECT * FROM test"
+                  }
+                }
+                """;
+        org.geotools.jackson.databind.filter.dto.Filter filter =
+                decode(json, org.geotools.jackson.databind.filter.dto.Filter.class);
+        assertFilterIsNative(filter, "SELECT * FROM test");
+    }
+
+    @Test
+    void testLayerGroupInfo_with_internationalStrings() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "LayerGroupInfo",
+                  "id": "lg2",
+                  "name": "i18nLg",
+                  "title": "LG Title",
+                  "abstract": "LG Abstract",
+                  "enabled": true,
+                  "advertised": true,
+                  "mode": "SINGLE",
+                  "layers": ["layer1"],
+                  "styles": ["style1"],
+                  "internationalTitle": {
+                    "en": "English Title",
+                    "fr": "French Title"
+                  },
+                  "internationalAbstract": {
+                    "en": "English Abstract",
+                    "fr": "French Abstract"
+                  }
+                }
+                """;
+        LayerGroupInfo lg = decode(json, LayerGroupInfo.class);
+        assertThat(lg.getAbstract()).isEqualTo("LG Abstract");
+    }
+
+    @Test
+    void testCoverageInfo_with_grid() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "CoverageInfo",
+                  "id": "cov2",
+                  "name": "testCov",
+                  "namespace": "ns1",
+                  "store": "cs1",
+                  "nativeName": "test_cov",
+                  "title": "Test Coverage",
+                  "abstract": "Coverage abstract",
+                  "srs": "EPSG:4326",
+                  "enabled": true,
+                  "serviceConfiguration": false,
+                  "nativeFormat": "GeoTIFF",
+                  "grid": {
+                    "low": [0, 0],
+                    "high": [1024, 768],
+                    "transform": [0.3515625, 0.0, 0.0, -0.234375, -179.82421875, 89.8828125],
+                    "crs": {
+                      "srs": "EPSG:4326"
+                    }
+                  }
+                }
+                """;
+        CoverageInfo c = decode(json, CoverageInfo.class);
+        assertThat(c.getAbstract()).isEqualTo("Coverage abstract");
+        assertThat(c.getSRS()).isEqualTo("EPSG:4326");
+        assertThat(c.getNativeFormat()).isEqualTo("GeoTIFF");
+    }
+
+    @Test
+    void testCoverageStoreInfo_url_with_metadata() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "CoverageStoreInfo",
+                  "id": "cs2",
+                  "name": "testCs",
+                  "workspace": "ws1",
+                  "enabled": true,
+                  "connectionParameters": {},
+                  "disableOnConnFailure": false,
+                  "url": "file:///data/raster.tif",
+                  "metadata": {
+                    "MetadataMap": {
+                      "indexingEnabled": {
+                        "Literal": {
+                          "type": "java.lang.Boolean",
+                          "value": "true"
+                        }
+                      }
+                    }
+                  }
+                }
+                """;
+        CoverageStoreInfo cs = decode(json, CoverageStoreInfo.class);
+        assertThat(cs.getURL()).isEqualTo("file:///data/raster.tif");
+        assertThat(cs.getMetadata()).containsKey("indexingEnabled");
+    }
+}

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/PatchSerializationBackwardsCompatibilityTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/PatchSerializationBackwardsCompatibilityTest.java
@@ -1,0 +1,419 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.jackson.databind.catalog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.geoserver.catalog.AttributionInfo;
+import org.geoserver.catalog.CoverageStoreInfo;
+import org.geoserver.catalog.DimensionInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.PublishedType;
+import org.geoserver.catalog.plugin.Patch;
+import org.geoserver.config.ContactInfo;
+import org.geoserver.config.ServiceInfo;
+import org.geoserver.jackson.databind.catalog.dto.InfoReference;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that hardcoded JSON produced by Jackson 2's property naming convention can be
+ * deserialized correctly into {@link Patch} objects. This ensures backwards compatibility when
+ * upgrading to Jackson 3.
+ *
+ * <p>Each test uses a hardcoded JSON text block captured from Jackson 2 serialization output, then
+ * calls {@link #decode(String, Class)} to verify deserialization.
+ *
+ * <p>Note: CatalogInfo and ServiceInfo objects used as Patch values are encoded as {@link
+ * InfoReference} (by type and id), not as full objects. After deserialization, these are converted
+ * to proxy Info objects by the {@link org.geoserver.jackson.databind.mapper.PatchMapper}.
+ */
+class PatchSerializationBackwardsCompatibilityTest extends BackwardsCompatibilityTestSupport {
+
+    @Test
+    void patchWithSimpleStringValue() throws Exception {
+        String json =
+                """
+                {
+                  "Patch": {
+                    "patches": [{
+                      "name": "abstract",
+                      "value": {
+                        "Literal": {
+                          "type": "java.lang.String",
+                          "value": "Test abstract value"
+                        }
+                      }
+                    }]
+                  }
+                }
+                """;
+        Patch patch = decode(json, Patch.class);
+        assertThat(patch.getPropertyNames()).containsExactly("abstract");
+        assertThat(patch.getValue("abstract")).hasValue("Test abstract value");
+    }
+
+    @Test
+    void patchWithListOfStrings() throws Exception {
+        String json =
+                """
+                {
+                  "Patch": {
+                    "patches": [{
+                      "name": "srs",
+                      "value": {
+                        "Literal": {
+                          "type": "java.util.List",
+                          "contentType": "java.lang.String",
+                          "value": ["EPSG:4326", "EPSG:3857"]
+                        }
+                      }
+                    }]
+                  }
+                }
+                """;
+        Patch patch = decode(json, Patch.class);
+        assertThat(patch.getPropertyNames()).containsExactly("srs");
+        assertThat(patch.getValue("srs")).hasValue(List.of("EPSG:4326", "EPSG:3857"));
+    }
+
+    @Test
+    void patchWithEnumValue() throws Exception {
+        String json =
+                """
+                {
+                  "Patch": {
+                    "patches": [{
+                      "name": "type",
+                      "value": {
+                        "Literal": {
+                          "type": "org.geoserver.catalog.PublishedType",
+                          "value": "VECTOR"
+                        }
+                      }
+                    }]
+                  }
+                }
+                """;
+        Patch patch = decode(json, Patch.class);
+        assertThat(patch.getPropertyNames()).containsExactly("type");
+        assertThat(patch.getValue("type")).hasValue(PublishedType.VECTOR);
+    }
+
+    @Test
+    void patchWithFeatureTypeInfo_encodedAsReference() throws Exception {
+        String json =
+                """
+                {
+                  "Patch": {
+                    "patches": [{
+                      "name": "resource",
+                      "value": {
+                        "Literal": {
+                          "type": "org.geoserver.jackson.databind.catalog.dto.InfoReference",
+                          "value": {
+                            "type": "FEATURETYPE",
+                            "id": "ft1"
+                          }
+                        }
+                      }
+                    }]
+                  }
+                }
+                """;
+        Patch patch = decode(json, Patch.class);
+        assertThat(patch.getPropertyNames()).containsExactly("resource");
+        assertThat(patch.getValue("resource").orElseThrow()).isInstanceOf(FeatureTypeInfo.class);
+    }
+
+    @Test
+    void patchWithNamespaceInfo_encodedAsReference() throws Exception {
+        String json =
+                """
+                {
+                  "Patch": {
+                    "patches": [{
+                      "name": "namespace",
+                      "value": {
+                        "Literal": {
+                          "type": "org.geoserver.jackson.databind.catalog.dto.InfoReference",
+                          "value": {
+                            "type": "NAMESPACE",
+                            "id": "ns1"
+                          }
+                        }
+                      }
+                    }]
+                  }
+                }
+                """;
+        Patch patch = decode(json, Patch.class);
+        assertThat(patch.getPropertyNames()).containsExactly("namespace");
+        assertThat(patch.getValue("namespace").orElseThrow()).isInstanceOf(NamespaceInfo.class);
+    }
+
+    @Test
+    void patchWithCoverageStoreInfo_encodedAsReference() throws Exception {
+        String json =
+                """
+                {
+                  "Patch": {
+                    "patches": [{
+                      "name": "store",
+                      "value": {
+                        "Literal": {
+                          "type": "org.geoserver.jackson.databind.catalog.dto.InfoReference",
+                          "value": {
+                            "type": "COVERAGESTORE",
+                            "id": "cs1"
+                          }
+                        }
+                      }
+                    }]
+                  }
+                }
+                """;
+        Patch patch = decode(json, Patch.class);
+        assertThat(patch.getPropertyNames()).containsExactly("store");
+        assertThat(patch.getValue("store").orElseThrow()).isInstanceOf(CoverageStoreInfo.class);
+    }
+
+    @Test
+    void patchWithLayerInfo_encodedAsReference() throws Exception {
+        String json =
+                """
+                {
+                  "Patch": {
+                    "patches": [{
+                      "name": "layer",
+                      "value": {
+                        "Literal": {
+                          "type": "org.geoserver.jackson.databind.catalog.dto.InfoReference",
+                          "value": {
+                            "type": "LAYER",
+                            "id": "layer1"
+                          }
+                        }
+                      }
+                    }]
+                  }
+                }
+                """;
+        Patch patch = decode(json, Patch.class);
+        assertThat(patch.getPropertyNames()).containsExactly("layer");
+        assertThat(patch.getValue("layer").orElseThrow()).isInstanceOf(LayerInfo.class);
+    }
+
+    @Test
+    void patchWithMetadataMap() throws Exception {
+        String json =
+                """
+                {
+                  "Patch": {
+                    "patches": [{
+                      "name": "metadata",
+                      "value": {
+                        "Literal": {
+                          "type": "java.util.Map",
+                          "value": {
+                            "k1": {
+                              "Literal": {
+                                "type": "java.lang.String",
+                                "value": "v1"
+                              }
+                            },
+                            "k2": {
+                              "Literal": {
+                                "type": "java.lang.String",
+                                "value": "v2"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }]
+                  }
+                }
+                """;
+        Patch patch = decode(json, Patch.class);
+        assertThat(patch.getPropertyNames()).containsExactly("metadata");
+        Object value = patch.getValue("metadata").orElseThrow();
+        assertThat(value).isInstanceOf(Map.class);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = (Map<String, Object>) value;
+        assertThat(map).containsEntry("k1", "v1").containsEntry("k2", "v2");
+    }
+
+    @Test
+    void patchWithWmsServiceInfo_encodedAsReference() throws Exception {
+        String json =
+                """
+                {
+                  "Patch": {
+                    "patches": [{
+                      "name": "wmsService",
+                      "value": {
+                        "Literal": {
+                          "type": "org.geoserver.jackson.databind.catalog.dto.InfoReference",
+                          "value": {
+                            "type": "SERVICE",
+                            "id": "wms-id"
+                          }
+                        }
+                      }
+                    }]
+                  }
+                }
+                """;
+        Patch patch = decode(json, Patch.class);
+        assertThat(patch.getPropertyNames()).containsExactly("wmsService");
+        assertThat(patch.getValue("wmsService").orElseThrow()).isInstanceOf(ServiceInfo.class);
+    }
+
+    @Test
+    void patchWithWfsServiceInfo_encodedAsReference() throws Exception {
+        String json =
+                """
+                {
+                  "Patch": {
+                    "patches": [{
+                      "name": "wfsService",
+                      "value": {
+                        "Literal": {
+                          "type": "org.geoserver.jackson.databind.catalog.dto.InfoReference",
+                          "value": {
+                            "type": "SERVICE",
+                            "id": "wfs-id"
+                          }
+                        }
+                      }
+                    }]
+                  }
+                }
+                """;
+        Patch patch = decode(json, Patch.class);
+        assertThat(patch.getPropertyNames()).containsExactly("wfsService");
+        assertThat(patch.getValue("wfsService").orElseThrow()).isInstanceOf(ServiceInfo.class);
+    }
+
+    @Test
+    void patchWithDimensionInfo() throws Exception {
+        String json =
+                """
+                {
+                  "Patch": {
+                    "patches": [{
+                      "name": "dimensionInfo",
+                      "value": {
+                        "Literal": {
+                          "type": "org.geoserver.catalog.DimensionInfo",
+                          "value": {
+                            "enabled": true,
+                            "attribute": "attribute",
+                            "presentation": "DISCRETE_INTERVAL",
+                            "resolution": 222.4066,
+                            "units": "metre",
+                            "unitSymbol": "m",
+                            "nearestMatchEnabled": false,
+                            "rawNearestMatchEnabled": false,
+                            "acceptableInterval": "searchRange",
+                            "defaultValueStrategy": "MAXIMUM",
+                            "defaultValueReferenceValue": "referenceValue"
+                          }
+                        }
+                      }
+                    }]
+                  }
+                }
+                """;
+        Patch patch = decode(json, Patch.class);
+        assertThat(patch.getPropertyNames()).containsExactly("dimensionInfo");
+        Object value = patch.getValue("dimensionInfo").orElseThrow();
+        assertThat(value).isInstanceOf(DimensionInfo.class);
+        DimensionInfo dim = (DimensionInfo) value;
+        assertThat(dim.isEnabled()).isTrue();
+        assertThat(dim.getAttribute()).isEqualTo("attribute");
+        assertThat(dim.getUnits()).isEqualTo("metre");
+    }
+
+    @Test
+    void patchWithContactInfo() throws Exception {
+        String json =
+                """
+                {
+                  "Patch": {
+                    "patches": [{
+                      "name": "contact",
+                      "value": {
+                        "Literal": {
+                          "type": "org.geoserver.config.ContactInfo",
+                          "value": {
+                            "id": "contact-1",
+                            "address": "123 Main St",
+                            "addressCity": "Springfield",
+                            "addressCountry": "US",
+                            "addressDeliveryPoint": "Suite 100",
+                            "addressPostalCode": "12345",
+                            "addressState": "IL",
+                            "contactFacsimile": "555-0102",
+                            "contactOrganization": "Test Org",
+                            "contactPerson": "John Doe",
+                            "contactVoice": "555-0101",
+                            "onlineResource": "www.example.com"
+                          }
+                        }
+                      }
+                    }]
+                  }
+                }
+                """;
+        Patch patch = decode(json, Patch.class);
+        assertThat(patch.getPropertyNames()).containsExactly("contact");
+        Object value = patch.getValue("contact").orElseThrow();
+        assertThat(value).isInstanceOf(ContactInfo.class);
+        ContactInfo contact = (ContactInfo) value;
+        assertThat(contact.getContactPerson()).isEqualTo("John Doe");
+        assertThat(contact.getContactOrganization()).isEqualTo("Test Org");
+        assertThat(contact.getAddressCity()).isEqualTo("Springfield");
+    }
+
+    @Test
+    void patchWithAttributionInfo() throws Exception {
+        String json =
+                """
+                {
+                  "Patch": {
+                    "patches": [{
+                      "name": "attribution",
+                      "value": {
+                        "Literal": {
+                          "type": "org.geoserver.catalog.impl.AttributionInfoImpl",
+                          "value": {
+                            "id": "attr-1",
+                            "title": "Test Attribution",
+                            "href": "www.example.com",
+                            "logoWidth": 345,
+                            "logoHeight": 327
+                          }
+                        }
+                      }
+                    }]
+                  }
+                }
+                """;
+        Patch patch = decode(json, Patch.class);
+        assertThat(patch.getPropertyNames()).containsExactly("attribution");
+        Object value = patch.getValue("attribution").orElseThrow();
+        assertThat(value).isInstanceOf(AttributionInfo.class);
+        AttributionInfo attr = (AttributionInfo) value;
+        assertThat(attr.getTitle()).isEqualTo("Test Attribution");
+        assertThat(attr.getLogoWidth()).isEqualTo(345);
+        assertThat(attr.getLogoHeight()).isEqualTo(327);
+    }
+}

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/config/GeoServerConfigModuleBackwardsCompatibilityTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/config/GeoServerConfigModuleBackwardsCompatibilityTest.java
@@ -1,0 +1,379 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.jackson.databind.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.geoserver.config.ContactInfo;
+import org.geoserver.config.GeoServerInfo;
+import org.geoserver.config.LoggingInfo;
+import org.geoserver.config.SettingsInfo;
+import org.geoserver.jackson.databind.catalog.BackwardsCompatibilityTestSupport;
+import org.geoserver.wcs.WCSInfo;
+import org.geoserver.wfs.WFSInfo;
+import org.geoserver.wms.WMSInfo;
+import org.geoserver.wps.WPSInfo;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that JSON produced by Jackson 2's property naming convention can be deserialized for
+ * GeoServer configuration objects. Tests focus on fields where Jackson 2's {@code
+ * legacyManglePropertyName} lowercases leading uppercase characters.
+ *
+ * <p>Key Jackson 2 property name mappings tested:
+ *
+ * <ul>
+ *   <li>{@code Service.Abstract} &rarr; {@code "abstract"}
+ *   <li>{@code WmsService.SRS} &rarr; {@code "srs"}
+ *   <li>{@code WmsService.BBOXForEachCRS} &rarr; {@code "bboxforEachCRS"}
+ *   <li>{@code WmsService.GetMapMimeTypes} &rarr; {@code "getMapMimeTypes"}
+ *   <li>{@code WmsService.GetMapMimeTypeCheckingEnabled} &rarr; {@code
+ *       "getMapMimeTypeCheckingEnabled"}
+ *   <li>{@code WmsService.GetFeatureInfoMimeTypes} &rarr; {@code "getFeatureInfoMimeTypes"}
+ *   <li>{@code WmsService.GetFeatureInfoMimeTypeCheckingEnabled} &rarr; {@code
+ *       "getFeatureInfoMimeTypeCheckingEnabled"}
+ *   <li>{@code WfsService.GML} &rarr; {@code "gml"}
+ *   <li>{@code WfsService.SRS} &rarr; {@code "srs"}
+ *   <li>{@code WcsService.GMLPrefixing} &rarr; {@code "gmlprefixing"}
+ *   <li>{@code WcsService.LatLon} &rarr; {@code "latLon"}
+ *   <li>{@code WcsService.SRS} &rarr; {@code "srs"}
+ * </ul>
+ */
+class GeoServerConfigModuleBackwardsCompatibilityTest extends BackwardsCompatibilityTestSupport {
+
+    @Test
+    void testGeoServerInfo() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "GeoServerInfo",
+                  "id": "gs1",
+                  "settings": {
+                    "@type": "SettingsInfo",
+                    "id": "settings1",
+                    "title": "GeoServer",
+                    "charset": "UTF-8",
+                    "numDecimals": 8,
+                    "verbose": false,
+                    "verboseExceptions": false,
+                    "localWorkspaceIncludesPrefix": false,
+                    "showCreatedTimeColumnsInAdminList": false,
+                    "showModifiedTimeColumnsInAdminList": false,
+                    "useHeadersProxyURL": false,
+                    "isShowModifiedUserInAdminList": false
+                  },
+                  "updateSequence": 0,
+                  "featureTypeCacheSize": 0,
+                  "globalServices": true,
+                  "trailingSlashMatch": false
+                }
+                """;
+        GeoServerInfo gs = decode(json, GeoServerInfo.class);
+        assertThat(gs.getSettings()).isNotNull();
+        assertThat(gs.getSettings().getTitle()).isEqualTo("GeoServer");
+    }
+
+    @Test
+    void testSettingsInfo() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "SettingsInfo",
+                  "id": "settings2",
+                  "title": "Test Settings",
+                  "charset": "UTF-8",
+                  "numDecimals": 4,
+                  "verbose": false,
+                  "verboseExceptions": false,
+                  "localWorkspaceIncludesPrefix": false,
+                  "showCreatedTimeColumnsInAdminList": false,
+                  "showModifiedTimeColumnsInAdminList": false,
+                  "useHeadersProxyURL": false,
+                  "isShowModifiedUserInAdminList": false
+                }
+                """;
+        SettingsInfo settings = decode(json, SettingsInfo.class);
+        assertThat(settings.getTitle()).isEqualTo("Test Settings");
+        assertThat(settings.getCharset()).isEqualTo("UTF-8");
+    }
+
+    @Test
+    void testContactInfo() throws Exception {
+        String json =
+                """
+                {
+                  "contactOrganization": "Test Org",
+                  "contactPerson": "John Doe",
+                  "contactEmail": "john@test.org",
+                  "contactVoice": "+1-555-0123",
+                  "address": "123 Test St",
+                  "addressCity": "Test City",
+                  "addressCountry": "US"
+                }
+                """;
+        ContactInfo contact = decode(json, ContactInfo.class);
+        assertThat(contact.getContactOrganization()).isEqualTo("Test Org");
+        assertThat(contact.getContactPerson()).isEqualTo("John Doe");
+    }
+
+    @Test
+    void testLoggingInfo() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "LoggingInfo",
+                  "id": "log1",
+                  "level": "DEFAULT_LOGGING.properties",
+                  "location": "logs/geoserver.log",
+                  "stdOutLogging": true
+                }
+                """;
+        LoggingInfo logging = decode(json, LoggingInfo.class);
+        assertThat(logging.getLevel()).isEqualTo("DEFAULT_LOGGING.properties");
+        assertThat(logging.isStdOutLogging()).isTrue();
+    }
+
+    @Test
+    void testWmsServiceInfo_abstract_and_srs() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "WMSInfo",
+                  "id": "wms1",
+                  "name": "WMS",
+                  "title": "GeoServer WMS",
+                  "citeCompliant": false,
+                  "enabled": true,
+                  "verbose": false,
+                  "srs": ["EPSG:4326", "EPSG:3857"],
+                  "maxBuffer": 0,
+                  "maxRequestMemory": 0,
+                  "maxRenderingTime": 0,
+                  "maxRenderingErrors": 0,
+                  "featuresReprojectionDisabled": false,
+                  "maxRequestedDimensionValues": 0,
+                  "remoteStyleMaxRequestTime": 0,
+                  "remoteStyleTimeout": 0,
+                  "defaultGroupStyleEnabled": false,
+                  "autoEscapeTemplateValues": false,
+                  "dynamicStylingDisabled": false,
+                  "transformFeatureInfoDisabled": false,
+                  "abstract": "A WMS service"
+                }
+                """;
+        WMSInfo wms = decode(json, WMSInfo.class);
+        assertThat(wms.getAbstract()).isEqualTo("A WMS service");
+        assertThat(wms.getSRS()).containsExactly("EPSG:4326", "EPSG:3857");
+    }
+
+    @Test
+    void testWmsServiceInfo_bboxForEachCRS() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "WMSInfo",
+                  "id": "wms2",
+                  "name": "WMS",
+                  "enabled": true,
+                  "citeCompliant": false,
+                  "verbose": false,
+                  "bboxforEachCRS": true,
+                  "maxBuffer": 0,
+                  "maxRequestMemory": 0,
+                  "maxRenderingTime": 0,
+                  "maxRenderingErrors": 0,
+                  "featuresReprojectionDisabled": false,
+                  "maxRequestedDimensionValues": 0,
+                  "remoteStyleMaxRequestTime": 0,
+                  "remoteStyleTimeout": 0,
+                  "defaultGroupStyleEnabled": false,
+                  "autoEscapeTemplateValues": false,
+                  "dynamicStylingDisabled": false,
+                  "transformFeatureInfoDisabled": false
+                }
+                """;
+        WMSInfo wms = decode(json, WMSInfo.class);
+        assertThat(wms.isBBOXForEachCRS()).isTrue();
+    }
+
+    @Test
+    void testWmsServiceInfo_getMapMimeTypes() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "WMSInfo",
+                  "id": "wms3",
+                  "name": "WMS",
+                  "enabled": true,
+                  "citeCompliant": false,
+                  "verbose": false,
+                  "getMapMimeTypeCheckingEnabled": true,
+                  "getMapMimeTypes": ["image/png", "image/jpeg"],
+                  "getFeatureInfoMimeTypeCheckingEnabled": true,
+                  "getFeatureInfoMimeTypes": ["text/html", "application/json"],
+                  "maxBuffer": 0,
+                  "maxRequestMemory": 0,
+                  "maxRenderingTime": 0,
+                  "maxRenderingErrors": 0,
+                  "featuresReprojectionDisabled": false,
+                  "maxRequestedDimensionValues": 0,
+                  "remoteStyleMaxRequestTime": 0,
+                  "remoteStyleTimeout": 0,
+                  "defaultGroupStyleEnabled": false,
+                  "autoEscapeTemplateValues": false,
+                  "dynamicStylingDisabled": false,
+                  "transformFeatureInfoDisabled": false
+                }
+                """;
+        WMSInfo wms = decode(json, WMSInfo.class);
+        assertThat(wms.isGetMapMimeTypeCheckingEnabled()).isTrue();
+        assertThat(wms.getGetMapMimeTypes()).contains("image/png", "image/jpeg");
+        assertThat(wms.isGetFeatureInfoMimeTypeCheckingEnabled()).isTrue();
+        assertThat(wms.getGetFeatureInfoMimeTypes()).contains("text/html", "application/json");
+    }
+
+    @Test
+    void testWfsServiceInfo_abstract_gml_srs() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "WFSInfo",
+                  "id": "wfs1",
+                  "name": "WFS",
+                  "title": "GeoServer WFS",
+                  "citeCompliant": false,
+                  "enabled": true,
+                  "verbose": false,
+                  "maxFeatures": 0,
+                  "featureBounding": false,
+                  "canonicalSchemaLocation": false,
+                  "encodeFeatureMember": false,
+                  "hitsIgnoreMaxFeatures": false,
+                  "includeWFSRequestDumpFile": false,
+                  "simpleConversionEnabled": false,
+                  "getFeatureOutputTypeCheckingEnabled": false,
+                  "disableStoredQueriesManagement": false,
+                  "gml": {
+                    "V_10": {
+                      "srsNameStyle": "XML",
+                      "overrideGMLAttributes": false
+                    },
+                    "V_20": {
+                      "srsNameStyle": "URN2",
+                      "overrideGMLAttributes": false
+                    }
+                  },
+                  "srs": ["EPSG:4326", "EPSG:3857"],
+                  "abstract": "A WFS service"
+                }
+                """;
+        WFSInfo wfs = decode(json, WFSInfo.class);
+        assertThat(wfs.getAbstract()).isEqualTo("A WFS service");
+        assertThat(wfs.getGML()).isNotNull();
+        assertThat(wfs.getGML()).containsKey(WFSInfo.Version.V_10);
+        assertThat(wfs.getGML()).containsKey(WFSInfo.Version.V_20);
+        assertThat(wfs.getSRS()).containsExactly("EPSG:4326", "EPSG:3857");
+    }
+
+    @Test
+    void testWcsServiceInfo_abstract_gmlprefixing_latlon_srs() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "WCSInfo",
+                  "id": "wcs1",
+                  "name": "WCS",
+                  "title": "GeoServer WCS",
+                  "citeCompliant": false,
+                  "enabled": true,
+                  "verbose": false,
+                  "maxInputMemory": 0,
+                  "maxOutputMemory": 0,
+                  "subsamplingEnabled": false,
+                  "maxRequestedDimensionValues": 0,
+                  "defaultDeflateCompressionLevel": 0,
+                  "gmlprefixing": true,
+                  "latLon": true,
+                  "srs": ["EPSG:4326", "EPSG:3857"],
+                  "abstract": "A WCS service"
+                }
+                """;
+        WCSInfo wcs = decode(json, WCSInfo.class);
+        assertThat(wcs.getAbstract()).isEqualTo("A WCS service");
+        assertThat(wcs.isGMLPrefixing()).isTrue();
+        assertThat(wcs.isLatLon()).isTrue();
+        assertThat(wcs.getSRS()).containsExactly("EPSG:4326", "EPSG:3857");
+    }
+
+    @Test
+    void testWpsServiceInfo_abstract() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "WPSInfo",
+                  "id": "wps1",
+                  "name": "WPS",
+                  "title": "GeoServer WPS",
+                  "citeCompliant": false,
+                  "enabled": true,
+                  "verbose": false,
+                  "connectionTimeout": 0.0,
+                  "resourceExpirationTimeout": 0,
+                  "maxSynchronousProcesses": 1,
+                  "maxAsynchronousProcesses": 1,
+                  "maxComplexInputSize": 0,
+                  "maxAsynchronousExecutionTime": 0,
+                  "maxSynchronousExecutionTime": 0,
+                  "remoteInputDisabled": false,
+                  "abstract": "A WPS service"
+                }
+                """;
+        WPSInfo wps = decode(json, WPSInfo.class);
+        assertThat(wps.getAbstract()).isEqualTo("A WPS service");
+        assertThat(wps.getName()).isEqualTo("WPS");
+    }
+
+    @Test
+    void testWmsServiceInfo_full() throws Exception {
+        String json =
+                """
+                {
+                  "@type": "WMSInfo",
+                  "id": "wms4",
+                  "name": "WMS",
+                  "title": "GeoServer WMS",
+                  "citeCompliant": false,
+                  "enabled": true,
+                  "verbose": false,
+                  "srs": ["EPSG:4326", "EPSG:3857", "EPSG:900913"],
+                  "getMapMimeTypeCheckingEnabled": true,
+                  "getMapMimeTypes": ["image/png", "image/jpeg", "image/gif"],
+                  "getFeatureInfoMimeTypeCheckingEnabled": false,
+                  "bboxforEachCRS": false,
+                  "maxBuffer": 25,
+                  "maxRequestMemory": 65536,
+                  "maxRenderingTime": 60,
+                  "maxRenderingErrors": 1000,
+                  "featuresReprojectionDisabled": false,
+                  "maxRequestedDimensionValues": 100,
+                  "remoteStyleMaxRequestTime": 60000,
+                  "remoteStyleTimeout": 30000,
+                  "defaultGroupStyleEnabled": true,
+                  "autoEscapeTemplateValues": true,
+                  "dynamicStylingDisabled": false,
+                  "transformFeatureInfoDisabled": false,
+                  "abstract": "Full WMS test"
+                }
+                """;
+        WMSInfo wms = decode(json, WMSInfo.class);
+        assertThat(wms.getAbstract()).isEqualTo("Full WMS test");
+        assertThat(wms.getSRS()).hasSize(3);
+        assertThat(wms.isGetMapMimeTypeCheckingEnabled()).isTrue();
+        assertThat(wms.getGetMapMimeTypes()).hasSize(3);
+        assertThat(wms.isBBOXForEachCRS()).isFalse();
+        assertThat(wms.getMaxBuffer()).isEqualTo(25);
+    }
+}


### PR DESCRIPTION
These tests verify that JSON produced by Jackson 2's legacyManglePropertyName behavior (which lowercases leading uppercase field names) deserializes correctly. They use hardcoded JSON text blocks with the known Jackson 2 property names (e.g., "abstract" for Abstract, "srs" for SRS, "uri" for URI, "url" for URL, "wkt" for WKT, "gml" for GML, "gmlprefixing" for GMLPrefixing, etc.).

This establishes a baseline for wire-format compatibility so that when upgrading to Jackson 3 (which preserves field casing), @JsonProperty annotations can be added to the DTOs with confidence that the tests catch any regressions.