### PR TITLE
fix(gateway): serve at root path with empty or "/" base path

### DIFF
--- a/docs/src/developer-guide/services/gateway-service.md
+++ b/docs/src/developer-guide/services/gateway-service.md
@@ -107,6 +107,10 @@ Set `geoserver.base-path` (or the environment variable `GEOSERVER_BASE_PATH`) to
 under a sub-path. Default: empty (served at root). The `StripBasePath` filter removes this prefix
 before forwarding requests to backend services.
 
+The gateway normalizes the value before routes consume it: `/` is equivalent to empty (served at
+root), trailing slashes are dropped (`/geoserver/` means `/geoserver`), and a missing leading slash
+is added (`geoserver` means `/geoserver`).
+
 ```yaml
 geoserver:
   base-path: /geoserver/cloud

--- a/src/apps/infrastructure/gateway-webmvc/src/main/java/org/geoserver/cloud/autoconfigure/gateway/GatewayApplicationAutoconfiguration.java
+++ b/src/apps/infrastructure/gateway-webmvc/src/main/java/org/geoserver/cloud/autoconfigure/gateway/GatewayApplicationAutoconfiguration.java
@@ -8,11 +8,13 @@ package org.geoserver.cloud.autoconfigure.gateway;
 import org.geoserver.cloud.gateway.filter.GeoServerGatewayFilterFunctions;
 import org.geoserver.cloud.gateway.filter.ProxyExceptionFilter;
 import org.geoserver.cloud.gateway.predicate.GeoServerGatewayRequestPredicates;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.gateway.server.mvc.filter.FilterSupplier;
 import org.springframework.cloud.gateway.server.mvc.predicate.PredicateSupplier;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
@@ -25,6 +27,19 @@ import org.springframework.web.filter.CorsFilter;
 })
 @SuppressWarnings("java:S1118") // Suppress SonarLint warning, constructor needs to be public
 public class GatewayApplicationAutoconfiguration {
+
+    /**
+     * Normalizes the {@code basepath} property before gateway route definitions bind it: {@code /}, trailing slashes
+     * and a missing leading slash all reduce to the canonical form (empty for the root path). Registered as a
+     * {@link BeanFactoryPostProcessor} to run after every property source is in place (including remote config from
+     * consul or the config server) and before route properties bind.
+     *
+     * @see NormalizedBasePathPropertySource
+     */
+    @Bean
+    static BeanFactoryPostProcessor gatewayBasePathNormalizer(ConfigurableEnvironment environment) {
+        return beanFactory -> NormalizedBasePathPropertySource.register(environment);
+    }
 
     /**
      * CORS filter driven by {@link GlobalCorsProperties}. SCG Server MVC does not support the WebFlux

--- a/src/apps/infrastructure/gateway-webmvc/src/main/java/org/geoserver/cloud/autoconfigure/gateway/NormalizedBasePathPropertySource.java
+++ b/src/apps/infrastructure/gateway-webmvc/src/main/java/org/geoserver/cloud/autoconfigure/gateway/NormalizedBasePathPropertySource.java
@@ -1,0 +1,117 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.autoconfigure.gateway;
+
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertySource;
+
+/**
+ * Resolves the {@code basepath} property to its canonical form before route definitions consume it.
+ *
+ * <p>The shipped gateway config splices {@code ${basepath}} textually into route predicates and redirect targets (e.g.
+ * {@code Path=${basepath}/wms}, {@code RedirectTo=302, ${basepath}/web/}). A base path of {@code /} or one with a
+ * trailing slash silently breaks all routes: {@code //wms} never matches a request path and a {@code Location: //web/}
+ * header is scheme-relative, sending browsers to {@code http://web/}. The canonical form has no trailing slash, and the
+ * root base path is the empty string.
+ *
+ * <p>This property source shadows {@code basepath} at the top of the environment: it finds the raw value the other
+ * sources define (typically the {@code basepath: ${geoserver.base-path}} alias in the shipped config), resolves its
+ * placeholders and normalizes the result. Values with unresolvable placeholders pass through untouched, and every other
+ * property name is left to the regular sources.
+ *
+ * @since 3.1.0
+ */
+class NormalizedBasePathPropertySource extends PropertySource<Object> {
+
+    static final String NAME = "geoserverNormalizedBasePath";
+
+    static final String BASE_PATH_PROPERTY = "basepath";
+
+    /**
+     * Guards against placeholder cycles (e.g. {@code basepath} and {@code geoserver.base-path} aliasing each other): a
+     * reentrant lookup falls through to the regular property sources instead of recursing.
+     */
+    private final ThreadLocal<Boolean> resolving = ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+    /**
+     * Kept out of {@link #getSource()} on purpose: Spring Boot's {@code SpringConfigurationPropertySources} recurses
+     * into any property source whose source object is a {@link ConfigurableEnvironment}, and this source lives inside
+     * the environment it reads from.
+     */
+    private final ConfigurableEnvironment environment;
+
+    private NormalizedBasePathPropertySource(ConfigurableEnvironment environment) {
+        super(NAME);
+        this.environment = environment;
+    }
+
+    /** Puts a normalizing source at the top of the environment's property sources; a no-op if already registered. */
+    static void register(ConfigurableEnvironment environment) {
+        MutablePropertySources sources = environment.getPropertySources();
+        if (!sources.contains(NAME)) {
+            sources.addFirst(new NormalizedBasePathPropertySource(environment));
+        }
+    }
+
+    @Override
+    public Object getProperty(String name) {
+        if (!BASE_PATH_PROPERTY.equals(name) || resolving.get().booleanValue()) {
+            return null;
+        }
+        resolving.set(Boolean.TRUE);
+        try {
+            return resolveNormalizedBasePath();
+        } finally {
+            resolving.set(Boolean.FALSE);
+        }
+    }
+
+    private String resolveNormalizedBasePath() {
+        String rawValue = findRawBasePath();
+        if (rawValue == null) {
+            return null;
+        }
+        String resolved = environment.resolvePlaceholders(rawValue);
+        if (containsUnresolvedPlaceholder(resolved)) {
+            return resolved;
+        }
+        return normalize(resolved);
+    }
+
+    /** Finds the {@code basepath} value the other property sources define, placeholders unresolved. */
+    private String findRawBasePath() {
+        for (PropertySource<?> candidate : environment.getPropertySources()) {
+            if (candidate == this) {
+                continue;
+            }
+            Object rawValue = candidate.getProperty(BASE_PATH_PROPERTY);
+            if (rawValue != null) {
+                return rawValue.toString();
+            }
+        }
+        return null;
+    }
+
+    private static boolean containsUnresolvedPlaceholder(String value) {
+        return value.contains("${");
+    }
+
+    /**
+     * Reduces the value to the canonical base path form: no trailing slashes, a leading slash when not empty. The root
+     * spellings ({@code ""}, {@code "/"}, whitespace) all reduce to the empty string.
+     */
+    private static String normalize(String rawValue) {
+        String value = rawValue.strip();
+        while (value.endsWith("/")) {
+            value = value.substring(0, value.length() - 1);
+        }
+        if (!value.isEmpty() && !value.startsWith("/")) {
+            value = "/" + value;
+        }
+        return value;
+    }
+}

--- a/src/apps/infrastructure/gateway-webmvc/src/main/java/org/geoserver/cloud/gateway/filter/GeoServerGatewayFilterFunctions.java
+++ b/src/apps/infrastructure/gateway-webmvc/src/main/java/org/geoserver/cloud/gateway/filter/GeoServerGatewayFilterFunctions.java
@@ -36,6 +36,19 @@ public interface GeoServerGatewayFilterFunctions {
     }
 
     /**
+     * No-op overload matched when the base path is empty. The shipped gateway config declares
+     * {@code StripBasePath=${basepath}} on every route; with an empty base path the shortcut expands to
+     * {@code StripBasePath=} with no arguments, and Spring Cloud Gateway Server MVC resolves shortcuts by matching
+     * methods with the same argument count. There is no prefix to strip, requests pass through unchanged.
+     *
+     * @see StripBasePath
+     */
+    @Shortcut
+    static HandlerFilterFunction<ServerResponse, ServerResponse> stripBasePath() {
+        return (request, next) -> next.handle(request);
+    }
+
+    /**
      * Enables a route only if a given Spring profile is active.
      *
      * <p>YAML: {@code filters: - RouteProfile=dev,403}

--- a/src/apps/infrastructure/gateway-webmvc/src/main/java/org/geoserver/cloud/gateway/filter/StripBasePath.java
+++ b/src/apps/infrastructure/gateway-webmvc/src/main/java/org/geoserver/cloud/gateway/filter/StripBasePath.java
@@ -52,7 +52,8 @@ class StripBasePath implements HandlerFilterFunction<ServerResponse, ServerRespo
     }
 
     private static int resolvePartsToStrip(String basePath, String requestPath) {
-        if (basePath == null || basePath.isEmpty() || !requestPath.startsWith(basePath)) {
+        boolean emptyPrefix = basePath == null || basePath.isEmpty() || "/".equals(basePath);
+        if (emptyPrefix || !requestPath.startsWith(basePath)) {
             return 0;
         }
         int basePathSteps = StringUtils.countOccurrencesOf(basePath, "/");

--- a/src/apps/infrastructure/gateway-webmvc/src/test/java/org/geoserver/cloud/autoconfigure/gateway/GatewayApplicationAutoconfigurationTest.java
+++ b/src/apps/infrastructure/gateway-webmvc/src/test/java/org/geoserver/cloud/autoconfigure/gateway/GatewayApplicationAutoconfigurationTest.java
@@ -58,6 +58,20 @@ class GatewayApplicationAutoconfigurationTest {
     }
 
     @Test
+    void basePathNormalized_rootBecomesEmpty() {
+        runner.withPropertyValues("geoserver.base-path=/", "basepath=${geoserver.base-path}")
+                .run(context -> assertThat(context.getEnvironment().getProperty("basepath"))
+                        .isEmpty());
+    }
+
+    @Test
+    void basePathNormalized_trailingSlashStripped() {
+        runner.withPropertyValues("geoserver.base-path=/geoserver/", "basepath=${geoserver.base-path}")
+                .run(context -> assertThat(context.getEnvironment().getProperty("basepath"))
+                        .isEqualTo("/geoserver"));
+    }
+
+    @Test
     void gatewaySharedAuth_enabledByDefault() {
         runner.run(context -> {
             assertThat(context).hasNotFailed();

--- a/src/apps/infrastructure/gateway-webmvc/src/test/java/org/geoserver/cloud/autoconfigure/gateway/NormalizedBasePathPropertySourceTest.java
+++ b/src/apps/infrastructure/gateway-webmvc/src/test/java/org/geoserver/cloud/autoconfigure/gateway/NormalizedBasePathPropertySourceTest.java
@@ -1,0 +1,108 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.autoconfigure.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+/**
+ * Unit tests for {@link NormalizedBasePathPropertySource}: the {@code basepath} property resolves to the canonical form
+ * no matter how {@code geoserver.base-path} is spelled ("/", trailing slashes, missing leading slash).
+ *
+ * @since 3.1.0
+ */
+class NormalizedBasePathPropertySourceTest {
+
+    private StandardEnvironment environment = new StandardEnvironment();
+
+    @Test
+    void rootBecomesEmpty() {
+        assertThat(resolvedBasePath("/")).isEmpty();
+    }
+
+    @Test
+    void emptyStaysEmpty() {
+        assertThat(resolvedBasePath("")).isEmpty();
+    }
+
+    @Test
+    void whitespaceRootBecomesEmpty() {
+        assertThat(resolvedBasePath(" / ")).isEmpty();
+    }
+
+    @Test
+    void trailingSlashStripped() {
+        assertThat(resolvedBasePath("/geoserver/")).isEqualTo("/geoserver");
+    }
+
+    @Test
+    void repeatedTrailingSlashesStripped() {
+        assertThat(resolvedBasePath("/geoserver/cloud//")).isEqualTo("/geoserver/cloud");
+    }
+
+    @Test
+    void missingLeadingSlashAdded() {
+        assertThat(resolvedBasePath("geoserver")).isEqualTo("/geoserver");
+    }
+
+    @Test
+    void canonicalValueUnchanged() {
+        assertThat(resolvedBasePath("/geoserver/cloud")).isEqualTo("/geoserver/cloud");
+    }
+
+    @Test
+    void undefinedBasePathStaysUndefined() {
+        NormalizedBasePathPropertySource.register(environment);
+        assertThat(environment.getProperty("basepath")).isNull();
+    }
+
+    @Test
+    void directValueWithoutAliasChainNormalized() {
+        addProperties(Map.of("basepath", "/foo/"));
+        NormalizedBasePathPropertySource.register(environment);
+        assertThat(environment.getProperty("basepath")).isEqualTo("/foo");
+    }
+
+    @Test
+    void unresolvablePlaceholderKeepsDefaultStrictBehavior() {
+        addProperties(Map.of("basepath", "${geoserver.base-path}"));
+        NormalizedBasePathPropertySource.register(environment);
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> environment.getProperty("basepath"))
+                .withMessageContaining("geoserver.base-path");
+    }
+
+    @Test
+    void registerTwice_singleSourceStillResolves() {
+        addProperties(Map.of("basepath", "/foo/"));
+        NormalizedBasePathPropertySource.register(environment);
+        NormalizedBasePathPropertySource.register(environment);
+        assertThat(environment.getProperty("basepath")).isEqualTo("/foo");
+    }
+
+    @Test
+    void otherPropertiesUnaffected() {
+        addProperties(Map.of("basepath", "/foo/", "other.property", "value/"));
+        NormalizedBasePathPropertySource.register(environment);
+        assertThat(environment.getProperty("other.property")).isEqualTo("value/");
+    }
+
+    /** Resolves {@code basepath} through the alias chain used in the shipped gateway config. */
+    private String resolvedBasePath(String rawBasePath) {
+        addProperties(Map.of("geoserver.base-path", rawBasePath, "basepath", "${geoserver.base-path}"));
+        NormalizedBasePathPropertySource.register(environment);
+        return environment.getProperty("basepath");
+    }
+
+    private void addProperties(Map<String, Object> properties) {
+        environment.getPropertySources().addLast(new MapPropertySource("testProperties", properties));
+    }
+}

--- a/src/apps/infrastructure/gateway-webmvc/src/test/java/org/geoserver/cloud/gateway/app/GatewayMvcEmptyBasePathTest.java
+++ b/src/apps/infrastructure/gateway-webmvc/src/test/java/org/geoserver/cloud/gateway/app/GatewayMvcEmptyBasePathTest.java
@@ -1,0 +1,54 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.gateway.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Regression test for the gateway failing to start when {@code geoserver.base-path} is empty.
+ *
+ * <p>The shipped gateway config expands {@code ${basepath}} into every route, producing the shortcut
+ * {@code StripBasePath=} with no arguments when the base path is empty. Spring Cloud Gateway Server MVC resolves
+ * shortcut filters by reflection, matching methods by argument count; without a zero-argument {@code stripBasePath()}
+ * overload the context fails with "Unable to find operation ... for stripBasePath with args {}".
+ *
+ * <p>The route properties below replicate the shapes used in the shipped {@code gateway.yml}: the root redirect route
+ * and a proxy route with {@code StripBasePath=${basepath}}.
+ *
+ * @since 3.1.0
+ */
+@SpringBootTest(
+        classes = GatewayMvcApplication.class,
+        properties = {
+            "geoserver.base-path=",
+            "basepath=${geoserver.base-path}",
+            "spring.cloud.gateway.server.webmvc.routes[0].id=root-redirect-to-webui",
+            "spring.cloud.gateway.server.webmvc.routes[0].uri=no://op",
+            "spring.cloud.gateway.server.webmvc.routes[0].predicates[0]=Path=/,${basepath},${basepath}/",
+            "spring.cloud.gateway.server.webmvc.routes[0].filters[0]=RedirectTo=302, ${basepath}/web/",
+            "spring.cloud.gateway.server.webmvc.routes[1].id=echo",
+            "spring.cloud.gateway.server.webmvc.routes[1].uri=http://localhost:1",
+            "spring.cloud.gateway.server.webmvc.routes[1].predicates[0]=Path=${basepath}/echo/**",
+            "spring.cloud.gateway.server.webmvc.routes[1].filters[0]=StripBasePath=${basepath}",
+            "spring.cloud.gateway.server.webmvc.routes[1].filters[1]=SecureHeaders"
+        })
+@ActiveProfiles("test")
+class GatewayMvcEmptyBasePathTest {
+
+    @Autowired
+    Environment environment;
+
+    @Test
+    void contextStarts_withEmptyBasePath() {
+        assertThat(environment.getProperty("basepath")).isEmpty();
+    }
+}

--- a/src/apps/infrastructure/gateway-webmvc/src/test/java/org/geoserver/cloud/gateway/app/GatewayMvcRootBasePathIT.java
+++ b/src/apps/infrastructure/gateway-webmvc/src/test/java/org/geoserver/cloud/gateway/app/GatewayMvcRootBasePathIT.java
@@ -1,0 +1,89 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.gateway.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Integration test for serving GeoServer at the root path with {@code geoserver.base-path=/}.
+ *
+ * <p>The base path is spliced textually into route predicates and the root redirect target (e.g.
+ * {@code Path=${basepath}/wms}, {@code RedirectTo=302, ${basepath}/web/}). A raw value of {@code /} would produce
+ * {@code //wms} patterns that never match and a scheme-relative {@code Location: //web/} that browsers resolve to
+ * {@code http://web/}. The gateway normalizes the value at property-resolution time: {@code /} and trailing slashes
+ * reduce to the canonical empty form, meaning "serve at the root path".
+ *
+ * <p>Routes replicate the shapes used in the shipped {@code gateway.yml}.
+ *
+ * @since 3.1.0
+ */
+@SpringBootTest(classes = GatewayMvcApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@AutoConfigureTestRestTemplate
+@Testcontainers(disabledWithoutDocker = true)
+class GatewayMvcRootBasePathIT {
+
+    @SuppressWarnings("resource")
+    @Container
+    static GenericContainer<?> echoServer = new GenericContainer<>("jmalloc/echo-server").withExposedPorts(8080);
+
+    @DynamicPropertySource
+    static void registerRoutes(DynamicPropertyRegistry registry) {
+        String echoUri = "http://%s:%d".formatted(echoServer.getHost(), echoServer.getMappedPort(8080));
+
+        registry.add("geoserver.base-path", () -> "/");
+        registry.add("basepath", () -> "${geoserver.base-path}");
+
+        String r0 = "spring.cloud.gateway.server.webmvc.routes[0]";
+        registry.add(r0 + ".id", () -> "root-redirect-to-webui");
+        registry.add(r0 + ".uri", () -> "no://op");
+        registry.add(r0 + ".predicates[0]", () -> "Path=/,${basepath},${basepath}/");
+        registry.add(r0 + ".filters[0]", () -> "RedirectTo=302, ${basepath}/web/");
+
+        String r1 = "spring.cloud.gateway.server.webmvc.routes[1]";
+        registry.add(r1 + ".id", () -> "echo");
+        registry.add(r1 + ".uri", () -> echoUri);
+        registry.add(r1 + ".predicates[0]", () -> "Path=${basepath}/echo/**");
+        registry.add(r1 + ".filters[0]", () -> "StripBasePath=${basepath}");
+        registry.add(r1 + ".filters[1]", () -> "SecureHeaders");
+    }
+
+    @Autowired
+    TestRestTemplate testRestTemplate;
+
+    @Test
+    void rootBasePath_routesMatchAtRoot() {
+        ResponseEntity<String> response = testRestTemplate.getForEntity("/echo/test?service=wfs", String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).contains("GET /echo/test?service=wfs");
+    }
+
+    @Test
+    void rootBasePath_redirectsRootToLocalWebPath() {
+        // the raw base path "/" would expand the redirect target to the scheme-relative "//web/",
+        // which browsers resolve to http://web/; the normalized base path yields a host-relative Location
+        ResponseEntity<String> response = testRestTemplate.getForEntity("/", String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
+        assertThat(response.getHeaders().getLocation()).hasToString("/web/");
+    }
+}

--- a/src/apps/infrastructure/gateway-webmvc/src/test/java/org/geoserver/cloud/gateway/filter/StripBasePathTest.java
+++ b/src/apps/infrastructure/gateway-webmvc/src/test/java/org/geoserver/cloud/gateway/filter/StripBasePathTest.java
@@ -41,6 +41,22 @@ class StripBasePathTest {
     }
 
     @Test
+    void rootPrefix_passesThrough() throws Exception {
+        assertThat(filterPath("/", "/wms")).isEqualTo("/wms");
+    }
+
+    @Test
+    void zeroArgShortcut_passesThrough() throws Exception {
+        HandlerFilterFunction<ServerResponse, ServerResponse> filter = GeoServerGatewayFilterFunctions.stripBasePath();
+        assertThat(applyFilter(filter, "/wms")).isEqualTo("/wms");
+    }
+
+    @Test
+    void rootPrefix_rootRequest_passesThrough() throws Exception {
+        assertThat(filterPath("/", "/")).isEqualTo("/");
+    }
+
+    @Test
     void singleSegment_strips() throws Exception {
         assertThat(filterPath("/geoserver", "/geoserver/ows")).isEqualTo("/ows");
     }
@@ -66,8 +82,11 @@ class StripBasePathTest {
     }
 
     private String filterPath(String prefix, String requestPath) throws Exception {
-        HandlerFilterFunction<ServerResponse, ServerResponse> filter =
-                GeoServerGatewayFilterFunctions.stripBasePath(prefix);
+        return applyFilter(GeoServerGatewayFilterFunctions.stripBasePath(prefix), requestPath);
+    }
+
+    private String applyFilter(HandlerFilterFunction<ServerResponse, ServerResponse> filter, String requestPath)
+            throws Exception {
         MockHttpServletRequest mockRequest = new MockHttpServletRequest("GET", requestPath);
         ServerRequest request = ServerRequest.create(mockRequest, List.of());
         AtomicReference<String> captured = new AtomicReference<>();


### PR DESCRIPTION
An empty `GEOSERVER_BASE_PATH` crashed the gateway at startup: every route expands to the shortcut `"StripBasePath="` with no arguments, and Spring Cloud Gateway Server MVC matches shortcut operations by argument count, with no zero-argument stripBasePath() to match. The WebFlux gateway accepted the empty value through lenient config binding.

Add a zero-argument `StripBasePath` shortcut overload that passes requests through unchanged Treat the `"/"` prefix as empty in `StripBasePath` instead of stripping the first path segment Normalize the basepath property before routes bind it: "/" and trailing slashes reduce to the canonical form, empty means root.

A raw `"/"` produced `Path=//wms` patterns that never match and a scheme-relative `"Location: //web/"` redirect to `http://web/`

on-behalf-of: @camptocamp <info@camptocamp.com>