### PR TITLE
Remove unused dependencies on gs-cloud-spring-factory

### DIFF
--- a/src/apps/base-images/geoserver/pom.xml
+++ b/src/apps/base-images/geoserver/pom.xml
@@ -11,7 +11,7 @@
   <dependencies>
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
-      <artifactId>gs-cloud-spring-factory</artifactId>
+      <artifactId>gs-spring-configuration</artifactId>
     </dependency>
     <!-- Base Spring Boot integration -->
     <dependency>

--- a/src/apps/geoserver/pom.xml
+++ b/src/apps/geoserver/pom.xml
@@ -34,7 +34,7 @@
   <dependencies>
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
-      <artifactId>gs-cloud-spring-factory</artifactId>
+      <artifactId>gs-spring-configuration</artifactId>
     </dependency>
     <!-- Base Spring Boot integration -->
     <dependency>

--- a/src/catalog/backends/common/pom.xml
+++ b/src/catalog/backends/common/pom.xml
@@ -24,10 +24,6 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
-      <artifactId>gs-cloud-spring-factory</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.geoserver.cloud</groupId>
       <artifactId>spring-boot-simplejndi</artifactId>
     </dependency>
     <dependency>

--- a/src/extensions/core/pom.xml
+++ b/src/extensions/core/pom.xml
@@ -15,10 +15,6 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
-      <artifactId>gs-cloud-spring-factory</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-spring-configuration</artifactId>
     </dependency>
     <dependency>

--- a/src/gwc/autoconfigure/pom.xml
+++ b/src/gwc/autoconfigure/pom.xml
@@ -14,10 +14,6 @@
       <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.geoserver.cloud</groupId>
-      <artifactId>gs-cloud-spring-factory</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver.cloud.gwc</groupId>
       <artifactId>gwc-cloud-core</artifactId>
     </dependency>

--- a/src/gwc/core/pom.xml
+++ b/src/gwc/core/pom.xml
@@ -11,10 +11,6 @@
   <dependencies>
     <dependency>
       <groupId>org.geoserver.cloud</groupId>
-      <artifactId>gs-cloud-spring-factory</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-cloud-starter-catalog-backend</artifactId>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
After the xml to java transpiled configuration, no module depends on gs-cloud-spring-factory anymore (the runtime xml spring configuration parser with support for filtering).

The module is left but considered deprecated.
