### PR TITLE
Upgrade GeoServer ACL 3.0.1

### DIFF
--- a/compose/.env
+++ b/compose/.env
@@ -2,7 +2,7 @@
 REPOSITORY=geoservercloud
 TAG=3.1.0-SNAPSHOT
 ACL_REPOSITORY=geoservercloud
-ACL_TAG=3.0.0
+ACL_TAG=3.0.1
 
 GS_USER="1000:1000"
 

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -36,7 +36,7 @@
     <gs.version>3.1.0-CLOUD-SNAPSHOT</gs.version>
     <gt.version>36-SNAPSHOT</gt.version>
     <wicket.version>10.9.1</wicket.version>
-    <acl.version>3.0.0</acl.version>
+    <acl.version>3.0.1</acl.version>
     <cloud-dependencies-bom.version>1.0.2</cloud-dependencies-bom.version>
     <jackson.version>3.1.2</jackson.version>
     <jackson2.version>2.21.0</jackson2.version>


### PR DESCRIPTION
fix: remove defunct jackson-datatype-jsr310 dependency

Poduced a stack trace due to `JavaTimeModule` being automatically picked up from spring boot's default jackson ObjectMapper:

```
geoserver-webui-1  | Caused by: java.lang.NoSuchFieldError: Class tools.jackson.databind.SerializationFeature does not have member field 'tools.jackson.databind.SerializationFeature WRITE_DURATIONS_AS_TIMESTAMPS'
geoserver-webui-1  | 	at tools.jackson.datatype.jsr310.ser.DurationSerializer.getTimestampsFeature(DurationSerializer.java:92)
geoserver-webui-1  | 	at tools.jackson.datatype.jsr310.ser.JSR310FormattedSerializerBase.useTimestampFromGlobalDefaults(JSR310FormattedSerializerBase.java:215)
...
``` 

on-behalf-of: @camptocamp <info@camptocamp.com>