### PR TITLE
Upgrade Spring Boot 4.0.5 -> 4.0.6

### DIFF
--- a/src/apps/base-images/geoserver/Dockerfile
+++ b/src/apps/base-images/geoserver/Dockerfile
@@ -3,6 +3,8 @@ ARG TAG=latest
 FROM $REPOSITORY/gs-cloud-base-jre:$TAG AS builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
+WORKDIR /builder
+
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
@@ -44,12 +46,12 @@ RUN mkdir -p /opt/app/data_directory /data/geowebcache \
 && chmod 0777 /opt/app/data_directory /data/geowebcache
 
 WORKDIR /opt/app/bin
-COPY --from=builder dependencies/ ./
-COPY --from=builder snapshot-dependencies/ ./
-COPY --from=builder spring-boot-loader/ ./
+COPY --from=builder /builder/dependencies/ ./
+COPY --from=builder /builder/snapshot-dependencies/ ./
+COPY --from=builder /builder/spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder application/ ./
+COPY --from=builder /builder/application/ ./
 
 # -----------------------------------------------------
 # Pre-install DuckDB extensions in the base image to create a shared layer for all GeoServer microservices

--- a/src/apps/base-images/spring-boot/Dockerfile
+++ b/src/apps/base-images/spring-boot/Dockerfile
@@ -5,6 +5,8 @@ FROM $REPOSITORY/gs-cloud-base-jre:$TAG AS builder
 
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
+WORKDIR /builder
+
 COPY ${JAR_FILE} application.jar
 
 RUN java -Djarmode=layertools -jar application.jar extract
@@ -31,13 +33,13 @@ WORKDIR /opt/app/bin
 EXPOSE 8080
 EXPOSE 8081
 
-COPY --from=builder dependencies/ ./
+COPY --from=builder /builder/dependencies/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder snapshot-dependencies/ ./
+COPY --from=builder /builder/snapshot-dependencies/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder spring-boot-loader/ ./
+COPY --from=builder /builder/spring-boot-loader/ ./
 
 HEALTHCHECK \
 --interval=10s \

--- a/src/apps/geoserver/gwc/Dockerfile
+++ b/src/apps/geoserver/gwc/Dockerfile
@@ -5,6 +5,8 @@ FROM $REPOSITORY/gs-cloud-base-jre:$TAG AS builder
 
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
+WORKDIR /builder
+
 COPY ${JAR_FILE} application.jar
 
 RUN java -Djarmode=layertools -jar application.jar extract
@@ -14,12 +16,12 @@ FROM $REPOSITORY/gs-cloud-base-geoserver-image:$TAG
 
 # WORKDIR already set to /opt/app/bin
 
-COPY --from=builder dependencies/ ./
-COPY --from=builder snapshot-dependencies/ ./
-COPY --from=builder spring-boot-loader/ ./
+COPY --from=builder /builder/dependencies/ ./
+COPY --from=builder /builder/snapshot-dependencies/ ./
+COPY --from=builder /builder/spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder application/ ./
+COPY --from=builder /builder/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
 RUN GEOSERVER_DATA_DIR=/tmp/datadir && \

--- a/src/apps/geoserver/restconfig/Dockerfile
+++ b/src/apps/geoserver/restconfig/Dockerfile
@@ -5,6 +5,8 @@ FROM $REPOSITORY/gs-cloud-base-jre:$TAG AS builder
 
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
+WORKDIR /builder
+
 COPY ${JAR_FILE} application.jar
 
 RUN java -Djarmode=layertools -jar application.jar extract
@@ -14,12 +16,12 @@ FROM $REPOSITORY/gs-cloud-base-geoserver-image:$TAG
 
 # WORKDIR already set to /opt/app/bin
 
-COPY --from=builder dependencies/ ./
-COPY --from=builder snapshot-dependencies/ ./
-COPY --from=builder spring-boot-loader/ ./
+COPY --from=builder /builder/dependencies/ ./
+COPY --from=builder /builder/snapshot-dependencies/ ./
+COPY --from=builder /builder/spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder application/ ./
+COPY --from=builder /builder/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
 RUN GEOSERVER_DATA_DIR=/tmp/datadir && \

--- a/src/apps/geoserver/wcs/Dockerfile
+++ b/src/apps/geoserver/wcs/Dockerfile
@@ -5,6 +5,8 @@ FROM $REPOSITORY/gs-cloud-base-jre:$TAG AS builder
 
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
+WORKDIR /builder
+
 COPY ${JAR_FILE} application.jar
 
 RUN java -Djarmode=layertools -jar application.jar extract
@@ -14,12 +16,12 @@ FROM $REPOSITORY/gs-cloud-base-geoserver-image:$TAG
 
 # WORKDIR already set to /opt/app/bin
 
-COPY --from=builder dependencies/ ./
-COPY --from=builder snapshot-dependencies/ ./
-COPY --from=builder spring-boot-loader/ ./
+COPY --from=builder /builder/dependencies/ ./
+COPY --from=builder /builder/snapshot-dependencies/ ./
+COPY --from=builder /builder/spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder application/ ./
+COPY --from=builder /builder/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
 RUN GEOSERVER_DATA_DIR=/tmp/datadir && \

--- a/src/apps/geoserver/webui/Dockerfile
+++ b/src/apps/geoserver/webui/Dockerfile
@@ -5,6 +5,8 @@ FROM $REPOSITORY/gs-cloud-base-jre:$TAG AS builder
 
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
+WORKDIR /builder
+
 COPY ${JAR_FILE} application.jar
 
 RUN java -Djarmode=layertools -jar application.jar extract
@@ -14,12 +16,12 @@ FROM $REPOSITORY/gs-cloud-base-geoserver-image:$TAG
 
 # WORKDIR already set to /opt/app/bin
 
-COPY --from=builder dependencies/ ./
-COPY --from=builder snapshot-dependencies/ ./
-COPY --from=builder spring-boot-loader/ ./
+COPY --from=builder /builder/dependencies/ ./
+COPY --from=builder /builder/snapshot-dependencies/ ./
+COPY --from=builder /builder/spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder application/ ./
+COPY --from=builder /builder/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
 RUN GEOSERVER_DATA_DIR=/tmp/datadir && \

--- a/src/apps/geoserver/wfs/Dockerfile
+++ b/src/apps/geoserver/wfs/Dockerfile
@@ -5,6 +5,8 @@ FROM $REPOSITORY/gs-cloud-base-jre:$TAG AS builder
 
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
+WORKDIR /builder
+
 COPY ${JAR_FILE} application.jar
 
 RUN java -Djarmode=layertools -jar application.jar extract
@@ -14,12 +16,12 @@ FROM $REPOSITORY/gs-cloud-base-geoserver-image:$TAG
 
 # WORKDIR already set to /opt/app/bin
 
-COPY --from=builder dependencies/ ./
-COPY --from=builder snapshot-dependencies/ ./
-COPY --from=builder spring-boot-loader/ ./
+COPY --from=builder /builder/dependencies/ ./
+COPY --from=builder /builder/snapshot-dependencies/ ./
+COPY --from=builder /builder/spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder application/ ./
+COPY --from=builder /builder/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
 RUN GEOSERVER_DATA_DIR=/tmp/datadir && \

--- a/src/apps/geoserver/wms/Dockerfile
+++ b/src/apps/geoserver/wms/Dockerfile
@@ -5,6 +5,8 @@ FROM $REPOSITORY/gs-cloud-base-jre:$TAG AS builder
 
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
+WORKDIR /builder
+
 COPY ${JAR_FILE} application.jar
 
 RUN java -Djarmode=layertools -jar application.jar extract
@@ -14,12 +16,12 @@ FROM $REPOSITORY/gs-cloud-base-geoserver-image:$TAG
 
 # WORKDIR already set to /opt/app/bin
 
-COPY --from=builder dependencies/ ./
-COPY --from=builder snapshot-dependencies/ ./
-COPY --from=builder spring-boot-loader/ ./
+COPY --from=builder /builder/dependencies/ ./
+COPY --from=builder /builder/snapshot-dependencies/ ./
+COPY --from=builder /builder/spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder application/ ./
+COPY --from=builder /builder/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
 RUN GEOSERVER_DATA_DIR=/tmp/datadir && \

--- a/src/apps/geoserver/wps/Dockerfile
+++ b/src/apps/geoserver/wps/Dockerfile
@@ -5,6 +5,8 @@ FROM $REPOSITORY/gs-cloud-base-jre:$TAG AS builder
 
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
+WORKDIR /builder
+
 COPY ${JAR_FILE} application.jar
 
 RUN java -Djarmode=layertools -jar application.jar extract
@@ -14,12 +16,12 @@ FROM $REPOSITORY/gs-cloud-base-geoserver-image:$TAG
 
 # WORKDIR already set to /opt/app/bin
 
-COPY --from=builder dependencies/ ./
-COPY --from=builder snapshot-dependencies/ ./
-COPY --from=builder spring-boot-loader/ ./
+COPY --from=builder /builder/dependencies/ ./
+COPY --from=builder /builder/snapshot-dependencies/ ./
+COPY --from=builder /builder/spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder application/ ./
+COPY --from=builder /builder/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
 RUN GEOSERVER_DATA_DIR=/tmp/datadir && \

--- a/src/apps/infrastructure/config/Dockerfile
+++ b/src/apps/infrastructure/config/Dockerfile
@@ -4,6 +4,8 @@ ARG TAG=latest
 FROM $REPOSITORY/gs-cloud-base-jre:$TAG AS builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
+WORKDIR /builder
+
 COPY ${JAR_FILE} application.jar
 
 RUN java -Djarmode=layertools -jar application.jar extract
@@ -13,12 +15,12 @@ FROM $REPOSITORY/gs-cloud-base-spring-boot:$TAG
 
 # WORKDIR already set to /opt/app/bin
 
-COPY --from=builder dependencies/ ./
-COPY --from=builder snapshot-dependencies/ ./
-COPY --from=builder spring-boot-loader/ ./
+COPY --from=builder /builder/dependencies/ ./
+COPY --from=builder /builder/snapshot-dependencies/ ./
+COPY --from=builder /builder/spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder application/ ./
+COPY --from=builder /builder/application/ ./
 
 # Either 'git' or 'native'.
 ENV SPRING_PROFILES_ACTIVE=native,standalone

--- a/src/apps/infrastructure/gateway-webflux/Dockerfile
+++ b/src/apps/infrastructure/gateway-webflux/Dockerfile
@@ -4,6 +4,8 @@ ARG TAG=latest
 FROM $REPOSITORY/gs-cloud-base-jre:$TAG AS builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
+WORKDIR /builder
+
 COPY ${JAR_FILE} application.jar
 
 RUN java -Djarmode=layertools -jar application.jar extract
@@ -12,9 +14,9 @@ RUN java -Djarmode=layertools -jar application.jar extract
 FROM $REPOSITORY/gs-cloud-base-spring-boot:$TAG
 # WORKDIR already set to /opt/app/bin
 
-COPY --from=builder dependencies/ ./
-COPY --from=builder snapshot-dependencies/ ./
-COPY --from=builder spring-boot-loader/ ./
+COPY --from=builder /builder/dependencies/ ./
+COPY --from=builder /builder/snapshot-dependencies/ ./
+COPY --from=builder /builder/spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder application/ ./
+COPY --from=builder /builder/application/ ./

--- a/src/apps/infrastructure/gateway-webmvc/Dockerfile
+++ b/src/apps/infrastructure/gateway-webmvc/Dockerfile
@@ -4,6 +4,8 @@ ARG TAG=latest
 FROM $REPOSITORY/gs-cloud-base-jre:$TAG AS builder
 ARG JAR_FILE=target/gs-cloud-*-bin.jar
 
+WORKDIR /builder
+
 COPY ${JAR_FILE} application.jar
 
 RUN java -Djarmode=layertools -jar application.jar extract
@@ -12,12 +14,12 @@ RUN java -Djarmode=layertools -jar application.jar extract
 FROM $REPOSITORY/gs-cloud-base-spring-boot:$TAG
 # WORKDIR already set to /opt/app/bin
 
-COPY --from=builder dependencies/ ./
-COPY --from=builder snapshot-dependencies/ ./
-COPY --from=builder spring-boot-loader/ ./
+COPY --from=builder /builder/dependencies/ ./
+COPY --from=builder /builder/snapshot-dependencies/ ./
+COPY --from=builder /builder/spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder application/ ./
+COPY --from=builder /builder/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
 RUN java -XX:AOTCacheOutput=app.aot \

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -24,7 +24,7 @@
     <!-- Project version management       -->
     <!-- ================================ -->
     <spring-cloud.version>2025.1.1</spring-cloud.version>
-    <spring-boot.version>4.0.5</spring-boot.version>
+    <spring-boot.version>4.0.6</spring-boot.version>
     <!-- match upstream geoserver dependencies -->
     <spring.version>7.0.7</spring.version>
     <spring.security.version>7.0.4</spring.security.version>


### PR DESCRIPTION
[Spring Boot 4.0.6](https://github.com/spring-projects/spring-boot/releases/tag/v4.0.6) upgrades to `spring-framework:7.0.7`, matches the version used by GeoServer upstream.

Extract Spring Boot layers under `/builder`, not `/`

Spring Boot 4 tightened `LayerToolsJarMode`'s destination check: extracting to `/` now fails with

```
  IllegalStateException: Layer 'dependencies' would be written to
  '/dependencies'. This is outside the output location of '//'.
```

The builder stages had no `WORKDIR` and inherited `/` from the JRE base image, so 'java -Djarmode=layertools ... extract' produced `/dependencies`, `/snapshot-dependencies`, etc., and Spring Boot 4 now rejects that.

Set `WORKDIR /builder` before the `COPY` of `application.jar` so extract writes to `/builder/<layer>`, and switch the corresponding `COPY --from=builder` paths to absolute `/builder/...` so they don't depend on Docker's relative-path resolution semantics for cross-stage copies.
