### PR TITLE
Add JVM AOT cache training to Docker images for faster startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ build-base-images: package-base-images
 
 .PHONY: build-image-infrastructure
 build-image-infrastructure: package-infrastructure-images
-	TAG=$(TAG) docker compose -f docker-build/infrastructure.yml build
+	TAG=$(TAG) docker compose -f docker-build/infrastructure.yml build  $(filter-out $@ build-image build-image-multiplatform,$(MAKECMDGOALS))
 
 # This uses $(MAKECMDGOALS) (all targets specified) and filters out the target itself ($@), passing the rest as arguments. The %: rule tells make to ignore any unrecognized "targets" (which are actually your service names).
 # Then you can call:

--- a/compose/.env
+++ b/compose/.env
@@ -22,6 +22,6 @@ GEOSERVER_BASE_PATH=/geoserver/cloud
 # For more information, see https://cloud.spring.io/spring-cloud-config/multi/multi__spring_cloud_config_server.html#_git_backend
 CONFIG_SERVER_DEFAULT_PROFILES=${LOGGING_PROFILE},native
 
-JAVA_OPTS_DEFAULT=-XshowSettings:system -Dlogging.config=file:/etc/geoserver/logback-spring.xml
+JAVA_OPTS_DEFAULT=-Xlog:aot -XshowSettings:system -Dlogging.config=file:/etc/geoserver/logback-spring.xml
 
-JAVA_OPTS_GEOSERVER=$JAVA_OPTS_DEFAULT -Dcontrol-flow=true
+JAVA_OPTS_GEOSERVER=$JAVA_OPTS_DEFAULT

--- a/compose/compose.yml
+++ b/compose/compose.yml
@@ -58,10 +58,10 @@ services:
       #- SPRING_PROFILES_ACTIVE=logging_debug,logging_debug_events
     depends_on:
       geodatabase:
-        condition: service_started
+        condition: service_healthy
         required: true
       rabbitmq:
-        condition: service_started
+        condition: service_healthy
         required: true
     deploy:
       resources:
@@ -116,9 +116,9 @@ services:
     user: ${GS_USER}
     depends_on:
       config:
-        condition: service_started
+        condition: service_healthy
       consul:
-        condition: service_started
+        condition: service_healthy
     environment:
       JAVA_OPTS: "${JAVA_OPTS_DEFAULT}"
       # eat our own dogfood and set a base path

--- a/src/apps/base-images/jre/Dockerfile
+++ b/src/apps/base-images/jre/Dockerfile
@@ -25,6 +25,9 @@ ENV DEFAULT_JAVA_TOOL_OPTIONS="\
 -XX:+IgnoreUnrecognizedVMOptions \
 -XX:UseSVE=0"
 
+# -XX:UseSVE=0 disables Scalable Vector Extension (SVE)
+# It is currently the primary workaround for a critical compatibility bug affecting Apple M4 chips running Docker on macOS 15.2+
+
 ENV JAVA_TOOL_OPTIONS="${DEFAULT_JAVA_TOOL_OPTIONS}"
 ENV JAVA_OPTS=
 

--- a/src/apps/base-images/spring-boot/Dockerfile
+++ b/src/apps/base-images/spring-boot/Dockerfile
@@ -46,4 +46,9 @@ HEALTHCHECK \
 --retries=5 \
 CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 
-CMD exec env USER_ID="$(id -u)" USER_GID="$(id -g)" java $JAVA_OPTS org.springframework.boot.loader.launch.JarLauncher
+# JVM AOT cache support: services that run an AOT training step during image build
+# produce an app.aot cache file. At startup, -XX:AOTMode=auto tells the JVM to use
+# the cache if present, or silently continue without it.
+# Override at runtime with -e AOT_MODE=off to disable AOT for a specific container.
+ENV AOT_MODE=auto
+CMD exec java $JAVA_OPTS -XX:AOTMode=$AOT_MODE -XX:AOTCache=app.aot org.springframework.boot.loader.launch.JarLauncher

--- a/src/apps/geoserver/gwc/Dockerfile
+++ b/src/apps/geoserver/gwc/Dockerfile
@@ -20,3 +20,13 @@ COPY --from=builder spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
 COPY --from=builder application/ ./
+
+# AOT training run for faster startup (each arch builds natively, no QEMU)
+RUN GEOSERVER_DATA_DIR=/tmp/datadir && \
+ mkdir $GEOSERVER_DATA_DIR && \
+ java -XX:AOTCacheOutput=app.aot -Dspring.context.exit=onRefresh \
+  -Dgeoserver.acl.client.startupCheck=false \
+  -Dgeoserver.bus.enabled=true \
+  -Dspring.profiles.active=standalone,datadir,acl \
+  org.springframework.boot.loader.launch.JarLauncher && \
+ rm -rf /tmp/*

--- a/src/apps/geoserver/restconfig/Dockerfile
+++ b/src/apps/geoserver/restconfig/Dockerfile
@@ -20,3 +20,13 @@ COPY --from=builder spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
 COPY --from=builder application/ ./
+
+# AOT training run for faster startup (each arch builds natively, no QEMU)
+RUN GEOSERVER_DATA_DIR=/tmp/datadir && \
+ mkdir $GEOSERVER_DATA_DIR && \
+ java -XX:AOTCacheOutput=app.aot -Dspring.context.exit=onRefresh \
+  -Dgeoserver.acl.client.startupCheck=false \
+  -Dgeoserver.bus.enabled=true \
+  -Dspring.profiles.active=standalone,datadir,acl \
+  org.springframework.boot.loader.launch.JarLauncher && \
+ rm -rf /tmp/*

--- a/src/apps/geoserver/wcs/Dockerfile
+++ b/src/apps/geoserver/wcs/Dockerfile
@@ -20,3 +20,13 @@ COPY --from=builder spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
 COPY --from=builder application/ ./
+
+# AOT training run for faster startup (each arch builds natively, no QEMU)
+RUN GEOSERVER_DATA_DIR=/tmp/datadir && \
+ mkdir $GEOSERVER_DATA_DIR && \
+ java -XX:AOTCacheOutput=app.aot -Dspring.context.exit=onRefresh \
+  -Dgeoserver.acl.client.startupCheck=false \
+  -Dgeoserver.bus.enabled=true \
+  -Dspring.profiles.active=standalone,datadir,acl \
+  org.springframework.boot.loader.launch.JarLauncher && \
+ rm -rf /tmp/*

--- a/src/apps/geoserver/webui/Dockerfile
+++ b/src/apps/geoserver/webui/Dockerfile
@@ -20,3 +20,13 @@ COPY --from=builder spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
 COPY --from=builder application/ ./
+
+# AOT training run for faster startup (each arch builds natively, no QEMU)
+RUN GEOSERVER_DATA_DIR=/tmp/datadir && \
+ mkdir $GEOSERVER_DATA_DIR && \
+ java -XX:AOTCacheOutput=app.aot -Dspring.context.exit=onRefresh \
+  -Dgeoserver.acl.client.startupCheck=false \
+  -Dgeoserver.bus.enabled=true \
+  -Dspring.profiles.active=standalone,datadir,acl \
+  org.springframework.boot.loader.launch.JarLauncher && \
+ rm -rf /tmp/*

--- a/src/apps/geoserver/wfs/Dockerfile
+++ b/src/apps/geoserver/wfs/Dockerfile
@@ -20,3 +20,13 @@ COPY --from=builder spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
 COPY --from=builder application/ ./
+
+# AOT training run for faster startup (each arch builds natively, no QEMU)
+RUN GEOSERVER_DATA_DIR=/tmp/datadir && \
+ mkdir $GEOSERVER_DATA_DIR && \
+ java -XX:AOTCacheOutput=app.aot -Dspring.context.exit=onRefresh \
+  -Dgeoserver.acl.client.startupCheck=false \
+  -Dgeoserver.bus.enabled=true \
+  -Dspring.profiles.active=standalone,datadir,acl \
+  org.springframework.boot.loader.launch.JarLauncher && \
+ rm -rf /tmp/*

--- a/src/apps/geoserver/wms/Dockerfile
+++ b/src/apps/geoserver/wms/Dockerfile
@@ -20,3 +20,13 @@ COPY --from=builder spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
 COPY --from=builder application/ ./
+
+# AOT training run for faster startup (each arch builds natively, no QEMU)
+RUN GEOSERVER_DATA_DIR=/tmp/datadir && \
+ mkdir $GEOSERVER_DATA_DIR && \
+ java -XX:AOTCacheOutput=app.aot -Dspring.context.exit=onRefresh \
+  -Dgeoserver.acl.client.startupCheck=false \
+  -Dgeoserver.bus.enabled=true \
+  -Dspring.profiles.active=standalone,datadir,acl \
+  org.springframework.boot.loader.launch.JarLauncher && \
+ rm -rf /tmp/*

--- a/src/apps/geoserver/wps/Dockerfile
+++ b/src/apps/geoserver/wps/Dockerfile
@@ -20,3 +20,13 @@ COPY --from=builder spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
 COPY --from=builder application/ ./
+
+# AOT training run for faster startup (each arch builds natively, no QEMU)
+RUN GEOSERVER_DATA_DIR=/tmp/datadir && \
+ mkdir $GEOSERVER_DATA_DIR && \
+ java -XX:AOTCacheOutput=app.aot -Dspring.context.exit=onRefresh \
+  -Dgeoserver.acl.client.startupCheck=false \
+  -Dgeoserver.bus.enabled=true \
+  -Dspring.profiles.active=standalone,datadir,acl \
+  org.springframework.boot.loader.launch.JarLauncher && \
+ rm -rf /tmp/*

--- a/src/apps/infrastructure/config/Dockerfile
+++ b/src/apps/infrastructure/config/Dockerfile
@@ -35,3 +35,10 @@ ENV SPRING_CLOUD_CONFIG_SERVER_GIT_DEFAULT_LABEL: master
 ENV CONFIG_GIT_BASEDIR: /tmp/git_config
 # avoid stack trace due to jgit not being able of creating a .config dir at $HOME
 ENV XDG_CONFIG_HOME: /tmp
+
+# AOT training run for faster startup (each arch builds natively, no QEMU)
+RUN java -XX:AOTCacheOutput=app.aot -Dspring.context.exit=onRefresh \
+  -Dspring.profiles.active=native \
+  org.springframework.boot.loader.launch.JarLauncher; \
+  rm -rf /tmp/*
+

--- a/src/apps/infrastructure/gateway-webmvc/Dockerfile
+++ b/src/apps/infrastructure/gateway-webmvc/Dockerfile
@@ -18,3 +18,10 @@ COPY --from=builder spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
 COPY --from=builder application/ ./
+
+# AOT training run for faster startup (each arch builds natively, no QEMU)
+RUN java -XX:AOTCacheOutput=app.aot \
+-Dspring.context.exit=onRefresh \
+-Dspring.profiles.active=standalone \
+org.springframework.boot.loader.launch.JarLauncher; \
+rm -rf /tmp/*


### PR DESCRIPTION
Run a JVM AOT training step during Docker image build for all geoserver service and infrastructure images. The training uses `-XX:AOTCacheOutput` to generate an `app.aot` cache with spring.context.exit=onRefresh, so the JVM exits right after context initialization without starting the server.

At runtime, `AOT_MODE=auto` and `-XX:AOTCache=app.aot` are set by default, which can be overridden via the `AOT_MODE` env var (e.g. with `on` or `off`).

Fixes #804
