### PR TITLE
Fix transpiler handling of package-private types and dotted bean names

### DIFF
--- a/src/build-tools/spring-config-transpiler/src/main/java/org/geoserver/spring/config/transpiler/generator/AbstractBeanMethodGenerator.java
+++ b/src/build-tools/spring-config-transpiler/src/main/java/org/geoserver/spring/config/transpiler/generator/AbstractBeanMethodGenerator.java
@@ -494,14 +494,35 @@ public abstract class AbstractBeanMethodGenerator implements BeanMethodGenerator
 
     /**
      * Resolve the return type for a {@code @Bean} method using {@link TypeNameResolver}. Returns {@code Object.class}
-     * if the type cannot be resolved.
+     * if the type cannot be resolved. If the resolved class is not public (and thus not accessible from a generated
+     * {@code @Bean} method in another package), falls back to its nearest public ancestor.
      */
     protected ClassName resolveReturnType(BeanDefinition beanDefinition, TranspilationContext context) {
         TypeNameResolver.TypeResolutionResult result = TypeNameResolver.resolveBeanReturnType(beanDefinition, context);
         if (!result.isResolved()) {
             return ClassName.get(Object.class);
         }
-        return typeNameToClassName(result.getResolvedTypeName());
+        return toAccessibleClassName(result.getResolvedTypeName());
+    }
+
+    /**
+     * Convert a fully qualified type name to a {@link ClassName}, substituting the nearest public ancestor if the class
+     * itself is not public. {@code @Bean} method return/parameter types must be accessible from the generated
+     * configuration class, which lives in a different package than Spring Security internals such as
+     * {@code HttpSecurityConfiguration}.
+     */
+    protected ClassName toAccessibleClassName(String typeName) {
+        try {
+            Class<?> clazz = Reflections.convertToRuntimeClass(typeName);
+            if (!Reflections.isPublic(clazz)) {
+                return ClassName.get(Reflections.findFirstPublicAncestor(clazz));
+            }
+        } catch (IllegalStateException _) {
+            // Reflections.convertToRuntimeClass wraps ClassNotFoundException — the class isn't on the
+            // annotation-processor classpath. Fall through to emit the literal name; downstream compile
+            // errors will point to the real missing dependency.
+        }
+        return typeNameToClassName(typeName);
     }
 
     /** Convert a fully qualified type name string to a JavaPoet ClassName. Falls back to Object on failure. */

--- a/src/build-tools/spring-config-transpiler/src/main/java/org/geoserver/spring/config/transpiler/generator/Reflections.java
+++ b/src/build-tools/spring-config-transpiler/src/main/java/org/geoserver/spring/config/transpiler/generator/Reflections.java
@@ -22,6 +22,48 @@ public class Reflections {
         return java.lang.reflect.Modifier.isPublic(constructor.getModifiers());
     }
 
+    public boolean isPublic(Class<?> type) {
+        return java.lang.reflect.Modifier.isPublic(type.getModifiers());
+    }
+
+    /**
+     * Walk the class hierarchy of {@code type} (super-classes first, then interfaces) and return the nearest public
+     * ancestor, or {@link Object} if none is found. Used to pick a method return/parameter type that is accessible from
+     * other packages when the declared bean class is itself package-private.
+     */
+    public Class<?> findFirstPublicAncestor(Class<?> type) {
+        if (type == null) {
+            return Object.class;
+        }
+        // Prefer super-classes (walk up to Object)
+        Class<?> walker = type.getSuperclass();
+        while (walker != null) {
+            if (isPublic(walker)) {
+                return walker;
+            }
+            walker = walker.getSuperclass();
+        }
+        // Fall back to any public interface implemented directly or indirectly
+        return findFirstPublicInterface(type).orElse(Object.class);
+    }
+
+    private Optional<Class<?>> findFirstPublicInterface(Class<?> type) {
+        for (Class<?> iface : type.getInterfaces()) {
+            if (isPublic(iface)) {
+                return Optional.of(iface);
+            }
+            Optional<Class<?>> nested = findFirstPublicInterface(iface);
+            if (nested.isPresent()) {
+                return nested;
+            }
+        }
+        Class<?> parent = type.getSuperclass();
+        if (parent != null) {
+            return findFirstPublicInterface(parent);
+        }
+        return Optional.empty();
+    }
+
     /** Check if a class represents a numeric type that should be rendered as a literal. */
     public static boolean isPrimitiveOrBoxedType(Class<?> type) {
         return type.isPrimitive()

--- a/src/build-tools/spring-config-transpiler/src/main/java/org/geoserver/spring/config/transpiler/generator/SimpleBeanMethodGenerator.java
+++ b/src/build-tools/spring-config-transpiler/src/main/java/org/geoserver/spring/config/transpiler/generator/SimpleBeanMethodGenerator.java
@@ -133,25 +133,31 @@ public class SimpleBeanMethodGenerator extends AbstractBeanMethodGenerator {
             // Need to handle property values
             methodBuilder.addJavadoc("Note: Property values will be applied using setter methods\n");
 
-            // Collect bean references from properties (base class returns unsanitized names)
-            List<String> propertyBeanReferences =
-                    super.collectPropertyBeanReferences(beanDefinition.getPropertyValues()).stream()
-                            .map(EnhancedBeanDefinition::sanitizeBeanName)
-                            .toList();
+            // Collect bean references from properties with original (unsanitized) names — needed
+            // both for @Qualifier (Spring looks up by the literal bean name, preserving dots) and
+            // for finding the matching property by name in the PropertyValues.
+            List<String> originalBeanReferences =
+                    super.collectPropertyBeanReferences(beanDefinition.getPropertyValues());
+            // Parallel list of sanitized identifiers to use as Java parameter/variable names.
+            List<String> sanitizedBeanReferences = originalBeanReferences.stream()
+                    .map(EnhancedBeanDefinition::sanitizeBeanName)
+                    .toList();
 
             // Add method parameters for property bean references with proper types
-            for (String beanRef : propertyBeanReferences) {
-                // Find the property name for this bean reference
-                String propertyName = findPropertyNameForBeanRef(beanRef, beanDefinition.getPropertyValues());
+            for (int i = 0; i < originalBeanReferences.size(); i++) {
+                String originalBeanRef = originalBeanReferences.get(i);
+                String sanitizedBeanRef = sanitizedBeanReferences.get(i);
+
+                // Find the property name for this bean reference (uses original name to match PropertyValues)
+                String propertyName = findPropertyNameForBeanRef(originalBeanRef, beanDefinition.getPropertyValues());
 
                 // Use enhanced type inference from base class
                 ClassName paramType = resolveParameterTypeWithInference(
-                        beanRef, beanClassName, null, propertyName, null, transpilationContext);
+                        originalBeanRef, beanClassName, null, propertyName, null, transpilationContext);
 
-                ParameterSpec.Builder paramBuilder = ParameterSpec.builder(
-                                paramType, EnhancedBeanDefinition.sanitizeBeanName(beanRef))
+                ParameterSpec.Builder paramBuilder = ParameterSpec.builder(paramType, sanitizedBeanRef)
                         .addAnnotation(AnnotationSpec.builder(Qualifier.class)
-                                .addMember("value", "$S", beanRef)
+                                .addMember("value", "$S", originalBeanRef)
                                 .build());
                 methodBuilder.addParameter(paramBuilder.build());
             }
@@ -162,11 +168,11 @@ public class SimpleBeanMethodGenerator extends AbstractBeanMethodGenerator {
             } else {
                 methodBuilder.addStatement("$T bean = new $T()", returnType, returnType);
             }
-            // Use the unified generatePropertySetters method from base class
+            // Pass the sanitized list — generatePropertySetters uses these as Java identifiers in the body.
             generatePropertySetters(
                     methodBuilder,
                     beanDefinition.getPropertyValues(),
-                    propertyBeanReferences,
+                    sanitizedBeanReferences,
                     beanClassName,
                     beanContext.getBeanName());
             methodBuilder.addStatement("return bean");

--- a/src/build-tools/spring-config-transpiler/src/test/java/org/geoserver/spring/config/processor/TranspileXmlConfigAnnotationProcessorMethodGenerationTest.java
+++ b/src/build-tools/spring-config-transpiler/src/test/java/org/geoserver/spring/config/processor/TranspileXmlConfigAnnotationProcessorMethodGenerationTest.java
@@ -569,6 +569,62 @@ class TranspileXmlConfigAnnotationProcessorMethodGenerationTest {
         testBeanMethodGeneneration("dataDirectoryResourceStore", xml, expectedJavaCode);
     }
 
+    /**
+     * Regression: when a bean's declared class is package-private, the generated {@code @Bean} method must declare its
+     * return type as the nearest public ancestor. Otherwise the generated code does not compile from a configuration
+     * class in a different package.
+     */
+    @Test
+    void testBeanWithPackagePrivateClass() {
+        final String xml =
+                """
+                <bean id="packagePrivateBean"
+                      class="org.geoserver.spring.config.test.components.PackagePrivateClassComponent"/>
+                """;
+
+        final String expectedJavaCode =
+                """
+                @org.springframework.context.annotation.Bean
+                org.geoserver.spring.config.test.components.PublicAncestor packagePrivateBean() throws java.lang.Exception {
+                  java.lang.reflect.Constructor constructor = java.lang.Class.forName("org.geoserver.spring.config.test.components.PackagePrivateClassComponent").getDeclaredConstructor();
+                  constructor.setAccessible(true);
+                  return (org.geoserver.spring.config.test.components.PublicAncestor) constructor.newInstance();
+                }
+                """;
+
+        testBeanMethodGeneneration("packagePrivateBean", xml, expectedJavaCode);
+    }
+
+    /**
+     * Regression: when a property {@code ref} attribute uses a dotted bean name (e.g.,
+     * {@code ref="org.springframework.security.config.annotation.web.configuration.HttpSecurityConfiguration.httpSecurity"}),
+     * the {@code @Qualifier} string value must preserve the dots so Spring can resolve the bean at runtime. Only the
+     * Java parameter identifier is sanitized with underscores.
+     */
+    @Test
+    void testBeanWithDottedBeanReference() {
+        final String xml =
+                """
+                <bean id="myBean"
+                      class="org.geoserver.platform.resource.DataDirectoryResourceStore">
+                    <property name="lockProvider" ref="some.qualified.bean.name"/>
+                </bean>
+                """;
+
+        final String expectedJavaCode =
+                """
+                @org.springframework.context.annotation.Bean
+                org.geoserver.platform.resource.DataDirectoryResourceStore myBean(
+                    @org.springframework.beans.factory.annotation.Qualifier("some.qualified.bean.name") org.geoserver.platform.resource.LockProvider some_qualified_bean_name) {
+                  org.geoserver.platform.resource.DataDirectoryResourceStore bean = new org.geoserver.platform.resource.DataDirectoryResourceStore();
+                  bean.setLockProvider(some_qualified_bean_name);
+                  return bean;
+                }
+                """;
+
+        testBeanMethodGeneneration("myBean", xml, expectedJavaCode);
+    }
+
     @Test
     void testBeanWithConstructorArgsAndRefProperty() {
         final String xml =

--- a/src/build-tools/spring-config-transpiler/src/test/java/org/geoserver/spring/config/test/components/PackagePrivateClassComponent.java
+++ b/src/build-tools/spring-config-transpiler/src/test/java/org/geoserver/spring/config/test/components/PackagePrivateClassComponent.java
@@ -1,0 +1,15 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.spring.config.test.components;
+
+/**
+ * Package-private class used to verify that the transpiler emits a {@code @Bean} method whose return type is not the
+ * bean class itself (which would be inaccessible from the generated configuration class's package) but its nearest
+ * public ancestor.
+ */
+@SuppressWarnings("java:S2094") // empty class is intentional
+class PackagePrivateClassComponent extends PublicAncestor {
+    PackagePrivateClassComponent() {}
+}

--- a/src/build-tools/spring-config-transpiler/src/test/java/org/geoserver/spring/config/test/components/PublicAncestor.java
+++ b/src/build-tools/spring-config-transpiler/src/test/java/org/geoserver/spring/config/test/components/PublicAncestor.java
@@ -1,0 +1,8 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.spring.config.test.components;
+
+/** Public base class used as expected return type for {@link PackagePrivateClassComponent} tests. */
+public class PublicAncestor {}


### PR DESCRIPTION
Two fixes to how `SimpleBeanMethodGenerator` emits `@Bean` methods:

1. When a bean's declared class is not public, the generated `@Bean` method used that same class as its return type, which fails to compile from the generated configuration class's package. The generator already used reflection to sidestep the non-public constructor but still emitted the class literal as the return type. `AbstractBeanMethodGenerator` now falls back to the nearest public ancestor (or Object) via a new helper in Reflections.

2. `SimpleBeanMethodGenerator` sanitized bean names before building `@Qualifier` string values and before looking up the property setter by ref name, turning dotted names into underscore-joined ones. Spring resolves `@Qualifier` by literal bean name, so the dots must be preserved - otherwise a `<property name="x" ref="a.b.c"/>` produces a `@Bean` method with `@Qualifier("a_b_c")`, which won't match. Original names are now kept for `@Qualifier` and for matching `PropertyValues`; sanitization applies only to the Java identifier used as the parameter / body variable.

Regression tests added: `testBeanWithPackagePrivateClass` and `testBeanWithDottedBeanReference`, plus two fixture classes (`PackagePrivateClassComponent`, `PublicAncestor`). 
