### PR TITLE
extensions: switch @ConditionalOnClass to string class name form

### DIFF
--- a/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServer.java
+++ b/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServer.java
@@ -11,7 +11,6 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.geoserver.config.GeoServer;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 
 /**
@@ -44,7 +43,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
  */
 // original idea was conditional on bean but it's a can of worms with all the forced spring initialization during
 // startup
-@ConditionalOnClass(GeoServer.class)
+@ConditionalOnClass(name = "org.geoserver.config.GeoServer")
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Inherited

--- a/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerGWC.java
+++ b/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerGWC.java
@@ -52,6 +52,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Documented
 @ConditionalOnGeoServer
-@ConditionalOnClass(org.geowebcache.GeoWebCache.class)
+@ConditionalOnClass(name = "org.geowebcache.GeoWebCache")
 @ConditionalOnProperty(name = "geoserver.service.gwc.enabled", havingValue = "true", matchIfMissing = false)
 public @interface ConditionalOnGeoServerGWC {}

--- a/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerREST.java
+++ b/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerREST.java
@@ -56,6 +56,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Documented
 @ConditionalOnGeoServer
-@ConditionalOnClass(org.geoserver.rest.security.RestConfigXStreamPersister.class)
+@ConditionalOnClass(name = "org.geoserver.rest.security.RestConfigXStreamPersister")
 @ConditionalOnProperty(name = "geoserver.service.restconfig.enabled", havingValue = "true", matchIfMissing = false)
 public @interface ConditionalOnGeoServerREST {}

--- a/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWCS.java
+++ b/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWCS.java
@@ -53,6 +53,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Documented
 @ConditionalOnGeoServer
-@ConditionalOnClass(org.geoserver.wcs.responses.CoverageResponseDelegateFinder.class)
+@ConditionalOnClass(name = "org.geoserver.wcs.responses.CoverageResponseDelegateFinder")
 @ConditionalOnProperty(name = "geoserver.service.wcs.enabled", havingValue = "true", matchIfMissing = false)
 public @interface ConditionalOnGeoServerWCS {}

--- a/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWFS.java
+++ b/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWFS.java
@@ -53,6 +53,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Documented
 @ConditionalOnGeoServer
-@ConditionalOnClass(org.geoserver.wfs.DefaultWebFeatureService.class)
+@ConditionalOnClass(name = "org.geoserver.wfs.DefaultWebFeatureService")
 @ConditionalOnProperty(name = "geoserver.service.wfs.enabled", havingValue = "true", matchIfMissing = false)
 public @interface ConditionalOnGeoServerWFS {}

--- a/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWMS.java
+++ b/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWMS.java
@@ -53,6 +53,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Documented
 @ConditionalOnGeoServer
-@ConditionalOnClass(org.geoserver.wms.DefaultWebMapService.class)
+@ConditionalOnClass(name = "org.geoserver.wms.DefaultWebMapService")
 @ConditionalOnProperty(name = "geoserver.service.wms.enabled", havingValue = "true", matchIfMissing = false)
 public @interface ConditionalOnGeoServerWMS {}

--- a/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWPS.java
+++ b/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWPS.java
@@ -54,7 +54,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Documented
 @ConditionalOnGeoServer
-@ConditionalOnClass(org.geoserver.wps.DefaultWebProcessingService.class)
+@ConditionalOnClass(name = "org.geoserver.wps.DefaultWebProcessingService")
 @ConditionalOnBean(name = "wpsResourceManager")
 @ConditionalOnProperty(name = "geoserver.service.wps.enabled", havingValue = "true", matchIfMissing = false)
 public @interface ConditionalOnGeoServerWPS {}

--- a/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerRESTTest.java
+++ b/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerRESTTest.java
@@ -5,9 +5,11 @@
 
 package org.geoserver.cloud.autoconfigure.extensions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.geoserver.rest.security.RestConfigXStreamPersister;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -24,13 +26,17 @@ class ConditionalOnGeoServerRESTTest extends AbstractConditionalTest {
                 ConditionalTestComponent.class);
     }
 
+    @Test
+    void testConditionalActivationWithFilteredClassLoader() {
+        createContextRunner()
+                .withClassLoader(new FilteredClassLoader(RestConfigXStreamPersister.class))
+                .withUserConfiguration(RestTestConfiguration.class)
+                .withPropertyValues("geoserver.service.restconfig.enabled=true")
+                .run(context -> assertThat(context).doesNotHaveBean(ConditionalTestComponent.class));
+    }
+
     @Configuration
     static class RestTestConfiguration {
-        @Bean
-        RestConfigXStreamPersister restConfigXStreamPersister() {
-            return Mockito.mock(RestConfigXStreamPersister.class);
-        }
-
         @Bean
         @ConditionalOnGeoServerREST
         ConditionalTestComponent conditionalComponent() {

--- a/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWCSTest.java
+++ b/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWCSTest.java
@@ -5,9 +5,11 @@
 
 package org.geoserver.cloud.autoconfigure.extensions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.geoserver.wcs.responses.CoverageResponseDelegateFinder;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -24,13 +26,17 @@ class ConditionalOnGeoServerWCSTest extends AbstractConditionalTest {
                 ConditionalTestComponent.class);
     }
 
+    @Test
+    void testConditionalActivationWithFilteredClassLoader() {
+        createContextRunner()
+                .withClassLoader(new FilteredClassLoader(CoverageResponseDelegateFinder.class))
+                .withUserConfiguration(WcsTestConfiguration.class)
+                .withPropertyValues("geoserver.service.wcs.enabled=true")
+                .run(context -> assertThat(context).doesNotHaveBean(ConditionalTestComponent.class));
+    }
+
     @Configuration
     static class WcsTestConfiguration {
-        @Bean
-        CoverageResponseDelegateFinder coverageResponseDelegateFinder() {
-            return Mockito.mock(CoverageResponseDelegateFinder.class);
-        }
-
         @Bean
         @ConditionalOnGeoServerWCS
         ConditionalTestComponent conditionalComponent() {

--- a/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWFSTest.java
+++ b/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWFSTest.java
@@ -5,9 +5,11 @@
 
 package org.geoserver.cloud.autoconfigure.extensions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.geoserver.wfs.DefaultWebFeatureService;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -24,13 +26,17 @@ class ConditionalOnGeoServerWFSTest extends AbstractConditionalTest {
                 ConditionalTestComponent.class);
     }
 
+    @Test
+    void testConditionalActivationWithFilteredClassLoader() {
+        createContextRunner()
+                .withClassLoader(new FilteredClassLoader(DefaultWebFeatureService.class))
+                .withUserConfiguration(WfsTestConfiguration.class)
+                .withPropertyValues("geoserver.service.wfs.enabled=true")
+                .run(context -> assertThat(context).doesNotHaveBean(ConditionalTestComponent.class));
+    }
+
     @Configuration
     static class WfsTestConfiguration {
-        @Bean
-        DefaultWebFeatureService wfsService() {
-            return Mockito.mock(DefaultWebFeatureService.class);
-        }
-
         @Bean
         @ConditionalOnGeoServerWFS
         ConditionalTestComponent conditionalComponent() {

--- a/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWMSTest.java
+++ b/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWMSTest.java
@@ -5,9 +5,11 @@
 
 package org.geoserver.cloud.autoconfigure.extensions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.geoserver.wms.DefaultWebMapService;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -24,13 +26,17 @@ class ConditionalOnGeoServerWMSTest extends AbstractConditionalTest {
                 ConditionalTestComponent.class);
     }
 
+    @Test
+    void testConditionalActivationWithFilteredClassLoader() {
+        createContextRunner()
+                .withClassLoader(new FilteredClassLoader(DefaultWebMapService.class))
+                .withUserConfiguration(WmsTestConfiguration.class)
+                .withPropertyValues("geoserver.service.wms.enabled=true")
+                .run(context -> assertThat(context).doesNotHaveBean(ConditionalTestComponent.class));
+    }
+
     @Configuration
     static class WmsTestConfiguration {
-        @Bean
-        DefaultWebMapService wmsService() {
-            return Mockito.mock(DefaultWebMapService.class);
-        }
-
         @Bean
         @ConditionalOnGeoServerWMS
         ConditionalTestComponent conditionalComponent() {

--- a/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWPSTest.java
+++ b/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ConditionalOnGeoServerWPSTest.java
@@ -5,12 +5,13 @@
 
 package org.geoserver.cloud.autoconfigure.extensions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import org.geoserver.wps.DefaultWebProcessingService;
 import org.geoserver.wps.resource.WPSResourceManager;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -29,13 +30,18 @@ class ConditionalOnGeoServerWPSTest extends AbstractConditionalTest {
                 ConditionalTestComponent.class);
     }
 
+    @Test
+    void testConditionalActivationWithFilteredClassLoader() {
+        createContextRunner()
+                .withBean("wpsResourceManager", WPSResourceManager.class, () -> mock(WPSResourceManager.class))
+                .withClassLoader(new FilteredClassLoader(DefaultWebProcessingService.class))
+                .withUserConfiguration(WpsTestConfiguration.class)
+                .withPropertyValues("geoserver.service.wps.enabled=true")
+                .run(context -> assertThat(context).doesNotHaveBean(ConditionalTestComponent.class));
+    }
+
     @Configuration
     static class WpsTestConfiguration {
-        @Bean
-        DefaultWebProcessingService wpsService() {
-            return Mockito.mock(DefaultWebProcessingService.class);
-        }
-
         @Bean
         @ConditionalOnGeoServerWPS
         ConditionalTestComponent conditionalComponent() {

--- a/src/extensions/output-formats/vector-tiles/pom.xml
+++ b/src/extensions/output-formats/vector-tiles/pom.xml
@@ -29,6 +29,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-gwc</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
       <scope>provided</scope>


### PR DESCRIPTION
The class-literal form silently drops the condition when the referenced class is missing at runtime: Spring logs a `TypeNotPresentException WARN` during meta-annotation introspection and treats the `@ConditionalOnClass` as if it were not present. The string form is robust against missing optional deps and is the recommended pattern.

Applied to `ConditionalOnGeoServer{,GWC,REST,WCS,WFS,WMS,WPS}`; `ConditionalOnGeoServerWebUI` and `ConditionalOnGeoServerWebUIUnavailable` already used the string form.

Add `testConditionalActivationWithFilteredClassLoader` to each existing conditional test (WCS, WPS, REST, WMS, WFS), mirroring the WebUI test. Drop the redundant service-mock `@Bean` from the inner test configs; the conditionals only check `@ConditionalOnClass`, not `@ConditionalOnBean` for those types, and the mock would prevent the config from loading under `FilteredClassLoader`.

Add `gs-gwc` as a test-scope dep to `vector-tiles`, which had been relying on the silent-drop quirk: `gs-cloud-extensions-core` declares `gs-gwc` `<optional>true</optional>` so it does not transit to consumers, and the GWC code path test was only "passing" because the missing class made `@ConditionalOnGeoServerGWC` collapse to the property check alone.
