### PR TITLE
gwc: integrate DiskQuota with the pgconfig catalog backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ target
 webapp
 
 docker-compose_datadir*
-
+hs_err_pid*.log
 node_modules
 package-lock.json
 package.json

--- a/src/apps/geoserver/gwc/pom.xml
+++ b/src/apps/geoserver/gwc/pom.xml
@@ -38,6 +38,16 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/apps/geoserver/gwc/src/test/java/org/geoserver/cloud/gwc/app/DiskQuotaControllerPgconfigIT.java
+++ b/src/apps/geoserver/gwc/src/test/java/org/geoserver/cloud/gwc/app/DiskQuotaControllerPgconfigIT.java
@@ -1,0 +1,150 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.gwc.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpStatus.OK;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * End-to-end integration test for the GeoWebCache {@code DiskQuotaController} on the {@code
+ * pgconfig-diskquota} profile.
+ *
+ * <p>Boots the GWC microservice with the pgconfig backend pointing at a Postgres testcontainer
+ * and {@code gwc.disk-quota.enabled=true}, then drives the {@code /gwc/rest/diskquota} REST API
+ * to verify the full GET/PUT round-trip works. This exercises the whole stack:
+ *
+ * <ol>
+ *   <li>Flyway runs the {@code V3_1_0__DiskQuota_Tables.sql} migration in the pgconfig schema.
+ *   <li>{@code PgconfigDiskQuotaAutoConfiguration} wires a {@code JDBCQuotaStore} on the pgconfig
+ *       DataSource and replaces the upstream {@code DiskQuotaStoreProvider}.
+ *   <li>{@code DiskQuotaMonitor} starts up (env post-processor leaves {@code GWC_DISKQUOTA_DISABLED}
+ *       unset) and the REST controller's PUT applies a new {@code DiskQuotaConfig} that subsequent
+ *       GETs see.
+ * </ol>
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@ActiveProfiles({"test", "pgconfig-diskquota"})
+@Testcontainers(disabledWithoutDocker = true)
+class DiskQuotaControllerPgconfigIT {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15");
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    static @TempDir Path datadir;
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) throws IOException {
+        Path gwcdir = datadir.resolve("gwc");
+        if (!Files.exists(gwcdir)) {
+            Files.createDirectory(gwcdir);
+        }
+        registry.add("geoserver.backend.data-directory.location", () -> datadir.toAbsolutePath()
+                .toString());
+        registry.add("gwc.cache-directory", () -> gwcdir.toAbsolutePath().toString());
+        registry.add("pgconfig.host", postgres::getHost);
+        registry.add("pgconfig.port", () -> postgres.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT));
+        registry.add("pgconfig.database", postgres::getDatabaseName);
+        registry.add("pgconfig.schema", () -> "pgconfig");
+        registry.add("pgconfig.username", postgres::getUsername);
+        registry.add("pgconfig.password", postgres::getPassword);
+    }
+
+    @Test
+    @Order(1)
+    @DirtiesContext
+    void smokeTest() {
+        // separate test to absorb the first-request 403 quirk seen in GeoWebCacheApplicationTest
+        TestRestTemplate authed = restTemplate.withBasicAuth("admin", "geoserver");
+        ResponseEntity<String> resp = authed.getForEntity("/gwc/rest/layers", String.class);
+        assertThat(resp.getStatusCode().is2xxSuccessful()
+                        || resp.getStatusCode().value() == 403)
+                .as("first call status: %s", resp.getStatusCode())
+                .isTrue();
+    }
+
+    @Test
+    @Order(2)
+    void getDefaultDiskQuotaConfigJson() {
+        TestRestTemplate authed = restTemplate.withBasicAuth("admin", "geoserver");
+        ResponseEntity<String> resp = authed.getForEntity("/gwc/rest/diskquota.json", String.class);
+        assertThat(resp.getStatusCode()).isEqualTo(OK);
+        assertThat(resp.getHeaders().getContentType()).isNotNull();
+        JsonObject root = JsonParser.parseString(resp.getBody()).getAsJsonObject();
+        assertThat(root.has("org.geowebcache.diskquota.DiskQuotaConfig")).isTrue();
+        JsonObject cfg = root.getAsJsonObject("org.geowebcache.diskquota.DiskQuotaConfig");
+        assertThat(cfg.has("enabled")).isTrue();
+    }
+
+    @Test
+    @Order(3)
+    void putThenGetRoundTripsCustomConfig() {
+        TestRestTemplate authed = restTemplate.withBasicAuth("admin", "geoserver");
+
+        String payload =
+                """
+                {
+                  "org.geowebcache.diskquota.DiskQuotaConfig": {
+                    "enabled": true,
+                    "cacheCleanUpFrequency": 5,
+                    "cacheCleanUpUnits": "SECONDS",
+                    "maxConcurrentCleanUps": 4,
+                    "globalExpirationPolicyName": "LFU"
+                  }
+                }
+                """;
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        ResponseEntity<String> putResp = authed.exchange(
+                "/gwc/rest/diskquota.json", HttpMethod.PUT, new HttpEntity<>(payload, headers), String.class);
+        assertThat(putResp.getStatusCode().is2xxSuccessful())
+                .as("PUT status: %s, body: %s", putResp.getStatusCode(), putResp.getBody())
+                .isTrue();
+
+        ResponseEntity<String> getResp = authed.getForEntity("/gwc/rest/diskquota.json", String.class);
+        assertThat(getResp.getStatusCode()).isEqualTo(OK);
+        JsonObject cfg = JsonParser.parseString(getResp.getBody())
+                .getAsJsonObject()
+                .getAsJsonObject("org.geowebcache.diskquota.DiskQuotaConfig");
+
+        assertThat(cfg.get("enabled").getAsBoolean()).isTrue();
+        assertThat(cfg.get("cacheCleanUpFrequency").getAsInt()).isEqualTo(5);
+        assertThat(cfg.get("cacheCleanUpUnits").getAsString()).isEqualTo("SECONDS");
+        assertThat(cfg.get("maxConcurrentCleanUps").getAsInt()).isEqualTo(4);
+        assertThat(cfg.get("globalExpirationPolicyName").getAsString()).isEqualTo("LFU");
+    }
+}

--- a/src/apps/geoserver/gwc/src/test/resources/bootstrap-test.yml
+++ b/src/apps/geoserver/gwc/src/test/resources/bootstrap-test.yml
@@ -24,3 +24,37 @@ logging:
     org.geowebcache.config.XMLConfiguration: off
     org.springframework.test: info
     org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader: off
+
+---
+spring.config.activate.on-profile: pgconfig-diskquota
+geoserver:
+  acl.enabled: false
+  security.enabled: true
+  backend:
+    data-directory:
+      enabled: false
+      location: # set by test classes (used as base for the gwc cache directory)
+    pgconfig:
+      enabled: true
+      initialize: true
+      schema: ${pgconfig.schema:pgconfig}
+      create-schema: true
+      datasource:
+        jndi-name: java:comp/env/jdbc/pgconfig
+jndi:
+  datasources:
+    pgconfig:
+      enabled: true
+      schema: ${pgconfig.schema:pgconfig}
+      wait-for-it: true
+      wait-timeout: 10
+      url: jdbc:postgresql://${pgconfig.host}:${pgconfig.port}/${pgconfig.database}
+      username: ${pgconfig.username}
+      password: ${pgconfig.password}
+      maximum-pool-size: 10
+      minimum-idle: 0
+      connection-timeout: 2500
+      idle-timeout: 60000
+gwc:
+  disk-quota:
+    enabled: true

--- a/src/apps/geoserver/webui/src/test/java/org/geoserver/cloud/web/diskquota/JDBCConnectionPoolPanelCloudTest.java
+++ b/src/apps/geoserver/webui/src/test/java/org/geoserver/cloud/web/diskquota/JDBCConnectionPoolPanelCloudTest.java
@@ -1,0 +1,120 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.web.diskquota;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.Serial;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import org.apache.wicket.markup.html.WebPage;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.util.tester.WicketTester;
+import org.geoserver.cloud.web.app.WebUIApplication;
+import org.geoserver.gwc.web.diskquota.JDBCConnectionPoolPanel;
+import org.geoserver.web.GeoServerApplication;
+import org.geowebcache.diskquota.jdbc.JDBCConfiguration.ConnectionPoolConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+/**
+ * Verifies that {@link JDBCConnectionPoolPanel}, exposed by the cloud webui module's
+ * {@code DisquotaWebUIConfiguration}, renders inside the cloud Wicket harness without leaking the
+ * password into the response markup.
+ *
+ * <p>Mirrors the upstream {@code JDBCConnectionPoolPanelTest} but uses the Spring-Boot-driven cloud
+ * {@code GeoServerApplication}.
+ */
+@SpringBootTest(
+        classes = WebUIApplication.class,
+        properties = {
+            "spring.cloud.bus.enabled: false",
+            "spring.cloud.config.enabled: false",
+            "spring.cloud.config.discovery.enabled: false",
+            "eureka.client.enabled: false"
+        })
+@ActiveProfiles("test")
+class JDBCConnectionPoolPanelCloudTest {
+
+    private @Autowired GeoServerApplication app;
+    private WicketTester tester;
+
+    static @TempDir Path tmpdir;
+
+    @DynamicPropertySource
+    static void setUpDataDir(DynamicPropertyRegistry registry) throws IOException {
+        Path datadir = tmpdir.resolve("datadir");
+        Path gwcdir = datadir.resolve("gwc");
+        Files.createDirectories(gwcdir);
+        registry.add("geoserver.backend.data-directory.location", datadir::toAbsolutePath);
+        registry.add("gwc.cache-directory", gwcdir::toAbsolutePath);
+        // Enable disk-quota so DisquotaWebUIConfiguration imports the gs-web-gwc menu page bean.
+        registry.add("gwc.disk-quota.enabled", () -> "true");
+    }
+
+    static @BeforeAll void beforeAll() {
+        System.setProperty("wicket.configuration", "deployment");
+        System.setProperty(GeoServerApplication.GEOSERVER_CSRF_DISABLED, "true");
+        Locale.setDefault(Locale.ENGLISH);
+    }
+
+    @BeforeEach
+    void setUpWicketTester() {
+        tester = new WicketTester(app, true);
+    }
+
+    @AfterEach
+    void tearDownWicketTester() {
+        if (tester != null) {
+            tester.destroy();
+        }
+    }
+
+    @Test
+    void renderingDoesNotLeakPassword() {
+        ConnectionPoolConfiguration pool = new ConnectionPoolConfiguration();
+        pool.setDriver("org.postgresql.Driver");
+        pool.setUrl("jdbc:postgresql://example:5432/quota");
+        pool.setUsername("sa");
+        pool.setPassword("topsecret");
+        pool.setMinConnections(1);
+        pool.setMaxConnections(1);
+        pool.setMaxOpenPreparedStatements(50);
+
+        FormTestPage page = new FormTestPage(new JDBCConnectionPoolPanel("panel", new Model<>(pool)));
+        tester.startPage(page);
+
+        String body = tester.getLastResponseAsString();
+        assertThat(body).as("password must not appear in rendered HTML").doesNotContain(pool.getPassword());
+    }
+
+    /**
+     * Minimal Wicket test page that wraps a single panel in a Form. The companion HTML file lives
+     * next to the compiled class so Wicket can locate the markup via classpath.
+     */
+    public static class FormTestPage extends WebPage {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        public FormTestPage(JDBCConnectionPoolPanel panel) {
+            Form<?> form = new Form<>("form");
+            add(form);
+            form.add(panel);
+        }
+    }
+}

--- a/src/apps/geoserver/webui/src/test/resources/org/geoserver/cloud/web/diskquota/JDBCConnectionPoolPanelCloudTest$FormTestPage.html
+++ b/src/apps/geoserver/webui/src/test/resources/org/geoserver/cloud/web/diskquota/JDBCConnectionPoolPanelCloudTest$FormTestPage.html
@@ -1,0 +1,7 @@
+<html xmlns:wicket="http://wicket.apache.org/">
+  <body>
+    <form wicket:id="form">
+      <div wicket:id="panel"></div>
+    </form>
+  </body>
+</html>

--- a/src/catalog/backends/pgconfig/src/main/resources/db/pgconfig/migration/postgresql/V3_1_0__DiskQuota_Tables.sql
+++ b/src/catalog/backends/pgconfig/src/main/resources/db/pgconfig/migration/postgresql/V3_1_0__DiskQuota_Tables.sql
@@ -1,0 +1,39 @@
+/*
+ * GeoWebCache JDBC Disk Quota tables.
+ *
+ * Mirrors the DDL in org.geowebcache.diskquota.jdbc.SQLDialect#TABLE_CREATION_MAP
+ * (PostgreSQL flavor) so that JDBCQuotaStore.initialize() finds the tables and
+ * skips its own DDL via the tableExists() check at startup.
+ *
+ * Created in the pgconfig schema (whatever Flyway is configured with), so the
+ * disk quota store shares the pgconfig DataSource and schema. The JDBC quota
+ * store is wired up by PgconfigDiskQuotaAutoConfiguration when both
+ * geoserver.backend.pgconfig.enabled=true and gwc.disk-quota.enabled=true.
+ */
+CREATE TABLE IF NOT EXISTS TILESET (
+  KEY VARCHAR(320) PRIMARY KEY,
+  LAYER_NAME VARCHAR(128),
+  GRIDSET_ID VARCHAR(32),
+  BLOB_FORMAT VARCHAR(64),
+  PARAMETERS_ID VARCHAR(41),
+  BYTES NUMERIC(21) NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS TILESET_LAYER ON TILESET(LAYER_NAME);
+
+CREATE TABLE IF NOT EXISTS TILEPAGE (
+  KEY VARCHAR(320) PRIMARY KEY,
+  TILESET_ID VARCHAR(320) REFERENCES TILESET(KEY) ON UPDATE CASCADE ON DELETE CASCADE, 
+  PAGE_Z SMALLINT,
+  PAGE_X INTEGER,
+  PAGE_Y INTEGER,
+  CREATION_TIME_MINUTES INTEGER,
+  FREQUENCY_OF_USE FLOAT,
+  LAST_ACCESS_TIME_MINUTES INTEGER,
+  FILL_FACTOR FLOAT,
+  NUM_HITS NUMERIC(64)
+);
+
+CREATE INDEX IF NOT EXISTS TILEPAGE_TILESET ON TILEPAGE(TILESET_ID, FILL_FACTOR);
+CREATE INDEX IF NOT EXISTS TILEPAGE_FREQUENCY ON TILEPAGE(FREQUENCY_OF_USE DESC);
+CREATE INDEX IF NOT EXISTS TILEPAGE_LAST_ACCESS ON TILEPAGE(LAST_ACCESS_TIME_MINUTES DESC);

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgconfig/PgconfigMigrationAutoConfigurationTest.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgconfig/PgconfigMigrationAutoConfigurationTest.java
@@ -117,7 +117,9 @@ class PgconfigMigrationAutoConfigurationTest {
                 "resourcestore",
                 "resource_lock",
                 "publishedinfos_mat",
-                "tilelayers_mat");
+                "tilelayers_mat",
+                "tileset",
+                "tilepage");
         List<String> sequences = List.of("gs_update_sequence", "resourcestore_id_seq");
 
         Map<String, String> expected = new TreeMap<>();

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigDiskQuotaAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigDiskQuotaAutoConfiguration.java
@@ -1,0 +1,74 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.autoconfigure.gwc.backend;
+
+import lombok.extern.slf4j.Slf4j;
+import org.geoserver.cloud.autoconfigure.catalog.backend.pgconfig.ConditionalOnPgconfigBackendEnabled;
+import org.geoserver.cloud.autoconfigure.catalog.backend.pgconfig.PgconfigDataSourceAutoConfiguration;
+import org.geoserver.cloud.autoconfigure.catalog.backend.pgconfig.PgconfigMigrationAutoConfiguration;
+import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnDiskQuotaEnabled;
+import org.geoserver.cloud.config.catalog.backend.pgconfig.PgconfigBackendProperties;
+import org.geoserver.gwc.config.GeoserverXMLResourceProvider;
+import org.geowebcache.diskquota.ConfigLoader;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Pre-configures GeoWebCache's DiskQuota subsystem to use the same database as the pgconfig
+ * catalog backend.
+ *
+ * <p>On first start (when neither {@code geowebcache-diskquota.xml} nor
+ * {@code geowebcache-diskquota-jdbc.xml} exists in the GWC config dir) writes default copies that:
+ *
+ * <ul>
+ *   <li>select the upstream JDBC quota store ({@code <quotaStore>JDBC</quotaStore>}), and
+ *   <li>point it at the pgconfig JNDI DataSource and schema, with the {@code PostgreSQL} dialect.
+ * </ul>
+ *
+ * <p>After that point the standard upstream flow drives store creation:
+ * {@code DiskQuotaMonitor} -> {@code ConfigurableQuotaStoreProvider#reloadQuotaStore} ->
+ * {@code JDBCQuotaStoreFactory#getJDBCStore} -> JNDI lookup -> {@code JDBCQuotaStore}, with
+ * {@link org.geowebcache.diskquota.jdbc.JDBCConfiguration#getSchema() the schema} honored at
+ * {@code JDBCQuotaStoreFactory:174}. The user can later edit the configuration through the
+ * {@code DiskQuotaSettingsPage} UI; we never overwrite an existing file.
+ *
+ * <p>Activates only when:
+ *
+ * <ul>
+ *   <li>{@link ConditionalOnDiskQuotaEnabled gwc.disk-quota.enabled=true},
+ *   <li>{@link ConditionalOnPgconfigBackendEnabled geoserver.backend.pgconfig.enabled=true}, and
+ *   <li>pgconfig is itself JNDI-backed
+ *       ({@code geoserver.backend.pgconfig.datasource.jndi-name} is set), since reusing the same
+ *       JNDI name is what makes the JDBC quota store share the pgconfig connection pool.
+ * </ul>
+ *
+ * <p>Note on {@code PostgreSQLQuotaDialect}: provided by the upstream
+ * {@code geowebcache-diskquota-context.xml} (already imported by
+ * {@code DiskQuotaConfiguration}), so this auto-config does not redeclare it.
+ *
+ * @since 2.28.3.1
+ */
+@AutoConfiguration(after = {PgconfigDataSourceAutoConfiguration.class, PgconfigMigrationAutoConfiguration.class})
+@ConditionalOnDiskQuotaEnabled
+@ConditionalOnPgconfigBackendEnabled
+@ConditionalOnProperty(prefix = "geoserver.backend.pgconfig.datasource", name = "jndi-name")
+@Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.backend")
+public class PgconfigDiskQuotaAutoConfiguration {
+
+    @Bean
+    PgconfigDiskQuotaBootstrap pgconfigDiskQuotaBootstrap(
+            @Qualifier("DiskQuotaConfigLoader") ConfigLoader configLoader,
+            @Qualifier("DiskQuotaConfigResourceProvider") GeoserverXMLResourceProvider diskQuotaConfigResourceProvider,
+            @Qualifier("jdbcDiskQuotaConfigResourceProvider")
+                    GeoserverXMLResourceProvider jdbcDiskQuotaConfigResourceProvider,
+            PgconfigBackendProperties pgconfigProperties) {
+        log.info("GeoWebCache DiskQuota will be pre-configured to share the pgconfig JNDI DataSource");
+        return new PgconfigDiskQuotaBootstrap(
+                configLoader, diskQuotaConfigResourceProvider, jdbcDiskQuotaConfigResourceProvider, pgconfigProperties);
+    }
+}

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigDiskQuotaBootstrap.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigDiskQuotaBootstrap.java
@@ -1,0 +1,118 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.autoconfigure.gwc.backend;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import javax.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.geoserver.cloud.config.catalog.backend.pgconfig.PgconfigBackendProperties;
+import org.geoserver.gwc.config.GeoserverXMLResourceProvider;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.Resources;
+import org.geowebcache.config.ConfigurationException;
+import org.geowebcache.diskquota.ConfigLoader;
+import org.geowebcache.diskquota.DiskQuotaConfig;
+import org.geowebcache.diskquota.jdbc.JDBCConfiguration;
+
+/**
+ * Writes default GeoWebCache DiskQuota config files on first start so the upstream JDBC quota
+ * store binds to the pgconfig JNDI DataSource.
+ *
+ * <p>Two files are seeded, each only when absent:
+ *
+ * <ol>
+ *   <li>{@code geowebcache-diskquota.xml}: a default {@link DiskQuotaConfig} with
+ *       {@code quotaStore=JDBC} (and {@code enabled=false} so users opt in explicitly), written via
+ *       {@link ConfigLoader#saveConfig(DiskQuotaConfig)}.
+ *   <li>{@code geowebcache-diskquota-jdbc.xml}: a {@link JDBCConfiguration} with the
+ *       {@code PostgreSQL} dialect, the pgconfig JNDI source, and the pgconfig schema, written
+ *       via {@link JDBCConfiguration#store(JDBCConfiguration, OutputStream)}.
+ * </ol>
+ *
+ * <p>Runs in {@link PostConstruct}: completes before any {@code ContextRefreshedEvent}, hence
+ * before the {@code DiskQuotaMonitor} drives {@code ConfigurableQuotaStoreProvider#reloadQuotaStore},
+ * so the upstream code reads the fresh files on the very first start. Idempotent: a second
+ * invocation with both files already present is a no-op.
+ * @since 2.28.3.1
+ */
+@Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.backend")
+public class PgconfigDiskQuotaBootstrap {
+
+    static final String DIALECT = "PostgreSQL";
+
+    private final ConfigLoader configLoader;
+    private final GeoserverXMLResourceProvider mainConfigResourceProvider;
+    private final GeoserverXMLResourceProvider jdbcConfigResourceProvider;
+    private final PgconfigBackendProperties pgconfigProperties;
+
+    public PgconfigDiskQuotaBootstrap(
+            ConfigLoader configLoader,
+            GeoserverXMLResourceProvider mainConfigResourceProvider,
+            GeoserverXMLResourceProvider jdbcConfigResourceProvider,
+            PgconfigBackendProperties pgconfigProperties) {
+        this.configLoader = configLoader;
+        this.mainConfigResourceProvider = mainConfigResourceProvider;
+        this.jdbcConfigResourceProvider = jdbcConfigResourceProvider;
+        this.pgconfigProperties = pgconfigProperties;
+    }
+
+    @PostConstruct
+    public void bootstrap() throws IOException, ConfigurationException {
+        seedDiskQuotaConfigIfMissing();
+        seedJdbcConfigIfMissing();
+    }
+
+    private void seedDiskQuotaConfigIfMissing() throws IOException, ConfigurationException {
+        Resource configFile = configFile(mainConfigResourceProvider);
+        if (Resources.exists(configFile)) {
+            log.debug("{} already present; not writing defaults", mainConfigResourceProvider.getConfigFileName());
+            return;
+        }
+        DiskQuotaConfig defaults = new DiskQuotaConfig();
+        defaults.setDefaults();
+        defaults.setEnabled(false);
+        defaults.setQuotaStore("JDBC");
+        configLoader.saveConfig(defaults);
+        log.info("Bootstrapped {} with quotaStore=JDBC, enabled=false", mainConfigResourceProvider.getConfigFileName());
+    }
+
+    private void seedJdbcConfigIfMissing() throws IOException {
+        Resource configFile = configFile(jdbcConfigResourceProvider);
+        if (Resources.exists(configFile)) {
+            log.debug("{} already present; not writing defaults", jdbcConfigResourceProvider.getConfigFileName());
+            return;
+        }
+        String jndiName = pgconfigJndiName();
+        String schema = pgconfigProperties.schema();
+        JDBCConfiguration cfg = newJdbcConfiguration(jndiName, schema);
+        try (OutputStream out = configFile.out()) {
+            JDBCConfiguration.store(cfg, out);
+        }
+        log.info(
+                "Bootstrapped {} (dialect=PostgreSQL, JNDISource={}, schema={})",
+                jdbcConfigResourceProvider.getConfigFileName(),
+                jndiName,
+                schema);
+    }
+
+    private Resource configFile(GeoserverXMLResourceProvider resourceProvider) {
+        Resource configDir = resourceProvider.getConfigDirectory();
+        return configDir.get(resourceProvider.getConfigFileName());
+    }
+
+    private String pgconfigJndiName() {
+        return pgconfigProperties.getDatasource().getJndiName();
+    }
+
+    private JDBCConfiguration newJdbcConfiguration(String jndiName, String schema) {
+        JDBCConfiguration cfg = new JDBCConfiguration();
+        cfg.setDialect(DIALECT);
+        cfg.setJNDISource(jndiName);
+        cfg.setSchema(schema);
+        return cfg;
+    }
+}

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigTileLayerCatalogAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigTileLayerCatalogAutoConfiguration.java
@@ -18,6 +18,7 @@ import org.geoserver.cloud.autoconfigure.catalog.backend.pgconfig.ConditionalOnP
 import org.geoserver.cloud.autoconfigure.catalog.backend.pgconfig.PgconfigDataSourceAutoConfiguration;
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoWebCacheEnabled;
 import org.geoserver.cloud.gwc.backend.pgconfig.CachingTileLayerInfoRepository;
+import org.geoserver.cloud.gwc.backend.pgconfig.PgconfigGwcCatalogRenameListener;
 import org.geoserver.cloud.gwc.backend.pgconfig.PgconfigTileLayerCatalog;
 import org.geoserver.cloud.gwc.backend.pgconfig.PgconfigTileLayerInfoRepository;
 import org.geoserver.cloud.gwc.backend.pgconfig.TileLayerInfoRepository;
@@ -79,6 +80,18 @@ public class PgconfigTileLayerCatalogAutoConfiguration {
         var config = new PgconfigTileLayerCatalog(repository, gridsetBroker, () -> catalog, defaultsProvider);
         Consumer<TileLayerEvent> gwcEventPublisher = eventPublisher::publishEvent;
         return new GeoServerTileLayerConfiguration(config, gwcEventPublisher);
+    }
+
+    /**
+     * Propagates Workspace / Resource / LayerGroup name changes to the GeoWebCache storage broker
+     * so the file blob store directory and pgconfig disk-quota tableset rows follow. Pgconfig
+     * derives tile-layer names from {@code PublishedInfo} on every lookup, which breaks
+     * upstream {@code CatalogLayerEventListener}'s rename path (lookup by old prefixed name
+     * returns empty after the SQL trigger refreshes the materialized view).
+     */
+    @Bean
+    PgconfigGwcCatalogRenameListener pgconfigGwcCatalogRenameListener(@Qualifier("rawCatalog") Catalog catalog) {
+        return new PgconfigGwcCatalogRenameListener(catalog);
     }
 
     @Bean

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/DiskQuotaAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/DiskQuotaAutoConfiguration.java
@@ -6,14 +6,45 @@
 package org.geoserver.cloud.autoconfigure.gwc.core;
 
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnDiskQuotaEnabled;
+import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoServerWebUIEnabled;
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoWebCacheRestConfigEnabled;
 import org.geoserver.cloud.autoconfigure.gwc.core.DiskQuotaAutoConfiguration.DisquotaRestAutoConfiguration;
+import org.geoserver.cloud.autoconfigure.gwc.core.DiskQuotaAutoConfiguration.DisquotaWebUIAutoConfiguration;
 import org.geoserver.cloud.gwc.config.core.DiskQuotaConfiguration;
 import org.geoserver.cloud.gwc.config.core.DisquotaRestConfiguration;
+import org.geoserver.cloud.gwc.config.core.DisquotaWebUIConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 /**
+ * Disk-quota auto-configuration.
+ *
+ * <p>
+ * {@link DiskQuotaConfiguration} is imported unconditionally - it contributes
+ * the {@code
+ * DiskQuotaMonitor} bean that {@code gwcFacade} (from
+ * {@code geowebcache-geoserver-context.xml}) keeps a hard reference to, so the
+ * bean must always exist. Whether the monitor runs at startup is controlled by
+ * the {@code GWC_DISKQUOTA_DISABLED} system property, set conditionally by
+ * {@code DiskQuotaConfiguration#diskQuotaDisabledPropertySetter} based on
+ * {@code
+ * gwc.disk-quota.enabled}.
+ *
+ * <p>
+ * The REST controller is enabled separately by
+ * {@link DisquotaRestAutoConfiguration} when both
+ * {@link ConditionalOnDiskQuotaEnabled disk-quota} and
+ * {@link ConditionalOnGeoWebCacheRestConfigEnabled rest-config} are enabled.
+ *
+ * <p>
+ * A backend-specific auto-configuration (e.g.
+ * {@code PgconfigDiskQuotaAutoConfiguration}) is required to override the
+ * default {@code DiskQuotaStoreProvider} with one that points at a cluster-safe
+ * quota store. Without that override and with
+ * {@code gwc.disk-quota.enabled=true}, the upstream
+ * {@code ConfigurableQuotaStoreProvider} would try to load a BDB-backed store,
+ * which isn't viable in a multi-pod deployment.
+ *
  * @see DiskQuotaConfiguration
  * @see DisquotaRestConfiguration
  * @see ConditionalOnDiskQuotaEnabled
@@ -21,16 +52,31 @@ import org.springframework.context.annotation.Import;
  * @since 1.0
  */
 @Configuration(proxyBeanMethods = false)
-@Import({DiskQuotaConfiguration.class, DisquotaRestAutoConfiguration.class})
+@Import({DiskQuotaConfiguration.class, DisquotaRestAutoConfiguration.class, DisquotaWebUIAutoConfiguration.class})
+@SuppressWarnings("java:S1118")
 public class DiskQuotaAutoConfiguration {
 
     /**
-     * Enables disk quota REST API if both {@link ConditionalOnDiskQuotaEnabled disk-quota} and
-     * {@link ConditionalOnGeoWebCacheRestConfigEnabled rest-config} are enabled.
+     * Enables disk quota REST API if both {@link ConditionalOnDiskQuotaEnabled
+     * disk-quota} and {@link ConditionalOnGeoWebCacheRestConfigEnabled rest-config}
+     * are enabled.
      */
-    @Configuration
+    @Configuration(proxyBeanMethods = false)
     @ConditionalOnDiskQuotaEnabled
     @ConditionalOnGeoWebCacheRestConfigEnabled
     @Import(DisquotaRestConfiguration.class)
     static class DisquotaRestAutoConfiguration {}
+
+    /**
+     * Enables disk quota Wicket components if both
+     * {@link ConditionalOnDiskQuotaEnabled} and
+     * {@link ConditionalOnGeoServerWebUIEnabled} are enabled.
+     * @see DisquotaWebUIConfiguration
+     * @since 2.28.3.1
+     */
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnDiskQuotaEnabled
+    @ConditionalOnGeoServerWebUIEnabled
+    @Import(DisquotaWebUIConfiguration.class)
+    static class DisquotaWebUIAutoConfiguration {}
 }

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/web/gwc/GeoServerWebUIAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/web/gwc/GeoServerWebUIAutoConfiguration.java
@@ -9,6 +9,7 @@ import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoServerWebUIEnabled;
 import org.geoserver.cloud.autoconfigure.gwc.GoServerWebUIConfigurationProperties;
+import org.geoserver.cloud.autoconfigure.gwc.core.DiskQuotaAutoConfiguration;
 import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.config.GeoServer;
 import org.geoserver.gwc.GWC;
@@ -37,9 +38,8 @@ import org.springframework.context.annotation.Configuration;
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.web.gwc")
 public class GeoServerWebUIAutoConfiguration {
 
-    /*
-     * Disable disk-quota by brute force for now. We need to resolve how and where to store the
-     * configuration and database.
+    /**
+     * Exclude disk-quota web components, {@link DiskQuotaAutoConfiguration} handles it.
      */
     static final String EXCLUDED_BEANS = "diskQuotaMenuPage|wmtsServiceDescriptor";
 

--- a/src/gwc/autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/src/gwc/autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,6 +1,7 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.geoserver.cloud.autoconfigure.gwc.core.GeoWebCacheAutoConfiguration,\
 org.geoserver.cloud.autoconfigure.gwc.backend.PgconfigTileLayerCatalogAutoConfiguration,\
+org.geoserver.cloud.autoconfigure.gwc.backend.PgconfigDiskQuotaAutoConfiguration,\
 org.geoserver.cloud.autoconfigure.gwc.backend.DefaultTileLayerCatalogAutoConfiguration,\
 org.geoserver.cloud.autoconfigure.gwc.core.CacheSeedingWebMapServiceAutoConfiguration,\
 org.geoserver.cloud.autoconfigure.gwc.integration.GeoWebCacheRemoteEventsAutoConfiguration,\

--- a/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigDiskQuotaAutoConfigurationTest.java
+++ b/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigDiskQuotaAutoConfigurationTest.java
@@ -1,0 +1,173 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.autoconfigure.gwc.backend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import javax.sql.DataSource;
+import org.geoserver.cloud.autoconfigure.catalog.backend.pgconfig.PgconfigBackendAutoConfiguration;
+import org.geoserver.cloud.autoconfigure.catalog.backend.pgconfig.PgconfigDataSourceAutoConfiguration;
+import org.geoserver.cloud.autoconfigure.catalog.backend.pgconfig.PgconfigMigrationAutoConfiguration;
+import org.geoserver.cloud.autoconfigure.catalog.backend.pgconfig.PgconfigTransactionManagerAutoConfiguration;
+import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheContextRunner;
+import org.geoserver.cloud.backend.pgconfig.support.PgConfigTestContainer;
+import org.geoserver.gwc.ConfigurableQuotaStoreProvider;
+import org.geowebcache.diskquota.DiskQuotaMonitor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Auto-configuration test for {@link PgconfigDiskQuotaAutoConfiguration}.
+ *
+ * <p>Verifies the conditional matrix (when the bootstrap bean is/isn't registered) and the
+ * end-to-end Flyway migrations against a real Postgres testcontainer. The bootstrap's file-writing
+ * behavior is covered separately in {@link PgconfigDiskQuotaBootstrapTest}.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class PgconfigDiskQuotaAutoConfigurationTest {
+
+    @Container
+    static PgConfigTestContainer<?> container = new PgConfigTestContainer<>();
+
+    @TempDir
+    File cacheDir;
+
+    private WebApplicationContextRunner runner;
+
+    @BeforeEach
+    void setUp() {
+        runner = GeoWebCacheContextRunner.newMinimalGeoWebCacheContextRunner(cacheDir)
+                .withConfiguration(AutoConfigurations.of(
+                        PgconfigTileLayerCatalogAutoConfiguration.class,
+                        PgconfigDiskQuotaAutoConfiguration.class,
+                        PgconfigBackendAutoConfiguration.class,
+                        PgconfigDataSourceAutoConfiguration.class,
+                        PgconfigTransactionManagerAutoConfiguration.class,
+                        PgconfigMigrationAutoConfiguration.class));
+        container.setUp();
+        runner = container.withJdbcUrlConfig(runner);
+    }
+
+    @AfterEach
+    void tearDown() {
+        container.tearDown();
+    }
+
+    @Test
+    void registersBootstrapWhenEnabledAndJndiConfigured() {
+        WebApplicationContextRunner jndiRunner = GeoWebCacheContextRunner.newMinimalGeoWebCacheContextRunner(cacheDir)
+                .withConfiguration(AutoConfigurations.of(
+                        PgconfigTileLayerCatalogAutoConfiguration.class,
+                        PgconfigDiskQuotaAutoConfiguration.class,
+                        PgconfigBackendAutoConfiguration.class,
+                        PgconfigDataSourceAutoConfiguration.class,
+                        PgconfigTransactionManagerAutoConfiguration.class,
+                        PgconfigMigrationAutoConfiguration.class));
+        jndiRunner = container.withJndiConfig(jndiRunner);
+        jndiRunner.withPropertyValues("gwc.disk-quota.enabled=true").run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).hasSingleBean(PgconfigDiskQuotaBootstrap.class);
+            assertThat(context).hasSingleBean(DiskQuotaMonitor.class);
+            assertThat(context).hasSingleBean(ConfigurableQuotaStoreProvider.class);
+        });
+    }
+
+    @Test
+    void flywayMigrationCreatesDiskQuotaTables() {
+        runner.withPropertyValues("gwc.disk-quota.enabled=true").run(context -> {
+            assertThat(context).hasNotFailed();
+
+            DataSource ds = context.getBean("pgconfigDataSource", DataSource.class);
+            JdbcTemplate jt = new JdbcTemplate(ds);
+
+            Long flywayRecord = jt.queryForObject(
+                    """
+                    SELECT count(*) FROM flyway_schema_history
+                    WHERE version = ? AND success
+                    """,
+                    Long.class,
+                    "3.1.0");
+            assertThat(flywayRecord).isOne();
+
+            Long tilesetCount = jt.queryForObject("SELECT count(*) FROM TILESET", Long.class);
+            Long tilepageCount = jt.queryForObject("SELECT count(*) FROM TILEPAGE", Long.class);
+            assertThat(tilesetCount).isNotNull();
+            assertThat(tilepageCount).isNotNull();
+        });
+    }
+
+    @Test
+    void resourceLockUpgradeMigrationApplied() {
+        runner.withPropertyValues("gwc.disk-quota.enabled=true").run(context -> {
+            assertThat(context).hasNotFailed();
+
+            DataSource ds = context.getBean("pgconfigDataSource", DataSource.class);
+            JdbcTemplate jt = new JdbcTemplate(ds);
+
+            Long expiredAfterColumn = jt.queryForObject(
+                    """
+                    SELECT count(*) FROM information_schema.columns
+                    WHERE table_schema = ?
+                      AND upper(table_name) = 'RESOURCE_LOCK'
+                      AND upper(column_name) = 'EXPIRED_AFTER'
+                    """,
+                    Long.class,
+                    container.getSchema());
+            assertThat(expiredAfterColumn).isOne();
+        });
+    }
+
+    /**
+     * With {@code gwc.disk-quota.enabled=false} (default), {@link DiskQuotaMonitor} and the upstream
+     * {@code ConfigurableQuotaStoreProvider} are still in the context (gwcFacade and the Wicket UI
+     * need them) but {@code DiskQuotaConfiguration#diskQuotaDisabledPropertySetter} sets
+     * {@code GWC_DISKQUOTA_DISABLED=true} so neither does anything at runtime. The bootstrap is
+     * also off.
+     */
+    @Test
+    void disabledByDefault() {
+        runner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).doesNotHaveBean(PgconfigDiskQuotaBootstrap.class);
+            assertThat(context).hasSingleBean(DiskQuotaMonitor.class);
+            assertThat(context).hasSingleBean(ConfigurableQuotaStoreProvider.class);
+            assertThat(context.getBean(DiskQuotaMonitor.class).isEnabled()).isFalse();
+        });
+    }
+
+    @Test
+    void skipsWhenPgconfigBackendDisabled() {
+        runner.withPropertyValues(
+                        "gwc.disk-quota.enabled=true",
+                        "geoserver.backend.pgconfig.enabled=false",
+                        "geoserver.backend.pgconfig.datasource.jndi-name=java:comp/env/jdbc/pgconfig")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).doesNotHaveBean(PgconfigDiskQuotaBootstrap.class);
+                });
+    }
+
+    /**
+     * The bootstrap is off when pgconfig is configured without a JNDI name (direct JDBC URL): the
+     * point of the bootstrap is to point DiskQuota at the same JNDI source pgconfig uses, so it has
+     * nothing to do when there isn't one.
+     */
+    @Test
+    void skipsWhenPgconfigJndiNotConfigured() {
+        runner.withPropertyValues("gwc.disk-quota.enabled=true").run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).doesNotHaveBean(PgconfigDiskQuotaBootstrap.class);
+        });
+    }
+}

--- a/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigDiskQuotaBootstrapTest.java
+++ b/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigDiskQuotaBootstrapTest.java
@@ -1,0 +1,118 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.autoconfigure.gwc.backend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.geoserver.cloud.config.catalog.backend.pgconfig.PgconfigBackendProperties;
+import org.geoserver.gwc.config.GeoserverXMLResourceProvider;
+import org.geoserver.platform.resource.FileSystemResourceStore;
+import org.geowebcache.config.ConfigurationException;
+import org.geowebcache.diskquota.ConfigLoader;
+import org.geowebcache.layer.TileLayerDispatcher;
+import org.geowebcache.storage.DefaultStorageFinder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+
+/**
+ * Pure unit test for {@link PgconfigDiskQuotaBootstrap}.
+ *
+ * <p>Exercises the bootstrap directly with a real {@link FileSystemResourceStore}-backed pair of
+ * {@link GeoserverXMLResourceProvider} instances; no Spring context, no DB, no JNDI. Verifies the
+ * default DiskQuota XML files end up in the expected location with the right values, and that an
+ * existing file is never overwritten.
+ */
+class PgconfigDiskQuotaBootstrapTest {
+
+    @TempDir
+    Path dataDir;
+
+    private Path gwcDir() {
+        return dataDir.resolve("gwc");
+    }
+
+    @Test
+    void writesBothFilesWhenAbsent() throws Exception {
+        PgconfigDiskQuotaBootstrap bootstrap = newBootstrap("java:comp/env/jdbc/pgconfig", "pgconfigschema");
+
+        bootstrap.bootstrap();
+
+        Path jdbc = gwcDir().resolve("geowebcache-diskquota-jdbc.xml");
+        assertThat(jdbc).exists();
+        String jdbcXml = Files.readString(jdbc);
+        assertThat(jdbcXml)
+                .contains("<dialect>PostgreSQL</dialect>")
+                .contains("<JNDISource>java:comp/env/jdbc/pgconfig</JNDISource>")
+                .contains("<schema>pgconfigschema</schema>");
+
+        Path main = gwcDir().resolve("geowebcache-diskquota.xml");
+        assertThat(main).exists();
+        String mainXml = Files.readString(main);
+        assertThat(mainXml).contains("<quotaStore>JDBC</quotaStore>").contains("<enabled>false</enabled>");
+    }
+
+    @Test
+    void doesNotOverwriteExistingJdbcConfig() throws Exception {
+        Files.createDirectories(gwcDir());
+        Path jdbc = gwcDir().resolve("geowebcache-diskquota-jdbc.xml");
+        String preexisting = "<gwcJdbcConfiguration><dialect>HSQL</dialect></gwcJdbcConfiguration>";
+        Files.writeString(jdbc, preexisting);
+
+        PgconfigDiskQuotaBootstrap bootstrap = newBootstrap("java:comp/env/jdbc/pgconfig", "pgconfigschema");
+        bootstrap.bootstrap();
+
+        assertThat(Files.readString(jdbc)).isEqualTo(preexisting);
+    }
+
+    @Test
+    void doesNotOverwriteExistingMainConfig() throws Exception {
+        Files.createDirectories(gwcDir());
+        Path main = gwcDir().resolve("geowebcache-diskquota.xml");
+        String preexisting = "<diskQuotaConfig><enabled>true</enabled></diskQuotaConfig>";
+        Files.writeString(main, preexisting);
+
+        PgconfigDiskQuotaBootstrap bootstrap = newBootstrap("java:comp/env/jdbc/pgconfig", "pgconfigschema");
+        bootstrap.bootstrap();
+
+        assertThat(Files.readString(main)).isEqualTo(preexisting);
+    }
+
+    @Test
+    void defaultsSchemaToPublicWhenUnset() throws Exception {
+        PgconfigDiskQuotaBootstrap bootstrap = newBootstrap("java:comp/env/jdbc/pgconfig", null);
+        bootstrap.bootstrap();
+
+        assertThat(Files.readString(gwcDir().resolve("geowebcache-diskquota-jdbc.xml")))
+                .contains("<schema>public</schema>");
+    }
+
+    private PgconfigDiskQuotaBootstrap newBootstrap(String jndiName, String schema) throws ConfigurationException {
+        FileSystemResourceStore resourceStore = new FileSystemResourceStore(dataDir.toFile());
+        // Default config directory name is "gwc", resolved relative to the data-dir-rooted resource
+        // store. This avoids the Resources.fromPath() branch that needs GeoServerExtensions wiring.
+        GeoserverXMLResourceProvider mainProvider =
+                new GeoserverXMLResourceProvider("geowebcache-diskquota.xml", resourceStore);
+        GeoserverXMLResourceProvider jdbcProvider =
+                new GeoserverXMLResourceProvider("geowebcache-diskquota-jdbc.xml", resourceStore);
+
+        ConfigLoader configLoader = new ConfigLoader(
+                mainProvider, Mockito.mock(DefaultStorageFinder.class), Mockito.mock(TileLayerDispatcher.class));
+
+        PgconfigBackendProperties properties = new PgconfigBackendProperties();
+        DataSourceProperties ds = new DataSourceProperties();
+        ds.setJndiName(jndiName);
+        properties.setDatasource(ds);
+        if (schema != null) {
+            properties.setSchema(schema);
+        }
+
+        return new PgconfigDiskQuotaBootstrap(configLoader, mainProvider, jdbcProvider, properties);
+    }
+}

--- a/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigGwcCatalogRenameListener.java
+++ b/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigGwcCatalogRenameListener.java
@@ -1,0 +1,233 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.gwc.backend.pgconfig;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogException;
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.Predicates;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.event.CatalogAddEvent;
+import org.geoserver.catalog.event.CatalogListener;
+import org.geoserver.catalog.event.CatalogModifyEvent;
+import org.geoserver.catalog.event.CatalogPostModifyEvent;
+import org.geoserver.catalog.event.CatalogRemoveEvent;
+import org.geoserver.catalog.util.CloseableIterator;
+import org.geoserver.gwc.GWC;
+
+/**
+ * Catalog listener that propagates name changes affecting a tile-layer's prefixed name to the
+ * GeoWebCache storage broker, so the file blob store directory and disk-quota tables follow.
+ *
+ * <p>Pgconfig derives tile-layer names from the underlying {@code PublishedInfo} on every lookup,
+ * so by the time upstream's {@link org.geoserver.gwc.layer.CatalogLayerEventListener
+ * CatalogLayerEventListener} runs in post-modify, the SQL trigger has already refreshed {@code
+ * publishedinfos_mat} and a lookup by old prefixed name returns empty. Upstream catches the
+ * resulting {@code IllegalArgumentException} and silently skips the rename, leaving stale
+ * directories under {@code /geowebcache_data/} and stale rows in {@code pgconfig.tileset}.
+ *
+ * <p>This listener bridges that gap: in {@link #handleModifyEvent(CatalogModifyEvent) pre-modify}
+ * it captures {@link NamePair (old, new)} prefixed-name pairs while the OLD names are still
+ * queryable, and in {@link #handlePostModifyEvent(CatalogPostModifyEvent) post-modify} it replays
+ * them through {@link GWC#layerRenamed(String, String)} - which calls {@code
+ * storageBroker.rename(...)} directly without going through {@code TileLayerDispatcher.rename}, so
+ * the broken old-name lookup is bypassed entirely.
+ *
+ * <p>Handled cases:
+ *
+ * <ul>
+ *   <li>{@link WorkspaceInfo} {@code name} change - all layers and layer-groups in the workspace.
+ *   <li>{@link ResourceInfo} {@code name} or {@code namespace} change - the single layer.
+ *   <li>{@link LayerGroupInfo} {@code name} change - the single layer-group.
+ * </ul>
+ * @since 2.28.3.1
+ */
+@Slf4j(topic = "org.geoserver.cloud.gwc.backend.pgconfig")
+public class PgconfigGwcCatalogRenameListener implements CatalogListener {
+
+    private record NamePair(String oldPrefixed, String newPrefixed) {}
+
+    private static final ThreadLocal<List<NamePair>> PENDING_RENAMES = new ThreadLocal<>();
+
+    @NonNull
+    private final Catalog catalog;
+
+    public PgconfigGwcCatalogRenameListener(@NonNull Catalog catalog) {
+        this.catalog = catalog;
+    }
+
+    @PostConstruct
+    void register() {
+        catalog.addListener(this);
+    }
+
+    @PreDestroy
+    void unregister() {
+        catalog.removeListener(this);
+    }
+
+    @Override
+    public void handleAddEvent(CatalogAddEvent event) throws CatalogException {
+        // no-op, only renames matter
+    }
+
+    @Override
+    public void handleRemoveEvent(CatalogRemoveEvent event) throws CatalogException {
+        // no-op, blob/quota removal on tile-layer delete is handled by PgconfigTileLayerCatalog
+    }
+
+    @Override
+    public void reloaded() {
+        // no-op
+    }
+
+    @Override
+    public void handleModifyEvent(CatalogModifyEvent event) throws CatalogException {
+        List<NamePair> pairs = collectRenames(event);
+        if (!pairs.isEmpty()) {
+            PENDING_RENAMES.set(pairs);
+        }
+    }
+
+    @Override
+    public void handlePostModifyEvent(CatalogPostModifyEvent event) throws CatalogException {
+        List<NamePair> pairs = PENDING_RENAMES.get();
+        if (pairs == null) {
+            return;
+        }
+        try {
+            replayRenames(pairs);
+        } finally {
+            PENDING_RENAMES.remove();
+        }
+    }
+
+    private List<NamePair> collectRenames(CatalogModifyEvent event) {
+        CatalogInfo source = event.getSource();
+        List<String> changedProperties = event.getPropertyNames();
+        if (source instanceof WorkspaceInfo && changedProperties.contains("name")) {
+            return collectWorkspaceRenames(event);
+        }
+        if (source instanceof ResourceInfo resource
+                && (changedProperties.contains("name") || changedProperties.contains("namespace"))) {
+            return collectResourceRename(resource, event);
+        }
+        if (source instanceof LayerGroupInfo group && changedProperties.contains("name")) {
+            return collectLayerGroupRename(group, event);
+        }
+        return List.of();
+    }
+
+    private List<NamePair> collectWorkspaceRenames(CatalogModifyEvent event) {
+        String oldWsName = stringPropertyOldValue(event, "name");
+        String newWsName = stringPropertyNewValue(event, "name");
+        if (oldWsName == null || newWsName == null || oldWsName.equals(newWsName)) {
+            return List.of();
+        }
+        List<NamePair> pairs = new ArrayList<>();
+        addLayerRenamesForWorkspace(oldWsName, newWsName, pairs);
+        addLayerGroupRenamesForWorkspace(oldWsName, newWsName, pairs);
+        return pairs;
+    }
+
+    private void addLayerRenamesForWorkspace(String oldWsName, String newWsName, List<NamePair> pairs) {
+        try (CloseableIterator<org.geoserver.catalog.LayerInfo> layers = catalog.list(
+                org.geoserver.catalog.LayerInfo.class, Predicates.equal("resource.store.workspace.name", oldWsName))) {
+            while (layers.hasNext()) {
+                String localName = layers.next().getName();
+                pairs.add(new NamePair(prefixed(oldWsName, localName), prefixed(newWsName, localName)));
+            }
+        }
+    }
+
+    private void addLayerGroupRenamesForWorkspace(String oldWsName, String newWsName, List<NamePair> pairs) {
+        try (CloseableIterator<LayerGroupInfo> groups =
+                catalog.list(LayerGroupInfo.class, Predicates.equal("workspace.name", oldWsName))) {
+            while (groups.hasNext()) {
+                String localName = groups.next().getName();
+                pairs.add(new NamePair(prefixed(oldWsName, localName), prefixed(newWsName, localName)));
+            }
+        }
+    }
+
+    private List<NamePair> collectResourceRename(ResourceInfo resource, CatalogModifyEvent event) {
+        List<String> changedProperties = event.getPropertyNames();
+        int nameIndex = changedProperties.indexOf("name");
+        int namespaceIndex = changedProperties.indexOf("namespace");
+
+        NamespaceInfo currentNamespace = resource.getNamespace();
+        NamespaceInfo oldNamespace =
+                namespaceIndex > -1 ? (NamespaceInfo) event.getOldValues().get(namespaceIndex) : currentNamespace;
+        if (oldNamespace == null || currentNamespace == null) {
+            return List.of();
+        }
+
+        String oldLocalName = nameIndex > -1 ? (String) event.getOldValues().get(nameIndex) : resource.getName();
+        String newLocalName = nameIndex > -1 ? (String) event.getNewValues().get(nameIndex) : resource.getName();
+
+        String oldPrefixed = prefixed(oldNamespace.getPrefix(), oldLocalName);
+        String newPrefixed = prefixed(currentNamespace.getPrefix(), newLocalName);
+        if (oldPrefixed.equals(newPrefixed)) {
+            return List.of();
+        }
+        return List.of(new NamePair(oldPrefixed, newPrefixed));
+    }
+
+    private List<NamePair> collectLayerGroupRename(LayerGroupInfo group, CatalogModifyEvent event) {
+        String oldName = stringPropertyOldValue(event, "name");
+        String newName = stringPropertyNewValue(event, "name");
+        if (oldName == null || newName == null || oldName.equals(newName)) {
+            return List.of();
+        }
+        WorkspaceInfo workspace = group.getWorkspace();
+        String prefix = workspace == null ? null : workspace.getName();
+        return List.of(new NamePair(prefixed(prefix, oldName), prefixed(prefix, newName)));
+    }
+
+    private void replayRenames(List<NamePair> pairs) {
+        GWC mediator;
+        try {
+            mediator = GWC.get();
+        } catch (NullPointerException npe) {
+            log.debug("Skipping {} tile layer rename(s); GWC singleton not available", pairs.size());
+            return;
+        }
+        if (mediator == null) {
+            log.debug("Skipping {} tile layer rename(s); GWC singleton not available", pairs.size());
+            return;
+        }
+        for (NamePair pair : pairs) {
+            try {
+                mediator.layerRenamed(pair.oldPrefixed(), pair.newPrefixed());
+            } catch (RuntimeException e) {
+                log.warn("Failed to rename tile layer cache '{}' -> '{}'", pair.oldPrefixed(), pair.newPrefixed(), e);
+            }
+        }
+    }
+
+    private static String prefixed(String workspaceOrPrefix, String localName) {
+        return workspaceOrPrefix == null ? localName : workspaceOrPrefix + ":" + localName;
+    }
+
+    private static String stringPropertyOldValue(CatalogModifyEvent event, String property) {
+        int index = event.getPropertyNames().indexOf(property);
+        return index > -1 ? (String) event.getOldValues().get(index) : null;
+    }
+
+    private static String stringPropertyNewValue(CatalogModifyEvent event, String property) {
+        int index = event.getPropertyNames().indexOf(property);
+        return index > -1 ? (String) event.getNewValues().get(index) : null;
+    }
+}

--- a/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigTileLayerCatalog.java
+++ b/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigTileLayerCatalog.java
@@ -25,6 +25,7 @@ import org.geoserver.catalog.impl.LayerInfoImpl;
 import org.geoserver.catalog.plugin.resolving.ModificationProxyDecorator;
 import org.geoserver.cloud.backend.pgconfig.catalog.PgconfigCatalogFacade;
 import org.geoserver.cloud.gwc.repository.CloudCatalogConfiguration;
+import org.geoserver.gwc.GWC;
 import org.geoserver.gwc.config.GWCConfig;
 import org.geoserver.gwc.config.GWCConfigPersister;
 import org.geoserver.gwc.layer.GeoServerTileLayer;
@@ -172,6 +173,36 @@ public class PgconfigTileLayerCatalog implements TileLayerConfiguration {
             workspaceName = localWorkspace.getName();
         }
         repository.delete(workspaceName, localName);
+        notifyBlobStoreLayerRemoved(prefixedName(workspaceName, localName));
+    }
+
+    /**
+     * Bridge to {@link GWC#layerRemoved(String)} so the {@link
+     * org.geowebcache.storage.StorageBroker} deletes the on-disk blob store directory and fires
+     * {@code BlobStoreListener.layerDeleted} (which lets {@code DiskQuotaMonitor} drop the
+     * layer's quota rows). Vanilla GeoServer's {@code CatalogConfiguration.removeLayer} does the
+     * equivalent call; without it the pgconfig backend leaves orphan blob directories and
+     * stale quota rows.
+     *
+     * <p>{@link GWC#get()} throws {@link NullPointerException} if the static singleton hasn't
+     * been initialized yet (typical in unit tests that don't wire a full Spring context). In
+     * that case the bridge is a no-op.
+     */
+    private void notifyBlobStoreLayerRemoved(String prefixedLayerName) {
+        GWC mediator;
+        try {
+            mediator = GWC.get();
+        } catch (NullPointerException npe) {
+            return;
+        }
+        if (mediator == null) {
+            return;
+        }
+        mediator.layerRemoved(prefixedLayerName);
+    }
+
+    private String prefixedName(String workspaceName, String localName) {
+        return workspaceName == null ? localName : workspaceName + ":" + localName;
     }
 
     @Override

--- a/src/gwc/backends/pgconfig/src/test/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigGwcCatalogRenameListenerIT.java
+++ b/src/gwc/backends/pgconfig/src/test/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigGwcCatalogRenameListenerIT.java
@@ -1,0 +1,204 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.gwc.backend.pgconfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.faker.CatalogFaker;
+import org.geoserver.catalog.plugin.CatalogPlugin;
+import org.geoserver.cloud.backend.pgconfig.PgconfigBackendBuilder;
+import org.geoserver.cloud.backend.pgconfig.support.PgConfigTestContainer;
+import org.geoserver.config.plugin.GeoServerImpl;
+import org.geoserver.gwc.GWC;
+import org.geoserver.gwc.GWCSynchEnv;
+import org.geoserver.gwc.config.GWCConfig;
+import org.geoserver.gwc.config.GWCConfigPersister;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Verifies the full pgconfig-catalog rename propagation chain ends with a {@link GWC#layerRenamed}
+ * (and {@link GWC#layerRemoved}) call against a mocked GWC mediator, without standing up the full
+ * GWC stack. The catalog and SQL triggers are real (Postgres testcontainer), so this covers the
+ * order-of-operations between the in-process event firing and the database-side {@code
+ * publishedinfos_mat} refresh that broke upstream's path.
+ *
+ * @since 2.28.3.1
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class PgconfigGwcCatalogRenameListenerIT {
+
+    @Container
+    static PgConfigTestContainer<?> container = new PgConfigTestContainer<>();
+
+    private CatalogPlugin catalog;
+    private CatalogFaker faker;
+    private PgconfigGwcCatalogRenameListener listener;
+    private PgconfigTileLayerCatalog tlCatalog;
+    private GWC mediator;
+
+    @BeforeEach
+    void setUp() {
+        container.setUp();
+        PgconfigBackendBuilder backendBuilder = new PgconfigBackendBuilder(container.getDataSource());
+        catalog = backendBuilder.createCatalog();
+        GeoServerImpl geoServer = backendBuilder.createGeoServer(catalog);
+        faker = new CatalogFaker(catalog, geoServer);
+
+        listener = new PgconfigGwcCatalogRenameListener(catalog);
+        listener.register();
+
+        GWCConfigPersister defaultsProvider = mock(GWCConfigPersister.class);
+        when(defaultsProvider.getConfig()).thenReturn(new GWCConfig());
+        TileLayerMocking support = new TileLayerMocking(catalog, geoServer);
+        tlCatalog = new PgconfigTileLayerCatalog(
+                container.getDataSource(), support.getGridsets(), () -> catalog, defaultsProvider);
+
+        mediator = mock(GWC.class);
+        GWC.set(mediator, mock(GWCSynchEnv.class));
+    }
+
+    @AfterEach
+    void tearDown() {
+        try {
+            listener.unregister();
+        } finally {
+            GWC.set(null, null);
+            container.tearDown();
+        }
+    }
+
+    @Test
+    void workspaceRename_firesLayerRenamedForEachLayerInWorkspace() {
+        WorkspaceInfo ws = addWorkspace("oldWs");
+        LayerInfo layer1 = addLayer(ws, "states");
+        LayerInfo layer2 = addLayer(ws, "roads");
+
+        assertThat(layer1.prefixedName()).isEqualTo("oldWs:states");
+        assertThat(layer2.prefixedName()).isEqualTo("oldWs:roads");
+
+        renameWorkspace(ws, "newWs");
+
+        verify(mediator).layerRenamed("oldWs:states", "newWs:states");
+        verify(mediator).layerRenamed("oldWs:roads", "newWs:roads");
+    }
+
+    @Test
+    void workspaceRename_firesLayerRenamedForLayerGroups() {
+        WorkspaceInfo ws = addWorkspace("oldWs");
+        LayerInfo layer = addLayer(ws, "states");
+        LayerGroupInfo group = addLayerGroup(ws, "grp", layer);
+
+        assertThat(group.prefixedName()).isEqualTo("oldWs:grp");
+
+        renameWorkspace(ws, "newWs");
+
+        verify(mediator).layerRenamed("oldWs:grp", "newWs:grp");
+    }
+
+    @Test
+    void resourceRename_firesLayerRenamed() {
+        WorkspaceInfo ws = addWorkspace("topp");
+        LayerInfo layer = addLayer(ws, "states");
+
+        FeatureTypeInfo resource = (FeatureTypeInfo) layer.getResource();
+        resource.setName("roads");
+        catalog.save(resource);
+
+        verify(mediator).layerRenamed("topp:states", "topp:roads");
+    }
+
+    @Test
+    void layerGroupRename_firesLayerRenamed() {
+        WorkspaceInfo ws = addWorkspace("topp");
+        LayerInfo layer = addLayer(ws, "states");
+        LayerGroupInfo group = addLayerGroup(ws, "groupOld", layer);
+
+        group = catalog.getLayerGroup(group.getId());
+        group.setName("groupNew");
+        catalog.save(group);
+
+        verify(mediator).layerRenamed("topp:groupOld", "topp:groupNew");
+    }
+
+    @Test
+    void unrelatedModify_doesNotFire() {
+        WorkspaceInfo ws = addWorkspace("topp");
+        addLayer(ws, "states");
+
+        // bump the workspace's "isolated" attribute (a non-name change)
+        ws = catalog.getWorkspace(ws.getId());
+        ws.setIsolated(!ws.isIsolated());
+        catalog.save(ws);
+
+        verify(mediator, never())
+                .layerRenamed(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void removeLayer_firesLayerRemoved() {
+        WorkspaceInfo ws = addWorkspace("topp");
+        LayerInfo layer = addLayer(ws, "states");
+        tlCatalog.addLayer(new TileLayerMocking(catalog, mock(GeoServerImpl.class)).geoServerTileLayer(layer));
+
+        tlCatalog.removeLayer(layer.prefixedName());
+
+        verify(mediator).layerRemoved("topp:states");
+    }
+
+    private WorkspaceInfo addWorkspace(String name) {
+        WorkspaceInfo ws = faker.workspaceInfo(name);
+        NamespaceInfo ns = faker.namespace(name);
+        catalog.add(ws);
+        catalog.add(ns);
+        return catalog.getWorkspaceByName(name);
+    }
+
+    private LayerInfo addLayer(WorkspaceInfo ws, String layerName) {
+        DataStoreInfo ds = faker.dataStoreInfo(ws);
+        catalog.add(ds);
+
+        StyleInfo style = faker.styleInfo();
+        catalog.add(style);
+
+        FeatureTypeInfo featureType = faker.featureTypeInfo(ds, layerName);
+        catalog.add(featureType);
+
+        LayerInfo layer = faker.layerInfo(featureType, style);
+        catalog.add(layer);
+        return catalog.getLayer(layer.getId());
+    }
+
+    private LayerGroupInfo addLayerGroup(WorkspaceInfo ws, String name, LayerInfo... layers) {
+        LayerGroupInfo group = faker.layerGroupInfo(ws);
+        group.setName(name);
+        for (LayerInfo layer : layers) {
+            group.getLayers().add(layer);
+        }
+        catalog.add(group);
+        return catalog.getLayerGroup(group.getId());
+    }
+
+    private void renameWorkspace(WorkspaceInfo ws, String newName) {
+        WorkspaceInfo persisted = catalog.getWorkspace(ws.getId());
+        persisted.setName(newName);
+        catalog.save(persisted);
+    }
+}

--- a/src/gwc/backends/pgconfig/src/test/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigGwcCatalogRenameListenerTest.java
+++ b/src/gwc/backends/pgconfig/src/test/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigGwcCatalogRenameListenerTest.java
@@ -1,0 +1,219 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.gwc.backend.pgconfig;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.event.CatalogModifyEvent;
+import org.geoserver.catalog.event.CatalogPostModifyEvent;
+import org.geoserver.catalog.util.CloseableIterator;
+import org.geoserver.catalog.util.CloseableIteratorAdapter;
+import org.geoserver.gwc.GWC;
+import org.geoserver.gwc.GWCSynchEnv;
+import org.geotools.api.filter.Filter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @since 2.28.3.1
+ */
+class PgconfigGwcCatalogRenameListenerTest {
+
+    private Catalog catalog;
+    private PgconfigGwcCatalogRenameListener listener;
+    private GWC mediator;
+
+    @BeforeEach
+    void setUp() {
+        catalog = mock(Catalog.class);
+        mediator = mock(GWC.class);
+        listener = new PgconfigGwcCatalogRenameListener(catalog);
+        GWC.set(mediator, mock(GWCSynchEnv.class));
+    }
+
+    @AfterEach
+    void tearDown() {
+        GWC.set(null, null);
+    }
+
+    @Test
+    void register_addsListenerToCatalog() {
+        listener.register();
+        verify(catalog).addListener(listener);
+    }
+
+    @Test
+    void unregister_removesListenerFromCatalog() {
+        listener.unregister();
+        verify(catalog).removeListener(listener);
+    }
+
+    @Test
+    void workspaceRename_emitsOneLayerRenamedPerLayerAndLayerGroup() {
+        WorkspaceInfo ws = mock(WorkspaceInfo.class);
+        when(ws.getName()).thenReturn("oldWs");
+
+        whenListByType(List.of(layerInfoMock("foo"), layerInfoMock("bar")), List.of(layerGroupInfoMock("grp")));
+
+        listener.handleModifyEvent(modifyEvent(ws, List.of("name"), List.of("oldWs"), List.of("newWs")));
+        listener.handlePostModifyEvent(postModifyEvent(ws));
+
+        verify(mediator).layerRenamed("oldWs:foo", "newWs:foo");
+        verify(mediator).layerRenamed("oldWs:bar", "newWs:bar");
+        verify(mediator).layerRenamed("oldWs:grp", "newWs:grp");
+    }
+
+    @Test
+    void resourceRename_emitsSingleLayerRenamedWithNamespacePrefix() {
+        NamespaceInfo ns = mock(NamespaceInfo.class);
+        when(ns.getPrefix()).thenReturn("topp");
+        FeatureTypeInfo resource = mock(FeatureTypeInfo.class);
+        when(resource.getNamespace()).thenReturn(ns);
+        when(resource.getName()).thenReturn("states");
+
+        listener.handleModifyEvent(modifyEvent(resource, List.of("name"), List.of("states"), List.of("roads")));
+        listener.handlePostModifyEvent(postModifyEvent(resource));
+
+        verify(mediator).layerRenamed("topp:states", "topp:roads");
+        verifyNoInteractions(catalog);
+    }
+
+    @Test
+    void resourceNamespaceChange_usesOldNamespaceForOldName() {
+        NamespaceInfo oldNs = mock(NamespaceInfo.class);
+        when(oldNs.getPrefix()).thenReturn("ns1");
+        NamespaceInfo newNs = mock(NamespaceInfo.class);
+        when(newNs.getPrefix()).thenReturn("ns2");
+        FeatureTypeInfo resource = mock(FeatureTypeInfo.class);
+        when(resource.getNamespace()).thenReturn(newNs);
+        when(resource.getName()).thenReturn("ft");
+
+        listener.handleModifyEvent(modifyEvent(resource, List.of("namespace"), List.of(oldNs), List.of(newNs)));
+        listener.handlePostModifyEvent(postModifyEvent(resource));
+
+        verify(mediator).layerRenamed("ns1:ft", "ns2:ft");
+    }
+
+    @Test
+    void layerGroupRename_workspaceScoped() {
+        WorkspaceInfo ws = mock(WorkspaceInfo.class);
+        when(ws.getName()).thenReturn("topp");
+        LayerGroupInfo group = mock(LayerGroupInfo.class);
+        when(group.getWorkspace()).thenReturn(ws);
+
+        listener.handleModifyEvent(modifyEvent(group, List.of("name"), List.of("groupOld"), List.of("groupNew")));
+        listener.handlePostModifyEvent(postModifyEvent(group));
+
+        verify(mediator).layerRenamed("topp:groupOld", "topp:groupNew");
+    }
+
+    @Test
+    void layerGroupRename_global() {
+        LayerGroupInfo group = mock(LayerGroupInfo.class);
+        when(group.getWorkspace()).thenReturn(null);
+
+        listener.handleModifyEvent(modifyEvent(group, List.of("name"), List.of("globalOld"), List.of("globalNew")));
+        listener.handlePostModifyEvent(postModifyEvent(group));
+
+        verify(mediator).layerRenamed("globalOld", "globalNew");
+    }
+
+    @Test
+    void unrelatedModify_doesNothing() {
+        listener.handleModifyEvent(
+                modifyEvent(mock(org.geoserver.catalog.StyleInfo.class), List.of("name"), List.of("a"), List.of("b")));
+        listener.handlePostModifyEvent(postModifyEvent(mock(org.geoserver.catalog.StyleInfo.class)));
+
+        verifyNoInteractions(mediator);
+    }
+
+    @Test
+    void postModify_drainsThreadLocal_andSecondPostIsNoOp() {
+        WorkspaceInfo ws = mock(WorkspaceInfo.class);
+        whenListByType(List.of(layerInfoMock("foo")), List.of());
+
+        CatalogModifyEvent pre = modifyEvent(ws, List.of("name"), List.of("oldWs"), List.of("newWs"));
+        CatalogPostModifyEvent post = postModifyEvent(ws);
+
+        listener.handleModifyEvent(pre);
+        listener.handlePostModifyEvent(post);
+        listener.handlePostModifyEvent(post);
+
+        verify(mediator).layerRenamed("oldWs:foo", "newWs:foo");
+        verify(mediator, never()).layerRenamed("anything-else", "anything-else");
+    }
+
+    @Test
+    void noGwcSingleton_isSafe() {
+        GWC.set(null, null); // tear down the @BeforeEach setup
+        WorkspaceInfo ws = mock(WorkspaceInfo.class);
+        whenListByType(List.of(layerInfoMock("foo")), List.of());
+
+        listener.handleModifyEvent(modifyEvent(ws, List.of("name"), List.of("oldWs"), List.of("newWs")));
+        listener.handlePostModifyEvent(postModifyEvent(ws));
+
+        verifyNoInteractions(mediator);
+    }
+
+    private LayerInfo layerInfoMock(String name) {
+        LayerInfo info = mock(LayerInfo.class);
+        when(info.getName()).thenReturn(name);
+        return info;
+    }
+
+    private LayerGroupInfo layerGroupInfoMock(String name) {
+        LayerGroupInfo info = mock(LayerGroupInfo.class);
+        when(info.getName()).thenReturn(name);
+        return info;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private void whenListByType(List<LayerInfo> layers, List<LayerGroupInfo> groups) {
+        when(catalog.list(any(Class.class), any(Filter.class))).thenAnswer(invocation -> {
+            Class<?> type = invocation.getArgument(0);
+            if (LayerInfo.class.equals(type)) {
+                return closeableIterator(layers);
+            }
+            if (LayerGroupInfo.class.equals(type)) {
+                return closeableIterator(groups);
+            }
+            return closeableIterator(List.of());
+        });
+    }
+
+    private <T> CloseableIterator<T> closeableIterator(List<T> values) {
+        return new CloseableIteratorAdapter<>(values.iterator());
+    }
+
+    private CatalogModifyEvent modifyEvent(
+            Object source, List<String> props, List<Object> oldValues, List<Object> newValues) {
+        CatalogModifyEvent event = mock(CatalogModifyEvent.class);
+        when(event.getSource()).thenReturn((org.geoserver.catalog.CatalogInfo) source);
+        when(event.getPropertyNames()).thenReturn(props);
+        when(event.getOldValues()).thenReturn(oldValues);
+        when(event.getNewValues()).thenReturn(newValues);
+        return event;
+    }
+
+    private CatalogPostModifyEvent postModifyEvent(Object source) {
+        CatalogPostModifyEvent event = mock(CatalogPostModifyEvent.class);
+        when(event.getSource()).thenReturn((org.geoserver.catalog.CatalogInfo) source);
+        return event;
+    }
+}

--- a/src/gwc/backends/pgconfig/src/test/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigTileLayerCatalogTest.java
+++ b/src/gwc/backends/pgconfig/src/test/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigTileLayerCatalogTest.java
@@ -29,6 +29,8 @@ import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.CatalogPlugin;
 import org.geoserver.config.plugin.GeoServerImpl;
+import org.geoserver.gwc.GWC;
+import org.geoserver.gwc.GWCSynchEnv;
 import org.geoserver.gwc.config.GWCConfig;
 import org.geoserver.gwc.config.GWCConfigPersister;
 import org.geoserver.gwc.layer.GeoServerTileLayer;
@@ -36,6 +38,7 @@ import org.geoserver.ows.LocalWorkspace;
 import org.geowebcache.config.BaseConfiguration;
 import org.geowebcache.grid.GridSetBroker;
 import org.geowebcache.layer.TileLayer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -48,6 +51,7 @@ class PgconfigTileLayerCatalogTest {
     private PgconfigTileLayerCatalog tlCatalog;
     private TileLayerMocking support;
     private GWCConfigPersister defaultsProvider;
+    private GWC gwcMediator;
 
     @BeforeEach
     void setUp() {
@@ -58,6 +62,15 @@ class PgconfigTileLayerCatalogTest {
         when(defaultsProvider.getConfig()).thenReturn(defaults);
         tlCatalog =
                 new PgconfigTileLayerCatalog(repository, support.getGridsets(), support.catalog(), defaultsProvider);
+
+        // Install a mock GWC singleton so removeLayer's bridge to GWC.layerRemoved doesn't NPE
+        gwcMediator = mock(GWC.class);
+        GWC.set(gwcMediator, mock(GWCSynchEnv.class));
+    }
+
+    @AfterEach
+    void tearDown() {
+        GWC.set(null, null);
     }
 
     @Test
@@ -273,6 +286,36 @@ class PgconfigTileLayerCatalogTest {
         } finally {
             LocalWorkspace.remove();
         }
+    }
+
+    @Test
+    void testRemoveLayer_bridges_to_GWC_layerRemoved() {
+        tlCatalog.removeLayer("ws1:layer1");
+        verify(repository, times(1)).delete("ws1", "layer1");
+        verify(gwcMediator, times(1)).layerRemoved("ws1:layer1");
+
+        clearInvocations(repository, gwcMediator);
+        tlCatalog.removeLayer("globalgroup");
+        verify(repository, times(1)).delete(null, "globalgroup");
+        verify(gwcMediator, times(1)).layerRemoved("globalgroup");
+
+        clearInvocations(repository, gwcMediator);
+        WorkspaceInfo localWs = support.workspace("ws3");
+        LocalWorkspace.set(localWs);
+        try {
+            tlCatalog.removeLayer("named");
+            verify(repository, times(1)).delete("ws3", "named");
+            verify(gwcMediator, times(1)).layerRemoved("ws3:named");
+        } finally {
+            LocalWorkspace.remove();
+        }
+    }
+
+    @Test
+    void testRemoveLayer_no_GWC_singleton_is_safe() {
+        GWC.set(null, null);
+        tlCatalog.removeLayer("ws1:layer1");
+        verify(repository, times(1)).delete("ws1", "layer1");
     }
 
     @Test

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/DiskQuotaConfiguration.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/DiskQuotaConfiguration.java
@@ -8,26 +8,66 @@ package org.geoserver.cloud.gwc.config.core;
 import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.geoserver.gwc.config.GeoserverXMLResourceProvider;
 import org.geowebcache.config.ConfigurationException;
+import org.geowebcache.diskquota.ConfigLoader;
 import org.geowebcache.diskquota.DiskQuotaMonitor;
 import org.geowebcache.layer.TileLayerDispatcher;
 import org.geowebcache.storage.DefaultStorageFinder;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
 /**
+ * Imports the upstream {@code geowebcache-diskquota-context.xml}, contributing the {@code
+ * DiskQuotaMonitor}, {@code DiskQuotaStoreProvider} and friends that {@code gwcFacade} (in
+ * {@code geowebcache-geoserver-context.xml}) and the GeoServer Wicket UI hold hard references to.
+ *
+ * <p>Whether the monitor actually runs at startup is controlled at runtime by the {@code
+ * GWC_DISKQUOTA_DISABLED} environment variable, which the upstream {@code DiskQuotaMonitor} and
+ * {@code ConfigurableQuotaStoreProvider} both read in their constructors. {@link
+ * #diskQuotaDisabledPropertySetter(Environment)} sets it to {@code true} when {@code
+ * gwc.disk-quota.enabled} is unset or {@code false} (the default) and clears it otherwise. The
+ * bean topology stays the same in both modes; only runtime behavior changes.
+ *
+ * <p>{@code DiskQuotaConfigLoader} is replaced below to drop the upstream {@code metaStoreRemover}
+ * dependency that doesn't exist in the cloud topology.
+ *
  * @since 1.0
  */
 @Configuration(proxyBeanMethods = false)
 @ImportFilteredResource("jar:gs-gwc-[0-9]+.*!/geowebcache-diskquota-context.xml#name=^(?!DiskQuotaConfigLoader).*$")
 public class DiskQuotaConfiguration {
 
-    static {
-        /*
-         * Disable disk-quota by brute force for now. We need to resolve how and where to store the
-         * configuration and database.
-         */
-        System.setProperty(DiskQuotaMonitor.GWC_DISKQUOTA_DISABLED, "true");
+    /**
+     * Sets the {@code GWC_DISKQUOTA_DISABLED} system property based on the {@code
+     * gwc.disk-quota.enabled} configuration property, before any beans are instantiated.
+     *
+     * <p>{@code DiskQuotaMonitor} and {@code ConfigurableQuotaStoreProvider} both read
+     * {@code GWC_DISKQUOTA_DISABLED} in their constructors and lock in
+     * {@code diskQuotaEnabled = !disabled}. By then it is too late for a regular bean
+     * post-processor to flip the switch - so this {@code BeanFactoryPostProcessor} runs during
+     * bean factory post-processing, well before any singleton is instantiated.
+     *
+     * <p>Both branches are explicit so a previous context's setting (e.g. an earlier test in the
+     * same JVM) cannot leak into the current bean topology.
+     *
+     * <p>The method is intentionally {@code static}: a non-static {@code @Bean} factory method
+     * for a {@code BeanFactoryPostProcessor} would force its declaring class to be instantiated
+     * eagerly, ahead of post-processing, with subtle side effects.
+     */
+    @Bean
+    static BeanFactoryPostProcessor diskQuotaDisabledPropertySetter(Environment environment) {
+        boolean enabled = environment.getProperty(
+                GeoWebCacheConfigurationProperties.DISKQUOTA_ENABLED, Boolean.class, Boolean.FALSE);
+        if (enabled) {
+            System.clearProperty(DiskQuotaMonitor.GWC_DISKQUOTA_DISABLED);
+        } else {
+            System.setProperty(DiskQuotaMonitor.GWC_DISKQUOTA_DISABLED, "true");
+        }
+        return beanFactory -> {
+            // no-op: the side effect of setting the system property happened before this lambda
+        };
     }
 
     /**
@@ -35,13 +75,13 @@ public class DiskQuotaConfiguration {
      * metaStoreRemover}
      */
     @Bean(name = "DiskQuotaConfigLoader")
-    org.geowebcache.diskquota.ConfigLoader diskQuotaConfigLoader( //
+    ConfigLoader diskQuotaConfigLoader( //
             @Qualifier("DiskQuotaConfigResourceProvider")
                     GeoserverXMLResourceProvider diskQuotaConfigResourceProvider, //
             @Qualifier("gwcDefaultStorageFinder") DefaultStorageFinder storageFinder, //
             TileLayerDispatcher tld)
             throws ConfigurationException {
 
-        return new org.geowebcache.diskquota.ConfigLoader(diskQuotaConfigResourceProvider, storageFinder, tld);
+        return new ConfigLoader(diskQuotaConfigResourceProvider, storageFinder, tld);
     }
 }

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/DisquotaWebUIConfiguration.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/DisquotaWebUIConfiguration.java
@@ -1,0 +1,18 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.gwc.config.core;
+
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Enables disk quota Wicket components.
+ *
+ * @since 2.28.3.1
+ */
+@Configuration
+@ImportFilteredResource("jar:gs-web-gwc-.*!/applicationContext.xml#name=diskQuotaMenuPage")
+public class DisquotaWebUIConfiguration {}


### PR DESCRIPTION
When the pgconfig spring profile is active and gwc.disk-quota.enabled is true, auto-configure the GWC DiskQuota subsystem to use a JDBC QuotaStore on the same Postgres database that backs the catalog.

This way the cluster has a single source of truth and tile usage tracking survives container restarts without a shared filesystem.

Pieces:

- V3_1_0__DiskQuota_Tables.sql: Flyway migration creating the TILESET and TILEPAGE tables in the pgconfig schema (FK cascade so deleting a tileset row clears its pages and ___GLOBAL_QUOTA___ is decremented by the BlobStoreListener).
- PgconfigDiskQuotaAutoConfiguration + PgconfigDiskQuotaBootstrap: conditional on pgconfig + disk-quota enabled. On @PostConstruct, seed geowebcache-diskquota.xml and geowebcache-diskquota-jdbc.xml in the data dir if absent, pointing the JDBC store at the pgconfig JNDI DataSource and the PostgreSQL dialect.
- DiskQuotaConfiguration: replace the static GWC_DISKQUOTA_DISABLED=true sentinel with a BeanFactoryPostProcessor that derives the env var from gwc.disk-quota.enabled, so the upstream context.xml's static initializer no longer hard-disables the monitor in cloud.
- DisquotaWebUIConfiguration + JDBCConnectionPoolPanelCloudTest: pull in the upstream diskQuotaMenuPage and the JDBC connection-pool panel in the webui app, restoring the Server -> DiskQuota admin page.

Storage propagation (without these the catalog row goes away but the on-disk cache and quota rows don't):

- PgconfigTileLayerCatalog.removeLayer now bridges to GWC.layerRemoved(prefixedName) after the repository delete, so StorageBroker.delete fires and FileBlobStore + DiskQuota's BlobStoreListener clean up the directory and tileset/tilepage rows.
- New PgconfigGwcCatalogRenameListener captures WorkspaceInfo, ResourceInfo and LayerGroupInfo name (and resource namespace) changes at pre-modify (when old names are still queryable) and replays them via GWC.layerRenamed(old, new) at post-modify. This bypasses upstream CatalogLayerEventListener's lookup-by-old-name path, which fails in pgconfig because the SQL workspaceinfo / namespaceinfo update triggers refresh publishedinfos_mat before the Java post-modify event fires.

Tests:

- DiskQuotaControllerPgconfigIT: boots the GWC microservice with a Postgres testcontainer and round-trips the /gwc/rest/diskquota REST API to verify the full stack wires up.
- PgconfigGwcCatalogRenameListenerTest / IT: unit + integration coverage for the rename listener (workspace / resource / layer group, with and without namespace, ThreadLocal cleanup, and safe no-op when the GWC singleton isn't wired).
- PgconfigDiskQuotaAutoConfigurationTest / BootstrapTest: verify the auto-config + bootstrap file-seeding behaviour against a real Postgres testcontainer.

on-behalf-of: @camptocamp <info@camptocamp.com>