### PR TITLE
fix: Return first match for ambiguous unqualified name lookups in pgconfig

### DIFF
--- a/src/apps/geoserver/wfs/pom.xml
+++ b/src/apps/geoserver/wfs/pom.xml
@@ -40,6 +40,11 @@
       <artifactId>gt-shapefile</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-property</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>

--- a/src/apps/geoserver/wfs/src/test/java/org/geoserver/cloud/wfs/app/WfsApplicationTest.java
+++ b/src/apps/geoserver/wfs/src/test/java/org/geoserver/cloud/wfs/app/WfsApplicationTest.java
@@ -7,10 +7,20 @@ package org.geoserver.cloud.wfs.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogBuilder;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.cloud.autoconfigure.extensions.test.ConditionalTestAutoConfiguration;
+import org.geotools.feature.NameImpl;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -27,6 +37,10 @@ abstract class WfsApplicationTest {
 
     @Autowired
     protected ApplicationContext context;
+
+    @Autowired
+    @Qualifier("rawCatalog")
+    private Catalog catalog;
 
     @Test
     void owsGetCapabilitiesSmokeTest(@LocalServerPort int servicePort) {
@@ -83,5 +97,89 @@ abstract class WfsApplicationTest {
         assertThat(context.containsBean("wpsConditionalBean")).isFalse();
         assertThat(context.containsBean("restConditionalBean")).isFalse();
         assertThat(context.containsBean("webUiConditionalBean")).isFalse();
+    }
+
+    @Test
+    void workspaceServiceGetFeatureWithUnqualifiedTypeName(@LocalServerPort int port) throws Exception {
+        createTestWorkspaces();
+        String wsa = getFeatureAsJson(port, "wsa");
+        assertThat(wsa)
+                .as("the wsa virtual service should not crash on the unqualified typeName")
+                .doesNotContain("ClassCastException", "cannot be cast");
+        assertThat(wsa)
+                .as("the wsa virtual service should return wsa's own 'roads' feature")
+                .contains("FeatureCollection")
+                .contains("wsa road")
+                .doesNotContain("wsb road");
+
+        String wsb = getFeatureAsJson(port, "wsb");
+        assertThat(wsb)
+                .as("the wsb virtual service should resolve the same unqualified name to its own feature")
+                .contains("FeatureCollection")
+                .contains("wsb road")
+                .doesNotContain("wsa road");
+    }
+
+    private void createTestWorkspaces() throws Exception {
+        if (catalog.getWorkspaceByName("base") != null
+                && catalog.getWorkspaceByName("wsa") != null
+                && catalog.getWorkspaceByName("wsb") != null) {
+            return;
+        }
+        // "base" is added first and so becomes the default workspace; it does NOT publish "roads",
+        // so the unqualified lookup is not short-circuited by the default namespace and must fall
+        // back to ANY_NAMESPACE.
+        addWorkspace("base");
+        addWorkspace("wsa");
+        addWorkspace("wsb");
+        publishRoads("wsa", "wsa road");
+        publishRoads("wsb", "wsb road");
+    }
+
+    private String getFeatureAsJson(int port, String workspace) {
+        String url =
+                "http://localhost:%d/%s/wfs?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=roads&outputFormat=application/json"
+                        .formatted(port, workspace);
+        return restTemplate.getForObject(url, String.class);
+    }
+
+    private void addWorkspace(String name) {
+        WorkspaceInfo ws = catalog.getFactory().createWorkspace();
+        ws.setName(name);
+        catalog.add(ws);
+        NamespaceInfo ns = catalog.getFactory().createNamespace();
+        ns.setPrefix(name);
+        ns.setURI("http://%s.example".formatted(name));
+        catalog.add(ns);
+    }
+
+    private void publishRoads(String workspaceName, String featureLabel) throws Exception {
+        WorkspaceInfo ws = catalog.getWorkspaceByName(workspaceName);
+        NamespaceInfo ns = catalog.getNamespaceByPrefix(workspaceName);
+
+        Path dir = Files.createTempDirectory("propstore-" + workspaceName + "-");
+        String properties =
+                """
+                _=id:Integer,name:String,geom:Point:srid=4326
+                roads.1=1|%s|POINT(1 1)
+                """
+                        .formatted(featureLabel);
+        Files.writeString(dir.resolve("roads.properties"), properties);
+
+        DataStoreInfo store = catalog.getFactory().createDataStore();
+        store.setName(workspaceName + "-roads-store");
+        store.setWorkspace(ws);
+        store.setType("Properties");
+        store.getConnectionParameters().put("directory", dir.toFile().getAbsolutePath());
+        store.getConnectionParameters().put("namespace", ns.getURI());
+        store.setEnabled(true);
+        catalog.add(store);
+
+        CatalogBuilder cb = new CatalogBuilder(catalog);
+        cb.setStore(store);
+        FeatureTypeInfo ft = cb.buildFeatureType(new NameImpl(ns.getURI(), "roads"));
+        cb.setupBounds(ft);
+        catalog.add(ft);
+        catalog.add(cb.buildLayer(ft));
     }
 }

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgconfigCatalogInfoRepository.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgconfigCatalogInfoRepository.java
@@ -337,6 +337,14 @@ public abstract class PgconfigCatalogInfoRepository<T extends CatalogInfo> exten
         return findOne(query, clazz, newRowMapper(), args);
     }
 
+    /**
+     * Returns the first row matching {@code query} that is an instance of {@code clazz}, or empty if none matches.
+     *
+     * <p>Never throws when the query matches multiple rows, mirroring the first-match semantics of upstream GeoServer's
+     * {@code DefaultCatalogFacade} for ambiguous lookups (e.g. an unqualified name present in several workspaces).
+     * Queries that can legitimately match several rows must include an {@code ORDER BY} clause; without it the returned
+     * row depends on the database's execution plan.
+     */
     protected <U extends T> Optional<U> findOne(
             @NonNull String query, Class<U> clazz, RowMapper<T> rowMapper, Object... args) {
         try (Stream<U> stream = template.queryForStream(query, rowMapper, args)

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgconfigCatalogInfoRepository.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgconfigCatalogInfoRepository.java
@@ -31,7 +31,6 @@ import org.geoserver.cloud.backend.pgconfig.catalog.filter.PgconfigQueryBuilder;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.sort.SortBy;
 import org.geotools.api.filter.sort.SortOrder;
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import tools.jackson.databind.ObjectMapper;
@@ -340,15 +339,10 @@ public abstract class PgconfigCatalogInfoRepository<T extends CatalogInfo> exten
 
     protected <U extends T> Optional<U> findOne(
             @NonNull String query, Class<U> clazz, RowMapper<T> rowMapper, Object... args) {
-
-        try {
-            T object = template.queryForObject(query, rowMapper, args);
-            return Optional.ofNullable(object)
-                    .filter(clazz::isInstance)
-                    .map(clazz::cast)
-                    .map(this::resolveOutbound);
-        } catch (EmptyResultDataAccessException _) {
-            return Optional.empty();
+        try (Stream<U> stream = template.queryForStream(query, rowMapper, args)
+                .filter(clazz::isInstance)
+                .map(clazz::cast)) {
+            return stream.findFirst().map(this::resolveOutbound);
         }
     }
 

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgconfigLayerRepository.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgconfigLayerRepository.java
@@ -42,7 +42,7 @@ public class PgconfigLayerRepository extends PgconfigPublishedInfoRepository<Lay
                 """
                 SELECT "@type", publishedinfo, resource, store, workspace, namespace, "defaultStyle" \
                 FROM %s \
-                WHERE "@type" = 'LayerInfo' AND "%s" = ?
+                WHERE "@type" = 'LayerInfo' AND "%s" = ? ORDER BY id
                 """;
         if (possiblyPrefixedName.contains(":")) {
             // two options here, it's either a prefixed name like in <workspace>:<name>, or the

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgconfigNamespaceRepository.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgconfigNamespaceRepository.java
@@ -58,7 +58,7 @@ public class PgconfigNamespaceRepository extends PgconfigCatalogInfoRepository<N
 
     @Override
     public Optional<NamespaceInfo> findOneByURI(@NonNull String uri) {
-        return findOne(select("WHERE uri = ?"), uri);
+        return findOne(select("WHERE uri = ? ORDER BY id"), uri);
     }
 
     @Override

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/catalog/PgconfigAmbiguousNameLookupIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/catalog/PgconfigAmbiguousNameLookupIT.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.geoserver.catalog.CatalogFactory;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.plugin.CatalogPlugin;
@@ -51,6 +52,22 @@ class PgconfigAmbiguousNameLookupIT {
     }
 
     @Test
+    void getLayerByNameReturnsFirstMatchWhenNameIsAmbiguous() {
+        LayerInfo layerA = addLayer("wsa", "roads");
+        LayerInfo layerB = addLayer("wsb", "roads");
+
+        LayerInfo found = catalog.getLayerByName("roads");
+        assertThat(found)
+                .as("an unqualified layer name present in >1 workspace must resolve to the first match, not throw")
+                .isNotNull();
+
+        // findOneByName resolves with "ORDER BY id", so the lowest id wins, repeatably.
+        String expected = layerA.getId().compareTo(layerB.getId()) <= 0 ? layerA.getId() : layerB.getId();
+        assertThat(found.getId()).isEqualTo(expected);
+        assertThat(catalog.getLayerByName("roads").getId()).isEqualTo(expected);
+    }
+
+    @Test
     void getFeatureTypeByNameReturnsFirstMatchWhenNameIsAmbiguous() {
         FeatureTypeInfo ft = catalog.getFeatureTypeByName("roads");
         assertThat(ft)
@@ -81,6 +98,15 @@ class PgconfigAmbiguousNameLookupIT {
                 .isNotNull();
         assertThat(ft.getName()).isEqualTo("lakes");
         assertThat(ft.getNamespace().getPrefix()).isEqualTo("wsa");
+    }
+
+    private LayerInfo addLayer(String workspaceName, String featureType) {
+        NamespaceInfo ns = catalog.getNamespaceByPrefix(workspaceName);
+        FeatureTypeInfo ft = catalog.getResourceByName(ns, featureType, FeatureTypeInfo.class);
+        LayerInfo layer = catalog.getFactory().createLayer();
+        layer.setResource(ft);
+        catalog.add(layer);
+        return catalog.getLayerByName("%s:%s".formatted(workspaceName, featureType));
     }
 
     private void createWorkspaceWithFeatureType(String workspaceName, String featureType) {

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/catalog/PgconfigAmbiguousNameLookupIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/catalog/PgconfigAmbiguousNameLookupIT.java
@@ -1,0 +1,118 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.backend.pgconfig.catalog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.geoserver.catalog.CatalogFactory;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.plugin.CatalogPlugin;
+import org.geoserver.cloud.backend.pgconfig.PgconfigBackendBuilder;
+import org.geoserver.cloud.backend.pgconfig.support.PgConfigTestContainer;
+import org.geoserver.cloud.backend.pgconfig.support.PgconfigTestDatabaseSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers(disabledWithoutDocker = true)
+class PgconfigAmbiguousNameLookupIT {
+
+    @Container
+    static PgConfigTestContainer container = new PgConfigTestContainer();
+
+    @RegisterExtension
+    PgconfigTestDatabaseSupport db = new PgconfigTestDatabaseSupport(container);
+
+    private CatalogPlugin catalog;
+
+    @BeforeEach
+    void setUp() {
+        catalog = new PgconfigBackendBuilder(db.getDataSource()).createCatalog();
+
+        // A default workspace that does NOT publish "roads", so the unqualified lookup misses the
+        // default namespace and falls back to the ANY_NAMESPACE path
+        // (as it does for a workspace virtual service whose workspace is not the catalog's default).
+        createWorkspaceWithFeatureType("base", "rivers");
+        catalog.setDefaultWorkspace(catalog.getWorkspaceByName("base"));
+        catalog.setDefaultNamespace(catalog.getNamespaceByPrefix("base"));
+
+        // Two workspaces publishing a feature type with the same name "roads",
+        // plus a feature type "lakes" unique to wsa.
+        createWorkspaceWithFeatureType("wsa", "roads");
+        createWorkspaceWithFeatureType("wsb", "roads");
+        addFeatureType(catalog.getWorkspaceByName("wsa"), "lakes");
+    }
+
+    @Test
+    void getFeatureTypeByNameReturnsFirstMatchWhenNameIsAmbiguous() {
+        FeatureTypeInfo ft = catalog.getFeatureTypeByName("roads");
+        assertThat(ft)
+                .as("an unqualified name present in >1 workspace must resolve to the first match, not throw")
+                .isNotNull();
+        assertThat(ft.getName()).isEqualTo("roads");
+    }
+
+    @Test
+    void getFeatureTypeByNameIsDeterministicWhenNameIsAmbiguous() {
+        NamespaceInfo nsA = catalog.getNamespaceByPrefix("wsa");
+        NamespaceInfo nsB = catalog.getNamespaceByPrefix("wsb");
+        String idA =
+                catalog.getResourceByName(nsA, "roads", FeatureTypeInfo.class).getId();
+        String idB =
+                catalog.getResourceByName(nsB, "roads", FeatureTypeInfo.class).getId();
+        // findFirstByName resolves with "ORDER BY id", so the lowest id wins, repeatably.
+        String expected = idA.compareTo(idB) <= 0 ? idA : idB;
+        assertThat(catalog.getFeatureTypeByName("roads").getId()).isEqualTo(expected);
+        assertThat(catalog.getFeatureTypeByName("roads").getId()).isEqualTo(expected);
+    }
+
+    @Test
+    void getFeatureTypeByNameResolvesUniqueName() {
+        FeatureTypeInfo ft = catalog.getFeatureTypeByName("lakes");
+        assertThat(ft)
+                .as("a unique unqualified name was never affected and must still resolve")
+                .isNotNull();
+        assertThat(ft.getName()).isEqualTo("lakes");
+        assertThat(ft.getNamespace().getPrefix()).isEqualTo("wsa");
+    }
+
+    private void createWorkspaceWithFeatureType(String workspaceName, String featureType) {
+        CatalogFactory factory = catalog.getFactory();
+        WorkspaceInfo workspace = factory.createWorkspace();
+        workspace.setName(workspaceName);
+        catalog.add(workspace);
+
+        NamespaceInfo namespace = factory.createNamespace();
+        namespace.setPrefix(workspaceName);
+        namespace.setURI("http://%s.example".formatted(workspaceName));
+        catalog.add(namespace);
+
+        addFeatureType(workspace, featureType);
+    }
+
+    private void addFeatureType(WorkspaceInfo workspace, String featureType) {
+        CatalogFactory factory = catalog.getFactory();
+        NamespaceInfo namespace = catalog.getNamespaceByPrefix(workspace.getName());
+
+        DataStoreInfo store = factory.createDataStore();
+        store.setName("%s-%s-store".formatted(workspace.getName(), featureType));
+        store.setWorkspace(workspace);
+        store.setEnabled(true);
+        catalog.add(store);
+
+        FeatureTypeInfo ft = factory.createFeatureType();
+        ft.setName(featureType);
+        ft.setNativeName(featureType);
+        ft.setStore(store);
+        ft.setNamespace(namespace);
+        ft.setEnabled(true);
+        catalog.add(ft);
+    }
+}


### PR DESCRIPTION
## pgconfig backend: fix `ClassCastException` when requesting unqualified typename in WFS workspace virtual service

On the **pgconfig** catalog backend, resolving an **unqualified** catalog name that exists in **more than one workspace** throws instead of returning the first match. This causes an error for WFS `GetFeature` requests to a workspace virtual service (`/{workspace}/ows`) with an unqualified `typeName`:

```
GET /geoserver/wsA/ows?service=WFS&version=2.0.0&request=GetFeature&typeNames=roads&count=1

java.lang.ClassCastException: class java.lang.String cannot be cast to class java.util.Collection
    at org.geoserver.wfs.WFSWorkspaceQualifier.qualifyTypeNames(WFSWorkspaceQualifier.java:71)
```

It occurs only when that layer name exists in more than one workspace. If the name is unique across the catalog, or the request is fully qualified (`ws:layer`), it works. This is different from the data dir backend, so requests that work against a standalone GeoServer break on geoserver-cloud + pgconfig.

## Root cause

An unqualified type name is resolved via `Catalog.getFeatureTypeByName(name)` -> `CatalogFacade.ANY_NAMESPACE` -> `findFirstByName` -> `PgconfigCatalogInfoRepository.findOne(...)`.

`findOne(...)` used `JdbcTemplate.queryForObject(...)`, which throws `IncorrectResultSizeDataAccessException` when the query matches **more than one row**; the surrounding code only handled the *empty* result case (`EmptyResultDataAccessException`).

- In contrast, GeoServers's `DefaultCatalogFacade` returns the **first match** here and never throws, so the WFS KVP parser proceeds and `WFSWorkspaceQualifier` later qualifies the unqualified name to the request's workspace.
- On pgconfig, the thrown exception leaves the `TYPENAMES` KVP unparsed (a raw `String`), and `WFSWorkspaceQualifier.qualifyTypeNames` then performs a cast of that value to `Collection` -> `ClassCastException`.

## Tests

- Added unit tests in `PgconfigAmbiguousNameLookupIT` that ensure the first match is returned in case of ambiguity
- Added an integration test case in `WfsApplicationTest` that demonstrates the user-facing bug is fixed with the pgconfig backend (data dir backend already succeeded).

Let me know if there is anything to improve.