### PR TITLE
build: allow running scripts from the root directory checkout

### DIFF
--- a/acceptance_tests/run_tests_locally.sh
+++ b/acceptance_tests/run_tests_locally.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+set -e
+# Change to the directory where the script is located
+cd "$(dirname "$0")"
 
 virtualenv -q .venv/
 source .venv/bin/activate

--- a/compose/acceptance_datadir
+++ b/compose/acceptance_datadir
@@ -1,4 +1,7 @@
-#/bin/bash
+#!/bin/bash
+set -e
+# Change to the directory where the script is located
+cd "$(dirname "$0")"
 
 GSUID=$(id -u)
 GSGID=$(id -g)

--- a/compose/acceptance_pgconfig
+++ b/compose/acceptance_pgconfig
@@ -1,4 +1,7 @@
-#/bin/bash
+#!/bin/bash
+set -e
+# Change to the directory where the script is located
+cd "$(dirname "$0")"
 
 GSUID=$(id -u)
 GSGID=$(id -g)

--- a/compose/datadir
+++ b/compose/datadir
@@ -1,4 +1,7 @@
-#/bin/sh
+#!/bin/sh
+set -e
+# Change to the directory where the script is located
+cd "$(dirname "$0")"
 
 mkdir -p catalog-datadir
 
@@ -6,4 +9,4 @@ GSUID=$(id -u)
 GSGID=$(id -g)
 
 GS_USER="$GSUID:$GSGID" \
-docker compose -f compose.yml -f catalog-datadir.yml $@
+docker compose -f compose.yml -f catalog-datadir.yml "$@"

--- a/compose/pgconfig
+++ b/compose/pgconfig
@@ -1,7 +1,10 @@
-#/bin/sh
+#!/bin/sh
+set -e
+# Change to the directory where the script is located
+cd "$(dirname "$0")"
 
 GSUID=$(id -u)
 GSGID=$(id -g)
 
 GS_USER="$GSUID:$GSGID" \
-docker compose -f compose.yml -f catalog-pgconfig.yml $@
+docker compose -f compose.yml -f catalog-pgconfig.yml "$@"

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -10,6 +10,9 @@ BANNER_MESSAGE="$2"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VENV_DIR="${SCRIPT_DIR}/.venv"
 
+# Change to the directory where the script is located
+cd "${SCRIPT_DIR}"
+
 echo "🏗️  Building GeoServer Cloud Documentation"
 echo "=========================================="
 

--- a/docs/clean.sh
+++ b/docs/clean.sh
@@ -6,6 +6,9 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Change to the directory where the script is located
+cd "${SCRIPT_DIR}"
+
 echo "🧹 Cleaning GeoServer Cloud Documentation"
 echo "========================================="
 

--- a/docs/serve.sh
+++ b/docs/serve.sh
@@ -9,6 +9,9 @@ BANNER_MESSAGE="$1"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VENV_DIR="${SCRIPT_DIR}/.venv"
 
+# Change to the directory where the script is located
+cd "${SCRIPT_DIR}"
+
 echo "🌐 Starting GeoServer Cloud Documentation Server"
 echo "================================================"
 


### PR DESCRIPTION
Update utility scripts to change their working directory to their respective locations before execution, allowing them to be run from any directory (e.g., ./compose/datadir).

Added 'set -e' to several scripts to fail fast on errors.