### PR TITLE
Fix RabbitMQ 4.x rejecting Spring Cloud Bus anonymous queue declarations

### DIFF
--- a/src/catalog/events/src/test/java/org/geoserver/cloud/event/bus/BusAmqpIntegrationTests.java
+++ b/src/catalog/events/src/test/java/org/geoserver/cloud/event/bus/BusAmqpIntegrationTests.java
@@ -79,6 +79,7 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.rabbitmq.RabbitMQContainer;
+import org.testcontainers.utility.MountableFile;
 
 @SpringBootTest(
         webEnvironment = RANDOM_PORT,
@@ -97,7 +98,12 @@ import org.testcontainers.rabbitmq.RabbitMQContainer;
 public abstract class BusAmqpIntegrationTests {
 
     @Container
-    private static final RabbitMQContainer rabbitMQContainer = new RabbitMQContainer("rabbitmq:4-management-alpine");
+    private static final RabbitMQContainer rabbitMQContainer = new RabbitMQContainer("rabbitmq:4-management-alpine")
+            // Permit the deprecated `queue_master_locator` feature so RabbitMQ 4.x
+            // accepts the `x-queue-master-locator` argument that spring-amqp 4.0.0
+            // AnonymousQueue adds to Spring Cloud Bus consumer queues.
+            // TODO: remove once spring-amqp/spring-cloud-bus stops emitting the argument.
+            .withRabbitMQConfig(MountableFile.forClasspathResource("rabbitmq.conf"));
 
     protected static ConfigurableApplicationContext remoteAppContext;
     private @Autowired ConfigurableApplicationContext localAppContext;

--- a/src/catalog/events/src/test/resources/rabbitmq.conf
+++ b/src/catalog/events/src/test/resources/rabbitmq.conf
@@ -1,0 +1,6 @@
+# RabbitMQ 4.x disables the `queue_master_locator` feature by default and rejects
+# any queue declaration carrying the `x-queue-master-locator` argument with a 541
+# INTERNAL_ERROR. spring-amqp 4.0.0 `AnonymousQueue` unconditionally adds that
+# argument, which breaks Spring Cloud Bus anonymous queue declarations.
+# TODO: remove once spring-amqp/spring-cloud-bus stops emitting x-queue-master-locator.
+deprecated_features.permit.queue_master_locator = true


### PR DESCRIPTION
Started happening with the latest `rabbitmq:4-management-alpine` Docker image.

The latest rabbitmq:4-management-alpine image disables the deprecated `queue_master_locator` feature by default and rejects any queue declaration carrying the `x-queue-master-locator` argument with reply-code=541 INTERNAL_ERROR. spring-amqp 4.0.0 `AnonymousQueue` unconditionally adds that argument via `setLeaderLocator("client-local")` in its constructor, so every Spring Cloud Bus anonymous consumer queue fails to declare - which made all IT tests under src/catalog/events fail.

Workaround: permit the deprecated feature on the broker, in both the production rabbitmq.conf and the Testcontainers config. Also done in the submodule config/.

This requires further investigation - likely a fix will come via a spring-cloud-bus / spring-amqp update that stops emitting x-queue-master-locator; the TODO comments mark the places to revert when that happens. RabbitMQ intends to remove the feature entirely in a future major release, so this is only a temporary mitigation.