### PR TITLE
feat(control-flow): throttling metrics, dashboards, and per-service rule configuration

### DIFF
--- a/compose/monitoring/MONITORING.md
+++ b/compose/monitoring/MONITORING.md
@@ -253,6 +253,18 @@ Count of healthy replicas per service:
 count by (service) (up{job="geoserver-cloud-services"} == 1)
 ```
 
+## Control-Flow Metrics
+
+Services running the control-flow extension export throttling gauges on `/actuator/prometheus`
+when `geoserver.metrics.enabled` is not `false`: the global running/blocked request counts and
+per-rule limit/running/waiting/queue gauges. The **GeoServer Control-Flow** dashboard
+(`geoserver-controlflow`) visualizes them; the overview dashboard shows the two global gauges.
+
+The full metric inventory, example PromQL queries, and the Grafana recipes the dashboard is
+built from are documented in the
+[control-flow metrics reference](https://geoserver.org/geoserver-cloud/user-guide/controlflow-metrics-reference/)
+of the user guide.
+
 ## Configuration
 
 ### Prometheus Configuration

--- a/compose/monitoring/grafana/provisioning/dashboards/geoserver-cloud-overview.json
+++ b/compose/monitoring/grafana/provisioning/dashboards/geoserver-cloud-overview.json
@@ -703,6 +703,68 @@
       ],
       "title": "JVM Threads",
       "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus"},
+      "description": "Requests currently admitted past control-flow, per service. Empty when the control-flow extension is disabled.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+          "links": [
+            {"title": "Control-Flow dashboard", "url": "/d/geoserver-controlflow/geoserver-control-flow?var-application=${__field.labels.application}"}
+          ],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 24},
+      "id": 100,
+      "options": {
+        "legend": {"calcs": [], "displayMode": "list", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus"},
+          "expr": "sum by (application) (geoserver_controlflow_requests_running)",
+          "legendFormat": "{{application}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Control-Flow Running Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus"},
+      "description": "Requests currently blocked inside control-flow acquisition, per service. Sustained non-zero values mean requests are being throttled.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+          "links": [
+            {"title": "Control-Flow dashboard", "url": "/d/geoserver-controlflow/geoserver-control-flow?var-application=${__field.labels.application}"}
+          ],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 24},
+      "id": 101,
+      "options": {
+        "legend": {"calcs": [], "displayMode": "list", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus"},
+          "expr": "sum by (application) (geoserver_controlflow_requests_blocked)",
+          "legendFormat": "{{application}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Control-Flow Blocked Requests",
+      "type": "timeseries"
     }
   ],
   "refresh": "10s",

--- a/compose/monitoring/grafana/provisioning/dashboards/geoserver-controlflow.json
+++ b/compose/monitoring/grafana/provisioning/dashboards/geoserver-controlflow.json
@@ -1,0 +1,268 @@
+{
+  "annotations": {"list": []},
+  "description": "Per-rule control-flow throttling: saturation against configured limits, blocking episodes, queue detail.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {"type": "prometheus"},
+      "description": "Requests currently admitted past control-flow across the selected services.",
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 6, "x": 0, "y": 0},
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus"},
+          "expr": "sum(geoserver_controlflow_requests_running{application=~\"$application\"})",
+          "legendFormat": "running",
+          "refId": "A"
+        }
+      ],
+      "title": "Running Requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus"},
+      "description": "Requests currently blocked inside control-flow acquisition. Non-zero means throttling is happening right now.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 5, "w": 6, "x": 6, "y": 0},
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus"},
+          "expr": "sum(geoserver_controlflow_requests_blocked{application=~\"$application\"})",
+          "legendFormat": "blocked",
+          "refId": "A"
+        }
+      ],
+      "title": "Blocked Requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus"},
+      "description": "Per-service blocking episodes over time: Blocked while any request is held inside control-flow acquisition.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "custom": {"fillOpacity": 70, "lineWidth": 0},
+          "mappings": [
+            {"options": {"0": {"color": "green", "index": 0, "text": "OK"}, "1": {"color": "red", "index": 1, "text": "Blocked"}}, "type": "value"}
+          ],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 5, "w": 12, "x": 12, "y": 0},
+      "id": 3,
+      "options": {
+        "alignValue": "left",
+        "legend": {"displayMode": "list", "placement": "bottom"},
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "never",
+        "tooltip": {"mode": "single"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus"},
+          "expr": "max by (application) (geoserver_controlflow_requests_blocked{application=~\"$application\"} > bool 0)",
+          "legendFormat": "{{application}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Blocking Episodes",
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {"type": "prometheus"},
+      "description": "Requests admitted under each rule as a percentage of its configured limit. A series pinned near 100% is the rule doing the throttling.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{"color": "green", "value": null}, {"color": "orange", "value": 70}, {"color": "red", "value": 90}]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 24, "x": 0, "y": 5},
+      "id": 4,
+      "options": {
+        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "right"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus"},
+          "expr": "100 * geoserver_controlflow_rule_running{application=~\"$application\", rule=~\"$rule\"} / geoserver_controlflow_rule_limit{application=~\"$application\", rule=~\"$rule\"}",
+          "legendFormat": "{{application}} {{rule}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Rule Saturation (running / limit)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus"},
+      "description": "Configured rules with their live state. A rule change shows up here on the scrape after the configuration reloads.",
+      "fieldConfig": {"defaults": {"custom": {"align": "auto", "cellOptions": {"type": "auto"}}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 9, "w": 24, "x": 0, "y": 14},
+      "id": 5,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {"countRows": false, "fields": "", "reducer": ["sum"], "show": false},
+        "showHeader": true,
+        "sortBy": [{"desc": false, "displayName": "rule"}]
+      },
+      "targets": [
+        {"datasource": {"type": "prometheus"}, "expr": "geoserver_controlflow_rule_limit{application=~\"$application\", rule=~\"$rule\"}", "format": "table", "instant": true, "refId": "A"},
+        {"datasource": {"type": "prometheus"}, "expr": "geoserver_controlflow_rule_running{application=~\"$application\", rule=~\"$rule\"}", "format": "table", "instant": true, "refId": "B"},
+        {"datasource": {"type": "prometheus"}, "expr": "geoserver_controlflow_rule_waiting{application=~\"$application\", rule=~\"$rule\"}", "format": "table", "instant": true, "refId": "C"},
+        {"datasource": {"type": "prometheus"}, "expr": "geoserver_controlflow_rule_queues_active{application=~\"$application\", rule=~\"$rule\"}", "format": "table", "instant": true, "refId": "D"}
+      ],
+      "title": "Configured Rules",
+      "transformations": [
+        {"id": "merge", "options": {}},
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {"Time": true, "__name__": true, "exported_instance_id": true, "instance": true, "instance_id": true, "job": true, "node": true, "service": true},
+            "renameByName": {
+              "Value #A": "limit",
+              "Value #B": "running",
+              "Value #C": "waiting",
+              "Value #D": "active queues",
+              "application": "service"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {"type": "prometheus"},
+      "description": "Live per-user and per-IP queues tracked by user/ip rules.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 23},
+      "id": 6,
+      "options": {
+        "legend": {"calcs": [], "displayMode": "list", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus"},
+          "expr": "geoserver_controlflow_rule_queues_active{application=~\"$application\", rule=~\"$rule\"}",
+          "legendFormat": "{{application}} {{rule}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Per-User / Per-IP Queues",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus"},
+      "description": "Requests parked in priority-blocker waiting queues (only rules with a priority provider report this).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 23},
+      "id": 7,
+      "options": {
+        "legend": {"calcs": [], "displayMode": "list", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus"},
+          "expr": "geoserver_controlflow_rule_waiting{application=~\"$application\", rule=~\"$rule\"}",
+          "legendFormat": "{{application}} {{rule}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Waiting in Priority Queue",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "tags": ["geoserver", "control-flow"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": {"type": "prometheus"},
+        "definition": "label_values(geoserver_controlflow_requests_running, application)",
+        "includeAll": true,
+        "multi": true,
+        "name": "application",
+        "options": [],
+        "query": "label_values(geoserver_controlflow_requests_running, application)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {"type": "prometheus"},
+        "definition": "label_values(geoserver_controlflow_rule_limit{application=~\"$application\"}, rule)",
+        "includeAll": true,
+        "multi": true,
+        "name": "rule",
+        "options": [],
+        "query": "label_values(geoserver_controlflow_rule_limit{application=~\"$application\"}, rule)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {"from": "now-30m", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "GeoServer Control-Flow",
+  "uid": "geoserver-controlflow",
+  "version": 1,
+  "weekStart": ""
+}

--- a/compose/monitoring/prometheus-consul.yml
+++ b/compose/monitoring/prometheus-consul.yml
@@ -15,6 +15,14 @@ scrape_configs:
       - server: 'consul:8500'
         refresh_interval: 30s
     relabel_configs:
+      # Spring Cloud Consul registers an extra <service>-management service for
+      # the separate management port. The main registration (rewritten to 8081
+      # below) already scrapes the same pod's actuator, making those targets
+      # duplicates that show up as <service>-management in every dashboard.
+      # Consul's own self-registration is scraped by the 'discovery' job.
+      - source_labels: [__meta_consul_service]
+        regex: '.*-management|consul'
+        action: drop
       # Consul returns port 8080 (app port), but actuator is on 8081
       # So we need to replace the port in the address
       - source_labels: [__address__]

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -110,7 +110,10 @@ nav:
         - Overview: deploy/kubernetes/helm/index.md
         - Example — pgconfig: deploy/kubernetes/helm/example-pgconfig.md
   - User Guide:
+    - Overview: user-guide/index.md
     - ImageMosaics through the REST API: user-guide/imagemosaic-rest-api.md
+    - Monitoring control-flow: user-guide/controlflow-monitoring.md
+    - Control-flow metrics reference: user-guide/controlflow-metrics-reference.md
   - Configuration:
     - Externalized configuration guide: configuration/index.md
     - Migration 2.28 to 3.0: configuration/migration-2.28-to-3.0.md

--- a/docs/src/user-guide/controlflow-metrics-reference.md
+++ b/docs/src/user-guide/controlflow-metrics-reference.md
@@ -1,0 +1,132 @@
+# Control-flow metrics reference
+
+Services running the control-flow extension export throttling gauges on the actuator
+Prometheus endpoint (`:8081/actuator/prometheus` in the standard deployments) whenever a
+Micrometer registry is available and `geoserver.metrics.enabled` is not `false`. The
+[Monitoring control-flow](controlflow-monitoring.md) tutorial shows them in action on the
+dev compose stack; this page is the lookup reference for the metrics and the queries built
+on them.
+
+Metric names below use the Prometheus form. The actuator's `/actuator/metrics` endpoint
+lists the same meters in dotted form (`geoserver.controlflow.requests.running`).
+
+## Global gauges
+
+| Metric | Meaning |
+|--------|---------|
+| `geoserver_controlflow_requests_running` | requests currently admitted past control-flow |
+| `geoserver_controlflow_requests_blocked` | requests currently blocked inside control-flow acquisition |
+
+## Per-rule gauges
+
+Labeled `rule` (the configuration key, e.g. `ows.wms.getmap`, `user`, `ip`) and
+`controller` (the implementing class). Label cardinality is bounded by the configured
+rules; metrics are never labeled by request user or client address, and a single-IP rule
+embeds its configured address in the rule key:
+
+| Metric | Meaning |
+|--------|---------|
+| `geoserver_controlflow_rule_limit` | configured concurrency or queue limit |
+| `geoserver_controlflow_rule_running` | requests currently admitted under the rule |
+| `geoserver_controlflow_rule_waiting` | requests parked in the rule's priority queue |
+| `geoserver_controlflow_rule_queues_active` | live per-user or per-IP queue count |
+| `geoserver_controlflow_rule_rate_limit` | configured maximum requests per rate window |
+
+## Example PromQL queries
+
+Current state:
+
+```promql
+# which rule is throttling: saturation of each rule against its limit, in percent
+100 * geoserver_controlflow_rule_running / geoserver_controlflow_rule_limit
+
+# is anything blocked right now, per service
+sum by (application) (geoserver_controlflow_requests_blocked)
+
+# free slots per rule (how much headroom is left)
+geoserver_controlflow_rule_limit - geoserver_controlflow_rule_running
+
+# rules running exactly at their limit right now
+geoserver_controlflow_rule_running >= geoserver_controlflow_rule_limit
+
+# requests parked in priority queues (needs ows.priority.http configured)
+geoserver_controlflow_rule_waiting > 0
+
+# busiest per-user/per-IP rules by live queue count
+topk(5, geoserver_controlflow_rule_queues_active)
+```
+
+Over time and across replicas:
+
+```promql
+# services that throttled at any point in the last 15 minutes
+max_over_time(geoserver_controlflow_requests_blocked[15m]) > 0
+
+# share of the last hour each pod spent throttling (0 to 1, sampled per scrape)
+avg_over_time((geoserver_controlflow_requests_blocked > bool 0)[1h:15s])
+
+# load distribution across the replicas of each service
+sum by (application, instance) (geoserver_controlflow_requests_running)
+
+# aggregate configured capacity per rule across all replicas of a service
+sum by (application, rule) (geoserver_controlflow_rule_limit)
+```
+
+Alert-shaped queries, ready to lift into an alerting system:
+
+```promql
+# sustained throttling: pair with "for: 5m" in an alert rule
+sum by (application) (geoserver_controlflow_requests_blocked) > 0
+
+# a rule pinned at its limit: pair with "for: 10m"
+geoserver_controlflow_rule_running >= geoserver_controlflow_rule_limit
+```
+
+The `application` label in these examples comes from the dev stack's Prometheus relabeling
+(the Consul service name); adjust it to whatever service-identity label your scrape
+configuration applies.
+
+## Grafana building blocks
+
+The **GeoServer Control-Flow** dashboard shipped with the dev compose stack
+([geoserver-controlflow.json](https://github.com/geoserver/geoserver-cloud/blob/main/compose/monitoring/grafana/provisioning/dashboards/geoserver-controlflow.json))
+is the worked example for all of these; the recipes below are its load-bearing pieces for
+reuse in your own dashboards.
+
+Template variables, chained so the rule list follows the service selection:
+
+```promql
+label_values(geoserver_controlflow_requests_running, application)
+label_values(geoserver_controlflow_rule_limit{application=~"$application"}, rule)
+```
+
+Rule saturation timeseries: plot the percent ratio with unit `percent`, `max` 100, and
+threshold steps at 70 and 90:
+
+```promql
+100 * geoserver_controlflow_rule_running{application=~"$application", rule=~"$rule"}
+    / geoserver_controlflow_rule_limit{application=~"$application", rule=~"$rule"}
+```
+
+Blocking episodes as a state timeline: map 0 to OK and 1 to Blocked with value mappings:
+
+```promql
+max by (application) (geoserver_controlflow_requests_blocked{application=~"$application"} > bool 0)
+```
+
+Live rule inventory as a table: four instant queries in `table` format (`rule_limit`,
+`rule_running`, `rule_waiting`, `rule_queues_active`), combined with the **Merge**
+transformation and an **Organize fields** step that renames the value columns and hides
+the scrape labels.
+
+## Behavior notes
+
+- Rule changes appear on the scrape after the control-flow configuration reloads.
+- Each service loads only the rules that apply to it; see the per-service profile
+  documents in `config/geoserver_control_flow.yml` and the
+  [externalized configuration guide](../configuration/index.md).
+- `geoserver_controlflow_rule_waiting` reports only on rules backed by a priority
+  blocker, configured through `ows.priority.http`.
+- With the data-directory configuration (`use-properties-file=true`) all per-rule gauges
+  work except `rule_running` on rules backed by a priority blocker (upstream keeps that
+  count private).

--- a/docs/src/user-guide/controlflow-monitoring.md
+++ b/docs/src/user-guide/controlflow-monitoring.md
@@ -1,0 +1,167 @@
+# Monitoring control-flow throttling
+
+GeoServer Cloud's control-flow extension throttles OWS requests instead of rejecting them: once a rule's concurrency limit is reached, further requests wait in a priority queue until a slot frees up, or until a configurable timeout expires and they are rejected. Because throttled requests wait rather than fail outright, the signal that a rule is limiting traffic is requests piling up and blocking, not errors in a log. This tutorial starts the development compose stack with Prometheus and Grafana, fires enough concurrent WMS requests to trip the default limits, and follows the throttling live on the "GeoServer Control-Flow" Grafana dashboard: rule saturation climbing to 100%, blocked requests appearing, and the effect of tightening a rule, overriding it with an environment variable, adding a per-IP limit, or turning on priority queuing.
+
+## Prerequisites
+
+- Docker Engine with Compose v2 (`docker compose version` reports a v2.x client).
+- A local clone of the geoserver-cloud repository.
+- About 4 GB of free RAM: the stack runs GeoServer Cloud's services alongside Consul, RabbitMQ, a database, Prometheus, and Grafana.
+
+## 1. Start the stack with monitoring
+
+Start the datadir-backed development stack with the monitoring overlay:
+
+```bash
+cd compose
+./datadir -f monitoring.yml up -d
+```
+
+The `datadir` script wires in the bundled sample data directory, the classic GeoServer demo workspaces (`topp`, `ne`, `sf`, and others); `-f monitoring.yml` adds Prometheus and Grafana to the same stack. Image pulls and sample catalog extraction take a minute or two on the first run.
+
+Check progress with:
+
+```bash
+./datadir -f monitoring.yml ps
+```
+
+Once every service reports healthy, open:
+
+- Grafana at [http://localhost:3000](http://localhost:3000), credentials `admin` / `admin`.
+- The GeoServer web UI through the gateway, at [http://localhost:9090/geoserver/cloud/web/](http://localhost:9090/geoserver/cloud/web/). Port 9090 is this stack's default gateway port, set by `GATEWAY_PORT` in `compose/.env`.
+- Prometheus at [http://localhost:9091](http://localhost:9091), optional for this walkthrough, useful later for running PromQL queries directly.
+
+## 2. Find the baseline
+
+In Grafana, open **Dashboards -> GeoServer Control-Flow**. Its **Configured Rules** table lists the rules active in `config/geoserver_control_flow.yml`, and each service loads only the rules that apply to it: the file's first document holds the universal settings (the queue timeout and commented per-user/per-IP examples; there is no global limit by default), and per-service profile documents add the specific rules. The `wms` service reports `ows.wms` and `ows.wms.getmap`; `wps` reports `ows.wps.execute`; `gwc` reports `ows.gwc` plus an `ows.wms.getmap` rule that throttles seed-triggered rendering; `wfs` and `wcs` load no rules by default; `restconfig` and `webui` serve no OWS requests and publish no control-flow metrics at all. The file's `timeout` setting applies to queued requests instead of appearing as a rule. With no traffic yet, every rule's running count is 0.
+
+The dashboard's `$application` and `$rule` variables narrow the view to one service or rule; leave them on "All" for now.
+
+For the same numbers without Grafana, query the wms pod's actuator endpoint directly:
+
+```bash
+./datadir -f monitoring.yml exec wms curl -s localhost:8081/actuator/prometheus | grep geoserver_controlflow
+```
+
+Each rule shows up as a `geoserver_controlflow_rule_*` gauge family labeled by `rule`; with the stack idle, every `_running` value is 0.
+
+## 3. Generate load
+
+`topp:states`, the classic census and state-boundaries demo layer bundled in the sample data directory, is a convenient target: small enough to render quickly, and present in every stock GeoServer Cloud sample catalog.
+
+Fire enough concurrent `GetMap` requests to exceed the default `ows.wms.getmap` limit, four times the container's allocated CPU count:
+
+```bash
+export GEOSERVER_URL="http://localhost:9090/geoserver/cloud"
+export GETMAP="$GEOSERVER_URL/wms?service=WMS&version=1.1.1&request=GetMap&layers=topp:states&bbox=-125,24,-66,50&width=800&height=400&srs=EPSG:4326&format=image/png"
+
+for round in $(seq 1 8); do
+  for i in $(seq 1 60); do
+    curl -s -o /dev/null "$GETMAP" &
+  done
+  wait
+done
+```
+
+The outer loop sustains the load for several seconds, long enough for at least one Prometheus scrape (15 second interval) to land mid-run. Switch to Grafana while it executes. On the **GeoServer Control-Flow** dashboard, **Rule Saturation (running / limit)** climbs toward 100% for `ows.wms.getmap`, **Blocking Episodes** shows the rule going active, and on the **GeoServer Cloud Overview** dashboard **Control-Flow Blocked Requests** goes non-zero. That is the throttle working as intended: requests are queuing behind the limit, not failing.
+
+## 4. Tighten a rule and watch it propagate
+
+Edit `config/geoserver_control_flow.yml` and, in the `wms` profile document, replace the `ows.wms.getmap` limit with a fixed, much lower value:
+
+```yaml
+'[ows.wms.getmap]': "2"
+```
+
+Restart the wms service to pick up the change:
+
+```bash
+./datadir -f monitoring.yml restart wms
+```
+
+Run the load loop from [Generate load](#3-generate-load) again. The **Configured Rules** table now shows `ows.wms.getmap` at limit 2, and **Rule Saturation** pins at 100% for the whole run: two requests running, the rest queued, since the loop's concurrency is far above the new limit.
+
+## 5. Override a rule with an environment variable
+
+Editing a tracked configuration file works for development, but a deployment usually wants to tune a limit per container without touching the shared file. Every rule can be set or overridden through an environment variable. The naming follows Spring Boot's relaxed binding, which is not obvious for map keys: uppercase the property path, turn dots into underscores, drop the dash in `control-flow`, and everything after `PROPERTIES_` is the rule key. `'[ows.wms.getmap]'` becomes `GEOSERVER_EXTENSION_CONTROLFLOW_PROPERTIES_OWS_WMS_GETMAP`.
+
+Create a compose overlay named `controlflow-override.yml` in the `compose` directory:
+
+```yaml
+services:
+  wms:
+    environment:
+      GEOSERVER_EXTENSION_CONTROLFLOW_PROPERTIES_OWS_WMS_GETMAP: "6"
+```
+
+and recreate the wms service with it:
+
+```bash
+./datadir -f monitoring.yml -f controlflow-override.yml up -d wms
+```
+
+Once wms reports healthy again, **Configured Rules** shows `ows.wms.getmap` at limit 6: the environment variable wins over the value in `config/geoserver_control_flow.yml`, including the 2 set in the previous step. Environment variables override or add rules per key; they cannot remove a rule defined in the file. Recreating the service without the overlay (`./datadir -f monitoring.yml up -d wms`) restores the file-defined limits. The header comments of `config/geoserver_control_flow.yml` document more override forms, including `SPRING_APPLICATION_JSON` for rule keys that cannot be spelled as a variable name, such as output formats containing a slash.
+
+## 6. Watch per-IP queues
+
+The commented-out `[ip]` rule in the same file limits concurrent requests per client address, independently of which OWS operation they call. Uncomment it:
+
+```yaml
+'[ip]': "6"
+```
+
+Restart wms again and re-run the load loop:
+
+```bash
+./datadir -f monitoring.yml restart wms
+```
+
+A new `ip` rule appears in **Configured Rules**, and **Active Per-User / Per-IP Queues** shows one active queue, since every request in the loop comes from the same client address, climbing to the configured limit of 6 while the rest wait behind it.
+
+## 7. See the priority queue
+
+The **Waiting in Priority Queue** panel stays empty in all the runs above, and that is expected: without a priority provider, rules use a simple blocker whose queued requests are not individually observable. Configuring `ows.priority.http` switches every global and per-OWS rule to a priority blocker that reports how many requests are parked in its queue, and lets clients influence their place in it through an HTTP header.
+
+In the first document of `config/geoserver_control_flow.yml`, under `properties`, add:
+
+```yaml
+'[ows.priority.http]': "gs-priority,3"
+```
+
+The pair names the header to read (`gs-priority`, any name works) and the default priority (3) for requests without it. Higher numbers win; equal priorities drain first-in first-out. Restart wms and re-run the load loop from [Generate load](#3-generate-load): **Waiting in Priority Queue** now shows the queued requests for `ows.wms` and `ows.wms.getmap` while the run lasts. The per-IP rule from the previous step keeps its own queue accounting and is not affected by the priority provider.
+
+To see priorities reorder the queue, start a batch of default-priority requests in the background, then immediately run a second batch that jumps ahead of it:
+
+```bash
+for i in $(seq 1 30); do curl -s -o /dev/null "$GETMAP" & done
+
+time ( for i in $(seq 1 30); do curl -s -o /dev/null -H "gs-priority: 10" "$GETMAP" & done; wait )
+wait
+```
+
+Although the high-priority batch enters a queue already full of default-priority requests, the blocker releases its requests first: the timed batch completes well before the background one drains.
+
+## 8. Clean up
+
+Stop the stack:
+
+```bash
+./datadir -f monitoring.yml down
+```
+
+`config/geoserver_control_flow.yml` is a tracked file in the repository, not a container volume: the edits from this tutorial are still on disk. Revert them, and delete the compose overlay if you created it:
+
+```bash
+git checkout -- config/geoserver_control_flow.yml
+rm -f controlflow-override.yml
+```
+
+!!! note
+    `down` leaves the Prometheus and Grafana volumes in place, preserving your dashboards and metric history across restarts. Add `-v` to drop them too.
+
+## Where to go next
+
+- The [control-flow metrics reference](controlflow-metrics-reference.md) for the full metric inventory, example PromQL queries, and the Grafana recipes behind the dashboard.
+- [MONITORING.md](https://github.com/geoserver/geoserver-cloud/blob/main/compose/monitoring/MONITORING.md) for the dev compose monitoring stack itself: ports, credentials, Consul-based scraping, and its limitations.
+- The [externalized configuration guide](../configuration/index.md) for how GeoServer Cloud services pick up configuration changes.
+- The upstream [GeoServer Control Flow extension documentation](https://docs.geoserver.org/main/en/user/extensions/controlflow/index.html) for every rule syntax control-flow supports, including per-user rate limiting and IP blacklists.

--- a/docs/src/user-guide/index.md
+++ b/docs/src/user-guide/index.md
@@ -1,0 +1,20 @@
+# User guide
+
+Task-oriented guides for operating GeoServer Cloud. Each one walks through a
+complete, real-world workflow against a running deployment.
+
+Available guides:
+
+- [ImageMosaics through the REST API](imagemosaic-rest-api.md): publish an
+  ImageMosaic of Cloud Optimized GeoTIFFs stored on object storage, using the
+  same REST API calls that work against vanilla GeoServer.
+- [Monitoring control-flow](controlflow-monitoring.md): run the dev compose
+  stack with Prometheus and Grafana, generate load, and watch request
+  throttling live on the control-flow dashboard.
+- [Control-flow metrics reference](controlflow-metrics-reference.md): the
+  exported metrics, example PromQL queries, and the Grafana recipes the
+  shipped dashboard is built from.
+
+For deployment instructions see the [Deployment](../deploy/index.md) section,
+and for service configuration the
+[externalized configuration guide](../configuration/index.md).

--- a/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/metrics/catalog/ConditionalOnGeoServerMetricsEnabled.java
+++ b/src/catalog/backends/common/src/main/java/org/geoserver/cloud/autoconfigure/metrics/catalog/ConditionalOnGeoServerMetricsEnabled.java
@@ -14,6 +14,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration;
 
 /**
@@ -22,6 +23,7 @@ import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConf
  * <ul>
  *   <li>Both spring-boot-actuator and micrometer shall be available;
  *   <li>A {@link MeterRegistry} bean shall be available as per {@link MetricsAutoConfiguration}
+ *   <li>{@literal geoserver.metrics.enabled} is unset or {@code true}
  * </ul>
  */
 @Retention(RetentionPolicy.RUNTIME)
@@ -29,4 +31,5 @@ import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConf
 @Documented
 @ConditionalOnClass({MeterRegistry.class, Timed.class})
 @ConditionalOnBean(MeterRegistry.class)
+@ConditionalOnProperty(name = "geoserver.metrics.enabled", havingValue = "true", matchIfMissing = true)
 public @interface ConditionalOnGeoServerMetricsEnabled {}

--- a/src/catalog/backends/common/src/test/java/org/geoserver/cloud/autoconfigure/metrics/catalog/CatalogMetricsAutoConfigurationTest.java
+++ b/src/catalog/backends/common/src/test/java/org/geoserver/cloud/autoconfigure/metrics/catalog/CatalogMetricsAutoConfigurationTest.java
@@ -1,0 +1,44 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.autoconfigure.metrics.catalog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.config.GeoServer;
+import org.geoserver.platform.config.UpdateSequence;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class CatalogMetricsAutoConfigurationTest {
+
+    private ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(CatalogMetricsAutoConfiguration.class))
+            .withBean("catalog", Catalog.class, () -> mock(Catalog.class))
+            .withBean("geoServer", GeoServer.class, () -> mock(GeoServer.class))
+            .withBean(UpdateSequence.class, () -> mock(UpdateSequence.class));
+
+    @Test
+    void enabledByDefaultWhenMeterRegistryPresent() {
+        runner.withBean(SimpleMeterRegistry.class)
+                .run(context -> assertThat(context).hasSingleBean(CatalogMetrics.class));
+    }
+
+    @Test
+    void disabledByProperty() {
+        runner.withBean(SimpleMeterRegistry.class)
+                .withPropertyValues("geoserver.metrics.enabled=false")
+                .run(context -> assertThat(context).doesNotHaveBean(CatalogMetrics.class));
+    }
+
+    @Test
+    void disabledWithoutMeterRegistry() {
+        runner.run(context -> assertThat(context).doesNotHaveBean(CatalogMetrics.class));
+    }
+}

--- a/src/extensions/control-flow/README.md
+++ b/src/extensions/control-flow/README.md
@@ -28,9 +28,8 @@ geoserver:
       use-properties-file: false  # Use externalized config (default: false)
       properties:
         '[timeout]': 10  # Request timeout in seconds
-        '[ows.global]': "${cpu.cores} * 2"  # Global OWS request limit
-        '[ows.wms]': "${cpu.cores} * 4"  # WMS service limit
-        '[ows.wms.getmap]': "${cpu.cores} * 2"  # GetMap request limit
+        '[ows.wms]': "${cpu.cores} * 8"  # WMS service limit
+        '[ows.wms.getmap]': "${cpu.cores} * 4"  # GetMap request limit
 ```
 
 The default configuration is provided in `config/geoserver_control_flow.yml`.
@@ -157,3 +156,25 @@ This works through the property placeholder: `${control-flow:true}`
 
 - [GeoServer Control Flow User Guide](https://docs.geoserver.org/main/en/user/extensions/controlflow/index.html)
 - Default configuration: `config/geoserver_control_flow.yml`
+
+## Metrics
+
+When a Micrometer `MeterRegistry` is available and `geoserver.metrics.enabled` is not
+`false`, the extension registers gauges on the actuator metrics endpoints:
+
+- `geoserver.controlflow.requests.running` / `geoserver.controlflow.requests.blocked`:
+  the global figures the module logs per request.
+- `geoserver.controlflow.rule.limit`, `.rule.running`, `.rule.waiting`,
+  `.rule.queues.active`, `.rule.rate.limit`: per-rule gauges, tagged `rule` (the
+  configuration key) and `controller` (the implementing class).
+
+All meters are tagged `instance-id` when `geoserver.metrics.instance-id` is set. Rule
+changes show up on the scrape after the configuration reloads. With
+`use-properties-file=true` every per-rule gauge works except `rule.running` on rules
+backed by a priority blocker (upstream keeps that count private).
+
+The user guide's
+[control-flow metrics reference](https://geoserver.org/geoserver-cloud/user-guide/controlflow-metrics-reference/)
+documents the Prometheus metric names, example queries, and dashboard recipes;
+`compose/monitoring/MONITORING.md` covers the dev compose monitoring stack that ships
+the Grafana dashboards.

--- a/src/extensions/control-flow/pom.xml
+++ b/src/extensions/control-flow/pom.xml
@@ -50,6 +50,25 @@
       <artifactId>spring-boot-autoconfigure-processor</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.cloud.catalog.backend</groupId>
+      <artifactId>gs-cloud-catalog-backend-common</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowMetrics.java
+++ b/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowMetrics.java
@@ -1,0 +1,169 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.controlflow;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MultiGauge;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import java.util.List;
+import java.util.function.ToDoubleFunction;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.geoserver.flow.ControlFlowCallback;
+import org.geoserver.flow.FlowController;
+import org.geoserver.flow.FlowControllerProvider;
+
+/**
+ * Registers control-flow metrics to be exported by micrometer's {@link MeterRegistry}.
+ *
+ * <p>Global gauges, sampled from the {@link ControlFlowCallback} singleton:
+ *
+ * <ul>
+ *   <li>{@literal geoserver.controlflow.requests.running}: requests admitted past flow control
+ *   <li>{@literal geoserver.controlflow.requests.blocked}: requests blocked inside flow-control acquisition
+ * </ul>
+ *
+ * <p>Per-rule gauges, resolved from the current {@link FlowControllerProvider} list via {@link ControlFlowRuleRows} and
+ * tagged {@literal rule} (the rule key, e.g. {@literal ows.global}, {@literal ows.wms.getmap},
+ * {@literal ip.192.168.1.1}) and {@literal controller} (the upstream {@link FlowController} implementation simple
+ * name):
+ *
+ * <ul>
+ *   <li>{@literal geoserver.controlflow.rule.limit}: configured concurrency or queue limit for the rule
+ *   <li>{@literal geoserver.controlflow.rule.running}: requests currently admitted under the rule
+ *   <li>{@literal geoserver.controlflow.rule.waiting}: requests waiting in the rule's priority queue
+ *   <li>{@literal geoserver.controlflow.rule.queues.active}: live per-user or per-IP queues tracked by the rule
+ *   <li>{@literal geoserver.controlflow.rule.rate.limit}: configured maximum requests per rate window
+ * </ul>
+ *
+ * <p>{@literal running} and {@literal waiting} are separate meters on purpose: upstream's
+ * {@code getRunningRequestsCount()} returns running requests on
+ * {@link org.geoserver.flow.controller.SimpleThreadBlocker} but waiting requests on
+ * {@link org.geoserver.flow.controller.PriorityThreadBlocker}; the binder normalizes the semantics instead of
+ * propagating the trap.
+ *
+ * <p>All meters are tagged {@literal instance-id} when {@literal geoserver.metrics.instance-id} is configured.
+ *
+ * @since 3.1
+ */
+@RequiredArgsConstructor
+@Slf4j(topic = "org.geoserver.cloud.metrics.controlflow")
+class ControlFlowMetrics implements MeterBinder {
+
+    private final @NonNull ControlFlowCallback callback;
+    private final @NonNull FlowControllerProvider provider;
+    private final String instanceId;
+
+    private MultiGauge ruleLimit;
+    private MultiGauge ruleRunning;
+    private MultiGauge ruleWaiting;
+    private MultiGauge ruleActiveQueues;
+    private MultiGauge ruleRateLimit;
+
+    private volatile List<FlowController> lastSeenControllers;
+    private volatile boolean lastRefreshFailed;
+
+    @Override
+    public void bindTo(@NonNull MeterRegistry registry) {
+        registerGlobalGauge(
+                registry,
+                "geoserver.controlflow.requests.running",
+                "Requests currently admitted past control-flow",
+                ControlFlowCallback::getRunningRequests);
+        registerGlobalGauge(
+                registry,
+                "geoserver.controlflow.requests.blocked",
+                "Requests currently blocked inside control-flow acquisition",
+                ControlFlowCallback::getBlockedRequests);
+        ruleLimit = ruleGauge(
+                registry,
+                "geoserver.controlflow.rule.limit",
+                "Configured concurrency or queue limit for the control-flow rule");
+        ruleRunning = ruleGauge(
+                registry,
+                "geoserver.controlflow.rule.running",
+                "Requests currently admitted under the control-flow rule");
+        ruleWaiting = ruleGauge(
+                registry, "geoserver.controlflow.rule.waiting", "Requests waiting in the rule's priority queue");
+        ruleActiveQueues = ruleGauge(
+                registry,
+                "geoserver.controlflow.rule.queues.active",
+                "Live per-user or per-IP queues tracked by the rule");
+        ruleRateLimit = ruleGauge(
+                registry, "geoserver.controlflow.rule.rate.limit", "Configured maximum requests per rate window");
+        refreshRuleRows();
+        log.info("GeoServer control-flow metrics enabled.");
+    }
+
+    private void registerGlobalGauge(
+            MeterRegistry registry, String name, String description, ToDoubleFunction<ControlFlowCallback> value) {
+
+        ToDoubleFunction<ControlFlowCallback> sampler = sampled -> {
+            refreshRuleRows();
+            return value.applyAsDouble(sampled);
+        };
+        Gauge.Builder<ControlFlowCallback> builder =
+                Gauge.builder(name, callback, sampler).description(description);
+        if (instanceId != null) {
+            builder = builder.tag("instance-id", instanceId);
+        }
+        builder.register(registry);
+    }
+
+    private MultiGauge ruleGauge(MeterRegistry registry, String name, String description) {
+        MultiGauge.Builder builder = MultiGauge.builder(name).description(description);
+        if (instanceId != null) {
+            builder = builder.tags(Tags.of("instance-id", instanceId));
+        }
+        return builder.register(registry);
+    }
+
+    /**
+     * Re-resolves the current flow controller list and rebuilds the per-rule gauge rows when the list identity changed.
+     * Sampling any global gauge invokes it, making rule changes take effect on the next scrape and dropping rows of
+     * discarded controllers.
+     */
+    void refreshRuleRows() {
+        if (ruleLimit == null) {
+            // a scrape can hit the global gauges while bindTo() is still
+            // registering the per-rule meters
+            return;
+        }
+        List<FlowController> current;
+        try {
+            // DefaultFlowControllerProvider ignores the request argument and
+            // returns the current list, rebuilding it if the configuration is stale
+            current = provider.getFlowControllers(null);
+            lastRefreshFailed = false;
+        } catch (Exception e) {
+            if (!lastRefreshFailed) {
+                lastRefreshFailed = true;
+                log.warn("Control-flow metrics could not resolve the flow controller list", e);
+            }
+            return;
+        }
+        if (current == lastSeenControllers) {
+            return;
+        }
+        synchronized (this) {
+            if (current == lastSeenControllers) {
+                return;
+            }
+            registerRuleRows(ControlFlowRuleRows.resolve(current));
+            lastSeenControllers = current;
+        }
+    }
+
+    private void registerRuleRows(ControlFlowRuleRows rows) {
+        ruleLimit.register(rows.limit(), true);
+        ruleRunning.register(rows.running(), true);
+        ruleWaiting.register(rows.waiting(), true);
+        ruleActiveQueues.register(rows.activeQueues(), true);
+        ruleRateLimit.register(rows.rateLimit(), true);
+    }
+}

--- a/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowMetricsAutoConfiguration.java
+++ b/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowMetricsAutoConfiguration.java
@@ -1,0 +1,47 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.controlflow;
+
+import org.geoserver.cloud.autoconfigure.metrics.catalog.ConditionalOnGeoServerMetricsEnabled;
+import org.geoserver.cloud.autoconfigure.metrics.catalog.GeoSeverMetricsConfigProperties;
+import org.geoserver.flow.ControlFlowCallback;
+import org.geoserver.flow.FlowControllerProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.micrometer.metrics.autoconfigure.CompositeMeterRegistryAutoConfiguration;
+import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for control-flow metrics; active when the control-flow extension
+ * runs, a {@code MeterRegistry} is available, and {@literal geoserver.metrics.enabled} is not {@code false}.
+ *
+ * @see ControlFlowMetrics
+ * @since 3.1
+ */
+@AutoConfiguration(
+        after = {
+            ControlFlowAutoConfiguration.class,
+            MetricsAutoConfiguration.class,
+            CompositeMeterRegistryAutoConfiguration.class
+        })
+@ConditionalOnControlFlow
+@ConditionalOnGeoServerMetricsEnabled
+@ConditionalOnBean(ControlFlowCallback.class)
+@EnableConfigurationProperties(GeoSeverMetricsConfigProperties.class)
+@SuppressWarnings("java:S1118")
+public class ControlFlowMetricsAutoConfiguration {
+
+    @Bean
+    ControlFlowMetrics controlFlowMetrics(
+            GeoSeverMetricsConfigProperties metricsConfig,
+            ControlFlowCallback callback,
+            FlowControllerProvider provider) {
+
+        return new ControlFlowMetrics(callback, provider, metricsConfig.getInstanceId());
+    }
+}

--- a/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowRuleRows.java
+++ b/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowRuleRows.java
@@ -1,0 +1,173 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.controlflow;
+
+import com.google.common.base.Predicate;
+import io.micrometer.core.instrument.MultiGauge;
+import io.micrometer.core.instrument.Tags;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.ToDoubleFunction;
+import lombok.extern.slf4j.Slf4j;
+import org.geoserver.flow.FlowController;
+import org.geoserver.flow.controller.CookieKeyGenerator;
+import org.geoserver.flow.controller.IpFlowController;
+import org.geoserver.flow.controller.IpRequestMatcher;
+import org.geoserver.flow.controller.OWSRequestMatcher;
+import org.geoserver.flow.controller.PriorityThreadBlocker;
+import org.geoserver.flow.controller.QueueController;
+import org.geoserver.flow.controller.QueueControllerState;
+import org.geoserver.flow.controller.RateFlowController;
+import org.geoserver.flow.controller.SimpleThreadBlocker;
+import org.geoserver.flow.controller.SingleQueueFlowController;
+import org.geoserver.flow.controller.ThreadBlocker;
+import org.geoserver.flow.controller.UserConcurrentFlowController;
+
+/**
+ * Resolves the per-rule gauge rows for a flow controller list.
+ *
+ * <p>Rule keys and limits derive from public state, identically for controllers built by
+ * {@link PropertiesControlFlowConfigurator} (externalized config) and by the upstream data-directory configurator:
+ * {@code getPriority()} returns the configured queue size on every queue-based controller, matchers expose their OWS
+ * service/method/format and single IPs, and rate controllers expose their window limit and key generator. Rows sample
+ * live controller objects; a sampling failure yields {@code NaN} instead of breaking the scrape.
+ */
+@Slf4j(topic = "org.geoserver.cloud.metrics.controlflow")
+class ControlFlowRuleRows {
+
+    private final List<MultiGauge.Row<?>> limit = new ArrayList<>();
+    private final List<MultiGauge.Row<?>> running = new ArrayList<>();
+    private final List<MultiGauge.Row<?>> waiting = new ArrayList<>();
+    private final List<MultiGauge.Row<?>> activeQueues = new ArrayList<>();
+    private final List<MultiGauge.Row<?>> rateLimit = new ArrayList<>();
+
+    static ControlFlowRuleRows resolve(List<FlowController> controllers) {
+        ControlFlowRuleRows rows = new ControlFlowRuleRows();
+        controllers.forEach(rows::add);
+        return rows;
+    }
+
+    List<MultiGauge.Row<?>> limit() {
+        return limit;
+    }
+
+    List<MultiGauge.Row<?>> running() {
+        return running;
+    }
+
+    List<MultiGauge.Row<?>> waiting() {
+        return waiting;
+    }
+
+    List<MultiGauge.Row<?>> activeQueues() {
+        return activeQueues;
+    }
+
+    List<MultiGauge.Row<?>> rateLimit() {
+        return rateLimit;
+    }
+
+    private void add(FlowController controller) {
+        if (controller instanceof RateFlowController rate) {
+            addRateRule(rate);
+        } else if (controller instanceof UserConcurrentFlowController user) {
+            addQueueRule("user", user);
+        } else if (controller instanceof IpFlowController ip) {
+            addQueueRule("ip", ip);
+        } else if (controller instanceof SingleQueueFlowController singleQueue) {
+            addSingleQueueRule(singleQueue);
+        }
+        // other FlowController implementations contribute no per-rule rows
+    }
+
+    private void addSingleQueueRule(SingleQueueFlowController controller) {
+        String rule = singleQueueRuleKey(controller);
+        if (rule == null) {
+            return;
+        }
+        Tags tags = ruleTags(rule, controller);
+        limit.add(row(tags, controller, SingleQueueFlowController::getPriority));
+        addBlockerRows(tags, controller.getBlocker());
+    }
+
+    private void addBlockerRows(Tags tags, ThreadBlocker blocker) {
+        if (blocker instanceof MonitoredPriorityThreadBlocker monitored) {
+            running.add(row(tags, monitored, MonitoredPriorityThreadBlocker::getAdmittedCount));
+            waiting.add(row(tags, monitored, PriorityThreadBlocker::getRunningRequestsCount));
+        } else if (blocker instanceof PriorityThreadBlocker priority) {
+            // upstream getRunningRequestsCount() reports the waiting queue here;
+            // the running count is private state with no accessor
+            waiting.add(row(tags, priority, PriorityThreadBlocker::getRunningRequestsCount));
+        } else if (blocker instanceof SimpleThreadBlocker simple) {
+            running.add(row(tags, simple, SimpleThreadBlocker::getRunningRequestsCount));
+        }
+    }
+
+    private String singleQueueRuleKey(SingleQueueFlowController controller) {
+        // guava's Predicate, which upstream's OWSRequestMatcher and IpRequestMatcher implement
+        Predicate<?> matcher = controller.getMatcher();
+        if (matcher instanceof IpRequestMatcher ipMatcher) {
+            return "ip." + ipMatcher.getIp();
+        }
+        if (matcher instanceof OWSRequestMatcher owsMatcher) {
+            return owsRuleKey(owsMatcher);
+        }
+        return null;
+    }
+
+    private String owsRuleKey(OWSRequestMatcher matcher) {
+        if (matcher.getService() == null) {
+            return "ows.global";
+        }
+        StringBuilder key = new StringBuilder("ows.").append(matcher.getService());
+        if (matcher.getMethod() != null) {
+            key.append('.').append(matcher.getMethod());
+            if (matcher.getOutputFormat() != null) {
+                key.append('.').append(matcher.getOutputFormat());
+            }
+        }
+        return key.toString();
+    }
+
+    private void addRateRule(RateFlowController controller) {
+        Tags tags = ruleTags(rateRuleKey(controller), controller);
+        rateLimit.add(row(tags, controller, RateFlowController::getMaxRequests));
+    }
+
+    private void addQueueRule(String rule, QueueController controller) {
+        Tags tags = ruleTags(rule, controller);
+        limit.add(row(tags, controller, QueueController::getPriority));
+        running.add(row(tags, controller, QueueControllerState::totalQueued));
+        activeQueues.add(row(tags, controller, QueueControllerState::activeQueues));
+    }
+
+    private String rateRuleKey(RateFlowController controller) {
+        String prefix = controller.getKeyGenerator() instanceof CookieKeyGenerator ? "user.ows" : "ip.ows";
+        if (controller.getMatcher() instanceof OWSRequestMatcher owsMatcher && owsMatcher.getService() != null) {
+            String owsSuffix = owsRuleKey(owsMatcher).substring("ows".length());
+            return prefix + owsSuffix;
+        }
+        return prefix;
+    }
+
+    private Tags ruleTags(String rule, FlowController controller) {
+        return Tags.of("rule", rule, "controller", controller.getClass().getSimpleName());
+    }
+
+    private static <T> MultiGauge.Row<T> row(Tags tags, T sampled, ToDoubleFunction<T> value) {
+        return MultiGauge.Row.of(tags, sampled, guarded(value));
+    }
+
+    private static <T> ToDoubleFunction<T> guarded(ToDoubleFunction<T> value) {
+        return sampled -> {
+            try {
+                return value.applyAsDouble(sampled);
+            } catch (RuntimeException e) {
+                log.debug("control-flow rule gauge sampling failed, reporting NaN", e);
+                return Double.NaN;
+            }
+        };
+    }
+}

--- a/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/MonitoredPriorityThreadBlocker.java
+++ b/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/MonitoredPriorityThreadBlocker.java
@@ -1,0 +1,49 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.controlflow;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.geoserver.flow.controller.PriorityProvider;
+import org.geoserver.flow.controller.PriorityThreadBlocker;
+import org.geoserver.ows.Request;
+
+/**
+ * A {@link PriorityThreadBlocker} that also tracks how many requests it has admitted.
+ *
+ * <p>The superclass keeps its running set private, and its {@link #getRunningRequestsCount()} returns the waiting-queue
+ * size, not the running count. This subclass mirrors the superclass bookkeeping with a set keyed by {@link Request}
+ * equality (a per-instance unique identifier, effectively identity): a request is added whenever
+ * {@code super.requestIncoming} returns normally (the superclass does this even for a timed-out request, until
+ * {@code requestComplete} removes it) and never when the wait is interrupted.
+ *
+ * @since 3.1
+ */
+class MonitoredPriorityThreadBlocker extends PriorityThreadBlocker {
+
+    private final Set<Request> admitted = ConcurrentHashMap.newKeySet();
+
+    public MonitoredPriorityThreadBlocker(int queueSize, PriorityProvider priorityProvider) {
+        super(queueSize, priorityProvider);
+    }
+
+    @Override
+    public boolean requestIncoming(Request request, long timeout) throws InterruptedException {
+        boolean proceed = super.requestIncoming(request, timeout);
+        admitted.add(request);
+        return proceed;
+    }
+
+    @Override
+    public void requestComplete(Request request) {
+        super.requestComplete(request);
+        admitted.remove(request);
+    }
+
+    /** Requests currently admitted under this blocker, feeding the {@literal rule.running} gauge. */
+    public int getAdmittedCount() {
+        return admitted.size();
+    }
+}

--- a/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/PropertiesControlFlowConfigurator.java
+++ b/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/PropertiesControlFlowConfigurator.java
@@ -23,7 +23,6 @@ import org.geoserver.flow.controller.IpKeyGenerator;
 import org.geoserver.flow.controller.KeyGenerator;
 import org.geoserver.flow.controller.OWSRequestMatcher;
 import org.geoserver.flow.controller.PriorityProvider;
-import org.geoserver.flow.controller.PriorityThreadBlocker;
 import org.geoserver.flow.controller.RateFlowController;
 import org.geoserver.flow.controller.SimpleThreadBlocker;
 import org.geoserver.flow.controller.SingleIpFlowController;
@@ -252,13 +251,13 @@ class PropertiesControlFlowConfigurator implements ControlFlowConfigurator {
      * Builds a {@link ThreadBlocker} based on a queue size and a prority provider
      *
      * @param queueSize The count of concurrent requests allowed to run
-     * @param priorityProvider The priority provider (if not null, a
-     *     {@link org.geoserver.flow.controller.PriorityThreadBlocker} will be built
+     * @param priorityProvider The priority provider (if not null, a {@link MonitoredPriorityThreadBlocker} will be
+     *     built
      * @return a {@link ThreadBlocker}
      */
     private ThreadBlocker buildBlocker(int queueSize, PriorityProvider priorityProvider) {
         if (priorityProvider != null) {
-            return new PriorityThreadBlocker(queueSize, priorityProvider);
+            return new MonitoredPriorityThreadBlocker(queueSize, priorityProvider);
         } else {
             return new SimpleThreadBlocker(queueSize);
         }

--- a/src/extensions/control-flow/src/main/java/org/geoserver/flow/controller/QueueControllerState.java
+++ b/src/extensions/control-flow/src/main/java/org/geoserver/flow/controller/QueueControllerState.java
@@ -1,0 +1,36 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.flow.controller;
+
+/**
+ * Read-only access to the package-private queue map of {@link QueueController} subclasses
+ * ({@link UserConcurrentFlowController}, {@link IpFlowController}) for metrics sampling.
+ *
+ * <p>Lives in the {@code org.geoserver.flow.controller} package (a split package with the upstream
+ * {@code gs-control-flow} jar) on purpose: the alternative is reflection, which would break at runtime instead of at
+ * compile time when upstream renames a member.
+ *
+ * @since 3.1
+ */
+public final class QueueControllerState {
+
+    private QueueControllerState() {
+        // static utility
+    }
+
+    /** Live per-user or per-IP queues currently tracked by the controller. */
+    public static int activeQueues(QueueController controller) {
+        return controller.queues.size();
+    }
+
+    /** Requests currently admitted under the controller, summed across its queues. */
+    public static int totalQueued(QueueController controller) {
+        int total = 0;
+        for (QueueController.TimedBlockingQueue queue : controller.queues.values()) {
+            total += queue.size();
+        }
+        return total;
+    }
+}

--- a/src/extensions/control-flow/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/extensions/control-flow/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 org.geoserver.cloud.autoconfigure.extensions.controlflow.ControlFlowAutoConfiguration
+org.geoserver.cloud.autoconfigure.extensions.controlflow.ControlFlowMetricsAutoConfiguration

--- a/src/extensions/control-flow/src/test/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowEnvironmentOverridesTest.java
+++ b/src/extensions/control-flow/src/test/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowEnvironmentOverridesTest.java
@@ -1,0 +1,66 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.controlflow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
+
+/**
+ * Pins the devops contract documented in {@code config/geoserver_control_flow.yml}: control-flow rules are map entries
+ * with dotted keys, and environment variables reach them through Spring Boot's relaxed binding. The variable name's
+ * tail after {@code PROPERTIES_} becomes the rule key, underscores turning back into dots, and the environment takes
+ * precedence over file-defined values.
+ */
+class ControlFlowEnvironmentOverridesTest {
+
+    @Test
+    void environmentVariablesBindDottedRuleKeys() {
+        Map<String, Object> environment = Map.of(
+                "GEOSERVER_EXTENSION_CONTROLFLOW_PROPERTIES_OWS_GLOBAL", "7",
+                "GEOSERVER_EXTENSION_CONTROLFLOW_PROPERTIES_OWS_WMS_GETMAP", "3");
+
+        runnerWithEnvironment(environment).run(context -> {
+            ControlFlowConfigurationProperties config = context.getBean(ControlFlowConfigurationProperties.class);
+            assertThat(config.resolvedProperties())
+                    .containsEntry("ows.global", "7")
+                    .containsEntry("ows.wms.getmap", "3");
+        });
+    }
+
+    @Test
+    void environmentVariableOverridesFileDefinedRule() {
+        Map<String, Object> environment = Map.of("GEOSERVER_EXTENSION_CONTROLFLOW_PROPERTIES_OWS_GLOBAL", "9");
+
+        runnerWithEnvironment(environment)
+                .withPropertyValues("geoserver.extension.control-flow.properties.[ows.global]=4")
+                .run(context -> {
+                    ControlFlowConfigurationProperties config =
+                            context.getBean(ControlFlowConfigurationProperties.class);
+                    assertThat(config.resolvedProperties()).containsEntry("ows.global", "9");
+                });
+    }
+
+    /**
+     * Mirrors production source ordering: the system environment sits above file-provided configuration. The source
+     * must use the {@code systemEnvironment} name: Spring Boot selects the environment-variable name mapper (uppercase
+     * and underscores to dotted keys) by that exact source name, and this replaces the real one, isolating the test
+     * from the host's variables.
+     */
+    private ApplicationContextRunner runnerWithEnvironment(Map<String, Object> environment) {
+        return new ApplicationContextRunner()
+                .withInitializer(new ControlFlowAppContextInitializer())
+                .withInitializer(context -> context.getEnvironment()
+                        .getPropertySources()
+                        .addFirst(new SystemEnvironmentPropertySource(
+                                StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, environment)))
+                .withConfiguration(AutoConfigurations.of(ControlFlowAutoConfiguration.class));
+    }
+}

--- a/src/extensions/control-flow/src/test/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowMetricsAutoConfigurationTest.java
+++ b/src/extensions/control-flow/src/test/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowMetricsAutoConfigurationTest.java
@@ -1,0 +1,51 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.controlflow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class ControlFlowMetricsAutoConfigurationTest {
+
+    private ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withInitializer(new ControlFlowAppContextInitializer())
+            .withConfiguration(AutoConfigurations.of(
+                    ControlFlowAutoConfiguration.class, ControlFlowMetricsAutoConfiguration.class));
+
+    @Test
+    void enabledByDefault() {
+        runner.withBean(SimpleMeterRegistry.class).run(context -> {
+            assertThat(context).hasSingleBean(ControlFlowMetrics.class);
+
+            SimpleMeterRegistry registry = context.getBean(SimpleMeterRegistry.class);
+            context.getBean(ControlFlowMetrics.class).bindTo(registry);
+            assertThat(registry.find("geoserver.controlflow.requests.running").gauge())
+                    .isNotNull();
+        });
+    }
+
+    @Test
+    void disabledWhenMetricsDisabled() {
+        runner.withBean(SimpleMeterRegistry.class)
+                .withPropertyValues("geoserver.metrics.enabled=false")
+                .run(context -> assertThat(context).doesNotHaveBean(ControlFlowMetrics.class));
+    }
+
+    @Test
+    void disabledWithoutMeterRegistry() {
+        runner.run(context -> assertThat(context).doesNotHaveBean(ControlFlowMetrics.class));
+    }
+
+    @Test
+    void disabledWhenControlFlowDisabled() {
+        runner.withBean(SimpleMeterRegistry.class)
+                .withPropertyValues("geoserver.extension.control-flow.enabled=false")
+                .run(context -> assertThat(context).doesNotHaveBean(ControlFlowMetrics.class));
+    }
+}

--- a/src/extensions/control-flow/src/test/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowMetricsTest.java
+++ b/src/extensions/control-flow/src/test/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowMetricsTest.java
@@ -1,0 +1,317 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.controlflow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import java.util.List;
+import java.util.Properties;
+import org.geoserver.flow.ControlFlowCallback;
+import org.geoserver.flow.DefaultFlowControllerProvider;
+import org.geoserver.flow.FlowController;
+import org.geoserver.flow.FlowControllerProvider;
+import org.geoserver.flow.controller.GlobalFlowController;
+import org.geoserver.flow.controller.IpFlowController;
+import org.geoserver.flow.controller.PriorityThreadBlocker;
+import org.geoserver.ows.Request;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class ControlFlowMetricsTest {
+
+    @Test
+    void registersGlobalRequestGauges() {
+        ControlFlowCallback callback = mock(ControlFlowCallback.class);
+        when(callback.getRunningRequests()).thenReturn(6L);
+        when(callback.getBlockedRequests()).thenReturn(2L);
+
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        new ControlFlowMetrics(callback, stubProvider(List.of()), "test-instance").bindTo(registry);
+
+        assertThat(registry.get("geoserver.controlflow.requests.running")
+                        .tag("instance-id", "test-instance")
+                        .gauge()
+                        .value())
+                .isEqualTo(6.0);
+        assertThat(registry.get("geoserver.controlflow.requests.blocked")
+                        .tag("instance-id", "test-instance")
+                        .gauge()
+                        .value())
+                .isEqualTo(2.0);
+    }
+
+    @Test
+    void omitsInstanceIdTagWhenNotConfigured() {
+        ControlFlowCallback callback = mock(ControlFlowCallback.class);
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        new ControlFlowMetrics(callback, stubProvider(List.of()), null).bindTo(registry);
+
+        assertThat(registry.get("geoserver.controlflow.requests.running")
+                        .gauge()
+                        .getId()
+                        .getTag("instance-id"))
+                .isNull();
+    }
+
+    @Test
+    void perRuleGaugesFromExternalizedConfiguration() {
+        Properties rules = new Properties();
+        rules.setProperty("ows.global", "8");
+        rules.setProperty("ows.wms.getmap", "2");
+        rules.setProperty("user.ows.wfs.getfeature", "5/s");
+
+        SimpleMeterRegistry registry = bindToRegistry(externalizedProvider(rules));
+
+        assertRuleGauge(registry, "geoserver.controlflow.rule.limit", "ows.global", 8);
+        assertRuleGauge(registry, "geoserver.controlflow.rule.limit", "ows.wms.getmap", 2);
+        assertRuleGauge(registry, "geoserver.controlflow.rule.running", "ows.global", 0);
+        assertRuleGauge(registry, "geoserver.controlflow.rule.running", "ows.wms.getmap", 0);
+        assertRuleGauge(registry, "geoserver.controlflow.rule.rate.limit", "user.ows.wfs.getfeature", 5);
+        assertThat(registry.find("geoserver.controlflow.rule.waiting").gauges())
+                .as("no waiting gauges without a priority provider")
+                .isEmpty();
+    }
+
+    @Test
+    void controllerTagReportsUpstreamType() {
+        Properties rules = new Properties();
+        rules.setProperty("ows.global", "8");
+
+        SimpleMeterRegistry registry = bindToRegistry(externalizedProvider(rules));
+
+        Gauge limit = registry.get("geoserver.controlflow.rule.limit")
+                .tag("rule", "ows.global")
+                .gauge();
+        assertThat(limit.getId().getTag("controller")).isEqualTo("GlobalFlowController");
+    }
+
+    @Test
+    void priorityRulesReportRunningAndWaiting() {
+        Properties rules = new Properties();
+        rules.setProperty("ows.global", "8");
+        rules.setProperty("ows.priority.http", "gs-priority,3");
+
+        SimpleMeterRegistry registry = bindToRegistry(externalizedProvider(rules));
+
+        assertRuleGauge(registry, "geoserver.controlflow.rule.running", "ows.global", 0);
+        assertRuleGauge(registry, "geoserver.controlflow.rule.waiting", "ows.global", 0);
+    }
+
+    @Test
+    void plainPriorityBlockerOmitsRunningGauge() {
+        GlobalFlowController plain = new GlobalFlowController(8, new PriorityThreadBlocker(8, request -> 0));
+
+        SimpleMeterRegistry registry = bindToRegistry(stubProvider(List.of(plain)));
+
+        assertRuleGauge(registry, "geoserver.controlflow.rule.limit", "ows.global", 8);
+        assertRuleGauge(registry, "geoserver.controlflow.rule.waiting", "ows.global", 0);
+        assertThat(registry.find("geoserver.controlflow.rule.running")
+                        .tag("rule", "ows.global")
+                        .gauge())
+                .as("running is not observable on a plain PriorityThreadBlocker")
+                .isNull();
+    }
+
+    @Test
+    void admittedRequestSeparatesRunningFromWaiting() throws InterruptedException {
+        MonitoredPriorityThreadBlocker blocker = new MonitoredPriorityThreadBlocker(8, request -> 0);
+        blocker.requestIncoming(new Request(), 0);
+        GlobalFlowController controller = new GlobalFlowController(8, blocker);
+
+        SimpleMeterRegistry registry = bindToRegistry(stubProvider(List.of(controller)));
+
+        assertRuleGauge(registry, "geoserver.controlflow.rule.running", "ows.global", 1);
+        assertRuleGauge(registry, "geoserver.controlflow.rule.waiting", "ows.global", 0);
+    }
+
+    @Test
+    void queueRuleGaugesFromExternalizedConfiguration() {
+        Properties rules = new Properties();
+        rules.setProperty("user", "4");
+        rules.setProperty("ip", "6");
+
+        SimpleMeterRegistry registry = bindToRegistry(externalizedProvider(rules));
+
+        assertRuleGauge(registry, "geoserver.controlflow.rule.limit", "user", 4);
+        assertRuleGauge(registry, "geoserver.controlflow.rule.limit", "ip", 6);
+        assertRuleGauge(registry, "geoserver.controlflow.rule.queues.active", "user", 0);
+        assertRuleGauge(registry, "geoserver.controlflow.rule.queues.active", "ip", 0);
+        assertRuleGauge(registry, "geoserver.controlflow.rule.running", "user", 0);
+        assertRuleGauge(registry, "geoserver.controlflow.rule.running", "ip", 0);
+    }
+
+    @Test
+    void queueRuleGaugesTrackLiveQueues() {
+        IpFlowController controller = new IpFlowController(2);
+        SimpleMeterRegistry registry = bindToRegistry(stubProvider(List.of(controller)));
+
+        Request req1 = owsRequest("10.0.0.1");
+        Request req2 = owsRequest("10.0.0.2");
+
+        controller.requestIncoming(req1, -1);
+        controller.requestIncoming(req2, -1);
+
+        assertRuleGauge(registry, "geoserver.controlflow.rule.queues.active", "ip", 2);
+        assertRuleGauge(registry, "geoserver.controlflow.rule.running", "ip", 2);
+
+        controller.requestComplete(req2);
+        // requestComplete resolves the queue from the thread-local of the last
+        // incoming request on this thread (10.0.0.2), one request leaves
+        assertRuleGauge(registry, "geoserver.controlflow.rule.running", "ip", 1);
+    }
+
+    @Test
+    void ruleChangesApplyOnNextSample() {
+        Properties rules = new Properties();
+        rules.setProperty("ows.global", "8");
+        PropertiesControlFlowConfigurator configurator = new PropertiesControlFlowConfigurator(rules);
+        DefaultFlowControllerProvider provider = new DefaultFlowControllerProvider(configurator);
+        configurator.setStale(false);
+
+        SimpleMeterRegistry registry = bindToRegistry(provider);
+        assertRuleGauge(registry, "geoserver.controlflow.rule.limit", "ows.global", 8);
+
+        rules.setProperty("ows.global", "16");
+        rules.setProperty("ows.wms.getmap", "2");
+        configurator.setStale(true);
+        sampleGlobalGauge(registry);
+
+        assertRuleGauge(registry, "geoserver.controlflow.rule.limit", "ows.global", 16);
+        assertRuleGauge(registry, "geoserver.controlflow.rule.limit", "ows.wms.getmap", 2);
+    }
+
+    @Test
+    void removedRulesStopBeingSampled() {
+        Properties rules = new Properties();
+        rules.setProperty("ows.global", "8");
+        rules.setProperty("ows.wms.getmap", "2");
+        PropertiesControlFlowConfigurator configurator = new PropertiesControlFlowConfigurator(rules);
+        DefaultFlowControllerProvider provider = new DefaultFlowControllerProvider(configurator);
+        configurator.setStale(false);
+
+        SimpleMeterRegistry registry = bindToRegistry(provider);
+        assertRuleGauge(registry, "geoserver.controlflow.rule.limit", "ows.wms.getmap", 2);
+
+        rules.remove("ows.wms.getmap");
+        configurator.setStale(true);
+        sampleGlobalGauge(registry);
+
+        assertThat(registry.find("geoserver.controlflow.rule.limit")
+                        .tag("rule", "ows.wms.getmap")
+                        .gauge())
+                .as("row of a removed rule")
+                .isNull();
+        assertRuleGauge(registry, "geoserver.controlflow.rule.limit", "ows.global", 8);
+    }
+
+    @Test
+    void providerFailureKeepsGlobalGaugesAlive() {
+        ControlFlowCallback callback = mock(ControlFlowCallback.class);
+        when(callback.getRunningRequests()).thenReturn(3L);
+        FlowControllerProvider failing = new FlowControllerProvider() {
+            @Override
+            public List<FlowController> getFlowControllers(Request request) {
+                throw new IllegalStateException("boom");
+            }
+
+            @Override
+            public long getTimeout(Request request) {
+                return -1;
+            }
+        };
+
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        new ControlFlowMetrics(callback, failing, null).bindTo(registry);
+
+        assertThat(registry.get("geoserver.controlflow.requests.running")
+                        .gauge()
+                        .value())
+                .isEqualTo(3.0);
+    }
+
+    @Test
+    void prometheusRenderedNamesMatchDocumentation() {
+        Properties rules = new Properties();
+        rules.setProperty("ows.global", "8");
+        rules.setProperty("user", "4");
+        rules.setProperty("user.ows.wfs.getfeature", "5/s");
+
+        PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        new ControlFlowMetrics(mock(ControlFlowCallback.class), externalizedProvider(rules), null).bindTo(registry);
+
+        String scrape = registry.scrape();
+
+        assertThat(scrape)
+                .as("global running gauge keeps its documented name")
+                .contains("geoserver_controlflow_requests_running")
+                .as("rule limit gauge keeps its documented name")
+                .contains("geoserver_controlflow_rule_limit")
+                .as("rule active queues gauge keeps its documented name")
+                .contains("geoserver_controlflow_rule_queues_active")
+                .as("rule rate limit gauge keeps its documented name")
+                .contains("geoserver_controlflow_rule_rate_limit");
+
+        assertThat(scrape)
+                .as("no base-unit suffix on the global running gauge")
+                .doesNotContain("_running_requests")
+                .as("no base-unit suffix on the rule active queues gauge")
+                .doesNotContain("_active_queues");
+    }
+
+    static FlowControllerProvider stubProvider(List<FlowController> controllers) {
+        return new FlowControllerProvider() {
+            @Override
+            public List<FlowController> getFlowControllers(Request request) {
+                return controllers;
+            }
+
+            @Override
+            public long getTimeout(Request request) {
+                return -1;
+            }
+        };
+    }
+
+    private SimpleMeterRegistry bindToRegistry(FlowControllerProvider provider) {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        new ControlFlowMetrics(mock(ControlFlowCallback.class), provider, null).bindTo(registry);
+        return registry;
+    }
+
+    private DefaultFlowControllerProvider externalizedProvider(Properties rules) {
+        PropertiesControlFlowConfigurator configurator = new PropertiesControlFlowConfigurator(rules);
+        DefaultFlowControllerProvider provider = new DefaultFlowControllerProvider(configurator);
+        // mirrors the auto-configuration wiring: the constructor built the
+        // controllers, mark the configurator fresh to stop per-call rebuilds
+        configurator.setStale(false);
+        return provider;
+    }
+
+    private void assertRuleGauge(SimpleMeterRegistry registry, String meter, String rule, double expected) {
+        Gauge gauge = registry.find(meter).tag("rule", rule).gauge();
+        assertThat(gauge).as("%s{rule=%s}", meter, rule).isNotNull();
+        assertThat(gauge.value()).as("%s{rule=%s}", meter, rule).isEqualTo(expected);
+    }
+
+    private void sampleGlobalGauge(SimpleMeterRegistry registry) {
+        registry.get("geoserver.controlflow.requests.running").gauge().value();
+    }
+
+    private Request owsRequest(String remoteAddr) {
+        MockHttpServletRequest http = new MockHttpServletRequest();
+        http.setRemoteAddr(remoteAddr);
+        Request request = new Request();
+        request.setHttpRequest(http);
+        request.setHttpResponse(new MockHttpServletResponse());
+        return request;
+    }
+}

--- a/src/extensions/control-flow/src/test/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/MonitoredPriorityThreadBlockerTest.java
+++ b/src/extensions/control-flow/src/test/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/MonitoredPriorityThreadBlockerTest.java
@@ -1,0 +1,36 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.controlflow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.geoserver.ows.Request;
+import org.junit.jupiter.api.Test;
+
+class MonitoredPriorityThreadBlockerTest {
+
+    @Test
+    void tracksAdmittedRequestsSeparatelyFromWaitingQueue() throws InterruptedException {
+        MonitoredPriorityThreadBlocker blocker = new MonitoredPriorityThreadBlocker(1, request -> 0);
+        Request first = new Request();
+        Request second = new Request();
+
+        assertThat(blocker.requestIncoming(first, -1)).isTrue();
+        assertThat(blocker.getAdmittedCount()).isEqualTo(1);
+        assertThat(blocker.getRunningRequestsCount()).as("waiting queue").isZero();
+
+        // over the limit with a timeout: the superclass still moves the request
+        // into its running set after the wait expires, the mirror must match
+        assertThat(blocker.requestIncoming(second, 20)).isFalse();
+        assertThat(blocker.getAdmittedCount()).isEqualTo(2);
+        assertThat(blocker.getRunningRequestsCount()).as("waiting queue").isZero();
+
+        blocker.requestComplete(second);
+        assertThat(blocker.getAdmittedCount()).isEqualTo(1);
+
+        blocker.requestComplete(first);
+        assertThat(blocker.getAdmittedCount()).isZero();
+    }
+}

--- a/src/extensions/control-flow/src/test/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/PropertiesControlFlowConfiguratorTest.java
+++ b/src/extensions/control-flow/src/test/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/PropertiesControlFlowConfiguratorTest.java
@@ -1,0 +1,47 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.controlflow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Properties;
+import org.geoserver.flow.FlowController;
+import org.geoserver.flow.controller.GlobalFlowController;
+import org.geoserver.flow.controller.SimpleThreadBlocker;
+import org.junit.jupiter.api.Test;
+
+class PropertiesControlFlowConfiguratorTest {
+
+    @Test
+    void priorityRulesUseMonitoredBlocker() throws Exception {
+        Properties rules = new Properties();
+        rules.setProperty("ows.global", "8");
+        rules.setProperty("ows.priority.http", "gs-priority,3");
+
+        GlobalFlowController global = buildGlobalController(rules);
+
+        assertThat(global.getBlocker()).isInstanceOf(MonitoredPriorityThreadBlocker.class);
+    }
+
+    @Test
+    void nonPriorityRulesKeepSimpleBlocker() throws Exception {
+        Properties rules = new Properties();
+        rules.setProperty("ows.global", "8");
+
+        GlobalFlowController global = buildGlobalController(rules);
+
+        assertThat(global.getBlocker()).isInstanceOf(SimpleThreadBlocker.class);
+    }
+
+    private GlobalFlowController buildGlobalController(Properties rules) throws Exception {
+        List<FlowController> controllers = new PropertiesControlFlowConfigurator(rules).buildFlowControllers();
+        return controllers.stream()
+                .filter(GlobalFlowController.class::isInstance)
+                .map(GlobalFlowController.class::cast)
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/src/extensions/control-flow/src/test/java/org/geoserver/flow/controller/QueueControllerStateTest.java
+++ b/src/extensions/control-flow/src/test/java/org/geoserver/flow/controller/QueueControllerStateTest.java
@@ -1,0 +1,45 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.flow.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.geoserver.ows.Request;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class QueueControllerStateTest {
+
+    @Test
+    void reportsActiveQueuesAndTotalQueuedRequests() {
+        IpFlowController controller = new IpFlowController(2);
+        assertThat(QueueControllerState.activeQueues(controller)).isZero();
+        assertThat(QueueControllerState.totalQueued(controller)).isZero();
+
+        Request fromFirstIp = request("10.0.0.1");
+        Request fromSecondIp = request("10.0.0.2");
+        controller.requestIncoming(fromFirstIp, -1);
+        controller.requestIncoming(fromSecondIp, -1);
+
+        assertThat(QueueControllerState.activeQueues(controller)).isEqualTo(2);
+        assertThat(QueueControllerState.totalQueued(controller)).isEqualTo(2);
+
+        // requestComplete resolves the queue from a thread-local set by the last
+        // requestIncoming on this thread, completing in reverse order works
+        controller.requestComplete(fromSecondIp);
+        assertThat(QueueControllerState.totalQueued(controller)).isEqualTo(1);
+        assertThat(QueueControllerState.activeQueues(controller)).isEqualTo(2);
+    }
+
+    private Request request(String remoteAddr) {
+        MockHttpServletRequest http = new MockHttpServletRequest();
+        http.setRemoteAddr(remoteAddr);
+        Request request = new Request();
+        request.setHttpRequest(http);
+        request.setHttpResponse(new MockHttpServletResponse());
+        return request;
+    }
+}


### PR DESCRIPTION
Expose the control-flow figures as Micrometer gauges on the actuator Prometheus endpoint: global running/blocked request counts, and per-rule limit, running, waiting, active-queues and rate gauges tagged by rule and controller.

Values resolve at scrape time from the live flow controllers, and rule changes take effect on the next scrape.

A small blocker subclass tracks the running count upstream keeps private, normalizing the running-vs-waiting semantics of priority queues, and a split-package helper reads the per-user/per-IP queue maps without reflection.

ConditionalOnGeoServerMetricsEnabled now honors geoserver.metrics.enabled, for catalog and control-flow metrics alike.

The dev compose monitoring stack gains control-flow panels on the overview dashboard and a dedicated per-rule dashboard showing saturation against configured limits, blocking episodes, and the live rule inventory.

Control-flow rules are now configured per service through profile documents in the config submodule: each service loads only the rules that apply to it, restconfig and webui disable the extension, and the defaults are relaxed following the guidance in #873 (no global cap, more generous rendering and tile limits). Rules can be overridden per container through environment variables, a contract pinned by tests.

The user guide gains a hands-on monitoring tutorial, a control-flow metrics reference with validated PromQL and Grafana examples, and an index page.

on-behalf-of: @camptocamp <info@camptocamp.com>