### PR TITLE
Upgrade to latest GeoServer 2.28.4-SNAPSHOT

### DIFF
--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/CoverageAccess.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/config/dto/CoverageAccess.java
@@ -21,4 +21,6 @@ public class CoverageAccess {
     private int maxPoolSize;
     private QueueType queueType;
     private long imageIOCacheThreshold;
+    private int granuleCacheMaxSizeMB;
+    private int granuleCacheThresholdKB;
 }

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/PatchSerializationTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/PatchSerializationTest.java
@@ -644,6 +644,8 @@ public abstract class PatchSerializationTest {
         CoverageAccessInfo coverageInfo = new CoverageAccessInfoImpl();
         coverageInfo.setCorePoolSize(10);
         coverageInfo.setQueueType(QueueType.UNBOUNDED);
+        coverageInfo.setGranuleCacheMaxSizeMB(128);
+        coverageInfo.setGranuleCacheThresholdKB(512);
 
         testPatch("coverageInfo", coverageInfo);
     }

--- a/src/extensions/input-formats/vector-formats/src/test/java/org/geoserver/cloud/autoconfigure/vectorformats/pmtiles/PMTilesPluginAutoConfigurationTest.java
+++ b/src/extensions/input-formats/vector-formats/src/test/java/org/geoserver/cloud/autoconfigure/vectorformats/pmtiles/PMTilesPluginAutoConfigurationTest.java
@@ -134,14 +134,14 @@ class PMTilesPluginAutoConfigurationTest {
             contextRunner.run(context -> assertThat(context)
                     .hasNotFailed()
                     .doesNotHaveBean(PMTilesWmsIntegrationConfiguration.class)
-                    .doesNotHaveBean("pmTilesScaleSetter"));
+                    .doesNotHaveBean("vectorTilesScaleSetter"));
 
             contextRunner
                     .withPropertyValues("geoserver.service.wms.enabled=true")
                     .run(context -> assertThat(context)
                             .hasNotFailed()
                             .hasSingleBean(PMTilesWmsIntegrationConfiguration.class)
-                            .hasBean("pmTilesScaleSetter"));
+                            .hasBean("vectorTilesScaleSetter"));
         }
     }
 }

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -33,7 +33,7 @@
     <jackson.version.annotations>2.21</jackson.version.annotations>
     <gs.version>2.28.4-SNAPSHOT</gs.version>
     <gt.version>34-SNAPSHOT</gt.version>
-    <wicket.version>9.21.0</wicket.version>
+    <wicket.version>9.23.0</wicket.version>
     <acl.version>2.4.0</acl.version>
     <postgresql.version>42.7.7</postgresql.version>
     <lombok.version>1.18.42</lombok.version>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -40,7 +40,6 @@
     <mapstruct.version>1.6.3</mapstruct.version>
     <flyway.version>11.16.0</flyway.version>
     <cloud-dependencies-bom.version>1.0.2</cloud-dependencies-bom.version>
-    <tileverse.version>1.4.0</tileverse.version>
     <testcontainers.version>1.21.4</testcontainers.version>
     <fork.javac>false</fork.javac>
     <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
@@ -83,13 +82,6 @@
         <groupId>io.tileverse</groupId>
         <artifactId>cloud-dependencies-bom</artifactId>
         <version>${cloud-dependencies-bom.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.tileverse</groupId>
-        <artifactId>tileverse-bom</artifactId>
-        <version>${tileverse.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
* Adapt PMTiles test to renamed vectorTilesScaleSetter bean
* Update CoverageAccess Jackson DTO to [GEOS-12151]
* Let the tileverse version be resolved transitively
* Upgrade wicket.version:9.21.0 -> 9.23.0

on-behalf-of: @camptocamp <info@camptocamp.com>