### PR TITLE
Peg gs.version to 3.0.0-RC

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -30,8 +30,8 @@
     <spring.security.version>7.0.4</spring.security.version>
     <spring-integration.version>7.0.4</spring-integration.version>
 
-    <gs.version>3.0.0-SNAPSHOT</gs.version>
-    <gt.version>35-SNAPSHOT</gt.version>
+    <gs.version>3.0.0-RC</gs.version>
+    <gt.version>35-RC</gt.version>
     <wicket.version>10.7.0</wicket.version>
     <acl.version>3.0-RC3</acl.version>
     <tileverse.version>1.3.4</tileverse.version>


### PR DESCRIPTION
upstream is using 3.0.0-SNAPSHOT and collides with the (soon to be gone) fork used by geoserver cloud.