### PR TITLE
feat(gwc): project catalog events into tile layers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ start-acceptance-tests-datadir:
 
 .PHONY: run-acceptance-tests-datadir
 run-acceptance-tests-datadir:
-	(cd compose/ && TAG=$(TAG) ./acceptance_datadir run --rm -T acceptance bash -c 'until [ -f /tmp/healthcheck ]; do echo "Waiting for /tmp/healthcheck to be available..."; sleep 5; done && COLUMNS=120 pytest -v --color=yes --pyargs geoserver_acceptance_tests.tests  -k "not test_i18n_layers_default_locale"')
+	(cd compose/ && TAG=$(TAG) ./acceptance_datadir run --rm -T acceptance bash -c 'until [ -f /tmp/healthcheck ]; do echo "Waiting for /tmp/healthcheck to be available..."; sleep 5; done && COLUMNS=120 pytest -v --color=yes --pyargs geoserver_acceptance_tests.tests -k "not test_i18n_layers_default_locale" && COLUMNS=120 pytest -v --color=yes /acceptance_tests/system_tests')
 
 .PHONY: clean-acceptance-tests-datadir
 clean-acceptance-tests-datadir:
@@ -168,7 +168,7 @@ start-acceptance-tests-pgconfig:
 
 .PHONY: run-acceptance-tests-pgconfig
 run-acceptance-tests-pgconfig:
-	(cd compose/ && TAG=$(TAG) ./acceptance_pgconfig run --rm -T acceptance bash -c 'until [ -f /tmp/healthcheck ]; do echo "Waiting for /tmp/healthcheck to be available..."; sleep 5; done && COLUMNS=120 pytest -v --color=yes --pyargs geoserver_acceptance_tests.tests  -k "not test_i18n_layers_default_locale"')
+	(cd compose/ && TAG=$(TAG) ./acceptance_pgconfig run --rm -T acceptance bash -c 'until [ -f /tmp/healthcheck ]; do echo "Waiting for /tmp/healthcheck to be available..."; sleep 5; done && COLUMNS=120 pytest -v --color=yes --pyargs geoserver_acceptance_tests.tests -k "not test_i18n_layers_default_locale" && COLUMNS=120 pytest -v --color=yes /acceptance_tests/system_tests')
 
 .PHONY: clean-acceptance-tests-pgconfig
 clean-acceptance-tests-pgconfig:

--- a/acceptance_tests/README.md
+++ b/acceptance_tests/README.md
@@ -52,6 +52,9 @@ cd ../compose
 
 # Run specific tests inside the container
 ./acceptance_datadir exec acceptance pytest --pyargs geoserver_acceptance_tests.tests.test_cog -v --color=yes
+
+# Run repository-owned cross-service system tests
+./acceptance_datadir exec acceptance pytest /acceptance_tests/system_tests -v --color=yes
 ```
 
 #### Run tests from host machine (full functionality)

--- a/acceptance_tests/system_tests/test_restconfig_gwc.py
+++ b/acceptance_tests/system_tests/test_restconfig_gwc.py
@@ -1,0 +1,80 @@
+"""System tests for catalog changes that cross the REST-config/GWC boundary."""
+
+import os
+import time
+import uuid
+from urllib.parse import quote
+
+import requests
+
+
+RESTCONFIG_URL = os.getenv("RESTCONFIG_URL", "http://restconfig:8080").rstrip("/")
+GWC_URL = os.getenv("GWC_URL", "http://gwc:8080").rstrip("/")
+GEOSERVER_USERNAME = os.getenv("GEOSERVER_USERNAME", "admin")
+GEOSERVER_PASSWORD = os.getenv("GEOSERVER_PASSWORD", "geoserver")
+REQUEST_TIMEOUT = float(os.getenv("SYSTEM_TEST_REQUEST_TIMEOUT", "10"))
+EVENT_TIMEOUT = float(os.getenv("SYSTEM_TEST_EVENT_TIMEOUT", "30"))
+
+
+def _session():
+    session = requests.Session()
+    session.auth = (GEOSERVER_USERNAME, GEOSERVER_PASSWORD)
+    return session
+
+
+def _response_details(response):
+    body = response.text.strip()
+    if len(body) > 1000:
+        body = f"{body[:1000]}..."
+    return f"{response.request.method} {response.url} returned {response.status_code}: {body}"
+
+
+def _wait_for_tile_layer(session, qualified_name):
+    encoded_name = quote(qualified_name, safe=":")
+    endpoint = f"{GWC_URL}/gwc/rest/layers/{encoded_name}.json"
+    deadline = time.monotonic() + EVENT_TIMEOUT
+    last_response = None
+
+    while time.monotonic() < deadline:
+        last_response = session.get(endpoint, timeout=REQUEST_TIMEOUT)
+        if last_response.status_code == 200:
+            return last_response
+        time.sleep(0.5)
+
+    assert last_response is not None
+    raise AssertionError(
+        f"GWC did not expose tile layer {qualified_name!r} within {EVENT_TIMEOUT} seconds; "
+        f"last response: {_response_details(last_response)}"
+    )
+
+
+def test_rest_created_layer_is_visible_in_the_gwc_service():
+    """REST catalog publication must create tile-layer state consumed by GWC."""
+
+    session = _session()
+    layer_name = f"rest_gwc_system_{uuid.uuid4().hex}"
+    qualified_name = f"sf:{layer_name}"
+    feature_type_endpoint = f"{RESTCONFIG_URL}/rest/workspaces/sf/datastores/sf/featuretypes"
+    layer_endpoint = f"{RESTCONFIG_URL}/rest/layers/{quote(qualified_name, safe=':')}.json"
+    delete_endpoint = f"{feature_type_endpoint}/{quote(layer_name, safe='')}?recurse=true"
+
+    payload = {
+        "featureType": {
+            "name": layer_name,
+            "nativeName": "roads",
+            "title": "REST/GWC system-test layer",
+        }
+    }
+
+    create_response = session.post(feature_type_endpoint, json=payload, timeout=REQUEST_TIMEOUT)
+    assert create_response.status_code == 201, _response_details(create_response)
+
+    try:
+        catalog_response = session.get(layer_endpoint, timeout=REQUEST_TIMEOUT)
+        assert catalog_response.status_code == 200, _response_details(catalog_response)
+
+        gwc_response = _wait_for_tile_layer(session, qualified_name)
+        assert qualified_name in gwc_response.text, _response_details(gwc_response)
+    finally:
+        delete_response = session.delete(delete_endpoint, timeout=REQUEST_TIMEOUT)
+        assert delete_response.status_code in (200, 202), _response_details(delete_response)

--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,11 @@
       </dependency>
       <dependency>
         <groupId>org.geoserver.cloud.gwc</groupId>
+        <artifactId>gwc-cloud-catalog-event-integration</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver.cloud.gwc</groupId>
         <artifactId>gwc-cloud-spring-boot-autoconfigure</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationTest.java
+++ b/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationTest.java
@@ -48,6 +48,12 @@ abstract class RestConfigApplicationTest {
     protected @Autowired Catalog catalog;
 
     @Test
+    void testDoesNotLoadGwcRuntime() {
+        assertThat(context.containsBean("gwc")).isFalse();
+        assertThat(context.containsBean("gwcCatalogConfiguration")).isFalse();
+    }
+
+    @Test
     void testAnnonymousForbidden() {
         ResponseEntity<String> response = restTemplate.getForEntity("/rest", String.class);
         assertThat(response.getStatusCode()).isEqualTo(FORBIDDEN);

--- a/src/gwc/autoconfigure/pom.xml
+++ b/src/gwc/autoconfigure/pom.xml
@@ -26,6 +26,10 @@
       <artifactId>gwc-cloud-bus-integration</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.geoserver.cloud.gwc</groupId>
+      <artifactId>gwc-cloud-catalog-event-integration</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.geoserver.cloud.catalog</groupId>
       <artifactId>gs-cloud-events</artifactId>
     </dependency>

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/CatalogEventTileLayerAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/integration/CatalogEventTileLayerAutoConfiguration.java
@@ -1,0 +1,34 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.autoconfigure.gwc.integration;
+
+import org.geoserver.catalog.Catalog;
+import org.geoserver.cloud.autoconfigure.catalog.event.ConditionalOnCatalogEvents;
+import org.geoserver.cloud.autoconfigure.gwc.ConditionalOnGeoWebCacheEnabled;
+import org.geoserver.cloud.autoconfigure.gwc.core.GeoWebCacheAutoConfiguration;
+import org.geoserver.cloud.event.catalog.CatalogInfoAdded;
+import org.geoserver.cloud.gwc.catalog.CatalogTileLayerProjector;
+import org.geoserver.gwc.GWC;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+/** Configures GWC-owned projection of GeoServer catalog events into tile-layer state. */
+@AutoConfiguration(after = GeoWebCacheAutoConfiguration.class)
+@ConditionalOnGeoWebCacheEnabled
+@ConditionalOnCatalogEvents
+@ConditionalOnClass({CatalogInfoAdded.class, GWC.class})
+@ConditionalOnBean({Catalog.class, GWC.class})
+public class CatalogEventTileLayerAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    CatalogTileLayerProjector catalogTileLayerProjector(Catalog catalog, GWC gwc) {
+        return new CatalogTileLayerProjector(catalog, gwc);
+    }
+}

--- a/src/gwc/autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/gwc/autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -2,6 +2,7 @@ org.geoserver.cloud.autoconfigure.gwc.core.GeoWebCacheAutoConfiguration
 org.geoserver.cloud.autoconfigure.gwc.core.CacheSeedingWebMapServiceAutoConfiguration
 
 org.geoserver.cloud.autoconfigure.gwc.integration.GeoWebCacheRemoteEventsAutoConfiguration
+org.geoserver.cloud.autoconfigure.gwc.integration.CatalogEventTileLayerAutoConfiguration
 org.geoserver.cloud.autoconfigure.gwc.integration.WMSIntegrationAutoConfiguration
 org.geoserver.cloud.autoconfigure.gwc.integration.WMTSIntegrationAutoConfiguration
 

--- a/src/gwc/integration-catalog-events/pom.xml
+++ b/src/gwc/integration-catalog-events/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.geoserver.cloud.gwc</groupId>
+    <artifactId>gwc-cloud</artifactId>
+    <version>${revision}</version>
+  </parent>
+  <artifactId>gwc-cloud-catalog-event-integration</artifactId>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.geoserver.cloud.gwc</groupId>
+      <artifactId>gwc-cloud-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.cloud.catalog</groupId>
+      <artifactId>gs-cloud-events</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/gwc/integration-catalog-events/src/main/java/org/geoserver/cloud/gwc/catalog/CatalogTileLayerProjector.java
+++ b/src/gwc/integration-catalog-events/src/main/java/org/geoserver/cloud/gwc/catalog/CatalogTileLayerProjector.java
@@ -1,0 +1,153 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.gwc.catalog;
+
+import java.util.List;
+import java.util.function.Function;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.PublishedInfo;
+import org.geoserver.cloud.event.catalog.CatalogInfoAdded;
+import org.geoserver.cloud.event.catalog.CatalogInfoModified;
+import org.geoserver.cloud.event.catalog.CatalogInfoRemoved;
+import org.geoserver.cloud.event.info.ConfigInfoType;
+import org.geoserver.gwc.GWC;
+import org.geoserver.gwc.config.GWCConfig;
+import org.geoserver.gwc.layer.GeoServerTileLayer;
+import org.springframework.context.event.EventListener;
+
+/**
+ * Projects distributed GeoServer catalog events into the tile-layer state owned by the GWC service.
+ *
+ * <p>Events are treated as notifications. Add and modify events resolve the latest catalog object by stable identifier
+ * and reconcile it with the current GWC configuration. Existing tile-layer settings are never regenerated or
+ * overwritten.
+ */
+@Slf4j(topic = "org.geoserver.cloud.gwc.catalog")
+public class CatalogTileLayerProjector {
+
+    private final @NonNull Catalog catalog;
+    private final @NonNull GWC gwc;
+    private final @NonNull Function<PublishedInfo, GeoServerTileLayer> tileLayerFactory;
+
+    public CatalogTileLayerProjector(@NonNull Catalog catalog, @NonNull GWC gwc) {
+        this(catalog, gwc, published -> new GeoServerTileLayer(published, gwc.getConfig(), gwc.getGridSetBroker()));
+    }
+
+    CatalogTileLayerProjector(
+            @NonNull Catalog catalog,
+            @NonNull GWC gwc,
+            @NonNull Function<PublishedInfo, GeoServerTileLayer> tileLayerFactory) {
+        this.catalog = catalog;
+        this.gwc = gwc;
+        this.tileLayerFactory = tileLayerFactory;
+    }
+
+    @EventListener(CatalogInfoAdded.class)
+    public void onCatalogInfoAdded(CatalogInfoAdded event) {
+        reconcile(event.getObjectType(), event.getObjectId());
+    }
+
+    @EventListener(CatalogInfoModified.class)
+    public void onCatalogInfoModified(CatalogInfoModified event) {
+        ConfigInfoType type = event.getObjectType();
+        PublishedInfo published = resolve(type, event.getObjectId());
+        if (published == null) {
+            warnNotVisible(type, event.getObjectId());
+            return;
+        }
+
+        String currentName = tileLayerName(published);
+        String oldName = qualifyOldName(event.getOldName(), currentName);
+        if (!oldName.equals(currentName) && gwc.tileLayerExists(oldName)) {
+            log.debug("Renaming GWC tile layer {} to {}", oldName, currentName);
+            gwc.rename(oldName, currentName);
+            return;
+        }
+        reconcile(published, event.getObjectId());
+    }
+
+    @EventListener(CatalogInfoRemoved.class)
+    public void onCatalogInfoRemoved(CatalogInfoRemoved event) {
+        if (!isPublished(event.getObjectType())) {
+            return;
+        }
+
+        String layerName = event.getObjectName();
+        if (gwc.tileLayerExists(layerName)) {
+            log.debug("Removing GWC tile layer {} after catalog removal", layerName);
+            gwc.removeTileLayers(List.of(layerName));
+        }
+    }
+
+    private void reconcile(ConfigInfoType type, String publishedId) {
+        PublishedInfo published = resolve(type, publishedId);
+        if (published == null) {
+            warnNotVisible(type, publishedId);
+            return;
+        }
+        reconcile(published, publishedId);
+    }
+
+    private void reconcile(PublishedInfo published, String publishedId) {
+        GeoServerTileLayer existing = existingTileLayer(published);
+        if (existing != null) {
+            return;
+        }
+
+        GWCConfig config = gwc.getConfig();
+        if (!config.isSane() || !config.isCacheLayersByDefault()) {
+            return;
+        }
+
+        log.debug("Creating automatic GWC tile layer for catalog object {}", publishedId);
+        gwc.add(tileLayerFactory.apply(published));
+    }
+
+    private GeoServerTileLayer existingTileLayer(PublishedInfo published) {
+        if (!gwc.hasTileLayer(published)) {
+            return null;
+        }
+        return gwc.getTileLayer(published);
+    }
+
+    private void warnNotVisible(ConfigInfoType type, String publishedId) {
+        if (isPublished(type)) {
+            log.warn("Unable to project catalog event for {} {}: the catalog object is not visible", type, publishedId);
+        }
+    }
+
+    private static String qualifyOldName(String oldName, String currentName) {
+        int prefixEnd = currentName.indexOf(':');
+        if (prefixEnd > 0 && oldName.indexOf(':') < 0) {
+            return currentName.substring(0, prefixEnd + 1) + oldName;
+        }
+        return oldName;
+    }
+
+    private PublishedInfo resolve(ConfigInfoType type, String publishedId) {
+        return switch (type) {
+            case LAYER -> catalog.getLayer(publishedId);
+            case LAYERGROUP -> catalog.getLayerGroup(publishedId);
+            default -> null;
+        };
+    }
+
+    private static boolean isPublished(ConfigInfoType type) {
+        return type == ConfigInfoType.LAYER || type == ConfigInfoType.LAYERGROUP;
+    }
+
+    private static String tileLayerName(PublishedInfo published) {
+        return switch (published) {
+            case LayerInfo layer -> GWC.tileLayerName(layer);
+            case LayerGroupInfo group -> GWC.tileLayerName(group);
+            default -> throw new IllegalArgumentException("Unsupported published object: " + published);
+        };
+    }
+}

--- a/src/gwc/integration-catalog-events/src/test/java/org/geoserver/cloud/gwc/catalog/CatalogTileLayerProjectorTest.java
+++ b/src/gwc/integration-catalog-events/src/test/java/org/geoserver/cloud/gwc/catalog/CatalogTileLayerProjectorTest.java
@@ -1,0 +1,172 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.gwc.catalog;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Function;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.PublishedInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.cloud.event.catalog.CatalogInfoAdded;
+import org.geoserver.cloud.event.catalog.CatalogInfoModified;
+import org.geoserver.cloud.event.catalog.CatalogInfoRemoved;
+import org.geoserver.cloud.event.info.ConfigInfoType;
+import org.geoserver.gwc.GWC;
+import org.geoserver.gwc.config.GWCConfig;
+import org.geoserver.gwc.layer.GeoServerTileLayer;
+import org.geoserver.gwc.layer.GeoServerTileLayerInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CatalogTileLayerProjectorTest {
+
+    private Catalog catalog;
+    private GWC gwc;
+    private GWCConfig config;
+    private Function<PublishedInfo, GeoServerTileLayer> factory;
+    private CatalogTileLayerProjector projector;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        catalog = mock(Catalog.class);
+        gwc = mock(GWC.class);
+        config = mock(GWCConfig.class);
+        factory = mock(Function.class);
+        projector = new CatalogTileLayerProjector(catalog, gwc, factory);
+        when(gwc.getConfig()).thenReturn(config);
+    }
+
+    @Test
+    void addedLayerCreatesTileLayerFromCurrentCatalogState() {
+        LayerInfo layer = layer("layer-id", "test:roads");
+        GeoServerTileLayer tileLayer = mock(GeoServerTileLayer.class);
+        CatalogInfoAdded event = event(CatalogInfoAdded.class, ConfigInfoType.LAYER, "layer-id", "test:roads");
+        when(catalog.getLayer("layer-id")).thenReturn(layer);
+        when(config.isSane()).thenReturn(true);
+        when(config.isCacheLayersByDefault()).thenReturn(true);
+        when(factory.apply(layer)).thenReturn(tileLayer);
+
+        projector.onCatalogInfoAdded(event);
+
+        verify(gwc).add(tileLayer);
+    }
+
+    @Test
+    void duplicateAddPreservesExistingTileLayerConfiguration() {
+        LayerInfo layer = layer("layer-id", "test:roads");
+        GeoServerTileLayer existing = tileLayer("test:roads");
+        CatalogInfoAdded event = event(CatalogInfoAdded.class, ConfigInfoType.LAYER, "layer-id", "test:roads");
+        when(catalog.getLayer("layer-id")).thenReturn(layer);
+        when(gwc.hasTileLayer(layer)).thenReturn(true);
+        when(gwc.getTileLayer(layer)).thenReturn(existing);
+
+        projector.onCatalogInfoAdded(event);
+
+        verifyNoInteractions(factory);
+        verify(gwc, never()).add(any());
+        verify(gwc, never()).rename(any(), any());
+    }
+
+    @Test
+    void automaticCachingDisabledDoesNotCreateTileLayer() {
+        LayerGroupInfo group = group("group-id", "test:basemap");
+        CatalogInfoAdded event = event(CatalogInfoAdded.class, ConfigInfoType.LAYERGROUP, "group-id", "test:basemap");
+        when(catalog.getLayerGroup("group-id")).thenReturn(group);
+        when(config.isSane()).thenReturn(true);
+        when(config.isCacheLayersByDefault()).thenReturn(false);
+
+        projector.onCatalogInfoAdded(event);
+
+        verifyNoInteractions(factory);
+        verify(gwc, never()).add(any());
+    }
+
+    @Test
+    void modifiedLayerRenamesExistingConfigurationWithoutReplacingIt() {
+        LayerInfo layer = layer("layer-id", "test:new-name");
+        CatalogInfoModified event = event(CatalogInfoModified.class, ConfigInfoType.LAYER, "layer-id", "test:new-name");
+        when(catalog.getLayer("layer-id")).thenReturn(layer);
+        when(event.getOldName()).thenReturn("old-name");
+        when(gwc.tileLayerExists("test:old-name")).thenReturn(true);
+
+        projector.onCatalogInfoModified(event);
+
+        verify(gwc).rename("test:old-name", "test:new-name");
+        verifyNoInteractions(factory);
+    }
+
+    @Test
+    void duplicateRemoveIsANoOp() {
+        CatalogInfoRemoved event = event(CatalogInfoRemoved.class, ConfigInfoType.LAYER, "layer-id", "test:roads");
+
+        projector.onCatalogInfoRemoved(event);
+
+        verify(gwc, never()).removeTileLayers(any());
+    }
+
+    @Test
+    void removeDeletesExistingTileLayerByRecordedName() {
+        CatalogInfoRemoved event = event(CatalogInfoRemoved.class, ConfigInfoType.LAYER, "layer-id", "test:roads");
+        when(gwc.tileLayerExists("test:roads")).thenReturn(true);
+
+        projector.onCatalogInfoRemoved(event);
+
+        verify(gwc).removeTileLayers(java.util.List.of("test:roads"));
+    }
+
+    @Test
+    void ignoresCatalogObjectsThatAreNotPublished() {
+        CatalogInfoAdded event = event(CatalogInfoAdded.class, ConfigInfoType.FEATURETYPE, "resource-id", "test:roads");
+
+        projector.onCatalogInfoAdded(event);
+
+        verifyNoInteractions(factory);
+        verifyNoInteractions(gwc);
+        verifyNoInteractions(catalog);
+    }
+
+    private LayerInfo layer(String id, String name) {
+        LayerInfo layer = mock(LayerInfo.class);
+        ResourceInfo resource = mock(ResourceInfo.class);
+        when(layer.getId()).thenReturn(id);
+        when(layer.getResource()).thenReturn(resource);
+        when(resource.prefixedName()).thenReturn(name);
+        return layer;
+    }
+
+    private LayerGroupInfo group(String id, String name) {
+        LayerGroupInfo group = mock(LayerGroupInfo.class);
+        when(group.getId()).thenReturn(id);
+        when(group.prefixedName()).thenReturn(name);
+        return group;
+    }
+
+    private GeoServerTileLayer tileLayer(String name) {
+        GeoServerTileLayer layer = mock(GeoServerTileLayer.class);
+        GeoServerTileLayerInfo info = mock(GeoServerTileLayerInfo.class);
+        when(layer.getInfo()).thenReturn(info);
+        when(info.getName()).thenReturn(name);
+        return layer;
+    }
+
+    private <T> T event(Class<T> eventType, ConfigInfoType objectType, String objectId, String objectName) {
+        T event = mock(eventType);
+        org.geoserver.cloud.event.info.InfoEvent infoEvent = (org.geoserver.cloud.event.info.InfoEvent) event;
+        when(infoEvent.getObjectType()).thenReturn(objectType);
+        when(infoEvent.getObjectId()).thenReturn(objectId);
+        when(infoEvent.getObjectName()).thenReturn(objectName);
+        return event;
+    }
+}

--- a/src/gwc/pom.xml
+++ b/src/gwc/pom.xml
@@ -15,6 +15,7 @@
     <module>backends</module>
     <module>blobstores</module>
     <module>integration-bus</module>
+    <module>integration-catalog-events</module>
     <module>autoconfigure</module>
     <module>starter</module>
   </modules>


### PR DESCRIPTION
Starting to explore what's required for #519 

Ran this via Codex and OpenSpec.

There are some interesting choices to be made re naming and when to overwrite tiles etc.

Testing wise passing in some data creating the layer and then triggering tiling via REST is ideal

Looks like there are some alternative conventions for the python tests though
