### PR TITLE
fix(pgconfig): stamp resource mtimes in UTC and fix parent mtime on move

### DIFF
--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceRowMapper.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceRowMapper.java
@@ -7,6 +7,8 @@ package org.geoserver.cloud.backend.pgconfig.resource;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Calendar;
+import java.util.TimeZone;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.geoserver.platform.resource.Resource;
@@ -15,6 +17,8 @@ import org.springframework.jdbc.core.RowMapper;
 /** @since 1.4 */
 @RequiredArgsConstructor
 public class PgconfigResourceRowMapper implements RowMapper<PgconfigResource> {
+
+    private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
     private final @NonNull PgconfigResourceStore store;
 
@@ -35,7 +39,11 @@ public class PgconfigResourceRowMapper implements RowMapper<PgconfigResource> {
         long parentId = rs.getLong("parentid");
         Resource.Type type = Resource.Type.valueOf(rs.getString("type"));
         String path = rs.getString("path");
-        long mtime = rs.getTimestamp("mtime").getTime();
+        // the mtime column is a timestamp without time zone holding UTC wall-clock values
+        // (written as timezone('UTC', now())); without an explicit UTC calendar here, the
+        // driver would interpret those UTC values as being in the JVM's default time zone,
+        // shifting the resulting epoch millis by the JVM's UTC offset
+        long mtime = rs.getTimestamp("mtime", Calendar.getInstance(UTC)).getTime();
         return new PgconfigResource(store, id, parentId, type, path, mtime);
     }
 

--- a/src/catalog/backends/pgconfig/src/main/resources/db/pgconfig/migration/postgresql/V3_1_1__ResourceStore_UTC_mtime.sql
+++ b/src/catalog/backends/pgconfig/src/main/resources/db/pgconfig/migration/postgresql/V3_1_1__ResourceStore_UTC_mtime.sql
@@ -1,0 +1,52 @@
+-- V3_1_1__ResourceStore_UTC_mtime.sql
+-- @since 3.1.0
+--
+-- Fix resourcestore_update_mtime() (from V1_4__ResourceStore_Tables.sql) and
+-- resourcestore_update_parent_mtime() (as redefined by V1_6__ResourceStore_NoCTE.sql, which
+-- renamed the "name" column to "path") in two ways.
+--
+-- 1. Stamp mtime in UTC. The mtime column is TIMESTAMP WITHOUT TIME ZONE. resourcestore's
+-- explicit UPSERT path already writes timezone('UTC'::text, now()), but these two trigger
+-- functions wrote plain now(), which is a timestamptz cast into the column using the session's
+-- TimeZone setting rather than UTC. Whenever the session TimeZone isn't UTC, resources touched
+-- only by these triggers (a bare UPDATE outside the UPSERT path, and a parent whose mtime is
+-- bumped after a child delete) get an mtime offset from the value the application later reads
+-- back assuming UTC, defeating any comparison against a wall-clock time (such as
+-- FileSystemResourceStoreCache's no-clobber rule).
+--
+-- 2. Fix the moved-resource branch of resourcestore_update_parent_mtime(). It previously ran
+-- UPDATE resourcestore SET mtime = NEW.mtime WHERE id = OLD.parentid OR parentid = NEW.parentid,
+-- which bumps the old parent directory and every row already inside the new parent directory
+-- (the moved row's new siblings), but never the new parent directory itself. The second condition
+-- is now id = NEW.parentid: the new parent directory is the one that gets bumped, and its existing
+-- children are left alone.
+
+CREATE OR REPLACE FUNCTION resourcestore_update_mtime() RETURNS trigger LANGUAGE plpgsql AS
+$$BEGIN
+  RAISE DEBUG 'resourcestore_update_mtime: %, %', OLD, NEW;
+  IF OLD.mtime = NEW.mtime THEN
+    RAISE DEBUG 'update mtime % to % on %', OLD.mtime, NEW.mtime, NEW.id;
+    NEW.mtime = timezone('UTC'::text, now());
+  ELSE
+    RAISE DEBUG 'mtime set explicitly to % on % (old mtime: %)', NEW.mtime, NEW.id, OLD.mtime;
+  END IF;
+  RETURN NEW;
+END;$$;
+
+CREATE OR REPLACE FUNCTION resourcestore_update_parent_mtime() RETURNS trigger LANGUAGE plpgsql AS
+$$BEGIN
+  RAISE DEBUG 'resourcestore_update_parent_mtime: %, %', OLD, NEW;
+  IF NEW IS NULL THEN -- delete
+    RAISE DEBUG 'updating mtime to % on parent (%) on delete of % (%)', OLD.mtime, OLD.parentid, OLD.id, OLD.path;
+    UPDATE resourcestore SET mtime = timezone('UTC'::text, now()) WHERE id = OLD.parentid;
+  ELSIF OLD IS NULL THEN -- insert
+    RAISE DEBUG 'updating mtime to % on parent (%) on insert of % (%)', NEW.mtime, NEW.parentid, NEW.id, NEW.path;
+    UPDATE resourcestore SET mtime = NEW.mtime WHERE id = NEW.parentid;
+  ELSIF OLD.parentid <> NEW.parentid THEN -- moved
+    RAISE DEBUG '% parent moved from % to %, updating mtime to % on both', NEW.id, NEW.mtime, OLD.parentid, NEW.parentid;
+	  UPDATE resourcestore SET mtime = NEW.mtime WHERE id = OLD.parentid OR id = NEW.parentid;
+	ELSIF OLD.mtime <> NEW.mtime THEN
+    RAISE DEBUG '% updated, parent %, does not trigger update of parent mtime', NEW.id, NEW.parentid;
+  END IF;
+  RETURN NEW;
+END;$$;

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceIT.java
@@ -375,6 +375,62 @@ class PgconfigResourceIT {
     }
 
     @Test
+    void testMoveStampsMtimeInUtc() throws Exception {
+        store.get("workspaces").dir();
+        store.get("workspaces/tzcheck").dir();
+        try (OutputStream out = store.get("workspaces/tzcheck/f.xml").out()) {
+            out.write("<a/>".getBytes(StandardCharsets.UTF_8));
+        }
+
+        // move() updates parentid and path but leaves mtime for the
+        // resourcestore_update_mtime() trigger to stamp
+        store.move("workspaces/tzcheck/f.xml", "workspaces/tzcheck/moved.xml");
+
+        long mtime = store.get("workspaces/tzcheck/moved.xml").lastmodified();
+        long driftMillis = Math.abs(System.currentTimeMillis() - mtime);
+        long fiveMinutesMillis = 5 * 60 * 1000;
+        // resourcestore_update_mtime() must stamp mtime in UTC, matching how it's read back. On a
+        // JVM running outside UTC, a regression to a plain now() (session-local time) would shift
+        // mtime by the JVM's UTC offset, far past this tolerance. On a UTC host this assertion is
+        // a no-op sanity check, since there would be no drift to catch either way.
+        assertTrue(driftMillis < fiveMinutesMillis, "mtime drifted by " + driftMillis + "ms from wall clock time");
+    }
+
+    @Test
+    void testMoveUpdatesParentDirectoryMtimes() throws Exception {
+        store.get("workspaces").dir();
+        store.get("workspaces/mvsrc").dir();
+        store.get("workspaces/mvdst").dir();
+        store.get("workspaces/mvsrc/a.xml").file();
+        store.get("workspaces/mvdst/keep.xml").file();
+
+        long srcDirMtimeBefore = store.get("workspaces/mvsrc").lastmodified();
+        long dstDirMtimeBefore = store.get("workspaces/mvdst").lastmodified();
+        long keepMtimeBefore = store.get("workspaces/mvdst/keep.xml").lastmodified();
+
+        store.move("workspaces/mvsrc/a.xml", "workspaces/mvdst/a.xml");
+
+        long srcDirMtimeAfter = store.get("workspaces/mvsrc").lastmodified();
+        long dstDirMtimeAfter = store.get("workspaces/mvdst").lastmodified();
+        long keepMtimeAfter = store.get("workspaces/mvdst/keep.xml").lastmodified();
+
+        assertTrue(srcDirMtimeAfter > srcDirMtimeBefore, "source directory mtime should be bumped on move");
+        assertTrue(dstDirMtimeAfter > dstDirMtimeBefore, "destination directory mtime should be bumped on move");
+        assertEquals(keepMtimeBefore, keepMtimeAfter, "sibling file mtime must not change on an unrelated move");
+
+        long fiveMinutesMillis = 5 * 60 * 1000;
+        // Piggybacks a UTC sanity check on both directory mtimes: on a non-UTC JVM, a regression
+        // to plain now() in the trigger would drift these far past this tolerance; on a UTC host
+        // this part of the assertion is a no-op, since there would be no drift to catch either way.
+        assertTrue(
+                Math.abs(System.currentTimeMillis() - srcDirMtimeAfter) < fiveMinutesMillis,
+                "source directory mtime drifted from wall clock time");
+        assertTrue(
+                Math.abs(System.currentTimeMillis() - dstDirMtimeAfter) < fiveMinutesMillis,
+                "destination directory mtime drifted from wall clock time");
+    }
+
+    @Test
     void testIgnoresFileSystemOnlyResourcesInDb() throws SQLException {
         // for pre 1.8.1 backwards compatibility, ignore fs-only resources already in the db
         DataSource ds = db.getDataSource();


### PR DESCRIPTION
The resourcestore mtime column is TIMESTAMP WITHOUT TIME ZONE and the explicit UPSERT path writes timezone('UTC', now()), but the row mapper read the column with the JVM default calendar and the V1_4/V1_6 trigger functions stamped plain now(), cast using the session TimeZone. On any JVM or database session not running in UTC, mtimes drifted by the zone offset, corrupting every mtime comparison. Read with an explicit UTC calendar and replace the trigger functions with UTC-stamping versions (V3_1_1).

While rewriting the move branch of resourcestore_update_parent_mtime(), found it also never bumped the new parent directory's own mtime: it updated the old parent directory and every existing child of the new parent directory (the moved resource's new siblings) instead. Fixed the condition to target the new parent directory itself.
