### PR TITLE
Update Dockerfiles to use Spring Boot tools jarmode

### DIFF
--- a/src/apps/base-images/geoserver/Dockerfile
+++ b/src/apps/base-images/geoserver/Dockerfile
@@ -6,7 +6,7 @@ ARG JAR_FILE=target/gs-cloud-*-bin.jar
 WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
-RUN java -Djarmode=layertools -jar application.jar extract
+RUN java -Djarmode=tools -jar application.jar extract --layers --launcher
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-spring-boot:$TAG

--- a/src/apps/base-images/spring-boot/Dockerfile
+++ b/src/apps/base-images/spring-boot/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
 
-RUN java -Djarmode=layertools -jar application.jar extract
+RUN java -Djarmode=tools -jar application.jar extract --layers --launcher
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-jre:$TAG

--- a/src/apps/geoserver/gwc/Dockerfile
+++ b/src/apps/geoserver/gwc/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
 
-RUN java -Djarmode=layertools -jar application.jar extract
+RUN java -Djarmode=tools -jar application.jar extract --layers --launcher
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-geoserver-image:$TAG

--- a/src/apps/geoserver/restconfig/Dockerfile
+++ b/src/apps/geoserver/restconfig/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
 
-RUN java -Djarmode=layertools -jar application.jar extract
+RUN java -Djarmode=tools -jar application.jar extract --layers --launcher
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-geoserver-image:$TAG

--- a/src/apps/geoserver/wcs/Dockerfile
+++ b/src/apps/geoserver/wcs/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
 
-RUN java -Djarmode=layertools -jar application.jar extract
+RUN java -Djarmode=tools -jar application.jar extract --layers --launcher
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-geoserver-image:$TAG

--- a/src/apps/geoserver/webui/Dockerfile
+++ b/src/apps/geoserver/webui/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
 
-RUN java -Djarmode=layertools -jar application.jar extract
+RUN java -Djarmode=tools -jar application.jar extract --layers --launcher
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-geoserver-image:$TAG

--- a/src/apps/geoserver/wfs/Dockerfile
+++ b/src/apps/geoserver/wfs/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
 
-RUN java -Djarmode=layertools -jar application.jar extract
+RUN java -Djarmode=tools -jar application.jar extract --layers --launcher
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-geoserver-image:$TAG

--- a/src/apps/geoserver/wms/Dockerfile
+++ b/src/apps/geoserver/wms/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
 
-RUN java -Djarmode=layertools -jar application.jar extract
+RUN java -Djarmode=tools -jar application.jar extract --layers --launcher
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-geoserver-image:$TAG

--- a/src/apps/geoserver/wps/Dockerfile
+++ b/src/apps/geoserver/wps/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
 
-RUN java -Djarmode=layertools -jar application.jar extract
+RUN java -Djarmode=tools -jar application.jar extract --layers --launcher
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-geoserver-image:$TAG

--- a/src/apps/infrastructure/config/Dockerfile
+++ b/src/apps/infrastructure/config/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
 
-RUN java -Djarmode=layertools -jar application.jar extract
+RUN java -Djarmode=tools -jar application.jar extract --layers --launcher
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-spring-boot:$TAG

--- a/src/apps/infrastructure/gateway-webflux/Dockerfile
+++ b/src/apps/infrastructure/gateway-webflux/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
 
-RUN java -Djarmode=layertools -jar application.jar extract
+RUN java -Djarmode=tools -jar application.jar extract --layers --launcher
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-spring-boot:$TAG

--- a/src/apps/infrastructure/gateway-webmvc/Dockerfile
+++ b/src/apps/infrastructure/gateway-webmvc/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
 
-RUN java -Djarmode=layertools -jar application.jar extract
+RUN java -Djarmode=tools -jar application.jar extract --layers --launcher
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-spring-boot:$TAG


### PR DESCRIPTION
## Description

Updates the Docker image build process to use Spring Boot's `tools` jarmode instead of the deprecated `layertools` mode.

## Changes

- Replaces `-Djarmode=layertools` with `-Djarmode=tools`
- Adds the required `--layers` and `--launcher` extraction flags
- Updates all 12 Dockerfiles containing the deprecated command
- Includes the current WebFlux and WebMVC gateway Dockerfiles

## Validation

- Confirmed that no `jarmode=layertools` occurrences remain in Dockerfiles
- Confirmed all 12 updated commands use `extract --layers --launcher`
- Ran `git diff --check` successfully
- Verified the project Maven wrapper with Maven 3.9.14 and Java 25.0.4
- Verified the local Docker 29.5.3 environment
- Full project build was not run locally

Fixes #791