### PR TITLE
Rename Testcontainers-based tests to *IT for Failsafe

### DIFF
--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgconfig/PgconfigBackendAutoConfigurationIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgconfig/PgconfigBackendAutoConfigurationIT.java
@@ -36,7 +36,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  */
 @Testcontainers(disabledWithoutDocker = true)
 @Execution(value = ExecutionMode.CONCURRENT)
-class PgconfigBackendAutoConfigurationTest {
+class PgconfigBackendAutoConfigurationIT {
 
     @Container
     static PgConfigTestContainer container = new PgConfigTestContainer();

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgconfig/PgconfigDataSourceAutoConfigurationIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgconfig/PgconfigDataSourceAutoConfigurationIT.java
@@ -34,7 +34,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers(disabledWithoutDocker = true)
 @Slf4j
 @Execution(value = ExecutionMode.CONCURRENT)
-class PgconfigDataSourceAutoConfigurationTest {
+class PgconfigDataSourceAutoConfigurationIT {
 
     @Container
     static PgConfigTestContainer container = new PgConfigTestContainer();

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgconfig/PgconfigMigrationAutoConfigurationIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgconfig/PgconfigMigrationAutoConfigurationIT.java
@@ -27,7 +27,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 /** @since 1.4 */
 @Testcontainers(disabledWithoutDocker = true)
-class PgconfigMigrationAutoConfigurationTest {
+class PgconfigMigrationAutoConfigurationIT {
 
     @Container
     static PgConfigTestContainer container = new PgConfigTestContainer();

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/catalog/PgconfigCatalogBackendConformanceIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/catalog/PgconfigCatalogBackendConformanceIT.java
@@ -34,7 +34,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 /** @since 1.4 */
 @Testcontainers(disabledWithoutDocker = true)
 @Execution(value = ExecutionMode.CONCURRENT)
-class PgconfigCatalogBackendConformanceTest extends CatalogConformanceTest {
+class PgconfigCatalogBackendConformanceIT extends CatalogConformanceTest {
 
     @Container
     static PgConfigTestContainer container = new PgConfigTestContainer();

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgconfigWorkspaceRepositoryIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgconfigWorkspaceRepositoryIT.java
@@ -23,7 +23,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 /** @since 1.4 */
 @Testcontainers(disabledWithoutDocker = true)
 @Execution(value = ExecutionMode.CONCURRENT)
-class PgconfigWorkspaceRepositoryTest {
+class PgconfigWorkspaceRepositoryIT {
 
     @Container
     static PgConfigTestContainer container = new PgConfigTestContainer();

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/config/PgconfigConfigRepositoryConformanceIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/config/PgconfigConfigRepositoryConformanceIT.java
@@ -31,7 +31,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 /** @since 1.4 */
 @Testcontainers(disabledWithoutDocker = true)
 @Execution(value = ExecutionMode.CONCURRENT)
-class PgconfigConfigRepositoryConformanceTest extends GeoServerConfigConformanceTest {
+class PgconfigConfigRepositoryConformanceIT extends GeoServerConfigConformanceTest {
 
     @Container
     static PgConfigTestContainer container = new PgConfigTestContainer();

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/config/PgconfigUpdateSequenceIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/config/PgconfigUpdateSequenceIT.java
@@ -22,7 +22,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers(disabledWithoutDocker = true)
 @Execution(value = ExecutionMode.CONCURRENT)
 @SuppressWarnings("java:S2187")
-class PgconfigUpdateSequenceTest implements UpdateSequenceConformanceTest {
+class PgconfigUpdateSequenceIT implements UpdateSequenceConformanceTest {
 
     @Container
     static PgConfigTestContainer container = new PgConfigTestContainer();

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceIT.java
@@ -59,7 +59,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Slf4j
 @Testcontainers(disabledWithoutDocker = true)
 @Execution(value = ExecutionMode.CONCURRENT)
-class PgconfigResourceTest {
+class PgconfigResourceIT {
 
     @Container
     static PgConfigTestContainer container = new PgConfigTestContainer();

--- a/src/config/spring-boot-simplejndi/src/test/java/org/geoserver/cloud/simplejndi/SimpleNamingContextBuilderIT.java
+++ b/src/config/spring-boot-simplejndi/src/test/java/org/geoserver/cloud/simplejndi/SimpleNamingContextBuilderIT.java
@@ -35,7 +35,7 @@ import org.testcontainers.ldap.LLdapContainer;
 @Testcontainers
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // Use per-class lifecycle to initialize container once
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class SimpleNamingContextBuilderTest {
+class SimpleNamingContextBuilderIT {
 
     @Container
     private static final LLdapContainer LDAP_CONTAINER = new LLdapContainer("lldap/lldap:v0.6.1-alpine");

--- a/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigTileLayerCatalogAutoConfigurationIT.java
+++ b/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigTileLayerCatalogAutoConfigurationIT.java
@@ -46,7 +46,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 /** GWC integration test for {@link PgconfigTileLayerCatalogAutoConfiguration} */
 @Testcontainers(disabledWithoutDocker = true)
 @Execution(value = ExecutionMode.SAME_THREAD) // FilteringXmlBeanDefinitionReader has a static HashMap race condition
-class PgconfigTileLayerCatalogAutoConfigurationTest {
+class PgconfigTileLayerCatalogAutoConfigurationIT {
 
     @Container
     static PgConfigTestContainer container = new PgConfigTestContainer();

--- a/src/gwc/autoconfigure/src/test/resources/logback-test.xml
+++ b/src/gwc/autoconfigure/src/test/resources/logback-test.xml
@@ -10,11 +10,11 @@
     <appender-ref ref="STDOUT" />
   </root>
 
-  <logger name="org.gwc.tiling.service" level="WARN" />
-  <logger name="org.gwc.tiling.cluster" level="DEBUG" />
   <logger name="org.springframework.test" level="ERROR" />
   <logger name="org.springframework.boot.test" level="ERROR" />
   <logger name="org.springframework.context" level="WARN" />
   <logger name="org.geoserver.platform.GeoServerExtensions" level="ERROR" />
+  <logger name="com.zaxxer.hikari" level="ERROR" />
+  <logger name="org.flywaydb" level="ERROR" />
   <logger name="org.springframework.context.support.PostProcessorRegistrationDelegate$BeanPostProcessorChecker" level="ERROR"/>
 </configuration>


### PR DESCRIPTION
Renames ten Testcontainers-backed test classes from *Test to *IT so they run under the maven-failsafe-plugin's integration-test phase instead of surefire's test phase, matching their actual nature as integration tests that require Docker.
