### PR TITLE
[Backport release/3.0.x] fix(catalog): don't cache by-name lookups under non-canonical name keys

### DIFF
--- a/src/catalog/cache/src/main/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacade.java
+++ b/src/catalog/cache/src/main/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacade.java
@@ -194,9 +194,14 @@ public class CachingCatalogFacade extends ForwardingExtendedCatalogFacade {
         return support.get(id(id, STYLE), () -> super.getStyle(id));
     }
 
+    /**
+     * An unqualified lookup can fall back to a workspace style when no global style has the requested name;
+     * {@link CachingCatalogFacadeContainmentSupport#getByName getByName} only caches the result when the requested name
+     * is the style's canonical prefixed name.
+     */
     @Override
     public StyleInfo getStyleByName(@NonNull String name) {
-        return support.get(name(name, STYLE), () -> super.getStyleByName(name));
+        return support.getByName(name(name, STYLE), () -> super.getStyleByName(name));
     }
 
     @Override
@@ -213,9 +218,14 @@ public class CachingCatalogFacade extends ForwardingExtendedCatalogFacade {
         return support.get(id(id, LAYER), () -> super.getLayer(id));
     }
 
+    /**
+     * The requested name may be unqualified while layers always cache under their namespace-prefixed name;
+     * {@link CachingCatalogFacadeContainmentSupport#getByName getByName} only caches the result when the requested name
+     * is the layer's canonical prefixed name.
+     */
     @Override
     public LayerInfo getLayerByName(@NonNull String name) {
-        return support.get(name(name, LAYER), () -> super.getLayerByName(name));
+        return support.getByName(name(name, LAYER), () -> super.getLayerByName(name));
     }
 
     @Override
@@ -230,7 +240,7 @@ public class CachingCatalogFacade extends ForwardingExtendedCatalogFacade {
 
     @Override
     public LayerGroupInfo getLayerGroupByName(@NonNull String name) {
-        return support.get(name(name, LAYERGROUP), () -> super.getLayerGroupByName(name));
+        return support.getByName(name(name, LAYERGROUP), () -> super.getLayerGroupByName(name));
     }
 
     @Override

--- a/src/catalog/cache/src/main/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeContainmentSupport.java
+++ b/src/catalog/cache/src/main/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeContainmentSupport.java
@@ -32,6 +32,7 @@ import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.cloud.event.info.ConfigInfoType;
 import org.geoserver.cloud.event.info.InfoEvent;
 import org.springframework.cache.Cache;
+import org.springframework.cache.Cache.ValueWrapper;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
 
 /** @since 1.7 */
@@ -160,6 +161,39 @@ class CachingCatalogFacadeContainmentSupport {
             cache.evict(key);
         }
         return value;
+    }
+
+    /**
+     * Cache-through lookup for by-name queries that may be issued with a name that is not the canonical
+     * {@link InfoEvent#prefixedName(org.geoserver.catalog.Info) prefixed name} of the object they resolve to.
+     *
+     * <p>{@code getLayerByName("roads")} can resolve to the layer {@code topp:roads}, and
+     * {@code getStyleByName("roads")} can fall back to a workspace style when there's no global style named
+     * {@code roads}. Caching such results under the requested key is unsafe: {@link #put put} and {@link #evict evict}
+     * always use the canonical prefixed name, hence the entry would never be evicted, and would keep answering with an
+     * arbitrary object when several workspaces have objects with the same local name.
+     *
+     * <p>The loaded value is hence cached only when {@code key} is its canonical name key, and returned without caching
+     * otherwise.
+     */
+    public <T extends CatalogInfo> T getByName(InfoNameKey key, Callable<T> loader) {
+        ValueWrapper cached = cache.get(key);
+        Object cachedValue = cached == null ? null : cached.get();
+        if (cachedValue != null) {
+            @SuppressWarnings("unchecked")
+            T value = (T) cachedValue;
+            return value;
+        }
+        T value = load(loader);
+        if (value != null && key.equals(InfoNameKey.valueOf(value))) {
+            put(key, value);
+        }
+        return value;
+    }
+
+    @SneakyThrows
+    private static <T> T load(Callable<T> loader) {
+        return loader.call();
     }
 
     public List<LayerInfo> getLayersByResource(String resourceInfoId, Callable<List<LayerInfo>> loader) {

--- a/src/catalog/cache/src/test/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeContainmentSupportTest.java
+++ b/src/catalog/cache/src/test/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeContainmentSupportTest.java
@@ -12,6 +12,7 @@ import static org.geoserver.cloud.catalog.cache.CachingCatalogFacadeTest.once;
 import static org.geoserver.cloud.event.info.ConfigInfoType.RESOURCE;
 import static org.geoserver.cloud.event.info.ConfigInfoType.STORE;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -142,6 +143,47 @@ class CachingCatalogFacadeContainmentSupportTest {
 
         assertThat(support.get(nameKey, loader)).isSameAs(ws);
         assertCached(nameKey, ws);
+    }
+
+    @Test
+    @DisplayName("getByName() caches when the requested key is the object's canonical name key")
+    void testGetByNameCanonicalKeyIsCached() throws Exception {
+        LayerInfo layer = stubReal(LayerInfo.class, "l1", "roads");
+        InfoNameKey canonicalKey = InfoNameKey.valueOf(layer);
+
+        Callable<LayerInfo> loader = loader();
+        when(loader.call()).thenReturn(layer);
+
+        assertThat(support.getByName(canonicalKey, loader)).isSameAs(layer);
+        assertCached(canonicalKey, layer);
+
+        assertThat(support.getByName(canonicalKey, loader)).isSameAs(layer);
+        verify(loader, once()).call();
+    }
+
+    @Test
+    @DisplayName("getByName() does not cache when the requested key differs from the object's canonical name key")
+    void testGetByNameNonCanonicalKeyIsNotCached() throws Exception {
+        LayerInfo layer = stubReal(LayerInfo.class, "l1", "roads");
+        InfoNameKey localNameKey = InfoNameKey.valueOf("roads", ConfigInfoType.LAYER);
+
+        Callable<LayerInfo> loader = loader();
+        when(loader.call()).thenReturn(layer);
+
+        assertThat(support.getByName(localNameKey, loader)).isSameAs(layer);
+        assertNotCached(localNameKey);
+
+        assertThat(support.getByName(localNameKey, loader)).isSameAs(layer);
+        verify(loader, times(2)).call();
+    }
+
+    @Test
+    void testGetByNameDoesNotCacheNullValues() throws Exception {
+        InfoNameKey key = InfoNameKey.valueOf("roads", ConfigInfoType.LAYER);
+        Callable<LayerInfo> loader = loader();
+
+        assertThat(support.getByName(key, loader)).isNull();
+        assertNotCached(key);
     }
 
     @Test

--- a/src/catalog/cache/src/test/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeTest.java
+++ b/src/catalog/cache/src/test/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeTest.java
@@ -362,11 +362,56 @@ class CachingCatalogFacadeTest {
         facade = new CachingCatalogFacade(subject);
         assertThrows(NullPointerException.class, () -> facade.getLayerByName(null));
 
-        LayerInfo info = stub(LayerInfo.class);
-        when(subject.getLayerByName(info.getName())).thenReturn(info);
+        LayerInfo info = stubLayer("topp", "roads");
+        when(subject.getLayerByName("topp:roads")).thenReturn(info);
 
-        assertSameTimesN(info, () -> facade.getLayerByName(info.getName()), 3);
-        verify(subject, once()).getLayerByName(info.getName());
+        assertSameTimesN(info, () -> facade.getLayerByName("topp:roads"), 3);
+        verify(subject, once()).getLayerByName("topp:roads");
+    }
+
+    @Test
+    void testGetLayerByNameUnqualifiedNameNotCached() {
+        facade = new CachingCatalogFacade(subject);
+
+        LayerInfo info = stubLayer("topp", "roads");
+        when(subject.getLayerByName("roads")).thenReturn(info);
+
+        assertSameTimesN(info, () -> facade.getLayerByName("roads"), 3);
+        verify(subject, times(3)).getLayerByName("roads");
+    }
+
+    @Test
+    void testGetLayerByNameSameLocalNameInMultipleWorkspaces() {
+        facade = new CachingCatalogFacade(subject);
+
+        LayerInfo draftRoads = stubLayer("draft", "roads");
+        LayerInfo publicRoads = stubLayer("public", "roads");
+        when(subject.getLayerByName("draft:roads")).thenReturn(draftRoads);
+        when(subject.getLayerByName("public:roads")).thenReturn(publicRoads);
+        when(subject.getLayerByName("roads")).thenReturn(draftRoads);
+
+        assertSame(draftRoads, facade.getLayerByName("roads"));
+        assertSame(publicRoads, facade.getLayerByName("public:roads"));
+        assertSame(draftRoads, facade.getLayerByName("draft:roads"));
+
+        // the ambiguous unqualified lookup must not pin its first result: when the backend
+        // resolves it differently (e.g. the draft layer was removed), the cache must not
+        // keep answering with the previously returned layer
+        when(subject.getLayerByName("roads")).thenReturn(publicRoads);
+        assertSame(publicRoads, facade.getLayerByName("roads"));
+    }
+
+    private LayerInfo stubLayer(String nsPrefix, String localName) {
+        LayerInfo layer = mock(LayerInfo.class);
+        ResourceInfo resource = mock(ResourceInfo.class);
+        NamespaceInfo namespace = mock(NamespaceInfo.class);
+        LenientStubber lenient = lenient();
+        lenient.when(layer.getId()).thenReturn(nsPrefix + ":" + localName + "-id");
+        lenient.when(layer.getName()).thenReturn(localName);
+        lenient.when(layer.getResource()).thenReturn(resource);
+        lenient.when(resource.getNamespace()).thenReturn(namespace);
+        lenient.when(namespace.getPrefix()).thenReturn(nsPrefix);
+        return layer;
     }
 
     @Test
@@ -419,6 +464,19 @@ class CachingCatalogFacadeTest {
 
         assertSameTimesN(info, () -> facade.getLayerGroupByName(info.getName()), 3);
         verify(subject, once()).getLayerGroupByName(info.getName());
+    }
+
+    @Test
+    void testGetLayerGroupByNameWorkspaceGroupNotCached() {
+        facade = new CachingCatalogFacade(subject);
+
+        WorkspaceInfo ws = stub(WorkspaceInfo.class);
+        LayerGroupInfo info = stub(LayerGroupInfo.class);
+        lenient().when(info.getWorkspace()).thenReturn(ws);
+        when(subject.getLayerGroupByName(info.getName())).thenReturn(info);
+
+        assertSameTimesN(info, () -> facade.getLayerGroupByName(info.getName()), 3);
+        verify(subject, times(3)).getLayerGroupByName(info.getName());
     }
 
     @Test
@@ -554,6 +612,19 @@ class CachingCatalogFacadeTest {
 
         assertSameTimesN(info, () -> facade.getStyleByName(info.getName()), 3);
         verify(subject, once()).getStyleByName(info.getName());
+    }
+
+    @Test
+    void testGetStyleByNameWorkspaceStyleNotCached() {
+        facade = new CachingCatalogFacade(subject);
+
+        WorkspaceInfo ws = stub(WorkspaceInfo.class);
+        StyleInfo info = stub(StyleInfo.class);
+        lenient().when(info.getWorkspace()).thenReturn(ws);
+        when(subject.getStyleByName(info.getName())).thenReturn(info);
+
+        assertSameTimesN(info, () -> facade.getStyleByName(info.getName()), 3);
+        verify(subject, times(3)).getStyleByName(info.getName());
     }
 
     @Test


### PR DESCRIPTION
Backport #885
 **Authored by:** @groldan