### PR TITLE
[Backport release/2.28.x] Backwards compat serialization for GeoServerTileLayerInfo after [GEOS-12049]: Remove GWC-in memory support

### DIFF
--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/repository/ResourceStoreTileLayerCatalog.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/repository/ResourceStoreTileLayerCatalog.java
@@ -340,6 +340,8 @@ public class ResourceStoreTileLayerCatalog implements TileLayerCatalog {
         xstream.allowTypes(new String[] {"java.util.Collections$UnmodifiableSet"});
         xstream.addDefaultImplementation(LinkedHashSet.class, Set.class);
         xstream.alias("warning", DimensionWarning.WarningType.class);
+        xstream.ignoreUnknownElements();
+
         return xstream;
     }
 }

--- a/src/gwc/core/src/main/java/org/geoserver/gwc/config/CloudGwcConfigPersister.java
+++ b/src/gwc/core/src/main/java/org/geoserver/gwc/config/CloudGwcConfigPersister.java
@@ -101,5 +101,6 @@ public class CloudGwcConfigPersister extends GWCConfigPersister {
         xs.ignoreUnknownElements("InnerCacheConfiguration");
         xs.allowTypes(new Class[] {GWCConfig.class, DimensionWarning.WarningType.class});
         xs.addDefaultImplementation(LinkedHashSet.class, Set.class);
+        xs.ignoreUnknownElements();
     }
 }


### PR DESCRIPTION
Backport #779
 **Authored by:** @groldan