### PR TITLE
GWC: Fix 'not found' error when deleting a layer with pgconfig

### DIFF
--- a/compose/catalog-datadir.yml
+++ b/compose/catalog-datadir.yml
@@ -8,15 +8,14 @@ name: gscloud_dev_datadir
 
 volumes:
   geowebcache_data:
-  data_directory:
-    driver_opts:
-      type: none
-      o: bind
-      device: ${CATALOG_DATADIR_PATH:-$PWD/catalog-datadir}
 
 # Append the shared data directory to the geoserver_volumes anchor
 x-volume-mounts: &geoserver_volumes
-  - data_directory:/opt/app/data_directory:z
+  - type: bind
+    source: ${CATALOG_DATADIR_PATH:-$PWD/catalog-datadir}
+    target: /opt/app/data_directory
+    bind:
+      selinux: z
 
 x-gs-dependencies: &gs-dependencies
   init-datadir:
@@ -31,7 +30,9 @@ services:
     user: root
     command: sh -c "cd /opt/app/data_directory; if [ ! -f global.xml ]; then tar xvzf /tmp/datadir.tgz; fi; chown -R ${GS_USER} /opt/app/data_directory"
     volumes:
-      - data_directory:/opt/app/data_directory
+      - type: bind
+        source: ${CATALOG_DATADIR_PATH:-$PWD/catalog-datadir}
+        target: /opt/app/data_directory
       - ./catalog-datadir.tgz:/tmp/datadir.tgz
   wfs:
     environment: *geoserver_environment

--- a/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigTileLayerCatalog.java
+++ b/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigTileLayerCatalog.java
@@ -17,6 +17,7 @@ import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import javax.sql.DataSource;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.catalog.WorkspaceInfo;
@@ -47,6 +48,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
  * @see PgconfigTileLayerInfoRepository
  * @since 1.7
  */
+@Slf4j(topic = "org.geoserver.cloud.gwc.backend.pgconfig")
 public class PgconfigTileLayerCatalog implements TileLayerConfiguration {
 
     final @NonNull TileLayerInfoRepository repository;
@@ -193,7 +195,15 @@ public class PgconfigTileLayerCatalog implements TileLayerConfiguration {
         if (mediator == null) {
             return;
         }
-        mediator.layerRemoved(prefixedLayerName);
+        try {
+            mediator.layerRemoved(prefixedLayerName);
+        } catch (RuntimeException e) {
+            // Best-effort cache/quota cleanup. The blob store may already have dropped the
+            // layer (the GWC REST controller deletes it before calling removeLayer), in which
+            // case GWC.layerRemoved throws on an "unknown layer". The authoritative removal
+            // already succeeded, so this is not an error.
+            log.debug("Blob store cleanup for removed layer {} skipped: {}", prefixedLayerName, e.getMessage());
+        }
     }
 
     private String prefixedName(String workspaceName, String localName) {


### PR DESCRIPTION
There seems to be a bug when removing a GWC layer when using the pgconfig backend.
It is visible in the acceptance tests with the failed test `test_cascaded_stores.py::test_cascaded_wmts`
The DELETE request throws a 500 while the GET request on the same endpoint does return a 200.
This is an attempt to fix this