### PR TITLE
pgconfig: evict cached layer lists on workspace/namespace rename

### DIFF
--- a/src/catalog/backends/pgconfig/pom.xml
+++ b/src/catalog/backends/pgconfig/pom.xml
@@ -25,6 +25,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.geoserver.cloud.catalog</groupId>
+      <artifactId>gs-cloud-catalog-cache</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-jdbc</artifactId>
     </dependency>

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/catalog/PgconfigCachingWorkspaceRenameTest.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/catalog/PgconfigCachingWorkspaceRenameTest.java
@@ -1,0 +1,228 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.backend.pgconfig.catalog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.geoserver.catalog.CatalogFactory;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.NamespaceWorkspaceConsistencyListener;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.plugin.CatalogPlugin;
+import org.geoserver.cloud.backend.pgconfig.PgconfigBackendBuilder;
+import org.geoserver.cloud.backend.pgconfig.support.PgConfigTestContainer;
+import org.geoserver.cloud.backend.pgconfig.support.PgconfigTestDatabaseSupport;
+import org.geoserver.cloud.catalog.cache.CachingCatalogFacade;
+import org.geotools.api.filter.Filter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Verifies that renaming a workspace (or its paired namespace) does not leave {@code CachingCatalogFacade} returning
+ * stale prefixed names through any of the catalog-level read paths.
+ *
+ * <p>Background: production users hit this when {@code geoserver.catalog.caching.enabled=true} - after renaming a
+ * workspace in the Wicket UI, the {@code NewCachedLayerPage} ("Tile Layers -> Add a new cached layer") kept showing the
+ * old prefixed layer names until the user clicked "Server Status -> Resource Cache -> Clear". The page exercises
+ * {@code Catalog.getLayerByName}, which internally calls {@code getResourceByName} then {@code getLayers(resource)} -
+ * the second call hits the {@code "layers@<resourceId>"} {@code List<LayerInfo>} cache that the cascade-evict pass did
+ * not visit (it only iterated {@link org.geoserver.catalog.CatalogInfo} cache values).
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class PgconfigCachingWorkspaceRenameTest {
+
+    @Container
+    static PgConfigTestContainer container = new PgConfigTestContainer();
+
+    @RegisterExtension
+    PgconfigTestDatabaseSupport db = new PgconfigTestDatabaseSupport(container);
+
+    private static final String CACHE_NAME = "gs-catalog";
+
+    private CatalogPlugin catalog;
+    private CachingCatalogFacade cachingFacade;
+
+    @BeforeEach
+    void setUp() {
+        catalog = newCachingCatalog();
+    }
+
+    @Test
+    void renamingWorkspaceUpdatesCachedLayerById() {
+        Fixture fx = newFixture();
+        primeCaches(fx);
+
+        renameWorkspace(fx.workspace, "ws_renamed");
+
+        LayerInfo layer = catalog.getLayer(fx.layerId);
+        assertThat(layer.getResource().prefixedName())
+                .as("getLayer(id).resource.prefixedName after rename")
+                .isEqualTo("ws_renamed:ft");
+    }
+
+    @Test
+    void renamingWorkspaceUpdatesCachedLayerByName() {
+        Fixture fx = newFixture();
+        primeCaches(fx);
+
+        renameWorkspace(fx.workspace, "ws_renamed");
+
+        assertThat(catalog.getLayerByName("ws1:ft"))
+                .as("getLayerByName(old prefix) after rename")
+                .isNull();
+
+        LayerInfo byNewName = catalog.getLayerByName("ws_renamed:ft");
+        assertThat(byNewName).as("getLayerByName(new prefix) after rename").isNotNull();
+        assertThat(byNewName.getResource().prefixedName())
+                .as("getLayerByName(new).resource.prefixedName")
+                .isEqualTo("ws_renamed:ft");
+    }
+
+    @Test
+    void renamingWorkspaceUpdatesCachedLayerByNameWithoutPriming() {
+        // Reproduction of the production symptom: even without an explicit cache prime,
+        // creating the fixture itself populates the "layers@<resourceId>" cache (via the
+        // catalog.getLayerByName("ws1:ft") at the end of fixture setup). Renaming the workspace
+        // must evict that list entry so the next prefixed-name lookup is fresh.
+        Fixture fx = newFixture();
+        renameWorkspace(fx.workspace, "ws_renamed");
+
+        LayerInfo byNewName = catalog.getLayerByName("ws_renamed:ft");
+        assertThat(byNewName).as("getLayerByName(new prefix) after rename").isNotNull();
+        assertThat(byNewName.getResource().prefixedName())
+                .as("getLayerByName(new).resource.prefixedName")
+                .isEqualTo("ws_renamed:ft");
+    }
+
+    @Test
+    void renamingWorkspaceUpdatesCachedNamespace() {
+        Fixture fx = newFixture();
+        primeCaches(fx);
+
+        renameWorkspace(fx.workspace, "ws_renamed");
+
+        assertThat(catalog.getNamespace(fx.namespaceId).getPrefix())
+                .as("getNamespace(id).prefix after rename")
+                .isEqualTo("ws_renamed");
+
+        assertThat(catalog.getNamespaceByPrefix("ws1"))
+                .as("getNamespaceByPrefix(old) after rename")
+                .isNull();
+        assertThat(catalog.getNamespaceByPrefix("ws_renamed"))
+                .as("getNamespaceByPrefix(new) after rename")
+                .isNotNull();
+    }
+
+    @Test
+    void renamingWorkspaceUpdatesListedLayers() {
+        Fixture fx = newFixture();
+        primeCaches(fx);
+
+        renameWorkspace(fx.workspace, "ws_renamed");
+
+        List<String> prefixedNames = listLayerPrefixedNames();
+        assertThat(prefixedNames)
+                .as("catalog.list(LayerInfo).map(prefixedName)")
+                .containsExactly("ws_renamed:ft");
+    }
+
+    private List<String> listLayerPrefixedNames() {
+        List<String> names = new ArrayList<>();
+        try (var it = catalog.list(LayerInfo.class, Filter.INCLUDE)) {
+            while (it.hasNext()) {
+                names.add(it.next().getResource().prefixedName());
+            }
+        }
+        return names;
+    }
+
+    private CatalogPlugin newCachingCatalog() {
+        CatalogPlugin plugin = new CatalogPlugin();
+        PgconfigCatalogFacade pgconfigFacade =
+                (PgconfigCatalogFacade) new PgconfigBackendBuilder(db.getDataSource()).createCatalogFacade();
+        cachingFacade = new CachingCatalogFacade(pgconfigFacade, newCache());
+        plugin.setFacade(cachingFacade);
+        new NamespaceWorkspaceConsistencyListener(plugin);
+        return plugin;
+    }
+
+    private static Cache newCache() {
+        CaffeineCacheManager manager = new CaffeineCacheManager(CACHE_NAME);
+        return Objects.requireNonNull(manager.getCache(CACHE_NAME));
+    }
+
+    private Fixture newFixture() {
+        CatalogFactory factory = catalog.getFactory();
+
+        WorkspaceInfo ws = factory.createWorkspace();
+        ws.setName("ws1");
+        catalog.add(ws);
+
+        NamespaceInfo ns = factory.createNamespace();
+        ns.setPrefix("ws1");
+        ns.setURI("http://ws1.example");
+        catalog.add(ns);
+
+        DataStoreInfo store = factory.createDataStore();
+        store.setName("ds");
+        store.setWorkspace(ws);
+        store.setEnabled(true);
+        catalog.add(store);
+
+        FeatureTypeInfo ft = factory.createFeatureType();
+        ft.setName("ft");
+        ft.setNativeName("ft");
+        ft.setStore(store);
+        ft.setNamespace(ns);
+        ft.setEnabled(true);
+        catalog.add(ft);
+
+        StyleInfo style = factory.createStyle();
+        style.setName("default-style");
+        style.setFilename("default-style.sld");
+        catalog.add(style);
+
+        LayerInfo layer = factory.createLayer();
+        layer.setResource(catalog.getResource(ft.getId(), FeatureTypeInfo.class));
+        layer.setDefaultStyle(catalog.getStyleByName("default-style"));
+        layer.setEnabled(true);
+        catalog.add(layer);
+
+        WorkspaceInfo persistedWs = catalog.getWorkspaceByName("ws1");
+        NamespaceInfo persistedNs = catalog.getNamespaceByPrefix("ws1");
+        LayerInfo persistedLayer = catalog.getLayerByName("ws1:ft");
+        return new Fixture(persistedWs, persistedNs.getId(), persistedLayer.getId(), ft.getId());
+    }
+
+    private void primeCaches(Fixture fx) {
+        // Force CachingCatalogFacade to populate entries on every key path that production exercises:
+        // by id, by prefixed name, by namespace prefix, and the layers-by-resource list cache.
+        catalog.getLayer(fx.layerId);
+        catalog.getLayerByName("ws1:ft");
+        catalog.getNamespace(fx.namespaceId);
+        catalog.getNamespaceByPrefix("ws1");
+        catalog.getLayers(catalog.getResource(fx.resourceId, FeatureTypeInfo.class));
+    }
+
+    private void renameWorkspace(WorkspaceInfo ws, String newName) {
+        WorkspaceInfo fresh = catalog.getWorkspace(ws.getId());
+        fresh.setName(newName);
+        catalog.save(fresh);
+    }
+
+    private record Fixture(WorkspaceInfo workspace, String namespaceId, String layerId, String resourceId) {}
+}

--- a/src/catalog/cache/src/main/java/org/geoserver/cloud/catalog/cache/CachedReferenceCleaner.java
+++ b/src/catalog/cache/src/main/java/org/geoserver/cloud/catalog/cache/CachedReferenceCleaner.java
@@ -7,6 +7,7 @@ package org.geoserver.cloud.catalog.cache;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.google.common.base.Stopwatch;
+import java.util.List;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Getter;
@@ -81,13 +82,46 @@ class CachedReferenceCleaner {
 
         CachedReferenceCleanerVisitor visitor = new CachedReferenceCleanerVisitor(cache, idKey);
 
-        return cache.values().stream()
+        int infoEvictions = cache.values().stream()
                 .filter(CatalogInfo.class::isInstance)
                 .map(CatalogInfo.class::cast)
                 .filter(info -> this.canReference(info, idKey))
                 .peek(i -> visited.incrementAndGet())
                 .map(visitor::cascadeEvict)
                 .reduce(0, (c1, c2) -> c1 + c2);
+
+        return infoEvictions + evictReferencingLayerLists(idKey, cache, visited);
+    }
+
+    /**
+     * Evicts cached {@code List<LayerInfo>} entries (produced by {@code CachingCatalogFacade.getLayers(ResourceInfo)}
+     * and keyed by {@code layers@<resourceId>}) when any layer in the list references the evicted object. The
+     * visitor-based traversal above only inspects {@link CatalogInfo} cache values, missing these list entries; without
+     * this pass, a workspace or namespace rename leaves the list cached with stale prefixed names embedded in each
+     * layer's resource, which then surfaces through {@code Catalog.getLayerByName(prefixed)} (which internally calls
+     * {@code getResource} then {@code getLayers}).
+     */
+    private int evictReferencingLayerLists(InfoIdKey idKey, ConcurrentMap<?, ?> cache, AtomicInteger visited) {
+        int evicted = 0;
+        for (var entry : cache.entrySet()) {
+            Object value = entry.getValue();
+            if (!(value instanceof List<?> list) || list.isEmpty()) {
+                continue;
+            }
+            if (!(list.get(0) instanceof LayerInfo)) {
+                continue;
+            }
+            visited.incrementAndGet();
+            boolean anyReferences = list.stream()
+                    .filter(LayerInfo.class::isInstance)
+                    .map(LayerInfo.class::cast)
+                    .anyMatch(layer -> canReference(layer, idKey));
+            if (anyReferences && cache.remove(entry.getKey()) != null) {
+                evicted++;
+                log.trace("cascade evicted layer list {} referencing {}", entry.getKey(), idKey.id());
+            }
+        }
+        return evicted;
     }
 
     /** @return whether {@code cached} can directly or indirectly reference {@code evicted} */


### PR DESCRIPTION
The `CachingCatalogFacade` caches `Catalog.getLayers(resource)` under `"layers@<resourceId>"` as a `List<LayerInfo>`.

`CachedReferenceCleaner`'s cascade-evict pass only iterates `CatalogInfo` cache values, so list entries were left intact when a workspace or namespace was renamed. The stale list kept stale prefixed names embedded in each layer's resource, which surfaced through `Catalog.getLayerByName(prefixed)` (used by the Wicket NewCachedLayerPage) since that path internally calls getResource then getLayers(resource).

Extend `cascadeEvict` with `evictReferencingLayerLists`: iterate `cache.entrySet`, find `List<LayerInfo>` values, and evict the entry if any contained layer references the evicted workspace/namespace/store. The existing `canReference` walker is reused so the cascade rules stay consistent across both `CatalogInfo` and list values.

The fix also covers the #841 cross-container scenario: `CachingCatalogFacade.onCatalogInfoModified` (remote bus events) and the local `update()` path both route through `support.evict` -> `evictInternal` -> `cascadeEvict`, so the new pass runs in both cases.
