### PR TITLE
Pin hsqldb to 2.7.2

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1512,6 +1512,11 @@
             <version>2.5.2</version>
             <scope>compile</scope>
           </dependency>
+          <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <version>2.7.2</version>
+          </dependency>
         </dependencies>
       </dependencyManagement>
       <build>


### PR DESCRIPTION
Since v2.28.1.2, dependency scanners detect a  critical CVE introduced by the hsqldb transitive dependency (version 2.5.2 is pulled instead of 2.7.1 since this commit https://github.com/geoserver/geoserver-cloud/commit/3432acfde1b0ccc1541e805f00ea4ca9046c5aed)
This PR aims to pin hsqldb to version 2.7.1. I built the images and ran trivy locally to confirm that the CVE is gone. Let me know @groldan if that's not the correct place to put this.
The PR intentionally targets `release/2.28.x`