### PR TITLE
Enable GWC DiskQuota with the pgconfig backend

### DIFF
--- a/src/apps/geoserver/gwc/src/test/java/org/geoserver/cloud/gwc/app/DiskQuotaControllerPgconfigIT.java
+++ b/src/apps/geoserver/gwc/src/test/java/org/geoserver/cloud/gwc/app/DiskQuotaControllerPgconfigIT.java
@@ -1,0 +1,128 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.gwc.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpStatus.OK;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+
+/**
+ * End-to-end integration test for the GeoWebCache {@code DiskQuotaController} on the pgconfig backend with disk-quota
+ * enabled.
+ *
+ * <p>Boots the GWC microservice with the pgconfig backend pointing at a Postgres testcontainer and
+ * {@code gwc.disk-quota.enabled=true}, then drives the {@code /gwc/rest/diskquota} REST API to verify the full GET/PUT
+ * round-trip works. Exercises:
+ *
+ * <ol>
+ *   <li>Flyway runs the {@code V3_1_0__DiskQuota_Tables.sql} migration in the pgconfig schema.
+ *   <li>{@code PgconfigDiskQuotaAutoConfiguration} wires a {@code JDBCQuotaStore} on the pgconfig DataSource and
+ *       supplies the {@code DiskQuotaStoreProvider} bean.
+ *   <li>{@code DiskQuotaMonitor} starts up (the BFPP gate leaves {@code GWC_DISKQUOTA_DISABLED} cleared) and the REST
+ *       controller's PUT applies a new {@code DiskQuotaConfig} that subsequent GETs see.
+ * </ol>
+ *
+ * <p>The upstream {@code DiskQuotaController} chooses XML vs JSON via {@code request.getPathInfo().contains("json")}.
+ * Spring Boot 4's path handling strips the {@code .json} suffix before the request reaches the controller, so the
+ * format check always picks XML; this test exercises the controller via the (working) XML representation.
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@AutoConfigureTestRestTemplate
+@Testcontainers(disabledWithoutDocker = true)
+class DiskQuotaControllerPgconfigIT {
+
+    @Container
+    static PostgreSQLContainer postgres = new PostgreSQLContainer("postgres:15");
+
+    static @TempDir Path datadir;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) throws IOException {
+        Path gwcdir = datadir.resolve("gwc");
+        if (!Files.exists(gwcdir)) {
+            Files.createDirectory(gwcdir);
+        }
+        registry.add("gwc.cache-directory", gwcdir::toAbsolutePath);
+        registry.add("gwc.disk-quota.enabled", () -> "true");
+        registry.add("geoserver.backend.pgconfig.enabled", () -> "true");
+        registry.add("geoserver.backend.pgconfig.jndi-name", () -> "pgconfig");
+        registry.add("pgconfig.host", postgres::getHost);
+        registry.add("pgconfig.port", () -> postgres.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT));
+        registry.add("pgconfig.database", postgres::getDatabaseName);
+        registry.add("pgconfig.schema", () -> "pgconfigdiskquota");
+        registry.add("pgconfig.username", postgres::getUsername);
+        registry.add("pgconfig.password", postgres::getPassword);
+    }
+
+    @Test
+    void getDefaultDiskQuotaConfig() {
+        TestRestTemplate authed = restTemplate.withBasicAuth("admin", "geoserver");
+        ResponseEntity<String> resp = authed.getForEntity("/gwc/rest/diskquota", String.class);
+        assertThat(resp.getStatusCode()).as("body: %s", resp.getBody()).isEqualTo(OK);
+        String body = resp.getBody();
+        assertThat(body).contains("<org.geowebcache.diskquota.DiskQuotaConfig>");
+        assertThat(body).contains("<enabled>");
+        assertThat(body).contains("<globalQuota>");
+    }
+
+    @Test
+    void putThenGetRoundTripsCustomConfig() {
+        TestRestTemplate authed = restTemplate.withBasicAuth("admin", "geoserver");
+
+        String payload =
+                """
+                <org.geowebcache.diskquota.DiskQuotaConfig>
+                  <enabled>true</enabled>
+                  <cacheCleanUpFrequency>5</cacheCleanUpFrequency>
+                  <cacheCleanUpUnits>SECONDS</cacheCleanUpUnits>
+                  <maxConcurrentCleanUps>4</maxConcurrentCleanUps>
+                  <globalExpirationPolicyName>LFU</globalExpirationPolicyName>
+                </org.geowebcache.diskquota.DiskQuotaConfig>
+                """;
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_XML);
+        ResponseEntity<String> putResp = authed.exchange(
+                "/gwc/rest/diskquota", HttpMethod.PUT, new HttpEntity<>(payload, headers), String.class);
+        assertThat(putResp.getStatusCode().is2xxSuccessful())
+                .as("PUT status: %s, body: %s", putResp.getStatusCode(), putResp.getBody())
+                .isTrue();
+
+        ResponseEntity<String> getResp = authed.getForEntity("/gwc/rest/diskquota", String.class);
+        assertThat(getResp.getStatusCode()).isEqualTo(OK);
+        String body = getResp.getBody();
+        assertThat(body).contains("<enabled>true</enabled>");
+        assertThat(body).contains("<cacheCleanUpFrequency>5</cacheCleanUpFrequency>");
+        assertThat(body).contains("<cacheCleanUpUnits>SECONDS</cacheCleanUpUnits>");
+        assertThat(body).contains("<maxConcurrentCleanUps>4</maxConcurrentCleanUps>");
+        assertThat(body).contains("<globalExpirationPolicyName>LFU</globalExpirationPolicyName>");
+    }
+}

--- a/src/apps/geoserver/webui/src/test/java/org/geoserver/cloud/web/diskquota/JDBCConnectionPoolPanelCloudTest.java
+++ b/src/apps/geoserver/webui/src/test/java/org/geoserver/cloud/web/diskquota/JDBCConnectionPoolPanelCloudTest.java
@@ -1,0 +1,120 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.web.diskquota;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.Serial;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import org.apache.wicket.markup.html.WebPage;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.util.tester.WicketTester;
+import org.geoserver.cloud.web.app.WebUIApplication;
+import org.geoserver.gwc.web.diskquota.JDBCConnectionPoolPanel;
+import org.geoserver.web.GeoServerApplication;
+import org.geowebcache.diskquota.jdbc.JDBCConfiguration.ConnectionPoolConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+/**
+ * Verifies that {@link JDBCConnectionPoolPanel}, exposed by the cloud webui module's disk-quota web-ui wiring, renders
+ * inside the cloud Wicket harness without leaking the password into the response markup.
+ *
+ * <p>Mirrors the upstream {@code JDBCConnectionPoolPanelTest} but uses the Spring-Boot-driven cloud
+ * {@code GeoServerApplication}. Disk-quota is enabled so the context also boots
+ * {@code DiskQuotaAutoConfiguration.DisquotaWebUIAutoConfiguration} and the {@code diskQuotaMenuPage} bean.
+ */
+@SpringBootTest(
+        classes = WebUIApplication.class,
+        properties = {
+            "spring.cloud.bus.enabled: false",
+            "spring.cloud.config.enabled: false",
+            "spring.cloud.config.discovery.enabled: false",
+            "spring.cloud.consul.enabled: false",
+            "spring.cloud.consul.discovery.enabled: false"
+        })
+@ActiveProfiles("test")
+class JDBCConnectionPoolPanelCloudTest {
+
+    private @Autowired GeoServerApplication app;
+    private WicketTester tester;
+
+    static @TempDir Path tmpdir;
+
+    @DynamicPropertySource
+    static void setUpDataDir(DynamicPropertyRegistry registry) throws IOException {
+        Path datadir = tmpdir.resolve("datadir");
+        Path gwcdir = datadir.resolve("gwc");
+        Files.createDirectories(gwcdir);
+        registry.add("geoserver.backend.data-directory.location", datadir::toAbsolutePath);
+        registry.add("gwc.cache-directory", gwcdir::toAbsolutePath);
+        registry.add("gwc.disk-quota.enabled", () -> "true");
+    }
+
+    static @BeforeAll void beforeAll() {
+        System.setProperty("wicket.configuration", "deployment");
+        System.setProperty(GeoServerApplication.GEOSERVER_CSRF_DISABLED, "true");
+        Locale.setDefault(Locale.ENGLISH);
+    }
+
+    @BeforeEach
+    void setUpWicketTester() {
+        tester = new WicketTester(app, true);
+    }
+
+    @AfterEach
+    void tearDownWicketTester() {
+        if (tester != null) {
+            tester.destroy();
+        }
+    }
+
+    @Test
+    void renderingDoesNotLeakPassword() {
+        ConnectionPoolConfiguration pool = new ConnectionPoolConfiguration();
+        pool.setDriver("org.postgresql.Driver");
+        pool.setUrl("jdbc:postgresql://example:5432/quota");
+        pool.setUsername("sa");
+        pool.setPassword("topsecret");
+        pool.setMinConnections(1);
+        pool.setMaxConnections(1);
+        pool.setMaxOpenPreparedStatements(50);
+
+        FormTestPage page = new FormTestPage(new JDBCConnectionPoolPanel("panel", new Model<>(pool)));
+        tester.startPage(page);
+
+        String body = tester.getLastResponseAsString();
+        assertThat(body).as("password must not appear in rendered HTML").doesNotContain(pool.getPassword());
+    }
+
+    /**
+     * Minimal Wicket test page that wraps a single panel in a Form. The companion HTML file lives next to the compiled
+     * class so Wicket can locate the markup via classpath.
+     */
+    public static class FormTestPage extends WebPage {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        public FormTestPage(JDBCConnectionPoolPanel panel) {
+            Form<?> form = new Form<>("form");
+            add(form);
+            form.add(panel);
+        }
+    }
+}

--- a/src/apps/geoserver/webui/src/test/resources/org/geoserver/cloud/web/diskquota/JDBCConnectionPoolPanelCloudTest$FormTestPage.html
+++ b/src/apps/geoserver/webui/src/test/resources/org/geoserver/cloud/web/diskquota/JDBCConnectionPoolPanelCloudTest$FormTestPage.html
@@ -1,0 +1,7 @@
+<html xmlns:wicket="http://wicket.apache.org/">
+  <body>
+    <form wicket:id="form">
+      <div wicket:id="panel"></div>
+    </form>
+  </body>
+</html>

--- a/src/catalog/backends/pgconfig/src/main/resources/db/pgconfig/migration/postgresql/V3_1_0__DiskQuota_Tables.sql
+++ b/src/catalog/backends/pgconfig/src/main/resources/db/pgconfig/migration/postgresql/V3_1_0__DiskQuota_Tables.sql
@@ -1,0 +1,39 @@
+/*
+ * GeoWebCache JDBC Disk Quota tables.
+ *
+ * Mirrors the DDL in org.geowebcache.diskquota.jdbc.SQLDialect#TABLE_CREATION_MAP
+ * (PostgreSQL flavor) so that JDBCQuotaStore.initialize() finds the tables and
+ * skips its own DDL via the tableExists() check at startup.
+ *
+ * Created in the pgconfig schema (whatever Flyway is configured with), so the
+ * disk quota store shares the pgconfig DataSource and schema. The JDBC quota
+ * store is wired up by PgconfigDiskQuotaAutoConfiguration when both
+ * geoserver.backend.pgconfig.enabled=true and gwc.disk-quota.enabled=true.
+ */
+CREATE TABLE IF NOT EXISTS TILESET (
+  KEY VARCHAR(320) PRIMARY KEY,
+  LAYER_NAME VARCHAR(128),
+  GRIDSET_ID VARCHAR(32),
+  BLOB_FORMAT VARCHAR(64),
+  PARAMETERS_ID VARCHAR(41),
+  BYTES NUMERIC(21) NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS TILESET_LAYER ON TILESET(LAYER_NAME);
+
+CREATE TABLE IF NOT EXISTS TILEPAGE (
+  KEY VARCHAR(320) PRIMARY KEY,
+  TILESET_ID VARCHAR(320) REFERENCES TILESET(KEY) ON UPDATE CASCADE ON DELETE CASCADE, 
+  PAGE_Z SMALLINT,
+  PAGE_X INTEGER,
+  PAGE_Y INTEGER,
+  CREATION_TIME_MINUTES INTEGER,
+  FREQUENCY_OF_USE FLOAT,
+  LAST_ACCESS_TIME_MINUTES INTEGER,
+  FILL_FACTOR FLOAT,
+  NUM_HITS NUMERIC(64)
+);
+
+CREATE INDEX IF NOT EXISTS TILEPAGE_TILESET ON TILEPAGE(TILESET_ID, FILL_FACTOR);
+CREATE INDEX IF NOT EXISTS TILEPAGE_FREQUENCY ON TILEPAGE(FREQUENCY_OF_USE DESC);
+CREATE INDEX IF NOT EXISTS TILEPAGE_LAST_ACCESS ON TILEPAGE(LAST_ACCESS_TIME_MINUTES DESC);

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgconfig/PgconfigMigrationAutoConfigurationIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgconfig/PgconfigMigrationAutoConfigurationIT.java
@@ -115,7 +115,9 @@ class PgconfigMigrationAutoConfigurationIT {
                 "resourcestore",
                 "resource_lock",
                 "publishedinfos_mat",
-                "tilelayers_mat");
+                "tilelayers_mat",
+                "tileset",
+                "tilepage");
         List<String> sequences = List.of("gs_update_sequence", "resourcestore_id_seq");
 
         Map<String, String> expected = new TreeMap<>();

--- a/src/config/geoserver-configuration/src/main/java/org/geoserver/configuration/gwc/GwcConfigurationTranspilerAggregator.java
+++ b/src/config/geoserver-configuration/src/main/java/org/geoserver/configuration/gwc/GwcConfigurationTranspilerAggregator.java
@@ -57,7 +57,14 @@ import org.geoserver.spring.config.annotations.TranspileXmlConfig;
         locations = "jar:gs-gwc-[0-9]+.*!/geowebcache-diskquota-context.xml",
         targetClass = "GwcDiskQuotaContextConfiguration",
         publicAccess = true,
-        excludes = {"DiskQuotaConfigLoader"})
+        excludes = {
+            // Replaced in DiskQuotaAutoConfiguration: the transpiler picks the wrong constructor.
+            "DiskQuotaConfigLoader",
+            // Replaced in DiskQuotaAutoConfiguration (fallback) and PgconfigDiskQuotaAutoConfiguration
+            // (pgconfig-aware subclass). Excluding lets backends override via standard bean wiring
+            // instead of relying on bean-definition overriding to win against the XML import.
+            "DiskQuotaStoreProvider"
+        })
 @TranspileXmlConfig(
         locations = "jar:gs-gwc-rest-[0-9]+.*!/applicationContext.xml",
         componentScanStrategy = ComponentScanStrategy.GENERATE,
@@ -96,13 +103,20 @@ import org.geoserver.spring.config.annotations.TranspileXmlConfig;
         publicAccess = true,
         excludes = {
             /*
-             * Disable disk-quota by brute force for now. We need to resolve how and where to store the
-             * configuration and database.
+             * diskQuotaMenuPage: excluded here and contributed separately by
+             * GwcDiskQuotaWebUIConfiguration, gated on gwc.disk-quota.enabled by
+             * DiskQuotaAutoConfiguration's DisquotaWebUIAutoConfiguration.
              *
              * wmtsServiceDescriptor: replaced by CloudGWCServiceDescriptionProvider
              */
             "diskQuotaMenuPage"
         })
+@TranspileXmlConfig(
+        locations = "jar:gs-web-gwc-.*!/applicationContext.xml",
+        targetClass = "GwcDiskQuotaWebUIConfiguration",
+        publicAccess = true,
+        // Server -> DiskQuota admin page; imported only when gwc.disk-quota.enabled=true.
+        includes = {"diskQuotaMenuPage"})
 @TranspileXmlConfig(
         locations = "jar:gs-wfs-core-.*!/applicationContext.xml",
         targetClass = "GwcWfsMinimalConfiguration",

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigDiskQuotaAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigDiskQuotaAutoConfiguration.java
@@ -1,0 +1,107 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.autoconfigure.gwc.backend;
+
+import jakarta.annotation.PostConstruct;
+import javax.sql.DataSource;
+import lombok.extern.slf4j.Slf4j;
+import org.geoserver.cloud.autoconfigure.catalog.backend.pgconfig.ConditionalOnPgconfigBackendEnabled;
+import org.geoserver.cloud.autoconfigure.catalog.backend.pgconfig.PgconfigDataSourceAutoConfiguration;
+import org.geoserver.cloud.autoconfigure.catalog.backend.pgconfig.PgconfigMigrationAutoConfiguration;
+import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnDiskQuotaEnabled;
+import org.geoserver.cloud.config.catalog.backend.pgconfig.PgconfigBackendProperties;
+import org.geoserver.cloud.gwc.backend.pgconfig.PgconfigQuotaStoreProvider;
+import org.geoserver.gwc.ConfigurableQuotaStoreProvider;
+import org.geoserver.gwc.JDBCConfigurationStorage;
+import org.geowebcache.diskquota.ConfigLoader;
+import org.geowebcache.diskquota.QuotaStore;
+import org.geowebcache.diskquota.jdbc.JDBCQuotaStore;
+import org.geowebcache.diskquota.jdbc.PostgreSQLDialect;
+import org.geowebcache.diskquota.jdbc.SQLDialect;
+import org.geowebcache.diskquota.storage.TilePageCalculator;
+import org.geowebcache.storage.DefaultStorageFinder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.datasource.DelegatingDataSource;
+
+/**
+ * Auto-configuration that wires GeoWebCache's JDBC disk-quota store to the {@code pgconfigDataSource} provided by the
+ * pgconfig catalog backend.
+ *
+ * <p>Activates only when:
+ *
+ * <ul>
+ *   <li>{@link ConditionalOnDiskQuotaEnabled gwc.disk-quota.enabled=true}, and
+ *   <li>{@link ConditionalOnPgconfigBackendEnabled geoserver.backend.pgconfig.enabled=true}, and
+ *   <li>{@link PgconfigQuotaStoreProvider} is on the classpath (i.e. the {@code gwc-cloud-catalog-pgconfig} module is
+ *       present).
+ * </ul>
+ *
+ * <p>Beans contributed:
+ *
+ * <ul>
+ *   <li>{@code PostgreSQLQuotaDialect} - the dialect bean keyed by the upstream factory's {@code dialectName +
+ *       "QuotaDialect"} convention.
+ *   <li>{@code pgconfigQuotaStore} - a {@link JDBCQuotaStore} initialized against the pgconfig DataSource. The
+ *       DataSource is wrapped with {@link DelegatingDataSource} so {@link JDBCQuotaStore#close()} cannot close the
+ *       shared pool (its {@code instanceof Closeable} branch is bypassed).
+ *   <li>{@code DiskQuotaStoreProvider} - a {@link PgconfigQuotaStoreProvider} (a {@link ConfigurableQuotaStoreProvider}
+ *       subclass) that returns the pre-built store. The bean id matches the one referenced by the upstream
+ *       {@code DiskQuotaMonitor} XML definition; extending {@link ConfigurableQuotaStoreProvider} keeps the GeoServer
+ *       Wicket UI's {@code getBeanOfType} lookup working.
+ * </ul>
+ *
+ * <p>The Flyway migration {@code V3_1_0__DiskQuota_Tables.sql} (in the {@code gs-cloud-catalog-backend-pgconfig}
+ * module) creates the {@code TILESET}/{@code TILEPAGE} tables in the pgconfig schema before this auto-config runs, so
+ * {@link JDBCQuotaStore#initialize()} skips its own DDL.
+ *
+ * @since 3.0.0
+ */
+@AutoConfiguration(after = {PgconfigDataSourceAutoConfiguration.class, PgconfigMigrationAutoConfiguration.class})
+@ConditionalOnClass(PgconfigQuotaStoreProvider.class)
+@ConditionalOnDiskQuotaEnabled
+@ConditionalOnPgconfigBackendEnabled
+@Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.backend")
+public class PgconfigDiskQuotaAutoConfiguration {
+
+    @PostConstruct
+    void log() {
+        log.info("GeoWebCache DiskQuota using PostgreSQL JDBC store on the pgconfig DataSource");
+    }
+
+    @Bean(name = "PostgreSQLQuotaDialect")
+    SQLDialect postgreSQLQuotaDialect() {
+        return new PostgreSQLDialect();
+    }
+
+    @Bean(name = "pgconfigQuotaStore", destroyMethod = "")
+    QuotaStore pgconfigQuotaStore(
+            @Qualifier("pgconfigDataSource") DataSource pgconfigDataSource,
+            @Qualifier("gwcDefaultStorageFinder") DefaultStorageFinder storageFinder,
+            @Qualifier("gwcTilePageCalculator") TilePageCalculator tilePageCalculator,
+            @Qualifier("PostgreSQLQuotaDialect") SQLDialect dialect,
+            PgconfigBackendProperties pgconfigProperties) {
+
+        DataSource nonClosingDataSource = new DelegatingDataSource(pgconfigDataSource);
+        JDBCQuotaStore store = new JDBCQuotaStore(storageFinder, tilePageCalculator);
+        store.setDataSource(nonClosingDataSource);
+        store.setDialect(dialect);
+        store.setSchema(pgconfigProperties.getSchema());
+        store.initialize();
+        return store;
+    }
+
+    @Bean(name = "DiskQuotaStoreProvider")
+    ConfigurableQuotaStoreProvider diskQuotaStoreProvider(
+            @Qualifier("DiskQuotaConfigLoader") ConfigLoader loader,
+            @Qualifier("gwcTilePageCalculator") TilePageCalculator tilePageCalculator,
+            @Qualifier("gwcJdbcConfigurationStorage") JDBCConfigurationStorage jdbcConfigStorage,
+            @Qualifier("pgconfigQuotaStore") QuotaStore store) {
+        return new PgconfigQuotaStoreProvider(loader, tilePageCalculator, jdbcConfigStorage, store);
+    }
+}

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigTileLayerCatalogAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigTileLayerCatalogAutoConfiguration.java
@@ -18,6 +18,7 @@ import org.geoserver.cloud.autoconfigure.catalog.backend.pgconfig.ConditionalOnP
 import org.geoserver.cloud.autoconfigure.catalog.backend.pgconfig.PgconfigDataSourceAutoConfiguration;
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoWebCacheEnabled;
 import org.geoserver.cloud.gwc.backend.pgconfig.CachingTileLayerInfoRepository;
+import org.geoserver.cloud.gwc.backend.pgconfig.PgconfigGwcCatalogRenameListener;
 import org.geoserver.cloud.gwc.backend.pgconfig.PgconfigTileLayerCatalog;
 import org.geoserver.cloud.gwc.backend.pgconfig.PgconfigTileLayerInfoRepository;
 import org.geoserver.cloud.gwc.backend.pgconfig.TileLayerInfoRepository;
@@ -66,6 +67,17 @@ public class PgconfigTileLayerCatalogAutoConfiguration {
     @Bean
     PgconfigGwcInitializer gwcInitializer(GWCConfigPersister configPersister, GeoServerConfigurationLock configLock) {
         return new PgconfigGwcInitializer(configPersister, configLock);
+    }
+
+    /**
+     * Propagates Workspace / Resource / LayerGroup name changes to the GeoWebCache storage broker so the file blob
+     * store directory and pgconfig disk-quota tileset rows follow. Pgconfig derives tile-layer names from
+     * {@code PublishedInfo} on every lookup, which breaks upstream {@code CatalogLayerEventListener}'s rename path
+     * (lookup by old prefixed name returns empty after the SQL trigger refreshes the materialized view).
+     */
+    @Bean
+    PgconfigGwcCatalogRenameListener pgconfigGwcCatalogRenameListener(@Qualifier("rawCatalog") Catalog catalog) {
+        return new PgconfigGwcCatalogRenameListener(catalog);
     }
 
     @Bean(name = "gwcCatalogConfiguration")

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/DiskQuotaAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/DiskQuotaAutoConfiguration.java
@@ -6,20 +6,46 @@
 package org.geoserver.cloud.autoconfigure.gwc.core;
 
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnDiskQuotaEnabled;
+import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoServerWebUIEnabled;
 import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoWebCacheRestConfigEnabled;
+import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheConfigurationProperties;
+import org.geoserver.cloud.autoconfigure.gwc.core.DiskQuotaAutoConfiguration.DisquotaWebUIAutoConfiguration;
 import org.geoserver.configuration.gwc.GwcDiskQuotaContextConfiguration;
 import org.geoserver.configuration.gwc.GwcDiskQuotaRestConfiguration;
+import org.geoserver.configuration.gwc.GwcDiskQuotaWebUIConfiguration;
+import org.geoserver.gwc.ConfigurableQuotaStoreProvider;
+import org.geoserver.gwc.JDBCConfigurationStorage;
 import org.geoserver.gwc.config.GeoserverXMLResourceProvider;
 import org.geowebcache.config.ConfigurationException;
+import org.geowebcache.diskquota.ConfigLoader;
 import org.geowebcache.diskquota.DiskQuotaMonitor;
+import org.geowebcache.diskquota.storage.TilePageCalculator;
 import org.geowebcache.layer.TileLayerDispatcher;
 import org.geowebcache.storage.DefaultStorageFinder;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.env.Environment;
 
 /**
+ * Imports the transpiled {@link GwcDiskQuotaContextConfiguration}, contributing the {@code DiskQuotaMonitor} and
+ * friends that {@code gwcFacade} (in {@link org.geoserver.configuration.gwc.GwcGeoServerContextConfiguration}) and the
+ * GeoServer Wicket UI hold hard references to.
+ *
+ * <p>Whether the monitor actually runs at startup is controlled at runtime by the {@code GWC_DISKQUOTA_DISABLED}
+ * environment variable, which the upstream {@code DiskQuotaMonitor} and {@code ConfigurableQuotaStoreProvider} both
+ * read in their constructors. {@link #diskQuotaDisabledPropertySetter(Environment)} sets it to {@code true} when
+ * {@code gwc.disk-quota.enabled} is unset or {@code false} (the default) and clears it otherwise.
+ *
+ * <p>{@code DiskQuotaStoreProvider} is excluded from {@link GwcDiskQuotaContextConfiguration}: a backend-specific
+ * auto-configuration supplies a {@link ConfigurableQuotaStoreProvider} subclass that knows where the cluster-safe quota
+ * store lives (e.g. {@code PgconfigQuotaStoreProvider} for the pgconfig backend). When no backend supplies one,
+ * {@link #fallbackDiskQuotaStoreProvider} below registers the upstream class directly - harmless in the
+ * disabled-by-default case because the system-property gate keeps it from doing any work.
+ *
  * @see GwcDiskQuotaContextConfiguration
  * @see GwcDiskQuotaRestConfiguration
  * @see ConditionalOnDiskQuotaEnabled
@@ -27,16 +53,38 @@ import org.springframework.context.annotation.Import;
  * @since 1.0
  */
 @Configuration(proxyBeanMethods = false)
-@Import({GwcDiskQuotaContextConfiguration.class})
+@Import({GwcDiskQuotaContextConfiguration.class, DisquotaWebUIAutoConfiguration.class})
 @SuppressWarnings({"java:S1118", "java:S6830"})
 public class DiskQuotaAutoConfiguration {
 
-    static {
-        /*
-         * Disable disk-quota by brute force for now. We need to resolve how and where
-         * to store the configuration and database.
-         */
-        System.setProperty(DiskQuotaMonitor.GWC_DISKQUOTA_DISABLED, "true");
+    /**
+     * Sets the {@code GWC_DISKQUOTA_DISABLED} system property based on the {@code gwc.disk-quota.enabled} configuration
+     * property, before any beans are instantiated.
+     *
+     * <p>{@code DiskQuotaMonitor} and {@code ConfigurableQuotaStoreProvider} both read {@code GWC_DISKQUOTA_DISABLED}
+     * in their constructors and lock in {@code diskQuotaEnabled = !disabled}. By then it is too late for a regular bean
+     * post-processor to flip the switch - so this {@code BeanFactoryPostProcessor} runs during bean factory
+     * post-processing, well before any singleton is instantiated.
+     *
+     * <p>Both branches are explicit so a previous context's setting (e.g. an earlier test in the same JVM) cannot leak
+     * into the current bean topology.
+     *
+     * <p>The method is intentionally {@code static}: a non-static {@code @Bean} factory method for a
+     * {@code BeanFactoryPostProcessor} would force its declaring class to be instantiated eagerly, ahead of
+     * post-processing.
+     */
+    @Bean
+    static BeanFactoryPostProcessor diskQuotaDisabledPropertySetter(Environment environment) {
+        boolean enabled = environment.getProperty(
+                GeoWebCacheConfigurationProperties.DISKQUOTA_ENABLED, Boolean.class, Boolean.FALSE);
+        if (enabled) {
+            System.clearProperty(DiskQuotaMonitor.GWC_DISKQUOTA_DISABLED);
+        } else {
+            System.setProperty(DiskQuotaMonitor.GWC_DISKQUOTA_DISABLED, "true");
+        }
+        return beanFactory -> {
+            // no-op: the side effect of setting the system property happened before this lambda
+        };
     }
 
     /**
@@ -44,13 +92,46 @@ public class DiskQuotaAutoConfiguration {
      * constructor so it's excluded there
      */
     @Bean(name = "DiskQuotaConfigLoader")
-    org.geowebcache.diskquota.ConfigLoader diskQuotaConfigLoader( //
+    ConfigLoader diskQuotaConfigLoader( //
             @Qualifier("DiskQuotaConfigResourceProvider")
                     GeoserverXMLResourceProvider diskQuotaConfigResourceProvider, //
             @Qualifier("gwcDefaultStorageFinder") DefaultStorageFinder storageFinder, //
             TileLayerDispatcher tld)
             throws ConfigurationException {
 
-        return new org.geowebcache.diskquota.ConfigLoader(diskQuotaConfigResourceProvider, storageFinder, tld);
+        return new ConfigLoader(diskQuotaConfigResourceProvider, storageFinder, tld);
     }
+
+    /**
+     * Fallback {@code DiskQuotaStoreProvider} bean used when no backend-specific auto-configuration registers one (e.g.
+     * when {@code gwc.disk-quota.enabled=false} or no compatible backend is active).
+     *
+     * <p>Uses the upstream {@link ConfigurableQuotaStoreProvider} directly so the GeoServer Wicket UI's
+     * {@code DiskQuotaWarningPanel} can resolve it by type. Its {@code reloadQuotaStore()} is a no-op when
+     * {@code GWC_DISKQUOTA_DISABLED=true} - the gate that {@link #diskQuotaDisabledPropertySetter} sets in the
+     * disabled-by-default case.
+     */
+    @Bean(name = "DiskQuotaStoreProvider")
+    @ConditionalOnMissingBean(name = "DiskQuotaStoreProvider")
+    ConfigurableQuotaStoreProvider fallbackDiskQuotaStoreProvider(
+            @Qualifier("DiskQuotaConfigLoader") ConfigLoader loader,
+            @Qualifier("gwcTilePageCalculator") TilePageCalculator calculator,
+            @Qualifier("gwcJdbcConfigurationStorage") JDBCConfigurationStorage jdbcConfigStorage) {
+        return new ConfigurableQuotaStoreProvider(loader, calculator, jdbcConfigStorage);
+    }
+
+    /**
+     * Contributes the Server -> DiskQuota Wicket admin page ({@code diskQuotaMenuPage}) when both
+     * {@link ConditionalOnDiskQuotaEnabled disk-quota} and {@link ConditionalOnGeoServerWebUIEnabled the GeoServer
+     * web-ui} are enabled.
+     *
+     * <p>The page bean is excluded from the main {@code GwcGeoServerWebUIConfiguration} and emitted separately as
+     * {@link GwcDiskQuotaWebUIConfiguration} so it can be gated at runtime here rather than always wired by the
+     * compile-time transpiler.
+     */
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnDiskQuotaEnabled
+    @ConditionalOnGeoServerWebUIEnabled
+    @Import(GwcDiskQuotaWebUIConfiguration.class)
+    static class DisquotaWebUIAutoConfiguration {}
 }

--- a/src/gwc/autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/gwc/autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -7,6 +7,7 @@ org.geoserver.cloud.autoconfigure.gwc.integration.WMTSIntegrationAutoConfigurati
 
 org.geoserver.cloud.autoconfigure.gwc.backend.DefaultTileLayerCatalogAutoConfiguration
 org.geoserver.cloud.autoconfigure.gwc.backend.PgconfigTileLayerCatalogAutoConfiguration
+org.geoserver.cloud.autoconfigure.gwc.backend.PgconfigDiskQuotaAutoConfiguration
 
 org.geoserver.cloud.autoconfigure.gwc.service.GwcRestServiceAutoConfiguration
 org.geoserver.cloud.autoconfigure.gwc.service.GwcKMLServiceAutoConfiguration

--- a/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigDiskQuotaAutoConfigurationIT.java
+++ b/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigDiskQuotaAutoConfigurationIT.java
@@ -1,0 +1,176 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.autoconfigure.gwc.backend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import javax.sql.DataSource;
+import org.geoserver.cloud.autoconfigure.catalog.backend.pgconfig.PgconfigBackendAutoConfiguration;
+import org.geoserver.cloud.autoconfigure.catalog.backend.pgconfig.PgconfigDataSourceAutoConfiguration;
+import org.geoserver.cloud.autoconfigure.catalog.backend.pgconfig.PgconfigMigrationAutoConfiguration;
+import org.geoserver.cloud.autoconfigure.catalog.backend.pgconfig.PgconfigTransactionManagerAutoConfiguration;
+import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheContextRunner;
+import org.geoserver.cloud.backend.pgconfig.support.PgConfigTestContainer;
+import org.geoserver.cloud.backend.pgconfig.support.PgconfigTestDatabaseSupport;
+import org.geoserver.cloud.gwc.backend.pgconfig.PgconfigQuotaStoreProvider;
+import org.geoserver.gwc.ConfigurableQuotaStoreProvider;
+import org.geowebcache.diskquota.DiskQuotaMonitor;
+import org.geowebcache.diskquota.QuotaStore;
+import org.geowebcache.diskquota.jdbc.JDBCQuotaStore;
+import org.geowebcache.diskquota.jdbc.PostgreSQLDialect;
+import org.geowebcache.diskquota.jdbc.SQLDialect;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Integration test for {@link PgconfigDiskQuotaAutoConfiguration}.
+ *
+ * <p>Verifies the conditional matrix and, when active, the JDBC quota store wiring against the pgconfig DataSource plus
+ * the Flyway-applied DDL.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+@Execution(value = ExecutionMode.SAME_THREAD) // FilteringXmlBeanDefinitionReader has a static HashMap race condition
+class PgconfigDiskQuotaAutoConfigurationIT {
+
+    @Container
+    static PgConfigTestContainer container = new PgConfigTestContainer();
+
+    @RegisterExtension
+    PgconfigTestDatabaseSupport db = new PgconfigTestDatabaseSupport(container);
+
+    @TempDir
+    File cacheDir;
+
+    private WebApplicationContextRunner runner;
+
+    @BeforeEach
+    void setUp() {
+        runner = GeoWebCacheContextRunner.newMinimalGeoWebCacheContextRunner(cacheDir)
+                .withConfiguration(AutoConfigurations.of(
+                        PgconfigTileLayerCatalogAutoConfiguration.class,
+                        PgconfigDiskQuotaAutoConfiguration.class,
+                        PgconfigBackendAutoConfiguration.class,
+                        PgconfigDataSourceAutoConfiguration.class,
+                        PgconfigTransactionManagerAutoConfiguration.class,
+                        PgconfigMigrationAutoConfiguration.class));
+        runner = db.withJdbcUrlConfig(runner);
+    }
+
+    @Test
+    void wiresJdbcQuotaStoreOnPgconfigDataSourceWhenEnabled() {
+        runner.withPropertyValues("gwc.disk-quota.enabled=true").run(context -> {
+            assertThat(context).hasNotFailed();
+
+            assertThat(context)
+                    .getBean("PostgreSQLQuotaDialect", SQLDialect.class)
+                    .isExactlyInstanceOf(PostgreSQLDialect.class);
+
+            assertThat(context).getBean("pgconfigQuotaStore", QuotaStore.class).isInstanceOf(JDBCQuotaStore.class);
+
+            // Bean id used by the upstream DiskQuotaMonitor XML definition.
+            assertThat(context)
+                    .getBean("DiskQuotaStoreProvider", ConfigurableQuotaStoreProvider.class)
+                    .isInstanceOf(PgconfigQuotaStoreProvider.class);
+
+            // The Wicket UI's DiskQuotaWarningPanel looks up the provider by type.
+            assertThat(context).hasSingleBean(ConfigurableQuotaStoreProvider.class);
+            assertThat(context).hasSingleBean(DiskQuotaMonitor.class);
+
+            ConfigurableQuotaStoreProvider provider =
+                    context.getBean("DiskQuotaStoreProvider", ConfigurableQuotaStoreProvider.class);
+            assertThat(provider.getQuotaStore()).isSameAs(context.getBean("pgconfigQuotaStore"));
+        });
+    }
+
+    @Test
+    void flywayMigrationCreatesDiskQuotaTables() {
+        runner.withPropertyValues("gwc.disk-quota.enabled=true").run(context -> {
+            assertThat(context).hasNotFailed();
+
+            DataSource ds = context.getBean("pgconfigDataSource", DataSource.class);
+            JdbcTemplate jt = new JdbcTemplate(ds);
+
+            Long flywayRecord = jt.queryForObject(
+                    """
+                    SELECT count(*) FROM flyway_schema_history
+                    WHERE version = ? AND success
+                    """,
+                    Long.class,
+                    "3.1.0");
+            assertThat(flywayRecord).isOne();
+
+            Long tilesetCount = jt.queryForObject("SELECT count(*) FROM TILESET", Long.class);
+            Long tilepageCount = jt.queryForObject("SELECT count(*) FROM TILEPAGE", Long.class);
+            assertThat(tilesetCount).isNotNull();
+            assertThat(tilepageCount).isNotNull();
+        });
+    }
+
+    @Test
+    void jdbcQuotaStoreInitializesGlobalQuotaRow() {
+        runner.withPropertyValues("gwc.disk-quota.enabled=true").run(context -> {
+            assertThat(context).hasNotFailed();
+
+            DataSource ds = context.getBean("pgconfigDataSource", DataSource.class);
+            JdbcTemplate jt = new JdbcTemplate(ds);
+
+            Long globalQuota = jt.queryForObject(
+                    "SELECT count(*) FROM TILESET WHERE KEY = ?", Long.class, JDBCQuotaStore.GLOBAL_QUOTA_NAME);
+            assertThat(globalQuota).isOne();
+        });
+    }
+
+    /**
+     * With {@code gwc.disk-quota.enabled=false} (default), {@link DiskQuotaMonitor} and the upstream
+     * {@code ConfigurableQuotaStoreProvider} are still in the context (gwcFacade and the Wicket UI need them) but
+     * {@code DiskQuotaAutoConfiguration#diskQuotaDisabledPropertySetter} sets {@code GWC_DISKQUOTA_DISABLED=true} so
+     * neither does anything at runtime.
+     */
+    @Test
+    void disabledByDefault() {
+        runner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).doesNotHaveBean("pgconfigQuotaStore");
+            assertThat(context).doesNotHaveBean(PgconfigQuotaStoreProvider.class);
+            assertThat(context).hasSingleBean(DiskQuotaMonitor.class);
+            // Fallback ConfigurableQuotaStoreProvider keeps the Wicket UI happy.
+            assertThat(context).hasSingleBean(ConfigurableQuotaStoreProvider.class);
+            assertThat(context.getBean(DiskQuotaMonitor.class).isEnabled()).isFalse();
+        });
+    }
+
+    @Test
+    void pgconfigAutoConfigSkipsWhenPgconfigBackendDisabled() {
+        runner.withPropertyValues("geoserver.backend.pgconfig.enabled=false").run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).doesNotHaveBean("pgconfigQuotaStore");
+            assertThat(context).doesNotHaveBean(PgconfigQuotaStoreProvider.class);
+            assertThat(context).doesNotHaveBean(JDBCQuotaStore.class);
+        });
+    }
+
+    @Test
+    void pgconfigAutoConfigSkipsWhenBackendModuleNotOnClasspath() {
+        runner.withClassLoader(new FilteredClassLoader(PgconfigQuotaStoreProvider.class))
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).doesNotHaveBean("pgconfigQuotaStore");
+                    assertThat(context).doesNotHaveBean(PgconfigQuotaStoreProvider.class);
+                    assertThat(context).doesNotHaveBean(JDBCQuotaStore.class);
+                });
+    }
+}

--- a/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigGwcCatalogRenameListener.java
+++ b/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigGwcCatalogRenameListener.java
@@ -1,0 +1,230 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.gwc.backend.pgconfig;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogException;
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.Predicates;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.event.CatalogAddEvent;
+import org.geoserver.catalog.event.CatalogListener;
+import org.geoserver.catalog.event.CatalogModifyEvent;
+import org.geoserver.catalog.event.CatalogPostModifyEvent;
+import org.geoserver.catalog.event.CatalogRemoveEvent;
+import org.geoserver.catalog.util.CloseableIterator;
+import org.geoserver.gwc.GWC;
+
+/**
+ * Catalog listener that propagates name changes affecting a tile-layer's prefixed name to the GeoWebCache storage
+ * broker, so the file blob store directory and disk-quota tables follow.
+ *
+ * <p>Pgconfig derives tile-layer names from the underlying {@code PublishedInfo} on every lookup, so by the time
+ * upstream's {@link org.geoserver.gwc.layer.CatalogLayerEventListener CatalogLayerEventListener} runs in post-modify,
+ * the SQL trigger has already refreshed {@code publishedinfos_mat} and a lookup by old prefixed name returns empty.
+ * Upstream catches the resulting {@code IllegalArgumentException} and silently skips the rename, leaving stale
+ * directories under {@code /geowebcache_data/} and stale rows in {@code pgconfig.tileset}.
+ *
+ * <p>This listener bridges that gap: in {@link #handleModifyEvent(CatalogModifyEvent) pre-modify} it captures
+ * {@link NamePair (old, new)} prefixed-name pairs while the OLD names are still queryable, and in
+ * {@link #handlePostModifyEvent(CatalogPostModifyEvent) post-modify} it replays them through
+ * {@link GWC#layerRenamed(String, String)} - which calls {@code storageBroker.rename(...)} directly without going
+ * through {@code TileLayerDispatcher.rename}, so the broken old-name lookup is bypassed entirely.
+ *
+ * <p>Handled cases:
+ *
+ * <ul>
+ *   <li>{@link WorkspaceInfo} {@code name} change - all layers and layer-groups in the workspace.
+ *   <li>{@link ResourceInfo} {@code name} or {@code namespace} change - the single layer.
+ *   <li>{@link LayerGroupInfo} {@code name} change - the single layer-group.
+ * </ul>
+ */
+@Slf4j(topic = "org.geoserver.cloud.gwc.backend.pgconfig")
+public class PgconfigGwcCatalogRenameListener implements CatalogListener {
+
+    private record NamePair(String oldPrefixed, String newPrefixed) {}
+
+    private static final ThreadLocal<List<NamePair>> PENDING_RENAMES = new ThreadLocal<>();
+
+    @NonNull
+    private final Catalog catalog;
+
+    public PgconfigGwcCatalogRenameListener(@NonNull Catalog catalog) {
+        this.catalog = catalog;
+    }
+
+    @PostConstruct
+    void register() {
+        catalog.addListener(this);
+    }
+
+    @PreDestroy
+    void unregister() {
+        catalog.removeListener(this);
+    }
+
+    @Override
+    public void handleAddEvent(CatalogAddEvent event) throws CatalogException {
+        // no-op, only renames matter
+    }
+
+    @Override
+    public void handleRemoveEvent(CatalogRemoveEvent event) throws CatalogException {
+        // no-op, blob/quota removal on tile-layer delete is handled by PgconfigTileLayerCatalog
+    }
+
+    @Override
+    public void reloaded() {
+        // no-op
+    }
+
+    @Override
+    public void handleModifyEvent(CatalogModifyEvent event) throws CatalogException {
+        List<NamePair> pairs = collectRenames(event);
+        if (!pairs.isEmpty()) {
+            PENDING_RENAMES.set(pairs);
+        }
+    }
+
+    @Override
+    public void handlePostModifyEvent(CatalogPostModifyEvent event) throws CatalogException {
+        List<NamePair> pairs = PENDING_RENAMES.get();
+        if (pairs == null) {
+            return;
+        }
+        try {
+            replayRenames(pairs);
+        } finally {
+            PENDING_RENAMES.remove();
+        }
+    }
+
+    private List<NamePair> collectRenames(CatalogModifyEvent event) {
+        CatalogInfo source = event.getSource();
+        List<String> changedProperties = event.getPropertyNames();
+        if (source instanceof WorkspaceInfo && changedProperties.contains("name")) {
+            return collectWorkspaceRenames(event);
+        }
+        if (source instanceof ResourceInfo resource
+                && (changedProperties.contains("name") || changedProperties.contains("namespace"))) {
+            return collectResourceRename(resource, event);
+        }
+        if (source instanceof LayerGroupInfo group && changedProperties.contains("name")) {
+            return collectLayerGroupRename(group, event);
+        }
+        return List.of();
+    }
+
+    private List<NamePair> collectWorkspaceRenames(CatalogModifyEvent event) {
+        String oldWsName = stringPropertyOldValue(event, "name");
+        String newWsName = stringPropertyNewValue(event, "name");
+        if (oldWsName == null || newWsName == null || oldWsName.equals(newWsName)) {
+            return List.of();
+        }
+        List<NamePair> pairs = new ArrayList<>();
+        addLayerRenamesForWorkspace(oldWsName, newWsName, pairs);
+        addLayerGroupRenamesForWorkspace(oldWsName, newWsName, pairs);
+        return pairs;
+    }
+
+    private void addLayerRenamesForWorkspace(String oldWsName, String newWsName, List<NamePair> pairs) {
+        try (CloseableIterator<org.geoserver.catalog.LayerInfo> layers = catalog.list(
+                org.geoserver.catalog.LayerInfo.class, Predicates.equal("resource.store.workspace.name", oldWsName))) {
+            while (layers.hasNext()) {
+                String localName = layers.next().getName();
+                pairs.add(new NamePair(prefixed(oldWsName, localName), prefixed(newWsName, localName)));
+            }
+        }
+    }
+
+    private void addLayerGroupRenamesForWorkspace(String oldWsName, String newWsName, List<NamePair> pairs) {
+        try (CloseableIterator<LayerGroupInfo> groups =
+                catalog.list(LayerGroupInfo.class, Predicates.equal("workspace.name", oldWsName))) {
+            while (groups.hasNext()) {
+                String localName = groups.next().getName();
+                pairs.add(new NamePair(prefixed(oldWsName, localName), prefixed(newWsName, localName)));
+            }
+        }
+    }
+
+    private List<NamePair> collectResourceRename(ResourceInfo resource, CatalogModifyEvent event) {
+        List<String> changedProperties = event.getPropertyNames();
+        int nameIndex = changedProperties.indexOf("name");
+        int namespaceIndex = changedProperties.indexOf("namespace");
+
+        NamespaceInfo currentNamespace = resource.getNamespace();
+        NamespaceInfo oldNamespace =
+                namespaceIndex > -1 ? (NamespaceInfo) event.getOldValues().get(namespaceIndex) : currentNamespace;
+        if (oldNamespace == null || currentNamespace == null) {
+            return List.of();
+        }
+
+        String oldLocalName = nameIndex > -1 ? (String) event.getOldValues().get(nameIndex) : resource.getName();
+        String newLocalName = nameIndex > -1 ? (String) event.getNewValues().get(nameIndex) : resource.getName();
+
+        String oldPrefixed = prefixed(oldNamespace.getPrefix(), oldLocalName);
+        String newPrefixed = prefixed(currentNamespace.getPrefix(), newLocalName);
+        if (oldPrefixed.equals(newPrefixed)) {
+            return List.of();
+        }
+        return List.of(new NamePair(oldPrefixed, newPrefixed));
+    }
+
+    private List<NamePair> collectLayerGroupRename(LayerGroupInfo group, CatalogModifyEvent event) {
+        String oldName = stringPropertyOldValue(event, "name");
+        String newName = stringPropertyNewValue(event, "name");
+        if (oldName == null || newName == null || oldName.equals(newName)) {
+            return List.of();
+        }
+        WorkspaceInfo workspace = group.getWorkspace();
+        String prefix = workspace == null ? null : workspace.getName();
+        return List.of(new NamePair(prefixed(prefix, oldName), prefixed(prefix, newName)));
+    }
+
+    private void replayRenames(List<NamePair> pairs) {
+        GWC mediator;
+        try {
+            mediator = GWC.get();
+        } catch (NullPointerException npe) {
+            log.debug("Skipping {} tile layer rename(s); GWC singleton not available", pairs.size());
+            return;
+        }
+        if (mediator == null) {
+            log.debug("Skipping {} tile layer rename(s); GWC singleton not available", pairs.size());
+            return;
+        }
+        for (NamePair pair : pairs) {
+            try {
+                mediator.layerRenamed(pair.oldPrefixed(), pair.newPrefixed());
+            } catch (RuntimeException e) {
+                log.warn("Failed to rename tile layer cache '{}' -> '{}'", pair.oldPrefixed(), pair.newPrefixed(), e);
+            }
+        }
+    }
+
+    private static String prefixed(String workspaceOrPrefix, String localName) {
+        return workspaceOrPrefix == null ? localName : workspaceOrPrefix + ":" + localName;
+    }
+
+    private static String stringPropertyOldValue(CatalogModifyEvent event, String property) {
+        int index = event.getPropertyNames().indexOf(property);
+        return index > -1 ? (String) event.getOldValues().get(index) : null;
+    }
+
+    private static String stringPropertyNewValue(CatalogModifyEvent event, String property) {
+        int index = event.getPropertyNames().indexOf(property);
+        return index > -1 ? (String) event.getNewValues().get(index) : null;
+    }
+}

--- a/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigQuotaStoreProvider.java
+++ b/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigQuotaStoreProvider.java
@@ -1,0 +1,60 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.gwc.backend.pgconfig;
+
+import lombok.NonNull;
+import org.geoserver.gwc.ConfigurableQuotaStoreProvider;
+import org.geoserver.gwc.JDBCConfigurationStorage;
+import org.geowebcache.diskquota.ConfigLoader;
+import org.geowebcache.diskquota.QuotaStore;
+import org.geowebcache.diskquota.storage.TilePageCalculator;
+
+/**
+ * {@link ConfigurableQuotaStoreProvider} that always returns a pre-built {@link QuotaStore} (a {@code JDBCQuotaStore}
+ * wired to the pgconfig DataSource by {@code PgconfigDiskQuotaAutoConfiguration}).
+ *
+ * <p>Extends {@code ConfigurableQuotaStoreProvider} (rather than the bare {@code QuotaStoreProvider}) because the
+ * GeoServer Wicket UI's {@code DiskQuotaWarningPanel} looks up the active provider by exact type via
+ * {@code getBeanOfType(ConfigurableQuotaStoreProvider.class)}, and a miss there NPEs the home page.
+ *
+ * <p>{@link #afterPropertiesSet()} is a no-op (the parent's H2-to-HSQL config rewrite and the factory dispatch through
+ * {@code geowebcache-diskquota.xml} aren't needed here - the catalog backend is fixed and the store is constructed
+ * eagerly by the auto-configuration). {@link #getQuotaStore()} returns the pre-built store directly. {@link #destroy()}
+ * closes it; the underlying DataSource is wrapped with a non-closing delegate so the shared pgconfig pool is preserved.
+ *
+ * @since 3.0.0
+ */
+public class PgconfigQuotaStoreProvider extends ConfigurableQuotaStoreProvider {
+
+    private final QuotaStore preBuiltStore;
+
+    public PgconfigQuotaStoreProvider(
+            @NonNull ConfigLoader loader,
+            @NonNull TilePageCalculator calculator,
+            @NonNull JDBCConfigurationStorage jdbcConfigStorage,
+            @NonNull QuotaStore store) {
+        super(loader, calculator, jdbcConfigStorage);
+        this.preBuiltStore = store;
+        this.store = store;
+    }
+
+    @Override
+    public synchronized QuotaStore getQuotaStore() {
+        return preBuiltStore;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        // intentional no-op: store is pre-built and injected via constructor
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        if (preBuiltStore != null) {
+            preBuiltStore.close();
+        }
+    }
+}

--- a/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigTileLayerCatalog.java
+++ b/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigTileLayerCatalog.java
@@ -25,6 +25,7 @@ import org.geoserver.catalog.impl.LayerInfoImpl;
 import org.geoserver.catalog.plugin.resolving.ModificationProxyDecorator;
 import org.geoserver.cloud.backend.pgconfig.catalog.PgconfigCatalogFacade;
 import org.geoserver.cloud.gwc.repository.CloudCatalogConfiguration;
+import org.geoserver.gwc.GWC;
 import org.geoserver.gwc.config.GWCConfig;
 import org.geoserver.gwc.config.GWCConfigPersister;
 import org.geoserver.gwc.layer.GeoServerTileLayer;
@@ -169,6 +170,34 @@ public class PgconfigTileLayerCatalog implements TileLayerConfiguration {
             workspaceName = localWorkspace.getName();
         }
         repository.delete(workspaceName, localName);
+        notifyBlobStoreLayerRemoved(prefixedName(workspaceName, localName));
+    }
+
+    /**
+     * Bridge to {@link GWC#layerRemoved(String)} so the {@link org.geowebcache.storage.StorageBroker} deletes the
+     * on-disk blob store directory and fires {@code BlobStoreListener.layerDeleted} (which lets
+     * {@code DiskQuotaMonitor} drop the layer's quota rows). Vanilla GeoServer's
+     * {@code CatalogConfiguration.removeLayer} does the equivalent call; without it the pgconfig backend leaves orphan
+     * blob directories and stale quota rows.
+     *
+     * <p>{@link GWC#get()} throws {@link NullPointerException} if the static singleton hasn't been initialized yet
+     * (typical in unit tests that don't wire a full Spring context). In that case the bridge is a no-op.
+     */
+    private void notifyBlobStoreLayerRemoved(String prefixedLayerName) {
+        GWC mediator;
+        try {
+            mediator = GWC.get();
+        } catch (NullPointerException npe) {
+            return;
+        }
+        if (mediator == null) {
+            return;
+        }
+        mediator.layerRemoved(prefixedLayerName);
+    }
+
+    private String prefixedName(String workspaceName, String localName) {
+        return workspaceName == null ? localName : workspaceName + ":" + localName;
     }
 
     @Override

--- a/src/gwc/backends/pgconfig/src/test/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigGwcCatalogRenameListenerIT.java
+++ b/src/gwc/backends/pgconfig/src/test/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigGwcCatalogRenameListenerIT.java
@@ -1,0 +1,183 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.gwc.backend.pgconfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.faker.CatalogFaker;
+import org.geoserver.catalog.plugin.CatalogPlugin;
+import org.geoserver.cloud.backend.pgconfig.PgconfigBackendBuilder;
+import org.geoserver.cloud.backend.pgconfig.support.PgConfigTestContainer;
+import org.geoserver.cloud.backend.pgconfig.support.PgconfigTestDatabaseSupport;
+import org.geoserver.config.plugin.GeoServerImpl;
+import org.geoserver.gwc.GWC;
+import org.geoserver.gwc.GWCSynchEnv;
+import org.geoserver.gwc.config.GWCConfig;
+import org.geoserver.gwc.config.GWCConfigPersister;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Verifies the full pgconfig-catalog rename propagation chain ends with a {@link GWC#layerRenamed} (and
+ * {@link GWC#layerRemoved}) call against a mocked GWC mediator, without standing up the full GWC stack. The catalog and
+ * SQL triggers are real (Postgres testcontainer), so this covers the order-of-operations between the in-process event
+ * firing and the database-side {@code publishedinfos_mat} refresh that broke upstream's path.
+ *
+ * <p>Runs single-threaded because {@link GWC#set(GWC, GWCSynchEnv)} installs a process-wide singleton.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+@Execution(value = ExecutionMode.SAME_THREAD)
+class PgconfigGwcCatalogRenameListenerIT {
+
+    @Container
+    static PgConfigTestContainer container = new PgConfigTestContainer();
+
+    @RegisterExtension
+    PgconfigTestDatabaseSupport db = new PgconfigTestDatabaseSupport(container);
+
+    private CatalogPlugin catalog;
+    private CatalogFaker faker;
+    private PgconfigGwcCatalogRenameListener listener;
+    private PgconfigTileLayerCatalog tlCatalog;
+    private TileLayerMocking support;
+    private GWC mediator;
+
+    @BeforeEach
+    void setUp() {
+        PgconfigBackendBuilder backendBuilder = new PgconfigBackendBuilder(db.getDataSource());
+        catalog = backendBuilder.createCatalog();
+        GeoServerImpl geoServer = backendBuilder.createGeoServer(catalog);
+        support = new TileLayerMocking(catalog, geoServer);
+        faker = support.getFaker();
+
+        listener = new PgconfigGwcCatalogRenameListener(catalog);
+        listener.register();
+
+        GWCConfigPersister defaultsProvider = mock(GWCConfigPersister.class);
+        when(defaultsProvider.getConfig()).thenReturn(new GWCConfig());
+        tlCatalog = new PgconfigTileLayerCatalog(
+                db.getDataSource(), support.getGridsets(), () -> catalog, defaultsProvider);
+
+        mediator = mock(GWC.class);
+        GWC.set(mediator, mock(GWCSynchEnv.class));
+    }
+
+    @AfterEach
+    void tearDown() {
+        try {
+            listener.unregister();
+        } finally {
+            GWC.set(null, null);
+        }
+    }
+
+    @Test
+    void workspaceRename_firesLayerRenamedForEachLayerInWorkspace() {
+        WorkspaceInfo ws = support.workspace("oldWs");
+        LayerInfo layer1 = support.layerInfo(ws, "states");
+        LayerInfo layer2 = support.layerInfo(ws, "roads");
+
+        assertThat(layer1.prefixedName()).isEqualTo("oldWs:states");
+        assertThat(layer2.prefixedName()).isEqualTo("oldWs:roads");
+
+        renameWorkspace(ws, "newWs");
+
+        verify(mediator).layerRenamed("oldWs:states", "newWs:states");
+        verify(mediator).layerRenamed("oldWs:roads", "newWs:roads");
+    }
+
+    @Test
+    void workspaceRename_firesLayerRenamedForLayerGroups() {
+        WorkspaceInfo ws = support.workspace("oldWs");
+        LayerInfo layer = support.layerInfo(ws, "states");
+        LayerGroupInfo group = addLayerGroup(ws, "grp", layer);
+
+        assertThat(group.prefixedName()).isEqualTo("oldWs:grp");
+
+        renameWorkspace(ws, "newWs");
+
+        verify(mediator).layerRenamed("oldWs:grp", "newWs:grp");
+    }
+
+    @Test
+    void resourceRename_firesLayerRenamed() {
+        WorkspaceInfo ws = support.workspace("topp");
+        LayerInfo layer = support.layerInfo(ws, "states");
+
+        FeatureTypeInfo resource = catalog.getResource(layer.getResource().getId(), FeatureTypeInfo.class);
+        resource.setName("roads");
+        catalog.save(resource);
+
+        verify(mediator).layerRenamed("topp:states", "topp:roads");
+    }
+
+    @Test
+    void layerGroupRename_firesLayerRenamed() {
+        WorkspaceInfo ws = support.workspace("topp");
+        LayerInfo layer = support.layerInfo(ws, "states");
+        LayerGroupInfo group = addLayerGroup(ws, "groupOld", layer);
+
+        group = catalog.getLayerGroup(group.getId());
+        group.setName("groupNew");
+        catalog.save(group);
+
+        verify(mediator).layerRenamed("topp:groupOld", "topp:groupNew");
+    }
+
+    @Test
+    void unrelatedModify_doesNotFire() {
+        WorkspaceInfo ws = support.workspace("topp");
+        support.layerInfo(ws, "states");
+
+        ws = catalog.getWorkspace(ws.getId());
+        ws.setIsolated(!ws.isIsolated());
+        catalog.save(ws);
+
+        verify(mediator, never())
+                .layerRenamed(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void removeLayer_firesLayerRemoved() {
+        WorkspaceInfo ws = support.workspace("topp");
+        LayerInfo layer = support.layerInfo(ws, "states");
+        tlCatalog.addLayer(support.geoServerTileLayer(layer));
+
+        tlCatalog.removeLayer(layer.prefixedName());
+
+        verify(mediator).layerRemoved("topp:states");
+    }
+
+    private LayerGroupInfo addLayerGroup(WorkspaceInfo ws, String name, LayerInfo... layers) {
+        LayerGroupInfo group = faker.layerGroupInfo(ws);
+        group.setName(name);
+        for (LayerInfo layer : layers) {
+            group.getLayers().add(layer);
+        }
+        catalog.add(group);
+        return catalog.getLayerGroup(group.getId());
+    }
+
+    private void renameWorkspace(WorkspaceInfo ws, String newName) {
+        WorkspaceInfo persisted = catalog.getWorkspace(ws.getId());
+        persisted.setName(newName);
+        catalog.save(persisted);
+    }
+}

--- a/src/gwc/backends/pgconfig/src/test/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigGwcCatalogRenameListenerTest.java
+++ b/src/gwc/backends/pgconfig/src/test/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigGwcCatalogRenameListenerTest.java
@@ -1,0 +1,216 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.gwc.backend.pgconfig;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.event.CatalogModifyEvent;
+import org.geoserver.catalog.event.CatalogPostModifyEvent;
+import org.geoserver.catalog.util.CloseableIterator;
+import org.geoserver.catalog.util.CloseableIteratorAdapter;
+import org.geoserver.gwc.GWC;
+import org.geoserver.gwc.GWCSynchEnv;
+import org.geotools.api.filter.Filter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PgconfigGwcCatalogRenameListenerTest {
+
+    private Catalog catalog;
+    private PgconfigGwcCatalogRenameListener listener;
+    private GWC mediator;
+
+    @BeforeEach
+    void setUp() {
+        catalog = mock(Catalog.class);
+        mediator = mock(GWC.class);
+        listener = new PgconfigGwcCatalogRenameListener(catalog);
+        GWC.set(mediator, mock(GWCSynchEnv.class));
+    }
+
+    @AfterEach
+    void tearDown() {
+        GWC.set(null, null);
+    }
+
+    @Test
+    void register_addsListenerToCatalog() {
+        listener.register();
+        verify(catalog).addListener(listener);
+    }
+
+    @Test
+    void unregister_removesListenerFromCatalog() {
+        listener.unregister();
+        verify(catalog).removeListener(listener);
+    }
+
+    @Test
+    void workspaceRename_emitsOneLayerRenamedPerLayerAndLayerGroup() {
+        WorkspaceInfo ws = mock(WorkspaceInfo.class);
+        when(ws.getName()).thenReturn("oldWs");
+
+        whenListByType(List.of(layerInfoMock("foo"), layerInfoMock("bar")), List.of(layerGroupInfoMock("grp")));
+
+        listener.handleModifyEvent(modifyEvent(ws, List.of("name"), List.of("oldWs"), List.of("newWs")));
+        listener.handlePostModifyEvent(postModifyEvent(ws));
+
+        verify(mediator).layerRenamed("oldWs:foo", "newWs:foo");
+        verify(mediator).layerRenamed("oldWs:bar", "newWs:bar");
+        verify(mediator).layerRenamed("oldWs:grp", "newWs:grp");
+    }
+
+    @Test
+    void resourceRename_emitsSingleLayerRenamedWithNamespacePrefix() {
+        NamespaceInfo ns = mock(NamespaceInfo.class);
+        when(ns.getPrefix()).thenReturn("topp");
+        FeatureTypeInfo resource = mock(FeatureTypeInfo.class);
+        when(resource.getNamespace()).thenReturn(ns);
+        when(resource.getName()).thenReturn("states");
+
+        listener.handleModifyEvent(modifyEvent(resource, List.of("name"), List.of("states"), List.of("roads")));
+        listener.handlePostModifyEvent(postModifyEvent(resource));
+
+        verify(mediator).layerRenamed("topp:states", "topp:roads");
+        verifyNoInteractions(catalog);
+    }
+
+    @Test
+    void resourceNamespaceChange_usesOldNamespaceForOldName() {
+        NamespaceInfo oldNs = mock(NamespaceInfo.class);
+        when(oldNs.getPrefix()).thenReturn("ns1");
+        NamespaceInfo newNs = mock(NamespaceInfo.class);
+        when(newNs.getPrefix()).thenReturn("ns2");
+        FeatureTypeInfo resource = mock(FeatureTypeInfo.class);
+        when(resource.getNamespace()).thenReturn(newNs);
+        when(resource.getName()).thenReturn("ft");
+
+        listener.handleModifyEvent(modifyEvent(resource, List.of("namespace"), List.of(oldNs), List.of(newNs)));
+        listener.handlePostModifyEvent(postModifyEvent(resource));
+
+        verify(mediator).layerRenamed("ns1:ft", "ns2:ft");
+    }
+
+    @Test
+    void layerGroupRename_workspaceScoped() {
+        WorkspaceInfo ws = mock(WorkspaceInfo.class);
+        when(ws.getName()).thenReturn("topp");
+        LayerGroupInfo group = mock(LayerGroupInfo.class);
+        when(group.getWorkspace()).thenReturn(ws);
+
+        listener.handleModifyEvent(modifyEvent(group, List.of("name"), List.of("groupOld"), List.of("groupNew")));
+        listener.handlePostModifyEvent(postModifyEvent(group));
+
+        verify(mediator).layerRenamed("topp:groupOld", "topp:groupNew");
+    }
+
+    @Test
+    void layerGroupRename_global() {
+        LayerGroupInfo group = mock(LayerGroupInfo.class);
+        when(group.getWorkspace()).thenReturn(null);
+
+        listener.handleModifyEvent(modifyEvent(group, List.of("name"), List.of("globalOld"), List.of("globalNew")));
+        listener.handlePostModifyEvent(postModifyEvent(group));
+
+        verify(mediator).layerRenamed("globalOld", "globalNew");
+    }
+
+    @Test
+    void unrelatedModify_doesNothing() {
+        listener.handleModifyEvent(
+                modifyEvent(mock(org.geoserver.catalog.StyleInfo.class), List.of("name"), List.of("a"), List.of("b")));
+        listener.handlePostModifyEvent(postModifyEvent(mock(org.geoserver.catalog.StyleInfo.class)));
+
+        verifyNoInteractions(mediator);
+    }
+
+    @Test
+    void postModify_drainsThreadLocal_andSecondPostIsNoOp() {
+        WorkspaceInfo ws = mock(WorkspaceInfo.class);
+        whenListByType(List.of(layerInfoMock("foo")), List.of());
+
+        CatalogModifyEvent pre = modifyEvent(ws, List.of("name"), List.of("oldWs"), List.of("newWs"));
+        CatalogPostModifyEvent post = postModifyEvent(ws);
+
+        listener.handleModifyEvent(pre);
+        listener.handlePostModifyEvent(post);
+        listener.handlePostModifyEvent(post);
+
+        verify(mediator).layerRenamed("oldWs:foo", "newWs:foo");
+        verify(mediator, never()).layerRenamed("anything-else", "anything-else");
+    }
+
+    @Test
+    void noGwcSingleton_isSafe() {
+        GWC.set(null, null); // tear down the @BeforeEach setup
+        WorkspaceInfo ws = mock(WorkspaceInfo.class);
+        whenListByType(List.of(layerInfoMock("foo")), List.of());
+
+        listener.handleModifyEvent(modifyEvent(ws, List.of("name"), List.of("oldWs"), List.of("newWs")));
+        listener.handlePostModifyEvent(postModifyEvent(ws));
+
+        verifyNoInteractions(mediator);
+    }
+
+    private LayerInfo layerInfoMock(String name) {
+        LayerInfo info = mock(LayerInfo.class);
+        when(info.getName()).thenReturn(name);
+        return info;
+    }
+
+    private LayerGroupInfo layerGroupInfoMock(String name) {
+        LayerGroupInfo info = mock(LayerGroupInfo.class);
+        when(info.getName()).thenReturn(name);
+        return info;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private void whenListByType(List<LayerInfo> layers, List<LayerGroupInfo> groups) {
+        when(catalog.list(any(Class.class), any(Filter.class))).thenAnswer(invocation -> {
+            Class<?> type = invocation.getArgument(0);
+            if (LayerInfo.class.equals(type)) {
+                return closeableIterator(layers);
+            }
+            if (LayerGroupInfo.class.equals(type)) {
+                return closeableIterator(groups);
+            }
+            return closeableIterator(List.of());
+        });
+    }
+
+    private <T> CloseableIterator<T> closeableIterator(List<T> values) {
+        return new CloseableIteratorAdapter<>(values.iterator());
+    }
+
+    private CatalogModifyEvent modifyEvent(
+            Object source, List<String> props, List<Object> oldValues, List<Object> newValues) {
+        CatalogModifyEvent event = mock(CatalogModifyEvent.class);
+        when(event.getSource()).thenReturn((org.geoserver.catalog.CatalogInfo) source);
+        when(event.getPropertyNames()).thenReturn(props);
+        when(event.getOldValues()).thenReturn(oldValues);
+        when(event.getNewValues()).thenReturn(newValues);
+        return event;
+    }
+
+    private CatalogPostModifyEvent postModifyEvent(Object source) {
+        CatalogPostModifyEvent event = mock(CatalogPostModifyEvent.class);
+        when(event.getSource()).thenReturn((org.geoserver.catalog.CatalogInfo) source);
+        return event;
+    }
+}

--- a/src/gwc/backends/pgconfig/src/test/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigTileLayerCatalogTest.java
+++ b/src/gwc/backends/pgconfig/src/test/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigTileLayerCatalogTest.java
@@ -29,6 +29,8 @@ import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.CatalogPlugin;
 import org.geoserver.config.plugin.GeoServerImpl;
+import org.geoserver.gwc.GWC;
+import org.geoserver.gwc.GWCSynchEnv;
 import org.geoserver.gwc.config.GWCConfig;
 import org.geoserver.gwc.config.GWCConfigPersister;
 import org.geoserver.gwc.layer.GeoServerTileLayer;
@@ -36,6 +38,7 @@ import org.geoserver.ows.LocalWorkspace;
 import org.geowebcache.config.BaseConfiguration;
 import org.geowebcache.grid.GridSetBroker;
 import org.geowebcache.layer.TileLayer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -46,6 +49,7 @@ class PgconfigTileLayerCatalogTest {
     private PgconfigTileLayerCatalog tlCatalog;
     private TileLayerMocking support;
     private GWCConfigPersister defaultsProvider;
+    private GWC gwcMediator;
 
     @BeforeEach
     void setUp() {
@@ -56,6 +60,15 @@ class PgconfigTileLayerCatalogTest {
         when(defaultsProvider.getConfig()).thenReturn(defaults);
         tlCatalog =
                 new PgconfigTileLayerCatalog(repository, support.getGridsets(), support.catalog(), defaultsProvider);
+
+        // Install a mock GWC singleton so removeLayer's bridge to GWC.layerRemoved doesn't NPE
+        gwcMediator = mock(GWC.class);
+        GWC.set(gwcMediator, mock(GWCSynchEnv.class));
+    }
+
+    @AfterEach
+    void tearDown() {
+        GWC.set(null, null);
     }
 
     @Test
@@ -272,6 +285,36 @@ class PgconfigTileLayerCatalogTest {
         } finally {
             LocalWorkspace.remove();
         }
+    }
+
+    @Test
+    void testRemoveLayer_bridges_to_GWC_layerRemoved() {
+        tlCatalog.removeLayer("ws1:layer1");
+        verify(repository, times(1)).delete("ws1", "layer1");
+        verify(gwcMediator, times(1)).layerRemoved("ws1:layer1");
+
+        clearInvocations(repository, gwcMediator);
+        tlCatalog.removeLayer("globalgroup");
+        verify(repository, times(1)).delete(null, "globalgroup");
+        verify(gwcMediator, times(1)).layerRemoved("globalgroup");
+
+        clearInvocations(repository, gwcMediator);
+        WorkspaceInfo localWs = support.workspace("ws3");
+        LocalWorkspace.set(localWs);
+        try {
+            tlCatalog.removeLayer("named");
+            verify(repository, times(1)).delete("ws3", "named");
+            verify(gwcMediator, times(1)).layerRemoved("ws3:named");
+        } finally {
+            LocalWorkspace.remove();
+        }
+    }
+
+    @Test
+    void testRemoveLayer_no_GWC_singleton_is_safe() {
+        GWC.set(null, null);
+        tlCatalog.removeLayer("ws1:layer1");
+        verify(repository, times(1)).delete("ws1", "layer1");
     }
 
     @Test


### PR DESCRIPTION
Forward port of #859

DiskQuota was hard-disabled in GeoServer Cloud because the upstream default (BDB) is incompatible with multi-pod deployments. With the pgconfig backend now standard, a JDBC quota store can share the same PostgreSQL database and the feature can be turned on per-deployment via gwc.disk-quota.enabled.

Store integration:

- V3_1_0__DiskQuota_Tables.sql: Flyway migration creating the TILESET and TILEPAGE tables in the pgconfig schema (FK cascade so deleting a tileset row clears its pages).
- PgconfigDiskQuotaAutoConfiguration builds a JDBCQuotaStore on the pgconfig DataSource and supplies a PgconfigQuotaStoreProvider.
- DiskQuotaAutoConfiguration replaces the static GWC_DISKQUOTA_DISABLED sentinel with a BeanFactoryPostProcessor that derives the env var from gwc.disk-quota.enabled, and registers a fallback provider so the DiskQuotaMonitor bean always exists.

Storage propagation (without these the catalog row goes away but the on-disk cache and quota rows don't):

- PgconfigTileLayerCatalog.removeLayer now bridges to GWC.layerRemoved(prefixedName) after the repository delete, so StorageBroker.delete fires and FileBlobStore + DiskQuota's BlobStoreListener clean up the directory and tileset/tilepage rows.
- New PgconfigGwcCatalogRenameListener captures WorkspaceInfo, ResourceInfo and LayerGroupInfo name (and resource namespace) changes at pre-modify (when old names are still queryable) and replays them via GWC.layerRenamed(old, new) at post-modify. This bypasses upstream CatalogLayerEventListener's lookup-by-old-name path, which fails in pgconfig because the SQL update triggers refresh publishedinfos_mat before the Java post-modify event fires.

Web UI:

- GwcDiskQuotaWebUIConfiguration: a dedicated transpiled config that contributes the diskQuotaMenuPage bean (excluded from the main web-ui config), imported by DiskQuotaAutoConfiguration only when both disk-quota and the web-ui are enabled, restoring the Server -> DiskQuota admin page.

Tests:

- DiskQuotaControllerPgconfigIT: boots the GWC microservice with a Postgres testcontainer and round-trips the /gwc/rest/diskquota REST API to verify the full stack wires up.
- PgconfigDiskQuotaAutoConfigurationIT: verifies the conditional matrix and the JDBC store wiring against a real Postgres testcontainer.
- PgconfigGwcCatalogRenameListenerTest / IT: unit + integration coverage for the rename listener.
- PgconfigTileLayerCatalogTest: covers the removeLayer -> GWC bridge.
- JDBCConnectionPoolPanelCloudTest: renders the JDBC connection-pool panel in the cloud web-ui harness.

on-behalf-of: @camptocamp <info@camptocamp.com>