### PR TITLE
Fix/pgconfig caching modificationproxy leak

### DIFF
--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/CatalogInfoRowMapper.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/CatalogInfoRowMapper.java
@@ -26,7 +26,6 @@ import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
-import org.geoserver.catalog.impl.ClassMappings;
 import org.geoserver.catalog.impl.LayerInfoImpl;
 import org.geoserver.catalog.impl.ModificationProxy;
 import org.springframework.jdbc.core.RowMapper;
@@ -274,7 +273,7 @@ public final class CatalogInfoRowMapper<T extends CatalogInfo> implements RowMap
         if (null != workspace) {
             String wsid = workspace.getId();
             WorkspaceInfo ws = mapWorkspace(wsid, rs);
-            style.setWorkspace(ModificationProxy.create(ws, WorkspaceInfo.class));
+            style.setWorkspace(ws);
         }
         return style;
     }
@@ -307,7 +306,7 @@ public final class CatalogInfoRowMapper<T extends CatalogInfo> implements RowMap
         if (null != store) {
             String wsid = store.getWorkspace().getId();
             WorkspaceInfo ws = mapWorkspace(wsid, rs);
-            store.setWorkspace(ModificationProxy.create(ws, WorkspaceInfo.class));
+            store.setWorkspace(ws);
         }
         return store;
     }
@@ -342,9 +341,13 @@ public final class CatalogInfoRowMapper<T extends CatalogInfo> implements RowMap
         if (resource instanceof FeatureTypeInfo ft) {
             List<AttributeTypeInfo> attributes = ft.getAttributes();
             if (attributes != null && !attributes.isEmpty()) {
-                FeatureTypeInfo mproxy = ModificationProxy.create(ft, FeatureTypeInfo.class);
+                /*
+                 * Raw back-reference, never a ModificationProxy: materialized graphs may be shared across threads by
+                 * the caching facade, and a proxy in the graph gets its unsynchronized state maps Java-serialized by
+                 * ModificationProxyCloner when attributes are deep-cloned, corrupting the stream under concurrency
+                 */
                 for (AttributeTypeInfo att : attributes) {
-                    att.setFeatureType(mproxy);
+                    att.setFeatureType(ft);
                 }
             }
         }
@@ -354,16 +357,13 @@ public final class CatalogInfoRowMapper<T extends CatalogInfo> implements RowMap
     protected void setStore(ResourceInfo resource, ResultSet rs) {
         String storeId = resource.getStore().getId();
         StoreInfo store = mapStore(storeId, rs);
-        @SuppressWarnings("unchecked")
-        Class<? extends StoreInfo> storeType = (Class<? extends StoreInfo>)
-                ClassMappings.fromImpl(store.getClass()).getInterface();
-        resource.setStore(ModificationProxy.create(store, storeType));
+        resource.setStore(store);
     }
 
     protected void setNamespace(ResultSet rs, ResourceInfo resource) {
         String nsid = resource.getNamespace().getId();
         NamespaceInfo ns = mapNamespace(nsid, rs);
-        resource.setNamespace(ModificationProxy.create(ns, NamespaceInfo.class));
+        resource.setNamespace(ns);
     }
 
     /**
@@ -428,7 +428,6 @@ public final class CatalogInfoRowMapper<T extends CatalogInfo> implements RowMap
         List<StyleInfo> styles = li.getStyles().stream()
                 .map(StyleInfo::getId)
                 .map(this::loadStyle)
-                .map(s -> ModificationProxy.create(s, StyleInfo.class))
                 .toList();
         li.setStyles(new HashSet<>(styles));
     }
@@ -455,7 +454,7 @@ public final class CatalogInfoRowMapper<T extends CatalogInfo> implements RowMap
             if (null != workspace) {
                 String wsid = workspace.getId();
                 WorkspaceInfo ws = mapWorkspace(wsid, rs);
-                layergroup.setWorkspace(ModificationProxy.create(ws, WorkspaceInfo.class));
+                layergroup.setWorkspace(ws);
             }
         }
         return layergroup;
@@ -476,7 +475,7 @@ public final class CatalogInfoRowMapper<T extends CatalogInfo> implements RowMap
         // resolving a layerinfo. In the later,
         // the relationship is 1:1 so caching them would be vane
         ResourceInfo resource = mapResource(rs);
-        layer.setResource(ModificationProxy.create(resource, ResourceInfo.class));
+        layer.setResource(resource);
     }
 
     private void setDefaultStyle(LayerInfo layer, ResultSet rs) {
@@ -484,11 +483,7 @@ public final class CatalogInfoRowMapper<T extends CatalogInfo> implements RowMap
         if (null != defaultStyle) {
             String styleId = defaultStyle.getId();
             defaultStyle = mapStyle(styleId, "defaultStyle", rs);
-            if (null == defaultStyle) {
-                layer.setDefaultStyle(null);
-            } else {
-                layer.setDefaultStyle(ModificationProxy.create(defaultStyle, StyleInfo.class));
-            }
+            layer.setDefaultStyle(defaultStyle);
         }
     }
 

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/catalog/PgconfigModificationProxyLeakTest.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/catalog/PgconfigModificationProxyLeakTest.java
@@ -1,0 +1,319 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.backend.pgconfig.catalog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.geoserver.catalog.AttributeTypeInfo;
+import org.geoserver.catalog.CatalogFactory;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.PublishedInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.catalog.plugin.CatalogPlugin;
+import org.geoserver.cloud.backend.pgconfig.PgconfigBackendBuilder;
+import org.geoserver.cloud.backend.pgconfig.support.PgConfigTestContainer;
+import org.geoserver.cloud.backend.pgconfig.support.PgconfigTestDatabaseSupport;
+import org.geoserver.cloud.catalog.cache.CachingCatalogFacade;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Verifies the DAO-layer invariant that materialized catalog object graphs contain no {@link ModificationProxy}
+ * instances: everything below {@link CatalogPlugin} trades in raw implementations, and proxy wrapping is exclusively a
+ * {@code CatalogPlugin} outbound concern applied per retrieval.
+ *
+ * <p>Background: with {@code geoserver.catalog.caching.enabled=true}, {@link CachingCatalogFacade} shares one
+ * materialized graph across all request threads. When that graph embeds live {@code ModificationProxy} instances
+ * (attribute {@code featureType} back-references, store/namespace/style references, layer group members), the proxies'
+ * non-transient, unsynchronized {@code properties}/{@code oldCollectionValues} maps are both written by reader threads
+ * (collection getters and setters intercepted by {@code ModificationProxy.invoke}) and included in the Java
+ * serialization streams produced by {@code ModificationProxyCloner.cloneSerializable} when a collection getter is
+ * deep-cloned (e.g. {@code FeatureTypeInfo.getAttributes()}). A write landing during another thread's
+ * {@code ObjectOutputStream} pass corrupts the stream and surfaces as {@code java.io.OptionalDataException} wrapped in
+ * {@code RuntimeException("Error cloning serializable object")}, as reported for WMS GetCapabilities on large
+ * workspaces with layer groups and data security rules.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class PgconfigModificationProxyLeakTest {
+
+    @Container
+    static PgConfigTestContainer container = new PgConfigTestContainer();
+
+    @RegisterExtension
+    PgconfigTestDatabaseSupport db = new PgconfigTestDatabaseSupport(container);
+
+    private static final String CACHE_NAME = "gs-catalog";
+
+    private CatalogPlugin catalog;
+    private Cache cache;
+
+    @BeforeEach
+    void setUp() {
+        catalog = newCachingCatalog();
+    }
+
+    @Test
+    void featureTypeAttributeBackReferenceIsNotAProxy() {
+        Fixture fx = newFixture();
+
+        FeatureTypeInfo ft = catalog.getResource(fx.resourceId, FeatureTypeInfo.class);
+        FeatureTypeInfo raw = ModificationProxy.unwrap(ft);
+
+        List<AttributeTypeInfo> attributes = raw.getAttributes();
+        assertThat(attributes).isNotEmpty();
+        for (AttributeTypeInfo att : attributes) {
+            FeatureTypeInfo backRef = att.getFeatureType();
+            assertNotAModificationProxy("attribute '%s' featureType back-reference".formatted(att.getName()), backRef);
+            assertThat(backRef)
+                    .as("attribute back-reference points to the raw feature type")
+                    .isSameAs(raw);
+        }
+    }
+
+    @Test
+    void resourceReferencesAreNotProxies() {
+        Fixture fx = newFixture();
+
+        FeatureTypeInfo raw = ModificationProxy.unwrap(catalog.getResource(fx.resourceId, FeatureTypeInfo.class));
+
+        assertNotAModificationProxy("resource.store", raw.getStore());
+        assertNotAModificationProxy("resource.namespace", raw.getNamespace());
+        assertNotAModificationProxy(
+                "resource.store.workspace",
+                ModificationProxy.unwrap(raw.getStore()).getWorkspace());
+    }
+
+    @Test
+    void layerReferencesAreNotProxies() {
+        Fixture fx = newFixture();
+
+        LayerInfo raw = ModificationProxy.unwrap(catalog.getLayer(fx.layerId));
+
+        assertNotAModificationProxy("layer.resource", raw.getResource());
+        assertNotAModificationProxy("layer.defaultStyle", raw.getDefaultStyle());
+    }
+
+    @Test
+    void layerGroupMembersAreNotProxies() {
+        Fixture fx = newFixture();
+
+        LayerGroupInfo raw = ModificationProxy.unwrap(catalog.getLayerGroup(fx.layerGroupId));
+
+        assertThat(raw.getLayers()).isNotEmpty();
+        for (PublishedInfo member : raw.getLayers()) {
+            assertNotAModificationProxy("layer group member '%s'".formatted(member.getName()), member);
+        }
+        for (StyleInfo style : raw.getStyles()) {
+            if (style != null) {
+                assertNotAModificationProxy("layer group style '%s'".formatted(style.getName()), style);
+            }
+        }
+    }
+
+    /**
+     * Reproduces the reported failure: concurrent deep-cloning of {@code getAttributes()} (which Java-serializes each
+     * attribute and, through the {@code featureType} back-reference, whatever object graph it reaches) while other
+     * threads exercise intercepted getters/setters against the same shared graph.
+     *
+     * <p>Each cycle evicts the cache entry to force a fresh materialization: freshly embedded proxies have empty state
+     * maps, and the racing first-touch writes are what corrupt a concurrent {@code ObjectOutputStream} pass.
+     */
+    @Test
+    void concurrentAttributeCloningDoesNotCorruptSerialization() throws Exception {
+        Fixture fx = newFixture();
+        final int cycles = 500;
+        final int readers = 2;
+        final int writers = 2;
+        List<Throwable> failures = new CopyOnWriteArrayList<>();
+
+        ExecutorService executor = Executors.newFixedThreadPool(readers + writers);
+        try {
+            for (int cycle = 0; cycle < cycles && failures.isEmpty(); cycle++) {
+                cache.clear();
+                CyclicBarrier barrier = new CyclicBarrier(readers + writers);
+                List<Future<?>> tasks = new CopyOnWriteArrayList<>();
+                for (int r = 0; r < readers; r++) {
+                    tasks.add(executor.submit(() -> {
+                        await(barrier);
+                        cloneAttributesThroughProxy(fx, failures);
+                    }));
+                }
+                for (int w = 0; w < writers; w++) {
+                    final int salt = w;
+                    tasks.add(executor.submit(() -> {
+                        await(barrier);
+                        touchSharedGraph(fx, salt, failures);
+                    }));
+                }
+                for (Future<?> task : tasks) {
+                    task.get();
+                }
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(failures)
+                .as("no serialization corruption expected; got: %s"
+                        .formatted(failures.stream().map(String::valueOf).toList()))
+                .isEmpty();
+    }
+
+    private void cloneAttributesThroughProxy(Fixture fx, List<Throwable> failures) {
+        try {
+            FeatureTypeInfo ft = catalog.getResource(fx.resourceId, FeatureTypeInfo.class);
+            // collection getter through the proxy: deep clone, Java-serializing each attribute
+            ft.getAttributes();
+        } catch (RuntimeException e) {
+            failures.add(e);
+        }
+    }
+
+    /**
+     * Emulates concurrent request traffic touching the shared graph: intercepted getters and setters whose state lands
+     * in whatever object {@code att.getFeatureType()} exposes. Against an embedded shared proxy these are
+     * unsynchronized map writes; against a raw back-reference they are plain field reads/writes.
+     */
+    private void touchSharedGraph(Fixture fx, int salt, List<Throwable> failures) {
+        try {
+            FeatureTypeInfo raw = ModificationProxy.unwrap(catalog.getResource(fx.resourceId, FeatureTypeInfo.class));
+            List<AttributeTypeInfo> attributes = raw.getAttributes();
+            if (attributes.isEmpty()) {
+                return;
+            }
+            FeatureTypeInfo backRef = attributes.get(0).getFeatureType();
+            if (salt % 2 == 0) {
+                backRef.setTitle("title");
+                backRef.setAbstract("abstract");
+                backRef.setDescription("description");
+                backRef.setNativeName("ft");
+                backRef.setSRS("EPSG:4326");
+                backRef.setCqlFilter(null);
+                backRef.setMaxFeatures(1000);
+                backRef.setNumDecimals(8);
+                backRef.setEnabled(true);
+                backRef.setAdvertised(true);
+            } else {
+                backRef.getKeywords();
+                backRef.getAlias();
+                backRef.getResponseSRS();
+                backRef.getMetadata();
+                backRef.getMetadataLinks();
+                backRef.getDataLinks();
+            }
+        } catch (RuntimeException e) {
+            failures.add(e);
+        }
+    }
+
+    private static void await(CyclicBarrier barrier) {
+        try {
+            barrier.await();
+        } catch (Exception e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void assertNotAModificationProxy(String role, Object info) {
+        assertThat(info).as(role).isNotNull();
+        assertThat(ModificationProxy.handler(info))
+                .as("%s must not be a ModificationProxy: the DAO layer trades in raw objects only".formatted(role))
+                .isNull();
+    }
+
+    private CatalogPlugin newCachingCatalog() {
+        CatalogPlugin plugin = new CatalogPlugin();
+        PgconfigCatalogFacade pgconfigFacade =
+                (PgconfigCatalogFacade) new PgconfigBackendBuilder(db.getDataSource()).createCatalogFacade();
+        cache = newCache();
+        CachingCatalogFacade cachingFacade = new CachingCatalogFacade(pgconfigFacade, cache);
+        plugin.setFacade(cachingFacade);
+        return plugin;
+    }
+
+    private static Cache newCache() {
+        CaffeineCacheManager manager = new CaffeineCacheManager(CACHE_NAME);
+        return Objects.requireNonNull(manager.getCache(CACHE_NAME));
+    }
+
+    private Fixture newFixture() {
+        CatalogFactory factory = catalog.getFactory();
+
+        WorkspaceInfo ws = factory.createWorkspace();
+        ws.setName("ws1");
+        catalog.add(ws);
+
+        NamespaceInfo ns = factory.createNamespace();
+        ns.setPrefix("ws1");
+        ns.setURI("http://ws1.example");
+        catalog.add(ns);
+
+        DataStoreInfo store = factory.createDataStore();
+        store.setName("ds");
+        store.setWorkspace(ws);
+        store.setEnabled(true);
+        catalog.add(store);
+
+        FeatureTypeInfo ft = factory.createFeatureType();
+        ft.setName("ft");
+        ft.setNativeName("ft");
+        ft.setStore(store);
+        ft.setNamespace(ns);
+        ft.setEnabled(true);
+        ft.getAttributes().add(attribute(factory, "geom", org.locationtech.jts.geom.Geometry.class));
+        ft.getAttributes().add(attribute(factory, "name", String.class));
+        catalog.add(ft);
+
+        StyleInfo style = factory.createStyle();
+        style.setName("default-style");
+        style.setFilename("default-style.sld");
+        catalog.add(style);
+
+        LayerInfo layer = factory.createLayer();
+        layer.setResource(catalog.getResource(ft.getId(), FeatureTypeInfo.class));
+        layer.setDefaultStyle(catalog.getStyleByName("default-style"));
+        layer.setEnabled(true);
+        catalog.add(layer);
+
+        LayerGroupInfo group = factory.createLayerGroup();
+        group.setName("group");
+        group.getLayers().add(catalog.getLayer(layer.getId()));
+        group.getStyles().add(null);
+        catalog.add(group);
+
+        return new Fixture(ft.getId(), layer.getId(), group.getId());
+    }
+
+    private AttributeTypeInfo attribute(CatalogFactory factory, String name, Class<?> binding) {
+        AttributeTypeInfo att = factory.createAttribute();
+        att.setName(name);
+        att.setBinding(binding);
+        att.setMinOccurs(0);
+        att.setMaxOccurs(1);
+        att.setNillable(true);
+        return att;
+    }
+
+    private record Fixture(String resourceId, String layerId, String layerGroupId) {}
+}

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/PatchSerializationTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/PatchSerializationTest.java
@@ -254,9 +254,9 @@ public abstract class PatchSerializationTest {
         final Patch resolved = testPatch(patch);
         Set<StyleInfo> styles = resolved.get("styles").orElseThrow().value();
         StyleInfo defaultStyle = resolved.get("defaultStyle").orElseThrow().value();
-        assertModificationProxy(defaultStyle);
+        assertNotAProxy(defaultStyle);
         assertCatalogSet(defaultStyle);
-        styles.forEach(this::assertModificationProxy);
+        styles.forEach(this::assertNotAProxy);
         styles.forEach(this::assertCatalogSet);
 
         final Patch unresolved = roundtrip(patch);
@@ -314,7 +314,7 @@ public abstract class PatchSerializationTest {
     void settingsInfo_workspace() throws Exception {
         Patch resolved = testPatch("settings", data.faker().settingsInfo(data.workspaceA));
         SettingsInfo setting = resolved.get("settings").orElseThrow().value();
-        assertModificationProxy(setting.getWorkspace());
+        assertResolvedTo(data.workspaceA, setting.getWorkspace());
     }
 
     @Test
@@ -507,7 +507,7 @@ public abstract class PatchSerializationTest {
         final Patch sent = patch("settings", settingsProxy);
         final SettingsInfo received =
                 testPatchNoEquals(sent).get("settings").orElseThrow().value();
-        assertModificationProxy(workspaceProxy, received.getWorkspace());
+        assertResolvedTo(workspaceProxy, received.getWorkspace());
         ContactInfo contact = received.getContact();
         assertNotAProxy(contact);
         assertEquals(contactInfo, contact);
@@ -556,7 +556,7 @@ public abstract class PatchSerializationTest {
                 roundTrippedAndResolved.get("attributes").orElseThrow().value();
 
         for (AttributeTypeInfo att : rtripAtts) {
-            assertModificationProxy(ft, att.getFeatureType());
+            assertResolvedTo(ft, att.getFeatureType());
         }
     }
 
@@ -787,9 +787,8 @@ public abstract class PatchSerializationTest {
         boolean encodeByReference = ProxyUtils.encodeByReference(patchValue);
         if (encodeByReference) {
             Info decodedValue = resolved.getPatches().get(0).value();
-            Info decodedUnwrapped = assertModificationProxy(decodedValue);
-            Info orig = ModificationProxy.unwrap(patch.getPatches().get(0).value());
-            assertThat(decodedUnwrapped).isSameAs(orig);
+            Info orig = patch.getPatches().get(0).value();
+            assertResolvedTo(orig, decodedValue);
         }
 
         return resolved;
@@ -873,21 +872,16 @@ public abstract class PatchSerializationTest {
         }
     }
 
-    protected <I extends Info> I assertModificationProxy(I info) {
-        assertThat(ProxyUtils.isModificationProxy(info))
-                .as(() -> "%s should be a ModificationProxy, got %s".formatted(info.getId(), typeName(info)))
-                .isTrue();
-
-        I real = ModificationProxy.unwrap(info);
-        assertNotNull(real);
-        return real;
-    }
-
-    protected <I extends Info> I assertModificationProxy(I expected, I actual) {
-        I actualUnwrapped = assertModificationProxy(actual);
+    /**
+     * Asserts that a resolved reference is the raw catalog object itself: {@code ProxyUtils.resolve} returns raw
+     * implementations, never {@code ModificationProxy} wrappers, because resolved references get stored into object
+     * graphs that may be shared across threads.
+     */
+    protected <I extends Info> I assertResolvedTo(I expected, I actual) {
+        assertNotAProxy(actual);
         I expectedUnwrapped = ModificationProxy.unwrap(expected);
-        assertSame(expectedUnwrapped, actualUnwrapped);
-        return actualUnwrapped;
+        assertSame(expectedUnwrapped, actual);
+        return actual;
     }
 
     protected void assertResolvingProxy(Info info) {

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogPlugin.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogPlugin.java
@@ -429,7 +429,46 @@ public class CatalogPlugin extends CatalogImpl implements Catalog {
 
     @Override
     public void save(LayerInfo layer) {
+        saveDelegatedResourceProperties(layer);
         doSave(layer);
+    }
+
+    /**
+     * {@code LayerInfo.enabled} and {@code LayerInfo.advertised} are delegated properties: {@code LayerInfoImpl} reads
+     * and writes both through the layer's {@link ResourceInfo} (upstream keeps them there until the resource/publish
+     * split is complete). A dirty {@code enabled} or {@code advertised} on the layer proxy is therefore a modification
+     * of the resource object, and is routed here as a resource save of its own so it goes through the regular
+     * validation, event, and cache consistency path. This must happen before {@link #doSave doSave(layer)} commits the
+     * layer proxy onto the underlying object, after which the pending change is no longer distinguishable from the
+     * resource's current state.
+     */
+    private void saveDelegatedResourceProperties(LayerInfo layer) {
+        ModificationProxy proxy = ProxyUtils.handler(layer, ModificationProxy.class);
+        if (null == proxy) {
+            return;
+        }
+        List<String> dirtyProperties = proxy.getPropertyNames();
+        boolean enabledChanged = dirtyProperties.contains("enabled");
+        boolean advertisedChanged = dirtyProperties.contains("advertised");
+        if (!enabledChanged && !advertisedChanged) {
+            return;
+        }
+        ResourceInfo resource = layer.getResource();
+        if (null == resource || null == ProxyUtils.handler(resource, ModificationProxy.class)) {
+            return;
+        }
+        boolean resourceNeedsUpdate = false;
+        if (enabledChanged && resource.isEnabled() != layer.isEnabled()) {
+            resource.setEnabled(layer.isEnabled());
+            resourceNeedsUpdate = true;
+        }
+        if (advertisedChanged && resource.isAdvertised() != layer.isAdvertised()) {
+            resource.setAdvertised(layer.isAdvertised());
+            resourceNeedsUpdate = true;
+        }
+        if (resourceNeedsUpdate) {
+            doSave(resource);
+        }
     }
 
     public static LayerInfo getLayerByName(Catalog catalog, String workspace, String resourceName) {

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/ProxyUtils.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/resolving/ProxyUtils.java
@@ -246,6 +246,12 @@ public class ProxyUtils {
      * configuration, and processes nested references via type-specific methods. Returns null if unresolved and
      * {@link #failOnMissingReference(boolean)} is false; otherwise, throws an exception.
      *
+     * <p>Resolved references are returned as raw implementations, never wrapped in {@link ModificationProxy}: they get
+     * stored into materialized object graphs that may be shared across threads (e.g. by the catalog caching facade),
+     * and a live proxy inside such a graph is both mutated by reader threads and Java-serialized along with its
+     * unsynchronized state maps by {@code ModificationProxyCloner}, corrupting the stream under concurrency. This
+     * matches upstream {@code org.geoserver.catalog.impl.ResolvingProxyResolver}, which unwraps likewise.
+     *
      * @param <T> The type of {@link Info}.
      * @param unresolved The {@link Info} object to resolve; may be null.
      * @return The resolved {@link Info}, or {@code unresolved} if unresolved and not failing.
@@ -258,15 +264,20 @@ public class ProxyUtils {
         }
 
         T resolved = ModificationProxy.unwrap(unresolved);
-        if (isResolvingProxy(unresolved)) {
-            resolved = resolveResolvingProxy(resolved);
+        final boolean wasResolvingProxy = isResolvingProxy(unresolved);
+        if (wasResolvingProxy) {
+            resolved = ModificationProxy.unwrap(resolveResolvingProxy(resolved));
         }
 
         if (failOnNotFound && (resolved == null || isResolvingProxy(resolved))) {
             throw new IllegalArgumentException("Reference to %s not found".formatted(unresolved.getId()));
         }
 
-        if (resolved != null && !Proxy.isProxyClass(resolved.getClass())) {
+        /*
+         * A reference resolved through the catalog comes back fully materialized; re-traversing it with
+         * resolveInternal would mutate collections of an object other threads may already share
+         */
+        if (resolved != null && !wasResolvingProxy && !Proxy.isProxyClass(resolved.getClass())) {
             resolved = (T) resolveInternal(resolved);
         }
         return resolved;

--- a/src/catalog/plugin/src/test/java/org/geoserver/catalog/plugin/CatalogConformanceTest.java
+++ b/src/catalog/plugin/src/test/java/org/geoserver/catalog/plugin/CatalogConformanceTest.java
@@ -1770,6 +1770,26 @@ public abstract class CatalogConformanceTest {
         assertFalse(l2.getResource().isEnabled());
     }
 
+    /**
+     * {@code LayerInfo.advertised} is delegated to the resource just like {@code enabled}; saving the layer must
+     * persist the flag on the resource
+     */
+    @Test
+    void testAdvertiseLayer() {
+        addLayer();
+
+        LayerInfo l2 = catalog.getLayerByName(data.layerFeatureTypeA.getName());
+        assertTrue(l2.isAdvertised());
+        assertTrue(l2.getResource().isAdvertised());
+
+        l2.setAdvertised(false);
+        catalog.save(l2);
+
+        l2 = catalog.getLayerByName(l2.getName());
+        assertFalse(l2.isAdvertised());
+        assertFalse(l2.getResource().isAdvertised());
+    }
+
     @Test
     void testLayerEvents() {
         addFeatureType();


### PR DESCRIPTION
With the pgconfig backend and catalog caching enabled, GetCapabilities on workspaces with many layers, layer groups, and data security rules failed intermittently with OptionalDataException ("Error cloning serializable object").

The object graphs the caching facade shares across request threads contained live ModificationProxy instances, embedded at materialization time for 1:1 references and attribute back-references, and stored by reference resolution for layer group members. A ModificationProxy records pending changes in unsynchronized, non-transient maps. The security subsystem's layer group containment checks both write to those maps from every request thread and Java-serialize them while deep-cloning attribute lists; a write landing during another thread's serialization corrupts the
stream. A corrupted map keeps failing every subsequent request until the cache entry is evicted, which is why the errors persisted across restarts.

The fix restores the invariant this design intended all along: everything below CatalogPlugin trades in raw objects, and proxy wrapping is exclusively a CatalogPlugin outbound concern applied per retrieval.
Materialization now sets raw references and reference resolution unwraps what the catalog returns. A new integration test reproduces the corruption under concurrency and asserts the invariant.

Removing the embedded proxies revealed that the LayerInfo enabled and advertised flags, which the object model delegates to the resource, were persisted only by accident through a shared proxy's dirty state. CatalogPlugin.save(LayerInfo) now routes changes to these delegated properties through a resource save of their own, keeping listeners and caches consistent on all backends.

on-behalf-of: @camptocamp <info@camptocamp.com>