### PR TITLE
Switch gateway to reactor-netty HTTP client, improve error handling and shutdown via actuator

### DIFF
--- a/src/apps/infrastructure/gateway-webmvc/pom.xml
+++ b/src/apps/infrastructure/gateway-webmvc/pom.xml
@@ -21,6 +21,10 @@
       <artifactId>spring-cloud-starter-gateway-server-webmvc</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.projectreactor.netty</groupId>
+      <artifactId>reactor-netty-http</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>

--- a/src/apps/infrastructure/gateway-webmvc/src/main/java/org/geoserver/cloud/gateway/filter/ProxyExceptionFilter.java
+++ b/src/apps/infrastructure/gateway-webmvc/src/main/java/org/geoserver/cloud/gateway/filter/ProxyExceptionFilter.java
@@ -13,8 +13,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.NestedExceptionUtils;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
@@ -36,20 +38,35 @@ public class ProxyExceptionFilter extends OncePerRequestFilter {
         try {
             chain.doFilter(request, response);
         } catch (Exception e) {
-            Throwable root = rootCause(e);
+            // get the most specific cause (e.g., ConnectException or HttpServerErrorException)
+            Throwable root = NestedExceptionUtils.getMostSpecificCause(e);
+
             if (isConnectionError(root)) {
-                log.warn(
-                        "{} {} -> 502: {}",
-                        sanitizeMethod(request.getMethod()),
-                        sanitizeUri(request.getRequestURI()),
-                        root.getMessage());
+                int status = determineStatus(root);
+                String message = root.getMessage();
+
+                String method = sanitizeMethod(request.getMethod());
+                String uri = sanitizeUri(request.getRequestURI());
+                log.warn("{} {} -> {}: {}", method, uri, status, message);
+
                 if (!response.isCommitted()) {
-                    response.sendError(HttpServletResponse.SC_BAD_GATEWAY, root.getMessage());
+                    response.sendError(status, message);
                 }
                 return;
             }
+            // let other handlers (like @ControllerAdvice) handle non-connection errors
             throw e;
         }
+    }
+
+    /** If the LoadBalancer already decided it's a 50x, keep it (HttpServerErrorException). */
+    private static int determineStatus(Throwable t) {
+        //
+        if (t instanceof HttpServerErrorException hsee) {
+            return hsee.getStatusCode().value();
+        }
+        // Socket issues are usually 502 Bad Gateway
+        return HttpServletResponse.SC_BAD_GATEWAY;
     }
 
     private static boolean isConnectionError(Throwable t) {
@@ -57,13 +74,5 @@ public class ProxyExceptionFilter extends OncePerRequestFilter {
                 || t instanceof java.net.NoRouteToHostException
                 || t instanceof java.net.SocketTimeoutException
                 || t instanceof java.net.UnknownHostException;
-    }
-
-    private static Throwable rootCause(Throwable t) {
-        Throwable cause = t;
-        while (cause.getCause() != null && cause.getCause() != cause) {
-            cause = cause.getCause();
-        }
-        return cause;
     }
 }

--- a/src/apps/infrastructure/gateway-webmvc/src/main/resources/application.yml
+++ b/src/apps/infrastructure/gateway-webmvc/src/main/resources/application.yml
@@ -22,6 +22,13 @@ spring:
     import:
       - classpath:geoserver_spring_boot_profiles.yml
       - classpath:geoserver_spring_cloud_profiles.yml
+  http:
+    clients:
+      imperative:
+        factory: reactor
+      reactive:
+        connector: reactor
+      connect-timeout: 5s
   cloud:
     gateway:
       server:

--- a/src/starters/spring-boot/src/main/java/org/geoserver/cloud/app/GeoServerApplicationLauncher.java
+++ b/src/starters/spring-boot/src/main/java/org/geoserver/cloud/app/GeoServerApplicationLauncher.java
@@ -5,10 +5,15 @@
 
 package org.geoserver.cloud.app;
 
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.metrics.buffering.BufferingApplicationStartup;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextClosedEvent;
 
 /**
  * Utility to launch a {@link SpringBootApplication @SpringBootApplication} annotated class, enabling the
@@ -16,23 +21,35 @@ import org.springframework.boot.context.metrics.buffering.BufferingApplicationSt
  */
 public class GeoServerApplicationLauncher {
 
+    private static Logger log;
+
     private GeoServerApplicationLauncher() {
         // utility
     }
 
     public static void run(Class<?> springBootApplicationClass, String... args) {
+        log = LoggerFactory.getLogger(springBootApplicationClass);
         try {
             SpringApplication app = new SpringApplication(springBootApplicationClass);
             // Set the startup implementation and buffer capacity, enables the
             // /actuator/startup endpoint
             app.setApplicationStartup(new BufferingApplicationStartup(2048));
+
+            // Centralized fix: Add a listener for context closure so the app exits on POST /actuator/shutdown
+            app.addListeners((ApplicationListener<ContextClosedEvent>) _ -> scheduleExit());
+
             app.run(args);
         } catch (RuntimeException e) {
             try {
-                LoggerFactory.getLogger(GeoServerApplicationLauncher.class).error("Application run failed", e);
+                log.error("Application run failed", e);
             } finally {
                 System.exit(-1);
             }
         }
+    }
+
+    @SuppressWarnings("java:S2095")
+    private static void scheduleExit() {
+        Executors.newSingleThreadScheduledExecutor().schedule(() -> System.exit(0), 5, TimeUnit.SECONDS);
     }
 }


### PR DESCRIPTION
Configure spring.http.clients to use the reactor-netty factory for the WebMVC gateway, replacing the default JDK HTTP client and add the reactor-netty-http dependency.

Refactor ProxyExceptionFilter to use NestedExceptionUtils instead of a hand-rolled rootCause() loop, and preserve upstream HTTP status codes from HttpServerErrorException rather than always returning 502.

Add a ContextClosedEvent listener to GeoServerApplicationLauncher that schedules System.exit(0) after 5 seconds, ensuring the JVM terminates after POST /actuator/shutdown.
