### PR TITLE
fix(pgconfig): race contidion with missing security directory before access rule DAOs load

### DIFF
--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/config/catalog/backend/pgconfig/PgconfigGeoServerResourceLoader.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/config/catalog/backend/pgconfig/PgconfigGeoServerResourceLoader.java
@@ -22,6 +22,22 @@ public class PgconfigGeoServerResourceLoader extends GeoServerResourceLoader {
         this.resourceStore = resourceStore;
         File baseDirectory = resourceStore.get("").dir();
         setBaseDirectory(baseDirectory);
+        createSecurityDirectory(resourceStore);
+    }
+
+    /**
+     * Creates the {@code security/} directory on a fresh database, before any {@code AbstractAccessRuleDAO} bean
+     * constructs.
+     *
+     * <p>The access rule DAOs ({@code rest.properties}, {@code layers.properties}, etc.) load their rules at bean
+     * construction time and permanently keep an empty rule set when the security directory does not exist at that
+     * point: their re-load check depends on a property-file watcher that is only created when the directory exists.
+     * GeoServer's security config migration creates the directory otherwise, but it runs after all beans are
+     * constructed. On a fresh database that ordering left the REST API with empty access rules, denying every request
+     * with a 403 status code.
+     */
+    private void createSecurityDirectory(PgconfigResourceStore store) {
+        store.get("security").dir();
     }
 
     public @NonNull LockProvider getLockProvider() {

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/catalog/PgconfigCatalogBackendConformanceIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/catalog/PgconfigCatalogBackendConformanceIT.java
@@ -29,6 +29,7 @@ import org.springframework.integration.jdbc.lock.DefaultLockRepository;
 import org.springframework.integration.jdbc.lock.JdbcLockRegistry;
 import org.springframework.integration.jdbc.lock.LockRepository;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -75,6 +76,11 @@ class PgconfigCatalogBackendConformanceIT extends CatalogConformanceTest {
         // override default table prefix "INT" by "RESOURCE_" (matching table definition
         // RESOURCE_LOCK in init.XXX.sql
         lockRepository.setPrefix("RESOURCE_");
+        // initialize like the pgconfigLockRepository bean in PgconfigBackendConfiguration does, the
+        // transaction templates are required to acquire locks
+        lockRepository.setTransactionManager(new DataSourceTransactionManager(dataSource));
+        lockRepository.afterPropertiesSet();
+        lockRepository.afterSingletonsInstantiated();
         return lockRepository;
     }
 

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/DbBackedFileSynchronizerIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/DbBackedFileSynchronizerIT.java
@@ -28,6 +28,7 @@ import org.springframework.integration.jdbc.lock.DefaultLockRepository;
 import org.springframework.integration.jdbc.lock.JdbcLockRegistry;
 import org.springframework.integration.jdbc.lock.LockRepository;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.util.FileSystemUtils;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -91,6 +92,11 @@ class DbBackedFileSynchronizerIT {
         DefaultLockRepository lockRepository = new DefaultLockRepository(dataSource, "test-instance");
         // override default table prefix "INT" by "RESOURCE_" (matching table RESOURCE_LOCK in flyway ddl scripts)
         lockRepository.setPrefix("RESOURCE_");
+        // initialize like the pgconfigLockRepository bean in PgconfigBackendConfiguration does, the
+        // transaction templates are required to acquire locks
+        lockRepository.setTransactionManager(new DataSourceTransactionManager(dataSource));
+        lockRepository.afterPropertiesSet();
+        lockRepository.afterSingletonsInstantiated();
         return lockRepository;
     }
 

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigDbBackedPatternsIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigDbBackedPatternsIT.java
@@ -25,6 +25,7 @@ import org.springframework.integration.jdbc.lock.DefaultLockRepository;
 import org.springframework.integration.jdbc.lock.JdbcLockRegistry;
 import org.springframework.integration.jdbc.lock.LockRepository;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.util.FileSystemUtils;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -71,6 +72,11 @@ class PgconfigDbBackedPatternsIT {
         DefaultLockRepository lockRepository = new DefaultLockRepository(dataSource, "test-instance");
         // override default table prefix "INT" by "RESOURCE_" (matching table RESOURCE_LOCK in flyway ddl scripts)
         lockRepository.setPrefix("RESOURCE_");
+        // initialize like the pgconfigLockRepository bean in PgconfigBackendConfiguration does, the
+        // transaction templates are required to acquire locks
+        lockRepository.setTransactionManager(new DataSourceTransactionManager(dataSource));
+        lockRepository.afterPropertiesSet();
+        lockRepository.afterSingletonsInstantiated();
         return lockRepository;
     }
 

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceIT.java
@@ -56,6 +56,7 @@ import org.springframework.integration.jdbc.lock.DefaultLockRepository;
 import org.springframework.integration.jdbc.lock.JdbcLockRegistry;
 import org.springframework.integration.jdbc.lock.LockRepository;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -151,6 +152,11 @@ class PgconfigResourceIT {
         DefaultLockRepository lockRepository = new DefaultLockRepository(dataSource, "test-instance");
         // override default table prefix "INT" by "RESOURCE_" (matching table RESOURCE_LOCK in flyway ddl scripts)
         lockRepository.setPrefix("RESOURCE_");
+        // initialize like the pgconfigLockRepository bean in PgconfigBackendConfiguration does, the
+        // transaction templates are required to acquire locks
+        lockRepository.setTransactionManager(new DataSourceTransactionManager(dataSource));
+        lockRepository.afterPropertiesSet();
+        lockRepository.afterSingletonsInstantiated();
         return lockRepository;
     }
 

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/config/catalog/backend/pgconfig/PgconfigGeoServerResourceLoaderIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/config/catalog/backend/pgconfig/PgconfigGeoServerResourceLoaderIT.java
@@ -1,0 +1,84 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.config.catalog.backend.pgconfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import javax.sql.DataSource;
+import org.geoserver.cloud.backend.pgconfig.resource.FileSystemResourceStoreCache;
+import org.geoserver.cloud.backend.pgconfig.resource.PgconfigLockProvider;
+import org.geoserver.cloud.backend.pgconfig.resource.PgconfigResourceStore;
+import org.geoserver.cloud.backend.pgconfig.support.PgConfigTestContainer;
+import org.geoserver.cloud.backend.pgconfig.support.PgconfigTestDatabaseSupport;
+import org.geoserver.platform.resource.Resource.Type;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.integration.jdbc.lock.DefaultLockRepository;
+import org.springframework.integration.jdbc.lock.JdbcLockRegistry;
+import org.springframework.integration.jdbc.lock.LockRepository;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+
+@org.testcontainers.junit.jupiter.Testcontainers(disabledWithoutDocker = true)
+class PgconfigGeoServerResourceLoaderIT {
+
+    @org.testcontainers.junit.jupiter.Container
+    static PgConfigTestContainer container = new PgConfigTestContainer();
+
+    @RegisterExtension
+    PgconfigTestDatabaseSupport db = new PgconfigTestDatabaseSupport(container);
+
+    @TempDir
+    File cacheDirectory;
+
+    private PgconfigResourceStore store;
+
+    @BeforeEach
+    void setUp() {
+        PgconfigLockProvider lockProvider = new PgconfigLockProvider(new JdbcLockRegistry(lockRepository()));
+        FileSystemResourceStoreCache cache = FileSystemResourceStoreCache.ofProvidedDirectory(
+                cacheDirectory.toPath(),
+                PgconfigResourceStore.antPathMatcher(PgconfigBackendProperties.defaultDbBackedFilePatterns()));
+        store = new PgconfigResourceStore(
+                cache,
+                db.getTemplate(),
+                lockProvider,
+                PgconfigResourceStore.defaultIgnoredResources(),
+                PgconfigResourceStore.antPathMatcher(PgconfigBackendProperties.defaultDbBackedFilePatterns()));
+    }
+
+    private LockRepository lockRepository() {
+        DataSource dataSource = db.getDataSource();
+        DefaultLockRepository lockRepository = new DefaultLockRepository(dataSource);
+        lockRepository.setPrefix("RESOURCE_");
+        // initialize like the pgconfigLockRepository bean in PgconfigBackendConfiguration does, the
+        // transaction templates are required to acquire locks
+        lockRepository.setTransactionManager(new DataSourceTransactionManager(dataSource));
+        lockRepository.afterPropertiesSet();
+        lockRepository.afterSingletonsInstantiated();
+        return lockRepository;
+    }
+
+    /**
+     * The security directory must exist before any {@code AbstractAccessRuleDAO} bean constructs.
+     *
+     * <p>The access rule DAOs (e.g. {@code rest.properties}, {@code layers.properties}) load their rules at bean
+     * construction time and permanently keep an empty rule set when the security directory does not exist at that
+     * point, because their re-load check depends on a property-file watcher that is only created when the directory
+     * exists. GeoServer's security config migration creates the directory only after all beans are constructed. On a
+     * fresh pgconfig database that ordering left the REST API denying every request with 403.
+     */
+    @Test
+    void createsSecurityDirectoryOnFreshDatabase() {
+        assertThat(store.get("security").getType()).isEqualTo(Type.UNDEFINED);
+
+        new PgconfigGeoServerResourceLoader(store);
+
+        assertThat(store.get("security").getType()).isEqualTo(Type.DIRECTORY);
+    }
+}


### PR DESCRIPTION
A startup race condition on a fresh database: the access rule DAOs read their property files at bean construction time, while the security config migration creates security/ only after all beans are constructed. Normally some other security bean persists its defaults first and the directory exists by the time the DAOs read. When the race is lost, `AbstractAccessRuleDAO` keeps an empty rule set for good, and with no REST rules every request is denied with 403 until restart. Only observed on a fresh database with the host under heavy load.

Fix: create `security/` in `PgconfigGeoServerResourceLoader`'s constructor, which runs before any rule DAO bean.

Also initialize the test `DefaultLockRepository` instances like the pgconfigLockRepository bean does; the DAOs now hold a property-file watcher and acquire real resource locks, which threw on the uninitialized repositories.

on-behalf-of: @multiversio <info@multivers.io>