### PR TITLE
pgconfig: cascade workspace changes to resources and layer groups

### DIFF
--- a/src/catalog/backends/pgconfig/src/main/resources/db/pgconfig/migration/postgresql/V3_0_0__UpgradeResourceLock.sql
+++ b/src/catalog/backends/pgconfig/src/main/resources/db/pgconfig/migration/postgresql/V3_0_0__UpgradeResourceLock.sql
@@ -1,0 +1,15 @@
+/*
+ * Upgrade the RESOURCE_LOCK table first defined in V1_4__ResourceStore_Tables
+ * after the migration to Spring Boot 4 / spring-integration-jdbc 7.0.2.
+ *
+ * The EXPIRED_AFTER column is required by spring-integration-jdbc 7.0.2 for
+ * lock expiration support.
+ *
+ * A DEFAULT value is provided for backwards compatibility: if a rollback to
+ * geoserver-cloud 2.28.2.0 (spring-integration-jdbc 6.x) is needed, the old
+ * code can still insert rows without specifying this column. The default of
+ * CURRENT_TIMESTAMP means any such locks would be considered immediately
+ * expired, which is a safe fallback for orphaned locks.
+ */
+ALTER TABLE RESOURCE_LOCK ADD COLUMN IF NOT EXISTS EXPIRED_AFTER TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+

--- a/src/catalog/backends/pgconfig/src/main/resources/db/pgconfig/migration/postgresql/V3_0_1__StoreInfo_Workspace_Cascade_Namespace.sql
+++ b/src/catalog/backends/pgconfig/src/main/resources/db/pgconfig/migration/postgresql/V3_0_1__StoreInfo_Workspace_Cascade_Namespace.sql
@@ -1,0 +1,88 @@
+-- V3_0_1__StoreInfo_Workspace_Cascade_Namespace.sql
+-- @since 2.28.3
+--
+-- Purpose:
+-- When a storeinfo row's workspace column changes, cascade the change to every
+-- resourceinfo belonging to that store so its namespace matches the workspace's
+-- namespace (resolved by name == workspace name, the invariant maintained by
+-- org.geoserver.catalog.impl.CatalogImpl#findNamespaceChange).
+--
+-- Background:
+-- CatalogPlugin.save(StoreInfo) already cascades namespace updates to resources
+-- when a store's workspace changes. This trigger is defense-in-depth: it ensures
+-- the invariant holds even if some future code path (REST import, XStream
+-- restore, direct SQL, in-process tooling) updates storeinfo.workspace without
+-- going through CatalogPlugin.save. Without it, resourceinfo rows can drift out
+-- of sync with their store's workspace, breaking layer prefixedName, the
+-- pgconfig.publishedinfos view, and the pgconfig.publishedinfos_mat
+-- materialized table.
+--
+-- Note on JSON shape:
+-- ResourceInfo.namespace is encoded in the resourceinfo.info JSONB column as a
+-- plain string ID (e.g. {"namespace": "NamespaceInfo-...."}). Updating
+-- resourceinfo.info with jsonb_set fires the existing BEFORE UPDATE trigger
+-- resourceinfo_populate, which calls populate_table_columns_from_jsonb() to
+-- keep the denormalized resourceinfo.namespace FK column in sync.
+
+CREATE OR REPLACE FUNCTION cascade_store_workspace_to_resource_namespace() RETURNS TRIGGER AS
+$func$
+DECLARE
+  new_namespace_id TEXT;
+BEGIN
+  SELECT n.id
+    INTO new_namespace_id
+    FROM namespaceinfo n
+    INNER JOIN workspaceinfo w ON w.name = n.name
+   WHERE w.id = NEW.workspace;
+
+  IF new_namespace_id IS NULL THEN
+    RAISE EXCEPTION
+      'No namespace matches workspace % (id %) - cannot cascade store % namespace',
+      (SELECT name FROM workspaceinfo WHERE id = NEW.workspace),
+      NEW.workspace,
+      NEW.id;
+  END IF;
+
+  -- Update the JSON; the existing resourceinfo_populate BEFORE trigger then
+  -- copies the new namespace id into the resourceinfo.namespace FK column.
+  UPDATE resourceinfo
+     SET info = jsonb_set(info, '{namespace}', to_jsonb(new_namespace_id))
+   WHERE store = NEW.id
+     AND namespace IS DISTINCT FROM new_namespace_id;
+
+  RETURN NEW;
+END
+$func$ LANGUAGE plpgsql;
+
+-- Fire on every storeinfo UPDATE, not "UPDATE OF workspace": the writable path
+-- updates the info JSONB column (UPDATE storeinfo SET info = ...) and the existing
+-- BEFORE trigger storeinfo_populate derives the workspace FK column from the new
+-- JSON. The workspace column is therefore never directly mentioned in a SET clause,
+-- so an "UPDATE OF workspace" trigger would never fire in production. The WHEN
+-- clause is evaluated AFTER the BEFORE triggers run, so OLD.workspace and
+-- NEW.workspace correctly compare the persisted workspace before and after.
+CREATE TRIGGER storeinfo_cascade_workspace_to_resource_namespace
+  AFTER UPDATE ON storeinfo
+  FOR EACH ROW
+  WHEN (NEW.workspace IS DISTINCT FROM OLD.workspace)
+  EXECUTE FUNCTION cascade_store_workspace_to_resource_namespace();
+
+-- One-time repair for catalogs that already have resourceinfo rows whose
+-- namespace drifted away from their store's workspace's namespace. Mirrors
+-- the invariant CatalogPlugin#findNamespaceChange relies on (namespace name
+-- equals workspace name). Updating resourceinfo.info fires resourceinfo_populate,
+-- which keeps the FK column consistent, and resourceinfo_update_trigger, which
+-- refreshes publishedinfos_mat.
+WITH expected AS (
+  SELECT r.id           AS resource_id,
+         n.id           AS expected_namespace_id
+    FROM resourceinfo r
+    INNER JOIN storeinfo     s ON r.store = s.id
+    INNER JOIN workspaceinfo w ON s.workspace = w.id
+    INNER JOIN namespaceinfo n ON n.name = w.name
+   WHERE r.namespace <> n.id
+)
+UPDATE resourceinfo r
+   SET info = jsonb_set(r.info, '{namespace}', to_jsonb(e.expected_namespace_id))
+  FROM expected e
+ WHERE r.id = e.resource_id;

--- a/src/catalog/backends/pgconfig/src/main/resources/db/pgconfig/migration/postgresql/V3_0_2__Fix_WorkspaceInfo_Update_Trigger.sql
+++ b/src/catalog/backends/pgconfig/src/main/resources/db/pgconfig/migration/postgresql/V3_0_2__Fix_WorkspaceInfo_Update_Trigger.sql
@@ -1,0 +1,37 @@
+-- V3_0_2__Fix_WorkspaceInfo_Update_Trigger.sql
+-- @since 2.28.3
+--
+-- Fix workspaceinfo_update_trigger() introduced in V2_0_0__PublishedInfos_Materialized_Table.sql.
+-- The original implementation collected the affected LayerGroupInfo IDs into
+-- affected_ids and then immediately overwrote that variable with the LayerInfo IDs in
+-- the very next SELECT INTO. As a result, LayerGroupInfo IDs were silently dropped:
+-- renaming a workspace did not refresh publishedinfos_mat (nor tilelayers_mat) for any
+-- LayerGroupInfo belonging to that workspace, leaving stale workspace.name /
+-- prefixedName values until publishedinfos_mat was rebuilt.
+--
+-- Combine the two queries with UNION so both kinds of publishedinfo are refreshed.
+
+CREATE OR REPLACE FUNCTION workspaceinfo_update_trigger() RETURNS TRIGGER AS
+$$
+DECLARE
+  affected_ids TEXT[];
+BEGIN
+  WITH ids AS (
+    -- LayerGroupInfo IDs directly owned by this workspace
+    SELECT id FROM layergroupinfo WHERE workspace = NEW.id
+    UNION
+    -- LayerInfo IDs reached via resource.store.workspace
+    SELECT l.id
+      FROM layerinfo l
+      INNER JOIN resourceinfo r ON l.resource = r.id
+      INNER JOIN storeinfo     s ON r.store = s.id
+     WHERE s.workspace = NEW.id
+  )
+  SELECT array_agg(id) INTO affected_ids FROM ids;
+
+  IF affected_ids IS NOT NULL THEN
+    PERFORM sync_publishedinfos_by_ids(affected_ids);
+  END IF;
+  RETURN NULL;
+END
+$$ LANGUAGE plpgsql;

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/catalog/PgconfigStoreNamespaceCascadeTest.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/catalog/PgconfigStoreNamespaceCascadeTest.java
@@ -1,0 +1,438 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.backend.pgconfig.catalog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.geoserver.catalog.CatalogFactory;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.plugin.CatalogPlugin;
+import org.geoserver.cloud.backend.pgconfig.PgconfigBackendBuilder;
+import org.geoserver.cloud.backend.pgconfig.support.PgConfigTestContainer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Verifies that moving a {@code StoreInfo} from one workspace to another correctly cascades the
+ * namespace change to every {@code ResourceInfo} belonging to that store. Unlike the standard
+ * conformance tests, these checks read the {@code resourceinfo} table directly via JDBC so they
+ * catch inconsistencies between the JSON {@code info} column and the denormalized {@code namespace}
+ * FK column.
+ *
+ * <p>Background: in production users reported that after moving a data store between workspaces,
+ * the resources kept their old namespace. The catalog-level read path was returning the resources
+ * via a JOIN through the FK column, masking partial cascade failures. These tests query the
+ * underlying table so any cascade gap surfaces immediately.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class PgconfigStoreNamespaceCascadeTest {
+
+    @Container
+    static PgConfigTestContainer<?> container = new PgConfigTestContainer<>();
+
+    private CatalogPlugin catalog;
+    private JdbcTemplate jdbc;
+
+    @BeforeEach
+    void setUp() {
+        container.setUp();
+        jdbc = container.getTemplate();
+        catalog = new PgconfigBackendBuilder(container.getDataSource()).createCatalog();
+    }
+
+    @AfterEach
+    void tearDown() {
+        container.tearDown();
+    }
+
+    @Test
+    void movingStoreUpdatesResourceinfoNamespaceFkColumn() {
+        Fixture fixture = newFixtureWithResources(3);
+
+        moveStore(fixture.store, fixture.targetWorkspace);
+
+        assertResourceinfoFkPointsTo(fixture.resourceIds, fixture.targetNamespace);
+    }
+
+    @Test
+    void movingStoreUpdatesResourceinfoInfoJson() {
+        Fixture fixture = newFixtureWithResources(3);
+
+        moveStore(fixture.store, fixture.targetWorkspace);
+
+        assertResourceinfoJsonNamespaceIs(fixture.resourceIds, fixture.targetNamespace);
+    }
+
+    @Test
+    void movingStoreWithSingleResourceCascades() {
+        Fixture fixture = newFixtureWithResources(1);
+
+        moveStore(fixture.store, fixture.targetWorkspace);
+
+        assertResourceinfoFkPointsTo(fixture.resourceIds, fixture.targetNamespace);
+        assertResourceinfoJsonNamespaceIs(fixture.resourceIds, fixture.targetNamespace);
+    }
+
+    @Test
+    void movingStoreWithManyResourcesCascades() {
+        Fixture fixture = newFixtureWithResources(10);
+
+        moveStore(fixture.store, fixture.targetWorkspace);
+
+        assertResourceinfoFkPointsTo(fixture.resourceIds, fixture.targetNamespace);
+        assertResourceinfoJsonNamespaceIs(fixture.resourceIds, fixture.targetNamespace);
+    }
+
+    @Test
+    void movingStoreToOriginalWorkspaceIsNoOp() {
+        Fixture fixture = newFixtureWithResources(2);
+
+        moveStore(fixture.store, fixture.targetWorkspace);
+        moveStore(reloadStore(fixture.store), fixture.sourceWorkspace);
+
+        assertResourceinfoFkPointsTo(fixture.resourceIds, fixture.sourceNamespace);
+        assertResourceinfoJsonNamespaceIs(fixture.resourceIds, fixture.sourceNamespace);
+    }
+
+    @Test
+    void triggerIsInstalled() {
+        Integer count = jdbc.queryForObject(
+                """
+                SELECT COUNT(*) FROM pg_trigger
+                WHERE tgname = 'storeinfo_cascade_workspace_to_resource_namespace'
+                """,
+                Integer.class);
+        assertThat(count)
+                .as("cascade trigger should be installed by V3_0_1 migration")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void dbTriggerCascadesWhenStoreWorkspaceChangedDirectly() {
+        Fixture fixture = newFixtureWithResources(3);
+
+        // Simulates a non-catalog write path (REST import, manual SQL, restore tool) that
+        // updates storeinfo.info directly. The existing BEFORE trigger derives the workspace
+        // FK column from the new JSON, and our AFTER trigger then propagates to the resources.
+        int updated = jdbc.update(
+                "UPDATE storeinfo SET info = jsonb_set(info, '{workspace}', to_jsonb(?::text)) WHERE id = ?",
+                fixture.targetWorkspace.getId(),
+                fixture.store.getId());
+        assertThat(updated).isOne();
+
+        assertResourceinfoFkPointsTo(fixture.resourceIds, fixture.targetNamespace);
+        assertResourceinfoJsonNamespaceIs(fixture.resourceIds, fixture.targetNamespace);
+    }
+
+    @Test
+    void dbTriggerRaisesWhenWorkspaceHasNoMatchingNamespace() {
+        Fixture fixture = newFixtureWithResources(1);
+
+        WorkspaceInfo orphanWs = catalog.getFactory().createWorkspace();
+        orphanWs.setName("orphan");
+        catalog.add(orphanWs);
+        WorkspaceInfo persistedOrphan = catalog.getWorkspaceByName("orphan");
+
+        assertThat(persistedOrphan).isNotNull();
+
+        Throwable thrown = catchThrowable(() -> jdbc.update(
+                "UPDATE storeinfo SET info = jsonb_set(info, '{workspace}', to_jsonb(?::text)) WHERE id = ?",
+                persistedOrphan.getId(),
+                fixture.store.getId()));
+
+        assertThat(thrown).isNotNull().hasMessageContaining("No namespace matches workspace orphan");
+    }
+
+    @Test
+    void renamingWorkspaceLeavesGlobalLayerGroupAlone() {
+        // A global layer group (workspace = NULL) referencing a layer/group from the renamed
+        // workspace must keep its own row stable in publishedinfos_mat (its "workspace.name" is
+        // NULL and its "prefixedName" has no workspace prefix). V3_0_2 trigger filters global
+        // groups out by WHERE workspace = NEW.id, which is the desired no-op behaviour.
+        Fixture fixture = newFixtureWithResources(1);
+        WorkspaceInfo ws = fixture.sourceWorkspace;
+
+        CatalogFactory factory = catalog.getFactory();
+        StyleInfo style = factory.createStyle();
+        style.setName("style1");
+        style.setFilename("style1.sld");
+        catalog.add(style);
+        LayerInfo layer = factory.createLayer();
+        layer.setResource(catalog.getResource(fixture.resourceIds.getFirst(), FeatureTypeInfo.class));
+        layer.setDefaultStyle(catalog.getStyleByName("style1"));
+        layer.setEnabled(true);
+        catalog.add(layer);
+
+        // Global group (workspace = NULL) wrapping the layer from `ws`. styles has a NULL entry
+        // (the "use the layer's default style" placeholder), exercising NULL-in-array handling.
+        LayerGroupInfo globalGroup = factory.createLayerGroup();
+        globalGroup.setName("globalg");
+        globalGroup.setMode(LayerGroupInfo.Mode.SINGLE);
+        globalGroup.setWorkspace(null);
+        globalGroup.getLayers().add(catalog.getLayer(layer.getId()));
+        globalGroup.getStyles().add(null);
+        catalog.add(globalGroup);
+
+        // Before rename
+        String globalPrefixedNameBefore = jdbc.queryForObject(
+                "SELECT \"prefixedName\" FROM publishedinfos_mat WHERE id = ?", String.class, globalGroup.getId());
+        assertThat(globalPrefixedNameBefore).isEqualTo("globalg");
+        assertWorkspaceNameInMat(layer.getId(), ws.getName());
+
+        jdbc.update(
+                "UPDATE workspaceinfo SET info = jsonb_set(info, '{name}', to_jsonb(?::text)) WHERE id = ?",
+                "renamed",
+                ws.getId());
+
+        // Layer row refreshed; global group row unchanged
+        assertWorkspaceNameInMat(layer.getId(), "renamed");
+        String globalPrefixedNameAfter = jdbc.queryForObject(
+                "SELECT \"prefixedName\" FROM publishedinfos_mat WHERE id = ?", String.class, globalGroup.getId());
+        assertThat(globalPrefixedNameAfter).isEqualTo("globalg");
+        String globalWsName = jdbc.queryForObject(
+                "SELECT \"workspace.name\" FROM publishedinfos_mat WHERE id = ?", String.class, globalGroup.getId());
+        assertThat(globalWsName).isNull();
+    }
+
+    @Test
+    void renamingWorkspaceRefreshesNestedLayerGroupHolders() {
+        // A layer group in workspace A whose layers array contains another layer group (also in
+        // workspace A) is just a row with layers.id = [nested-group-id]. Renaming workspace A
+        // refreshes the outer group via the V3_0_2 trigger; the layers.id array (by ID) doesn't
+        // need to change.
+        Fixture fixture = newFixtureWithResources(1);
+        WorkspaceInfo ws = fixture.sourceWorkspace;
+
+        CatalogFactory factory = catalog.getFactory();
+        StyleInfo style = factory.createStyle();
+        style.setName("style1");
+        style.setFilename("style1.sld");
+        catalog.add(style);
+        LayerInfo layer = factory.createLayer();
+        layer.setResource(catalog.getResource(fixture.resourceIds.getFirst(), FeatureTypeInfo.class));
+        layer.setDefaultStyle(catalog.getStyleByName("style1"));
+        layer.setEnabled(true);
+        catalog.add(layer);
+
+        LayerGroupInfo inner = factory.createLayerGroup();
+        inner.setName("inner");
+        inner.setMode(LayerGroupInfo.Mode.SINGLE);
+        inner.setWorkspace(ws);
+        inner.getLayers().add(catalog.getLayer(layer.getId()));
+        inner.getStyles().add(null);
+        catalog.add(inner);
+
+        LayerGroupInfo outer = factory.createLayerGroup();
+        outer.setName("outer");
+        outer.setMode(LayerGroupInfo.Mode.SINGLE);
+        outer.setWorkspace(ws);
+        outer.getLayers().add(catalog.getLayerGroup(inner.getId()));
+        outer.getStyles().add(null);
+        catalog.add(outer);
+
+        assertWorkspaceNameInMat(inner.getId(), ws.getName());
+        assertWorkspaceNameInMat(outer.getId(), ws.getName());
+
+        jdbc.update(
+                "UPDATE workspaceinfo SET info = jsonb_set(info, '{name}', to_jsonb(?::text)) WHERE id = ?",
+                "renamed",
+                ws.getId());
+
+        assertWorkspaceNameInMat(inner.getId(), "renamed");
+        assertWorkspaceNameInMat(outer.getId(), "renamed");
+    }
+
+    @Test
+    void renamingWorkspaceRefreshesPublishedInfosMatForBothLayersAndLayerGroups() {
+        // Regression for V2_0_0 workspaceinfo_update_trigger(): the trigger had two SELECT INTO
+        // statements overwriting each other, dropping LayerGroupInfo IDs from affected_ids
+        // before the PERFORM. Without V3_0_2, renaming a workspace leaves the layer-group rows
+        // in publishedinfos_mat with stale workspace.name / prefixedName.
+        Fixture fixture = newFixtureWithResources(1);
+        WorkspaceInfo ws = fixture.sourceWorkspace;
+
+        CatalogFactory factory = catalog.getFactory();
+        StyleInfo style = factory.createStyle();
+        style.setName("style1");
+        style.setFilename("style1.sld");
+        catalog.add(style);
+        LayerInfo layer = factory.createLayer();
+        layer.setResource(catalog.getResource(fixture.resourceIds.getFirst(), FeatureTypeInfo.class));
+        layer.setDefaultStyle(catalog.getStyleByName("style1"));
+        layer.setEnabled(true);
+        catalog.add(layer);
+
+        LayerGroupInfo group = factory.createLayerGroup();
+        group.setName("lg");
+        group.setMode(LayerGroupInfo.Mode.SINGLE);
+        group.setWorkspace(ws);
+        group.getLayers().add(catalog.getLayer(layer.getId()));
+        group.getStyles().add(null);
+        catalog.add(group);
+
+        assertWorkspaceNameInMat(layer.getId(), ws.getName());
+        assertWorkspaceNameInMat(group.getId(), ws.getName());
+
+        // Direct JDBC rename so only the workspaceinfo BEFORE+AFTER triggers run; this isolates
+        // the trigger from any Java-side catalog cascade and exposes the regression.
+        jdbc.update(
+                "UPDATE workspaceinfo SET info = jsonb_set(info, '{name}', to_jsonb(?::text)) WHERE id = ?",
+                "renamed",
+                ws.getId());
+
+        assertWorkspaceNameInMat(layer.getId(), "renamed");
+        assertWorkspaceNameInMat(group.getId(), "renamed");
+    }
+
+    private void assertWorkspaceNameInMat(String publishedId, String expectedWorkspaceName) {
+        String layerWsName = jdbc.queryForObject(
+                """
+                SELECT COALESCE("workspace.name", "resource.store.workspace.name")
+                  FROM publishedinfos_mat
+                 WHERE id = ?
+                """,
+                String.class,
+                publishedId);
+        assertThat(layerWsName)
+                .as("publishedinfos_mat[%s] workspace name", publishedId)
+                .isEqualTo(expectedWorkspaceName);
+    }
+
+    @Test
+    void dataRepairFixesPreexistingMismatch() {
+        Fixture fixture = newFixtureWithResources(3);
+
+        // Simulate the broken production state: disable the cascade trigger and force the
+        // store into the target workspace via the JSON path. The existing BEFORE trigger
+        // still updates the FK column, but the resource namespaces stay out of sync.
+        jdbc.execute("ALTER TABLE storeinfo DISABLE TRIGGER storeinfo_cascade_workspace_to_resource_namespace");
+        try {
+            int moved = jdbc.update(
+                    "UPDATE storeinfo SET info = jsonb_set(info, '{workspace}', to_jsonb(?::text)) WHERE id = ?",
+                    fixture.targetWorkspace.getId(),
+                    fixture.store.getId());
+            assertThat(moved).isOne();
+            // resources still point at the source namespace - confirms broken state
+            assertResourceinfoFkPointsTo(fixture.resourceIds, fixture.sourceNamespace);
+        } finally {
+            jdbc.execute("ALTER TABLE storeinfo ENABLE TRIGGER storeinfo_cascade_workspace_to_resource_namespace");
+        }
+
+        // Run the same one-shot repair SQL the migration ships.
+        int repaired = jdbc.update(
+                """
+                WITH expected AS (
+                  SELECT r.id           AS resource_id,
+                         n.id           AS expected_namespace_id
+                    FROM resourceinfo r
+                    INNER JOIN storeinfo     s ON r.store = s.id
+                    INNER JOIN workspaceinfo w ON s.workspace = w.id
+                    INNER JOIN namespaceinfo n ON n.name = w.name
+                   WHERE r.namespace <> n.id
+                )
+                UPDATE resourceinfo r
+                   SET info = jsonb_set(r.info, '{namespace}', to_jsonb(e.expected_namespace_id))
+                  FROM expected e
+                 WHERE r.id = e.resource_id
+                """);
+        assertThat(repaired).isEqualTo(3);
+
+        assertResourceinfoFkPointsTo(fixture.resourceIds, fixture.targetNamespace);
+        assertResourceinfoJsonNamespaceIs(fixture.resourceIds, fixture.targetNamespace);
+    }
+
+    private Fixture newFixtureWithResources(int resourceCount) {
+        CatalogFactory factory = catalog.getFactory();
+
+        WorkspaceInfo wsSource = factory.createWorkspace();
+        wsSource.setName("src");
+        catalog.add(wsSource);
+
+        NamespaceInfo nsSource = factory.createNamespace();
+        nsSource.setPrefix("src");
+        nsSource.setURI("http://src.example");
+        catalog.add(nsSource);
+
+        WorkspaceInfo wsTarget = factory.createWorkspace();
+        wsTarget.setName("tgt");
+        catalog.add(wsTarget);
+
+        NamespaceInfo nsTarget = factory.createNamespace();
+        nsTarget.setPrefix("tgt");
+        nsTarget.setURI("http://tgt.example");
+        catalog.add(nsTarget);
+
+        DataStoreInfo store = factory.createDataStore();
+        store.setName("ds");
+        store.setWorkspace(wsSource);
+        store.setEnabled(true);
+        catalog.add(store);
+
+        List<String> resourceIds = new ArrayList<>(resourceCount);
+        for (int i = 0; i < resourceCount; i++) {
+            FeatureTypeInfo ft = factory.createFeatureType();
+            ft.setName("ft" + i);
+            ft.setNativeName("ft" + i);
+            ft.setStore(store);
+            ft.setNamespace(nsSource);
+            ft.setEnabled(true);
+            catalog.add(ft);
+            resourceIds.add(ft.getId());
+        }
+
+        DataStoreInfo persistedStore = catalog.getDataStore(store.getId());
+        NamespaceInfo persistedSrc = catalog.getNamespaceByPrefix("src");
+        NamespaceInfo persistedTgt = catalog.getNamespaceByPrefix("tgt");
+        WorkspaceInfo persistedSrcWs = catalog.getWorkspaceByName("src");
+        WorkspaceInfo persistedTgtWs = catalog.getWorkspaceByName("tgt");
+        return new Fixture(persistedStore, persistedSrcWs, persistedTgtWs, persistedSrc, persistedTgt, resourceIds);
+    }
+
+    private void moveStore(DataStoreInfo store, WorkspaceInfo target) {
+        DataStoreInfo fresh = catalog.getDataStore(store.getId());
+        fresh.setWorkspace(target);
+        catalog.save(fresh);
+    }
+
+    private DataStoreInfo reloadStore(DataStoreInfo store) {
+        return catalog.getDataStore(store.getId());
+    }
+
+    private void assertResourceinfoFkPointsTo(List<String> resourceIds, NamespaceInfo expected) {
+        for (String id : resourceIds) {
+            String fk = jdbc.queryForObject("SELECT namespace FROM resourceinfo WHERE id = ?", String.class, id);
+            assertThat(fk).as("resourceinfo[%s].namespace FK column", id).isEqualTo(expected.getId());
+        }
+    }
+
+    private void assertResourceinfoJsonNamespaceIs(List<String> resourceIds, NamespaceInfo expected) {
+        for (String id : resourceIds) {
+            String jsonNs =
+                    jdbc.queryForObject("SELECT info->>'namespace' FROM resourceinfo WHERE id = ?", String.class, id);
+            assertThat(jsonNs).as("resourceinfo[%s].info->>'namespace'", id).isEqualTo(expected.getId());
+        }
+    }
+
+    private record Fixture(
+            DataStoreInfo store,
+            WorkspaceInfo sourceWorkspace,
+            WorkspaceInfo targetWorkspace,
+            NamespaceInfo sourceNamespace,
+            NamespaceInfo targetNamespace,
+            List<String> resourceIds) {}
+}


### PR DESCRIPTION
Includes V3_0_0__UpgradeResourceLock.sql, the migration that brings the 2.28.x branch in sync with the 3.0.x series from main (adds the EXPIRED_AFTER column required by spring-integration-jdbc 7.0.2 to RESOURCE_LOCK, with CURRENT_TIMESTAMP default for rollback safety).

Fix two related referential-integrity issues in pgconfig when a store is moved between workspaces or a workspace is renamed:

- After moving a store to a different workspace, every ResourceInfo belonging to that store kept its old namespace_id in both the JSON and the FK column. The Java cascade in CatalogPlugin.save(StoreInfo) handles this for catalog.save(), but any other write path that updates storeinfo.info bypasses it.
- workspaceinfo_update_trigger() (Flyway migration V2_0_0) had two consecutive SELECT array_agg(id) INTO affected_ids statements; the second clobbered the first, dropping LayerGroupInfo IDs before sync_publishedinfos_by_ids was called. Renaming a workspace left the layer groups' rows in publishedinfos_mat (and therefore tilelayers_mat) with stale workspace.name and prefixedName.

Flyway migration V3_0_1 installs an AFTER UPDATE ON storeinfo trigger that fires when the workspace column changes, sets resourceinfo.info.namespace to the namespace whose name matches the new workspace name, and lets the existing BEFORE trigger keep the FK column in sync. The same migration runs a one-shot repair UPDATE to align any pre-existing inconsistent rows on first deploy.

Flyway migration V3_0_2 replaces the workspaceinfo_update_trigger() body with a single CTE that UNIONs both layer-group and layer ids, so renames refresh the materialized rows for both kinds of published info. Verified that the new test fails without V3_0_2 (the layer group's row stays stale) and passes with it.

Add tests cover store move via Java cascade (5 variants), bypass via direct JSON UPDATE, the orphan-workspace exception path, the data repair logic, global layer groups, NULL entries in the layers/styles arrays, and nested layer-group references.