### PR TITLE
Split pgconfig and acceptance jobs into their own PR workflows

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -9,6 +9,11 @@ on:
     branches:
       - main
       - "release/**"
+    paths:
+      - "src/**"
+      - "**/pom.xml"
+      - "acceptance_tests/**"
+      - ".github/workflows/codeql.yaml"
   schedule:
     - cron: '0 0 * * 1'  # Weekly on Monday
 

--- a/.github/workflows/pr-acceptance.yaml
+++ b/.github/workflows/pr-acceptance.yaml
@@ -1,12 +1,12 @@
 # Triggers the workflow on pull request events to the main branch
-name: Pull Request
+name: PR Acceptance
 on:
   pull_request:
     branches:
       - main
       - "release/**"
     paths:
-      - ".github/workflows/pull-request.yaml"
+      - ".github/workflows/pr-acceptance.yaml"
       - ".github/workflows/build-and-push.yaml"
       - "pom.xml"
       - "Makefile"
@@ -22,77 +22,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Build and Test Pull Request
-    if: github.repository == 'geoserver/geoserver-cloud'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        submodules: recursive
-    - name: Set up java
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '25'
-        cache: 'maven'
-
-    - name: Validate pom formatting
-      run: make build-tools lint-pom
-
-    - name: Validate source code formatting
-      run: make lint-java
-
-    - name: Test
-      run: |
-        make test
-
-    - name: Remove project jars from cached repository
-      if: always()
-      run: |
-        rm -rf ~/.m2/repository/org/geoserver/cloud
-        find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}
-
-  pgconfig-pg-compat:
-    name: pgconfig (postgres:${{ matrix.pg_version }})
-    if: github.repository == 'geoserver/geoserver-cloud'
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        pg_version: [ '15', '16', '17', '18' ]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        submodules: recursive
-    - name: Set up java
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '25'
-        cache: 'maven'
-    - name: Build dependencies
-      run: |
-        ./mvnw clean install -pl :gs-cloud-catalog-backend-pgconfig -ntp -U -am -DskipTests -T1C
-    - name: Test pgconfig with PostgreSQL ${{ matrix.pg_version }}
-      run: |
-        ./mvnw -nsu -ntp verify -pl :gs-cloud-catalog-backend-pgconfig -Dpgconfig.test.image=postgres:${{ matrix.pg_version }} -T1C
-    - name: Remove project jars from cached repository
-      if: always()
-      run: |
-        rm -rf ~/.m2/repository/org/geoserver/cloud
-        find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}
-
   acceptance:
     name: Acceptance
     if: github.repository == 'geoserver/geoserver-cloud'
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    #needs: test
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-build-and-test.yaml
+++ b/.github/workflows/pr-build-and-test.yaml
@@ -1,0 +1,56 @@
+# Triggers the workflow on pull request events to the main branch
+name: PR Build and Test
+on:
+  pull_request:
+    branches:
+      - main
+      - "release/**"
+    paths:
+      - ".github/workflows/pr-build-and-test.yaml"
+      - ".github/workflows/build-and-push.yaml"
+      - "pom.xml"
+      - "Makefile"
+      - "config"
+      - "src/**"
+      - "acceptance_tests/**"
+      - "ci/**"
+      - "compose/**"
+
+# cancel in-progress jobs or runs for this workflow for the same pr or branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Build and Test Pull Request
+    if: github.repository == 'geoserver/geoserver-cloud'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - name: Set up java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '25'
+        cache: 'maven'
+
+    - name: Validate pom formatting
+      run: make build-tools lint-pom
+
+    - name: Validate source code formatting
+      run: make lint-java
+
+    - name: Test
+      run: |
+        make test
+
+    - name: Remove project jars from cached repository
+      if: always()
+      run: |
+        rm -rf ~/.m2/repository/org/geoserver/cloud
+        find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/pr-pgconfig.yaml
+++ b/.github/workflows/pr-pgconfig.yaml
@@ -1,0 +1,55 @@
+# Triggers the workflow on pull request events to the main branch
+name: PR pgconfig
+on:
+  pull_request:
+    branches:
+      - main
+      - "release/**"
+    paths:
+      - ".github/workflows/pr-pgconfig.yaml"
+      - ".github/workflows/build-and-push.yaml"
+      - "pom.xml"
+      - "Makefile"
+      - "config"
+      - "src/**"
+      - "acceptance_tests/**"
+      - "ci/**"
+      - "compose/**"
+
+# cancel in-progress jobs or runs for this workflow for the same pr or branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pgconfig-pg-compat:
+    name: pgconfig (postgres:${{ matrix.pg_version }})
+    if: github.repository == 'geoserver/geoserver-cloud'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        pg_version: [ '15', '16', '17', '18' ]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - name: Set up java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '25'
+        cache: 'maven'
+    - name: Build dependencies
+      run: |
+        ./mvnw clean install -pl :gs-cloud-catalog-backend-pgconfig -ntp -U -am -DskipTests -T1C
+    - name: Test pgconfig with PostgreSQL ${{ matrix.pg_version }}
+      run: |
+        ./mvnw -nsu -ntp verify -pl :gs-cloud-catalog-backend-pgconfig -Dpgconfig.test.image=postgres:${{ matrix.pg_version }} -T1C
+    - name: Remove project jars from cached repository
+      if: always()
+      run: |
+        rm -rf ~/.m2/repository/org/geoserver/cloud
+        find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}


### PR DESCRIPTION
A single transient failure in one of pgconfig and acceptance jobs cannot be re-run in isolation until the whole workflow run completes, despite the three jobs being independent.

Move each into its own workflow file with its own concurrency group so they can be re-run independently from the GitHub Actions UI.
