### PR TITLE
[Backport release/2.28.x] fix(pgconfig): race contidion with missing security directory before access rule DAOs load

### DIFF
--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/config/catalog/backend/pgconfig/PgconfigGeoServerResourceLoader.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/config/catalog/backend/pgconfig/PgconfigGeoServerResourceLoader.java
@@ -22,5 +22,21 @@ public class PgconfigGeoServerResourceLoader extends GeoServerResourceLoader {
         super(resourceStore);
         File baseDirectory = resourceStore.get("").dir();
         setBaseDirectory(baseDirectory);
+        createSecurityDirectory(resourceStore);
+    }
+
+    /**
+     * Creates the {@code security/} directory on a fresh database, before any {@code AbstractAccessRuleDAO} bean
+     * constructs.
+     *
+     * <p>The access rule DAOs ({@code rest.properties}, {@code layers.properties}, etc.) load their rules at bean
+     * construction time and permanently keep an empty rule set when the security directory does not exist at that
+     * point: their re-load check depends on a property-file watcher that is only created when the directory exists.
+     * GeoServer's security config migration creates the directory otherwise, but it runs after all beans are
+     * constructed. On a fresh database that ordering left the REST API with empty access rules, denying every request
+     * with a 403 status code.
+     */
+    private void createSecurityDirectory(ResourceStore store) {
+        store.get("security").dir();
     }
 }

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/catalog/PgconfigCatalogBackendConformanceIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/catalog/PgconfigCatalogBackendConformanceIT.java
@@ -80,6 +80,9 @@ class PgconfigCatalogBackendConformanceIT extends CatalogConformanceTest {
         lockRepository.setPrefix("RESOURCE_");
         // time in ms to expire dead locks (10k is the default)
         lockRepository.setTimeToLive(300_000);
+        // initialize like the pgconfigLockRepository bean in PgconfigBackendConfiguration does, the
+        // transaction templates created by afterPropertiesSet() are required to acquire locks
+        lockRepository.afterPropertiesSet();
         return lockRepository;
     }
 

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/DbBackedFileSynchronizerIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/DbBackedFileSynchronizerIT.java
@@ -91,6 +91,9 @@ class DbBackedFileSynchronizerIT {
         DefaultLockRepository lockRepository = new DefaultLockRepository(dataSource, "test-instance");
         // override default table prefix "INT" by "RESOURCE_" (matching table RESOURCE_LOCK in flyway ddl scripts)
         lockRepository.setPrefix("RESOURCE_");
+        // initialize like the pgconfigLockRepository bean in PgconfigBackendConfiguration does, the
+        // transaction templates created by afterPropertiesSet() are required to acquire locks
+        lockRepository.afterPropertiesSet();
         return lockRepository;
     }
 

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigDbBackedPatternsIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigDbBackedPatternsIT.java
@@ -71,6 +71,9 @@ class PgconfigDbBackedPatternsIT {
         DefaultLockRepository lockRepository = new DefaultLockRepository(dataSource, "test-instance");
         // override default table prefix "INT" by "RESOURCE_" (matching table RESOURCE_LOCK in flyway ddl scripts)
         lockRepository.setPrefix("RESOURCE_");
+        // initialize like the pgconfigLockRepository bean in PgconfigBackendConfiguration does, the
+        // transaction templates created by afterPropertiesSet() are required to acquire locks
+        lockRepository.afterPropertiesSet();
         return lockRepository;
     }
 

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceIT.java
@@ -154,6 +154,9 @@ class PgconfigResourceIT {
         lockRepository.setPrefix("RESOURCE_");
         // time in ms to expire dead locks (10k is the default)
         lockRepository.setTimeToLive(300_000);
+        // initialize like the pgconfigLockRepository bean in PgconfigBackendConfiguration does, the
+        // transaction templates created by afterPropertiesSet() are required to acquire locks
+        lockRepository.afterPropertiesSet();
         return lockRepository;
     }
 

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/config/catalog/backend/pgconfig/PgconfigGeoServerResourceLoaderIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/config/catalog/backend/pgconfig/PgconfigGeoServerResourceLoaderIT.java
@@ -1,0 +1,81 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.config.catalog.backend.pgconfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import javax.sql.DataSource;
+import org.geoserver.cloud.backend.pgconfig.resource.FileSystemResourceStoreCache;
+import org.geoserver.cloud.backend.pgconfig.resource.PgconfigLockProvider;
+import org.geoserver.cloud.backend.pgconfig.resource.PgconfigResourceStore;
+import org.geoserver.cloud.backend.pgconfig.support.PgConfigTestContainer;
+import org.geoserver.cloud.backend.pgconfig.support.PgconfigTestDatabaseSupport;
+import org.geoserver.platform.resource.Resource.Type;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.integration.jdbc.lock.DefaultLockRepository;
+import org.springframework.integration.jdbc.lock.JdbcLockRegistry;
+import org.springframework.integration.jdbc.lock.LockRepository;
+
+@org.testcontainers.junit.jupiter.Testcontainers(disabledWithoutDocker = true)
+class PgconfigGeoServerResourceLoaderIT {
+
+    @org.testcontainers.junit.jupiter.Container
+    static PgConfigTestContainer container = new PgConfigTestContainer();
+
+    @RegisterExtension
+    PgconfigTestDatabaseSupport db = new PgconfigTestDatabaseSupport(container);
+
+    @TempDir
+    File cacheDirectory;
+
+    private PgconfigResourceStore store;
+
+    @BeforeEach
+    void setUp() {
+        PgconfigLockProvider lockProvider = new PgconfigLockProvider(new JdbcLockRegistry(lockRepository()));
+        FileSystemResourceStoreCache cache = FileSystemResourceStoreCache.ofProvidedDirectory(
+                cacheDirectory.toPath(),
+                PgconfigResourceStore.antPathMatcher(PgconfigBackendProperties.defaultDbBackedFilePatterns()));
+        store = new PgconfigResourceStore(
+                cache,
+                db.getTemplate(),
+                lockProvider,
+                PgconfigResourceStore.defaultIgnoredResources(),
+                PgconfigResourceStore.antPathMatcher(PgconfigBackendProperties.defaultDbBackedFilePatterns()));
+    }
+
+    private LockRepository lockRepository() {
+        DataSource dataSource = db.getDataSource();
+        DefaultLockRepository lockRepository = new DefaultLockRepository(dataSource);
+        lockRepository.setPrefix("RESOURCE_");
+        // initialize like the pgconfigLockRepository bean in PgconfigBackendConfiguration does, the
+        // transaction templates created by afterPropertiesSet() are required to acquire locks
+        lockRepository.afterPropertiesSet();
+        return lockRepository;
+    }
+
+    /**
+     * The security directory must exist before any {@code AbstractAccessRuleDAO} bean constructs.
+     *
+     * <p>The access rule DAOs (e.g. {@code rest.properties}, {@code layers.properties}) load their rules at bean
+     * construction time and permanently keep an empty rule set when the security directory does not exist at that
+     * point, because their re-load check depends on a property-file watcher that is only created when the directory
+     * exists. GeoServer's security config migration creates the directory only after all beans are constructed. On a
+     * fresh pgconfig database that ordering left the REST API denying every request with 403.
+     */
+    @Test
+    void createsSecurityDirectoryOnFreshDatabase() {
+        assertThat(store.get("security").getType()).isEqualTo(Type.UNDEFINED);
+
+        new PgconfigGeoServerResourceLoader(store);
+
+        assertThat(store.get("security").getType()).isEqualTo(Type.DIRECTORY);
+    }
+}


### PR DESCRIPTION
Backport https://github.com/geoserver/geoserver-cloud/pull/892
Authored by: @groldan