### PR TITLE
Add GWC catalog integration to the restconfig app

### DIFF
--- a/acceptance_tests/requirements.txt
+++ b/acceptance_tests/requirements.txt
@@ -1,4 +1,4 @@
-geoservercloud==0.8.5
+geoservercloud==0.8.10
 # To debug a local version of python-geoservercloud:
 # git clone git@github.com:camptocamp/python-geoservercloud
 # and then uncomment the following line and adjust the path accordingly

--- a/docs/src/developer-guide/services/restconfig-v1-service.md
+++ b/docs/src/developer-guide/services/restconfig-v1-service.md
@@ -8,7 +8,19 @@ Spring Boot/Cloud microservice that exposes GeoServer [REST API](https://docs.ge
 
 The Gateway service discovers this service via Consul and performs client-side load balancing.
 
+The service runs the GeoWebCache catalog integration: creating, renaming, or
+deleting layers and layer groups through the REST API creates, renames, or
+deletes the corresponding GWC tile layers, honoring the "automatically cache
+new layers" setting, and truncates caches affected by style changes. Changes
+propagate to the other services through the event bus and the shared
+tile-layer configuration storage.
+
 ## Configuration
+
+Like the `wms`, `webui`, and `gwc` services, this service needs access to the
+GeoWebCache cache directory (`gwc.cache-directory`, usually set through the
+`GEOWEBCACHE_CACHE_DIR` environment variable) in order to apply tile-layer
+deletions and cache truncations.
 
 ## Developing
 

--- a/src/apps/geoserver/restconfig/pom.xml
+++ b/src/apps/geoserver/restconfig/pom.xml
@@ -39,6 +39,11 @@
       <artifactId>gs-restconfig-wmts</artifactId>
     </dependency>
     <dependency>
+      <!-- runs the GWC catalog listeners here so tile layers follow REST catalog changes -->
+      <groupId>org.geoserver.cloud.gwc</groupId>
+      <artifactId>gwc-cloud-spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.geoserver.cloud.catalog.backend</groupId>
       <artifactId>gs-cloud-catalog-backend-pgconfig</artifactId>
       <version>${project.version}</version>

--- a/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/ParquetryRestApiIT.java
+++ b/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/ParquetryRestApiIT.java
@@ -9,9 +9,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
+import java.nio.file.Path;
 import java.util.List;
 import org.geoserver.cloud.backend.pgconfig.support.PgConfigTestContainer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
@@ -70,9 +72,12 @@ class ParquetryRestApiIT {
                     "/data/" + BUCKET + "/populated_places.parquet")
             .waitingFor(Wait.forListeningPort());
 
+    static @TempDir Path gwcCacheDir;
+
     @DynamicPropertySource
     static void setUpPgConfig(DynamicPropertyRegistry registry) {
         pgconfig.setupDynamicPropertySource(registry);
+        registry.add("gwc.cache-directory", gwcCacheDir::toAbsolutePath);
     }
 
     @Autowired

--- a/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationPgconfigIT.java
+++ b/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationPgconfigIT.java
@@ -5,7 +5,9 @@
 
 package org.geoserver.cloud.restconfig;
 
+import java.nio.file.Path;
 import org.geoserver.cloud.backend.pgconfig.support.PgConfigTestContainer;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.ActiveProfiles;
@@ -34,8 +36,11 @@ class RestConfigApplicationPgconfigIT extends RestConfigApplicationTest {
      *   <li>pgconfig.password
      * </ul>
      */
+    static @TempDir Path gwcCacheDir;
+
     @DynamicPropertySource
     static void setUpDataDir(DynamicPropertyRegistry registry) {
         container.setupDynamicPropertySource(registry);
+        registry.add("gwc.cache-directory", gwcCacheDir::toAbsolutePath);
     }
 }

--- a/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationTest.java
+++ b/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationTest.java
@@ -17,13 +17,27 @@ import static org.springframework.http.MediaType.TEXT_HTML;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogFactory;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.SLDHandler;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.Styles;
+import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.cloud.autoconfigure.extensions.test.ConditionalTestAutoConfiguration;
+import org.geoserver.gwc.GWC;
 import org.geotools.api.style.Style;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
@@ -46,6 +60,176 @@ abstract class RestConfigApplicationTest {
     protected ConfigurableApplicationContext context;
 
     protected @Autowired Catalog catalog;
+
+    @Test
+    void gwcCoreIntegrationPresent() {
+        assertThat(context.containsBean("gwcFacade"))
+                .as("the GWC mediator bean must exist for tile layers to follow catalog changes (issue #519)")
+                .isTrue();
+        assertThat(context.containsBean("gwcCatalogConfiguration")).isTrue();
+    }
+
+    @Test
+    void tileLayerFollowsCatalogLifecycle(@TempDir Path storeDirectory) throws IOException {
+        GWC gwc = context.getBean("gwcFacade", GWC.class);
+        assertThat(gwc.getConfig().isCacheLayersByDefault()).isTrue();
+
+        try {
+            LayerInfo layer = createVectorLayer(storeDirectory, "gwclifecycle", "gwclifecyclestore", "roads");
+
+            assertThat(gwc.tileLayerExists("gwclifecycle:roads"))
+                    .as("adding a layer must create its tile layer")
+                    .isTrue();
+
+            FeatureTypeInfo toRename = catalog.getFeatureTypeByName("gwclifecycle", "roads");
+            toRename.setName("streets");
+            catalog.save(toRename);
+
+            assertThat(gwc.tileLayerExists("gwclifecycle:streets"))
+                    .as("renaming the resource must rename the tile layer")
+                    .isTrue();
+            assertThat(gwc.tileLayerExists("gwclifecycle:roads")).isFalse();
+
+            catalog.remove(catalog.getLayer(layer.getId()));
+            catalog.remove(catalog.getFeatureTypeByName("gwclifecycle", "streets"));
+
+            assertThat(gwc.tileLayerExists("gwclifecycle:streets"))
+                    .as("removing the layer must remove its tile layer")
+                    .isFalse();
+        } finally {
+            dropVectorLayerTree("gwclifecycle", "gwclifecyclestore", "streets", "roads");
+        }
+    }
+
+    @Test
+    void tileLayerFollowsWorkspaceRename(@TempDir Path storeDirectory) throws IOException {
+        GWC gwc = context.getBean("gwcFacade", GWC.class);
+
+        try {
+            createVectorLayer(storeDirectory, "gwcwsrename", "gwcwsrenamestore", "roads");
+            assertThat(gwc.tileLayerExists("gwcwsrename:roads")).isTrue();
+
+            WorkspaceInfo ws = catalog.getWorkspaceByName("gwcwsrename");
+            ws.setName("gwcwsrenamed");
+            catalog.save(ws);
+            NamespaceInfo ns = catalog.getNamespaceByPrefix("gwcwsrename");
+            if (ns != null) {
+                ns.setPrefix("gwcwsrenamed");
+                catalog.save(ns);
+            }
+
+            assertThat(gwc.tileLayerExists("gwcwsrenamed:roads"))
+                    .as("renaming the workspace must rename its tile layers")
+                    .isTrue();
+            assertThat(gwc.tileLayerExists("gwcwsrename:roads")).isFalse();
+        } finally {
+            dropVectorLayerTree("gwcwsrenamed", "gwcwsrenamestore", "roads");
+            dropVectorLayerTree("gwcwsrename", "gwcwsrenamestore", "roads");
+        }
+    }
+
+    @Test
+    void tileLayerFollowsStoreMoveToAnotherWorkspace(@TempDir Path storeDirectory) throws IOException {
+        GWC gwc = context.getBean("gwcFacade", GWC.class);
+
+        try {
+            createVectorLayer(storeDirectory, "gwcmovesource", "gwcmovestore", "roads");
+            assertThat(gwc.tileLayerExists("gwcmovesource:roads")).isTrue();
+
+            WorkspaceInfo targetWs = catalog.getFactory().createWorkspace();
+            targetWs.setName("gwcmovetarget");
+            NamespaceInfo targetNs = catalog.getFactory().createNamespace();
+            targetNs.setPrefix("gwcmovetarget");
+            targetNs.setURI("http://gwcmovetarget.test");
+            catalog.add(targetWs);
+            catalog.add(targetNs);
+
+            DataStoreInfo store = catalog.getDataStoreByName("gwcmovesource", "gwcmovestore");
+            store.setWorkspace(catalog.getWorkspaceByName("gwcmovetarget"));
+            catalog.save(store);
+
+            assertThat(gwc.tileLayerExists("gwcmovetarget:roads"))
+                    .as("relocating the store must rename the tile layers of its layers")
+                    .isTrue();
+            assertThat(gwc.tileLayerExists("gwcmovesource:roads")).isFalse();
+        } finally {
+            dropVectorLayerTree("gwcmovetarget", "gwcmovestore", "roads");
+            dropVectorLayerTree("gwcmovesource", "gwcmovestore", "roads");
+        }
+    }
+
+    /**
+     * Creates a workspace, namespace, property-file datastore, feature type, and layer, returning the layer. The
+     * datastore is backed by a real property file to make the layer loadable, as required for automatic tile layer
+     * creation.
+     */
+    private LayerInfo createVectorLayer(Path storeDirectory, String wsName, String storeName, String ftName)
+            throws IOException {
+        Files.writeString(
+                storeDirectory.resolve(ftName + ".properties"),
+                """
+                _=geom:Point:srid=4326,name:String
+                %s.1=POINT(1 1)|first street
+                """
+                        .formatted(ftName));
+
+        CatalogFactory factory = catalog.getFactory();
+        WorkspaceInfo ws = factory.createWorkspace();
+        ws.setName(wsName);
+        NamespaceInfo ns = factory.createNamespace();
+        ns.setPrefix(wsName);
+        ns.setURI("http://%s.test".formatted(wsName));
+        catalog.add(ws);
+        catalog.add(ns);
+
+        DataStoreInfo store = factory.createDataStore();
+        store.setWorkspace(catalog.getWorkspace(ws.getId()));
+        store.setName(storeName);
+        store.setEnabled(true);
+        store.getConnectionParameters().put("directory", storeDirectory.toFile().getAbsolutePath());
+        store.getConnectionParameters().put("namespace", ns.getURI());
+        catalog.add(store);
+
+        FeatureTypeInfo ft = factory.createFeatureType();
+        ft.setStore(catalog.getDataStore(store.getId()));
+        ft.setNamespace(catalog.getNamespace(ns.getId()));
+        ft.setName(ftName);
+        ft.setNativeName(ftName);
+        ft.setSRS("EPSG:4326");
+        ReferencedEnvelope world = new ReferencedEnvelope(-180, 180, -90, 90, DefaultGeographicCRS.WGS84);
+        ft.setNativeBoundingBox(world);
+        ft.setLatLonBoundingBox(world);
+        ft.setEnabled(true);
+        catalog.add(ft);
+
+        LayerInfo layer = factory.createLayer();
+        layer.setResource(catalog.getFeatureType(ft.getId()));
+        catalog.add(layer);
+        return catalog.getLayer(layer.getId());
+    }
+
+    /** Best-effort removal of the whole tree created by {@link #createVectorLayer}, never masking test outcomes. */
+    private void dropVectorLayerTree(String wsName, String storeName, String... ftNames) {
+        for (String ftName : ftNames) {
+            removeQuietly(() -> catalog.getLayerByName(wsName + ":" + ftName), catalog::remove);
+            removeQuietly(() -> catalog.getFeatureTypeByName(wsName, ftName), catalog::remove);
+        }
+        removeQuietly(() -> catalog.getDataStoreByName(wsName, storeName), catalog::remove);
+        removeQuietly(() -> catalog.getNamespaceByPrefix(wsName), catalog::remove);
+        removeQuietly(() -> catalog.getWorkspaceByName(wsName), catalog::remove);
+    }
+
+    /** Best-effort cleanup that never masks the test outcome. */
+    private <T> void removeQuietly(Supplier<T> finder, Consumer<T> remover) {
+        try {
+            T found = finder.get();
+            if (found != null) {
+                remover.accept(found);
+            }
+        } catch (RuntimeException e) {
+            // ignore, the assertion failure is the interesting outcome
+        }
+    }
 
     @Test
     void testAnnonymousForbidden() {

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigTileLayerCatalogAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigTileLayerCatalogAutoConfiguration.java
@@ -76,8 +76,9 @@ public class PgconfigTileLayerCatalogAutoConfiguration {
      * (lookup by old prefixed name returns empty after the SQL trigger refreshes the materialized view).
      */
     @Bean
-    PgconfigGwcCatalogRenameListener pgconfigGwcCatalogRenameListener(@Qualifier("rawCatalog") Catalog catalog) {
-        return new PgconfigGwcCatalogRenameListener(catalog);
+    PgconfigGwcCatalogRenameListener pgconfigGwcCatalogRenameListener(
+            @Qualifier("rawCatalog") Catalog catalog, ApplicationEventPublisher eventPublisher) {
+        return new PgconfigGwcCatalogRenameListener(catalog, eventPublisher::publishEvent);
     }
 
     @Bean(name = "gwcCatalogConfiguration")

--- a/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/CachingTileLayerInfoRepository.java
+++ b/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/CachingTileLayerInfoRepository.java
@@ -33,7 +33,7 @@ public class CachingTileLayerInfoRepository implements TileLayerInfoRepository {
     private final @NonNull Cache nameCache;
 
     /** cached value for {@link #findAllNames()}, cleared upon any {@link TileLayerEvent} */
-    private Set<String> cachedNames;
+    private volatile Set<String> cachedNames;
 
     @EventListener(TileLayerEvent.class)
     void onTileLayerEvent(TileLayerEvent event) {

--- a/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigGwcCatalogRenameListener.java
+++ b/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigGwcCatalogRenameListener.java
@@ -9,15 +9,19 @@ import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogException;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.Predicates;
+import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.event.CatalogAddEvent;
 import org.geoserver.catalog.event.CatalogListener;
@@ -25,7 +29,9 @@ import org.geoserver.catalog.event.CatalogModifyEvent;
 import org.geoserver.catalog.event.CatalogPostModifyEvent;
 import org.geoserver.catalog.event.CatalogRemoveEvent;
 import org.geoserver.catalog.util.CloseableIterator;
+import org.geoserver.cloud.gwc.event.TileLayerEvent;
 import org.geoserver.gwc.GWC;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Catalog listener that propagates name changes affecting a tile-layer's prefixed name to the GeoWebCache storage
@@ -38,7 +44,7 @@ import org.geoserver.gwc.GWC;
  * directories under {@code /geowebcache_data/} and stale rows in {@code pgconfig.tileset}.
  *
  * <p>This listener bridges that gap: in {@link #handleModifyEvent(CatalogModifyEvent) pre-modify} it captures
- * {@link NamePair (old, new)} prefixed-name pairs while the OLD names are still queryable, and in
+ * {@link TileLayerRename (old, new)} prefixed-name pairs while the OLD names are still queryable, and in
  * {@link #handlePostModifyEvent(CatalogPostModifyEvent) post-modify} it replays them through
  * {@link GWC#layerRenamed(String, String)} - which calls {@code storageBroker.rename(...)} directly without going
  * through {@code TileLayerDispatcher.rename}, so the broken old-name lookup is bypassed entirely.
@@ -49,20 +55,26 @@ import org.geoserver.gwc.GWC;
  *   <li>{@link WorkspaceInfo} {@code name} change - all layers and layer-groups in the workspace.
  *   <li>{@link ResourceInfo} {@code name} or {@code namespace} change - the single layer.
  *   <li>{@link LayerGroupInfo} {@code name} change - the single layer-group.
+ *   <li>{@link StoreInfo} {@code workspace} change - all the store's layers, whose namespaces follow the new workspace.
  * </ul>
  */
 @Slf4j(topic = "org.geoserver.cloud.gwc.backend.pgconfig")
 public class PgconfigGwcCatalogRenameListener implements CatalogListener {
 
-    private record NamePair(String oldPrefixed, String newPrefixed) {}
+    private record TileLayerRename(@Nullable String publishedId, String oldPrefixed, String newPrefixed) {}
 
-    private static final ThreadLocal<List<NamePair>> PENDING_RENAMES = new ThreadLocal<>();
+    private static final ThreadLocal<List<TileLayerRename>> PENDING_RENAMES = new ThreadLocal<>();
 
     @NonNull
     private final Catalog catalog;
 
-    public PgconfigGwcCatalogRenameListener(@NonNull Catalog catalog) {
+    @NonNull
+    private final Consumer<TileLayerEvent> eventPublisher;
+
+    public PgconfigGwcCatalogRenameListener(
+            @NonNull Catalog catalog, @NonNull Consumer<TileLayerEvent> eventPublisher) {
         this.catalog = catalog;
+        this.eventPublisher = eventPublisher;
     }
 
     @PostConstruct
@@ -80,9 +92,20 @@ public class PgconfigGwcCatalogRenameListener implements CatalogListener {
         // no-op, only renames matter
     }
 
+    /**
+     * Publishes the deleted {@link TileLayerEvent} when a layer or layer-group is removed.
+     *
+     * <p>On pgconfig the tile layer is stored on the same row as its {@code PublishedInfo}: by the time
+     * {@code GWC#removeTileLayers} runs, the row is gone, the tile-layer lookup returns empty and
+     * {@code GeoServerTileLayerConfiguration} publishes no deleted event. Publishing it here, from the removed object's
+     * in-memory state, evicts the name from every node's tile-layer cache. Blob and quota removal on tile-layer delete
+     * is handled by {@code PgconfigTileLayerCatalog}.
+     */
     @Override
     public void handleRemoveEvent(CatalogRemoveEvent event) throws CatalogException {
-        // no-op, blob/quota removal on tile-layer delete is handled by PgconfigTileLayerCatalog
+        if (event.getSource() instanceof PublishedInfo published) {
+            eventPublisher.accept(TileLayerEvent.deleted(this, published.getId(), published.prefixedName()));
+        }
     }
 
     @Override
@@ -92,7 +115,7 @@ public class PgconfigGwcCatalogRenameListener implements CatalogListener {
 
     @Override
     public void handleModifyEvent(CatalogModifyEvent event) throws CatalogException {
-        List<NamePair> pairs = collectRenames(event);
+        List<TileLayerRename> pairs = collectRenames(event);
         if (!pairs.isEmpty()) {
             PENDING_RENAMES.set(pairs);
         }
@@ -100,7 +123,7 @@ public class PgconfigGwcCatalogRenameListener implements CatalogListener {
 
     @Override
     public void handlePostModifyEvent(CatalogPostModifyEvent event) throws CatalogException {
-        List<NamePair> pairs = PENDING_RENAMES.get();
+        List<TileLayerRename> pairs = PENDING_RENAMES.get();
         if (pairs == null) {
             return;
         }
@@ -111,7 +134,7 @@ public class PgconfigGwcCatalogRenameListener implements CatalogListener {
         }
     }
 
-    private List<NamePair> collectRenames(CatalogModifyEvent event) {
+    private List<TileLayerRename> collectRenames(CatalogModifyEvent event) {
         CatalogInfo source = event.getSource();
         List<String> changedProperties = event.getPropertyNames();
         if (source instanceof WorkspaceInfo && changedProperties.contains("name")) {
@@ -124,50 +147,96 @@ public class PgconfigGwcCatalogRenameListener implements CatalogListener {
         if (source instanceof LayerGroupInfo group && changedProperties.contains("name")) {
             return collectLayerGroupRename(group, event);
         }
+        if (source instanceof StoreInfo store && changedProperties.contains("workspace")) {
+            return collectStoreMove(store, event);
+        }
         return List.of();
     }
 
-    private List<NamePair> collectWorkspaceRenames(CatalogModifyEvent event) {
+    /**
+     * A store moved to another workspace renames all its layers: the resources' namespaces follow the new workspace
+     * (see {@code CatalogPlugin#save(StoreInfo)}), but the modify events fired for those resources already expose the
+     * new namespace as both the old and the new value, leaving no usable old name. The store's own modify event does
+     * provide the old workspace: collect the renames here, while the resources still expose the old namespace.
+     */
+    private List<TileLayerRename> collectStoreMove(StoreInfo store, CatalogModifyEvent event) {
+        int workspaceIndex = event.getPropertyNames().indexOf("workspace");
+        WorkspaceInfo oldWorkspace = (WorkspaceInfo) event.getOldValues().get(workspaceIndex);
+        WorkspaceInfo newWorkspace = (WorkspaceInfo) event.getNewValues().get(workspaceIndex);
+        if (oldWorkspace == null
+                || newWorkspace == null
+                || oldWorkspace.getName().equals(newWorkspace.getName())) {
+            return List.of();
+        }
+        String newPrefix = newWorkspace.getName();
+        List<TileLayerRename> pairs = new ArrayList<>();
+        for (ResourceInfo resource : catalog.getResourcesByStore(store, ResourceInfo.class)) {
+            NamespaceInfo oldNamespace = resource.getNamespace();
+            if (oldNamespace == null) {
+                continue;
+            }
+            String oldPrefixed = prefixed(oldNamespace.getPrefix(), resource.getName());
+            String newPrefixed = prefixed(newPrefix, resource.getName());
+            if (oldPrefixed.equals(newPrefixed)) {
+                continue;
+            }
+            String layerId = catalog.getLayers(resource).stream()
+                    .map(LayerInfo::getId)
+                    .findFirst()
+                    .orElse(null);
+            pairs.add(new TileLayerRename(layerId, oldPrefixed, newPrefixed));
+        }
+        return pairs;
+    }
+
+    private List<TileLayerRename> collectWorkspaceRenames(CatalogModifyEvent event) {
         String oldWsName = stringPropertyOldValue(event, "name");
         String newWsName = stringPropertyNewValue(event, "name");
         if (oldWsName == null || newWsName == null || oldWsName.equals(newWsName)) {
             return List.of();
         }
-        List<NamePair> pairs = new ArrayList<>();
+        List<TileLayerRename> pairs = new ArrayList<>();
         addLayerRenamesForWorkspace(oldWsName, newWsName, pairs);
         addLayerGroupRenamesForWorkspace(oldWsName, newWsName, pairs);
         return pairs;
     }
 
-    private void addLayerRenamesForWorkspace(String oldWsName, String newWsName, List<NamePair> pairs) {
-        try (CloseableIterator<org.geoserver.catalog.LayerInfo> layers = catalog.list(
-                org.geoserver.catalog.LayerInfo.class, Predicates.equal("resource.store.workspace.name", oldWsName))) {
+    private void addLayerRenamesForWorkspace(String oldWsName, String newWsName, List<TileLayerRename> pairs) {
+        try (CloseableIterator<org.geoserver.catalog.LayerInfo> layers =
+                catalog.list(LayerInfo.class, Predicates.equal("resource.store.workspace.name", oldWsName))) {
             while (layers.hasNext()) {
-                String localName = layers.next().getName();
-                pairs.add(new NamePair(prefixed(oldWsName, localName), prefixed(newWsName, localName)));
+                LayerInfo layer = layers.next();
+                String localName = layer.getName();
+                pairs.add(new TileLayerRename(
+                        layer.getId(), prefixed(oldWsName, localName), prefixed(newWsName, localName)));
             }
         }
     }
 
-    private void addLayerGroupRenamesForWorkspace(String oldWsName, String newWsName, List<NamePair> pairs) {
+    private void addLayerGroupRenamesForWorkspace(String oldWsName, String newWsName, List<TileLayerRename> pairs) {
         try (CloseableIterator<LayerGroupInfo> groups =
                 catalog.list(LayerGroupInfo.class, Predicates.equal("workspace.name", oldWsName))) {
             while (groups.hasNext()) {
-                String localName = groups.next().getName();
-                pairs.add(new NamePair(prefixed(oldWsName, localName), prefixed(newWsName, localName)));
+                LayerGroupInfo group = groups.next();
+                String localName = group.getName();
+                pairs.add(new TileLayerRename(
+                        group.getId(), prefixed(oldWsName, localName), prefixed(newWsName, localName)));
             }
         }
     }
 
-    private List<NamePair> collectResourceRename(ResourceInfo resource, CatalogModifyEvent event) {
+    private List<TileLayerRename> collectResourceRename(ResourceInfo resource, CatalogModifyEvent event) {
         List<String> changedProperties = event.getPropertyNames();
         int nameIndex = changedProperties.indexOf("name");
         int namespaceIndex = changedProperties.indexOf("namespace");
 
-        NamespaceInfo currentNamespace = resource.getNamespace();
-        NamespaceInfo oldNamespace =
-                namespaceIndex > -1 ? (NamespaceInfo) event.getOldValues().get(namespaceIndex) : currentNamespace;
-        if (oldNamespace == null || currentNamespace == null) {
+        NamespaceInfo oldNamespace = namespaceIndex > -1
+                ? (NamespaceInfo) event.getOldValues().get(namespaceIndex)
+                : resource.getNamespace();
+        NamespaceInfo newNamespace = namespaceIndex > -1
+                ? (NamespaceInfo) event.getNewValues().get(namespaceIndex)
+                : resource.getNamespace();
+        if (oldNamespace == null || newNamespace == null) {
             return List.of();
         }
 
@@ -175,14 +244,18 @@ public class PgconfigGwcCatalogRenameListener implements CatalogListener {
         String newLocalName = nameIndex > -1 ? (String) event.getNewValues().get(nameIndex) : resource.getName();
 
         String oldPrefixed = prefixed(oldNamespace.getPrefix(), oldLocalName);
-        String newPrefixed = prefixed(currentNamespace.getPrefix(), newLocalName);
+        String newPrefixed = prefixed(newNamespace.getPrefix(), newLocalName);
         if (oldPrefixed.equals(newPrefixed)) {
             return List.of();
         }
-        return List.of(new NamePair(oldPrefixed, newPrefixed));
+        String layerId = catalog.getLayers(resource).stream()
+                .map(LayerInfo::getId)
+                .findFirst()
+                .orElse(null);
+        return List.of(new TileLayerRename(layerId, oldPrefixed, newPrefixed));
     }
 
-    private List<NamePair> collectLayerGroupRename(LayerGroupInfo group, CatalogModifyEvent event) {
+    private List<TileLayerRename> collectLayerGroupRename(LayerGroupInfo group, CatalogModifyEvent event) {
         String oldName = stringPropertyOldValue(event, "name");
         String newName = stringPropertyNewValue(event, "name");
         if (oldName == null || newName == null || oldName.equals(newName)) {
@@ -190,10 +263,11 @@ public class PgconfigGwcCatalogRenameListener implements CatalogListener {
         }
         WorkspaceInfo workspace = group.getWorkspace();
         String prefix = workspace == null ? null : workspace.getName();
-        return List.of(new NamePair(prefixed(prefix, oldName), prefixed(prefix, newName)));
+        return List.of(new TileLayerRename(group.getId(), prefixed(prefix, oldName), prefixed(prefix, newName)));
     }
 
-    private void replayRenames(List<NamePair> pairs) {
+    private void replayRenames(List<TileLayerRename> pairs) {
+        publishTileLayerEvents(pairs);
         GWC mediator;
         try {
             mediator = GWC.get();
@@ -205,11 +279,28 @@ public class PgconfigGwcCatalogRenameListener implements CatalogListener {
             log.debug("Skipping {} tile layer rename(s); GWC singleton not available", pairs.size());
             return;
         }
-        for (NamePair pair : pairs) {
+        for (TileLayerRename pair : pairs) {
             try {
                 mediator.layerRenamed(pair.oldPrefixed(), pair.newPrefixed());
             } catch (RuntimeException e) {
                 log.warn("Failed to rename tile layer cache '{}' -> '{}'", pair.oldPrefixed(), pair.newPrefixed(), e);
+            }
+        }
+    }
+
+    /**
+     * Notifies every service of the rename through {@link TileLayerEvent}s, keyed by the old prefixed name.
+     *
+     * <p>Upstream {@code CatalogLayerEventListener} only publishes its rename when the old prefixed name still
+     * resolves, which on pgconfig depends on the caching tile-layer repository holding a warm entry at the service
+     * handling the rename. These events make cache eviction independent of that: each node's
+     * {@link CachingTileLayerInfoRepository} drops the old-name entry and the name listing memo.
+     */
+    private void publishTileLayerEvents(List<TileLayerRename> pairs) {
+        for (TileLayerRename pair : pairs) {
+            if (pair.publishedId() != null) {
+                eventPublisher.accept(
+                        TileLayerEvent.modified(this, pair.publishedId(), pair.newPrefixed(), pair.oldPrefixed()));
             }
         }
     }

--- a/src/gwc/backends/pgconfig/src/test/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigGwcCatalogRenameListenerIT.java
+++ b/src/gwc/backends/pgconfig/src/test/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigGwcCatalogRenameListenerIT.java
@@ -6,6 +6,7 @@
 package org.geoserver.cloud.gwc.backend.pgconfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -106,6 +107,11 @@ class PgconfigGwcCatalogRenameListenerIT {
 
         verify(mediator).layerRenamed("oldWs:states", "newWs:states");
         verify(mediator).layerRenamed("oldWs:roads", "newWs:roads");
+        assertThat(events)
+                .extracting(TileLayerEvent::getPublishedId, TileLayerEvent::getName, TileLayerEvent::getOldName)
+                .containsExactlyInAnyOrder(
+                        tuple(layer1.getId(), "newWs:states", "oldWs:states"),
+                        tuple(layer2.getId(), "newWs:roads", "oldWs:roads"));
     }
 
     @Test
@@ -119,6 +125,9 @@ class PgconfigGwcCatalogRenameListenerIT {
         renameWorkspace(ws, "newWs");
 
         verify(mediator).layerRenamed("oldWs:grp", "newWs:grp");
+        assertThat(events)
+                .extracting(TileLayerEvent::getPublishedId, TileLayerEvent::getName, TileLayerEvent::getOldName)
+                .contains(tuple(group.getId(), "newWs:grp", "oldWs:grp"));
     }
 
     @Test
@@ -131,6 +140,9 @@ class PgconfigGwcCatalogRenameListenerIT {
         catalog.save(resource);
 
         verify(mediator).layerRenamed("topp:states", "topp:roads");
+        assertThat(events)
+                .extracting(TileLayerEvent::getPublishedId, TileLayerEvent::getName, TileLayerEvent::getOldName)
+                .containsExactly(tuple(layer.getId(), "topp:roads", "topp:states"));
     }
 
     @Test
@@ -144,6 +156,9 @@ class PgconfigGwcCatalogRenameListenerIT {
         catalog.save(group);
 
         verify(mediator).layerRenamed("topp:groupOld", "topp:groupNew");
+        assertThat(events)
+                .extracting(TileLayerEvent::getPublishedId, TileLayerEvent::getName, TileLayerEvent::getOldName)
+                .containsExactly(tuple(group.getId(), "topp:groupNew", "topp:groupOld"));
     }
 
     @Test
@@ -157,6 +172,19 @@ class PgconfigGwcCatalogRenameListenerIT {
 
         verify(mediator, never())
                 .layerRenamed(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString());
+        assertThat(events).isEmpty();
+    }
+
+    @Test
+    void layerRemoved_publishesDeletedEvent() {
+        WorkspaceInfo ws = support.workspace("topp");
+        LayerInfo layer = support.layerInfo(ws, "states");
+
+        catalog.remove(catalog.getLayer(layer.getId()));
+
+        assertThat(events)
+                .extracting(TileLayerEvent::getPublishedId, TileLayerEvent::getName)
+                .containsExactly(tuple(layer.getId(), "topp:states"));
     }
 
     @Test

--- a/src/gwc/backends/pgconfig/src/test/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigGwcCatalogRenameListenerIT.java
+++ b/src/gwc/backends/pgconfig/src/test/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigGwcCatalogRenameListenerIT.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
@@ -20,6 +22,7 @@ import org.geoserver.catalog.plugin.CatalogPlugin;
 import org.geoserver.cloud.backend.pgconfig.PgconfigBackendBuilder;
 import org.geoserver.cloud.backend.pgconfig.support.PgConfigTestContainer;
 import org.geoserver.cloud.backend.pgconfig.support.PgconfigTestDatabaseSupport;
+import org.geoserver.cloud.gwc.event.TileLayerEvent;
 import org.geoserver.config.plugin.GeoServerImpl;
 import org.geoserver.gwc.GWC;
 import org.geoserver.gwc.GWCSynchEnv;
@@ -55,6 +58,7 @@ class PgconfigGwcCatalogRenameListenerIT {
     private CatalogPlugin catalog;
     private CatalogFaker faker;
     private PgconfigGwcCatalogRenameListener listener;
+    private List<TileLayerEvent> events;
     private PgconfigTileLayerCatalog tlCatalog;
     private TileLayerMocking support;
     private GWC mediator;
@@ -67,7 +71,8 @@ class PgconfigGwcCatalogRenameListenerIT {
         support = new TileLayerMocking(catalog, geoServer);
         faker = support.getFaker();
 
-        listener = new PgconfigGwcCatalogRenameListener(catalog);
+        events = new ArrayList<>();
+        listener = new PgconfigGwcCatalogRenameListener(catalog, events::add);
         listener.register();
 
         GWCConfigPersister defaultsProvider = mock(GWCConfigPersister.class);

--- a/src/gwc/backends/pgconfig/src/test/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigGwcCatalogRenameListenerTest.java
+++ b/src/gwc/backends/pgconfig/src/test/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigGwcCatalogRenameListenerTest.java
@@ -5,6 +5,8 @@
 
 package org.geoserver.cloud.gwc.backend.pgconfig;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -12,17 +14,21 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.event.CatalogModifyEvent;
 import org.geoserver.catalog.event.CatalogPostModifyEvent;
 import org.geoserver.catalog.util.CloseableIterator;
 import org.geoserver.catalog.util.CloseableIteratorAdapter;
+import org.geoserver.cloud.gwc.event.TileLayerEvent;
 import org.geoserver.gwc.GWC;
 import org.geoserver.gwc.GWCSynchEnv;
 import org.geotools.api.filter.Filter;
@@ -35,12 +41,14 @@ class PgconfigGwcCatalogRenameListenerTest {
     private Catalog catalog;
     private PgconfigGwcCatalogRenameListener listener;
     private GWC mediator;
+    private List<TileLayerEvent> events;
 
     @BeforeEach
     void setUp() {
         catalog = mock(Catalog.class);
         mediator = mock(GWC.class);
-        listener = new PgconfigGwcCatalogRenameListener(catalog);
+        events = new ArrayList<>();
+        listener = new PgconfigGwcCatalogRenameListener(catalog, events::add);
         GWC.set(mediator, mock(GWCSynchEnv.class));
     }
 
@@ -74,6 +82,12 @@ class PgconfigGwcCatalogRenameListenerTest {
         verify(mediator).layerRenamed("oldWs:foo", "newWs:foo");
         verify(mediator).layerRenamed("oldWs:bar", "newWs:bar");
         verify(mediator).layerRenamed("oldWs:grp", "newWs:grp");
+        assertThat(events)
+                .extracting(TileLayerEvent::getPublishedId, TileLayerEvent::getName, TileLayerEvent::getOldName)
+                .containsExactlyInAnyOrder(
+                        tuple("foo-id", "newWs:foo", "oldWs:foo"),
+                        tuple("bar-id", "newWs:bar", "oldWs:bar"),
+                        tuple("grp-id", "newWs:grp", "oldWs:grp"));
     }
 
     @Test
@@ -84,11 +98,16 @@ class PgconfigGwcCatalogRenameListenerTest {
         when(resource.getNamespace()).thenReturn(ns);
         when(resource.getName()).thenReturn("states");
 
+        LayerInfo statesLayer = layerInfoMock("states");
+        when(catalog.getLayers(resource)).thenReturn(List.of(statesLayer));
+
         listener.handleModifyEvent(modifyEvent(resource, List.of("name"), List.of("states"), List.of("roads")));
         listener.handlePostModifyEvent(postModifyEvent(resource));
 
         verify(mediator).layerRenamed("topp:states", "topp:roads");
-        verifyNoInteractions(catalog);
+        assertThat(events)
+                .extracting(TileLayerEvent::getPublishedId, TileLayerEvent::getName, TileLayerEvent::getOldName)
+                .containsExactly(tuple("states-id", "topp:roads", "topp:states"));
     }
 
     @Test
@@ -98,13 +117,21 @@ class PgconfigGwcCatalogRenameListenerTest {
         NamespaceInfo newNs = mock(NamespaceInfo.class);
         when(newNs.getPrefix()).thenReturn("ns2");
         FeatureTypeInfo resource = mock(FeatureTypeInfo.class);
-        when(resource.getNamespace()).thenReturn(newNs);
+        // at pre-modify time the source still exposes the old namespace; the new one
+        // is only available through the event's new values
+        when(resource.getNamespace()).thenReturn(oldNs);
         when(resource.getName()).thenReturn("ft");
+
+        LayerInfo ftLayer = layerInfoMock("ft");
+        when(catalog.getLayers(resource)).thenReturn(List.of(ftLayer));
 
         listener.handleModifyEvent(modifyEvent(resource, List.of("namespace"), List.of(oldNs), List.of(newNs)));
         listener.handlePostModifyEvent(postModifyEvent(resource));
 
         verify(mediator).layerRenamed("ns1:ft", "ns2:ft");
+        assertThat(events)
+                .extracting(TileLayerEvent::getPublishedId, TileLayerEvent::getName, TileLayerEvent::getOldName)
+                .containsExactly(tuple("ft-id", "ns2:ft", "ns1:ft"));
     }
 
     @Test
@@ -129,6 +156,64 @@ class PgconfigGwcCatalogRenameListenerTest {
         listener.handlePostModifyEvent(postModifyEvent(group));
 
         verify(mediator).layerRenamed("globalOld", "globalNew");
+    }
+
+    @Test
+    void storeMoveToAnotherWorkspace_renamesAllStoreLayers() {
+        WorkspaceInfo oldWs = mock(WorkspaceInfo.class);
+        when(oldWs.getName()).thenReturn("sourceWs");
+        WorkspaceInfo newWs = mock(WorkspaceInfo.class);
+        when(newWs.getName()).thenReturn("targetWs");
+        DataStoreInfo store = mock(DataStoreInfo.class);
+
+        NamespaceInfo oldNs = mock(NamespaceInfo.class);
+        when(oldNs.getPrefix()).thenReturn("sourceWs");
+        FeatureTypeInfo resource = mock(FeatureTypeInfo.class);
+        when(resource.getName()).thenReturn("roads");
+        when(resource.getNamespace()).thenReturn(oldNs);
+        when(catalog.getResourcesByStore(store, ResourceInfo.class)).thenReturn(List.of(resource));
+        LayerInfo roadsLayer = layerInfoMock("roads");
+        when(catalog.getLayers(resource)).thenReturn(List.of(roadsLayer));
+
+        listener.handleModifyEvent(modifyEvent(store, List.of("workspace"), List.of(oldWs), List.of(newWs)));
+        listener.handlePostModifyEvent(postModifyEvent(store));
+
+        verify(mediator).layerRenamed("sourceWs:roads", "targetWs:roads");
+        assertThat(events)
+                .extracting(TileLayerEvent::getPublishedId, TileLayerEvent::getName, TileLayerEvent::getOldName)
+                .containsExactly(tuple("roads-id", "targetWs:roads", "sourceWs:roads"));
+    }
+
+    @Test
+    void layerRemoved_publishesDeletedEvent() {
+        LayerInfo layer = layerInfoMock("roads");
+        when(layer.prefixedName()).thenReturn("topp:roads");
+
+        listener.handleRemoveEvent(removeEvent(layer));
+
+        assertThat(events)
+                .extracting(TileLayerEvent::getPublishedId, TileLayerEvent::getName)
+                .containsExactly(tuple("roads-id", "topp:roads"));
+    }
+
+    @Test
+    void layerGroupRemoved_publishesDeletedEvent() {
+        LayerGroupInfo group = layerGroupInfoMock("basemap");
+        when(group.prefixedName()).thenReturn("topp:basemap");
+
+        listener.handleRemoveEvent(removeEvent(group));
+
+        assertThat(events)
+                .extracting(TileLayerEvent::getPublishedId, TileLayerEvent::getName)
+                .containsExactly(tuple("basemap-id", "topp:basemap"));
+    }
+
+    @Test
+    void nonPublishedRemoval_publishesNothing() {
+        listener.handleRemoveEvent(removeEvent(mock(WorkspaceInfo.class)));
+        listener.handleRemoveEvent(removeEvent(mock(FeatureTypeInfo.class)));
+
+        assertThat(events).isEmpty();
     }
 
     @Test
@@ -166,16 +251,22 @@ class PgconfigGwcCatalogRenameListenerTest {
         listener.handlePostModifyEvent(postModifyEvent(ws));
 
         verifyNoInteractions(mediator);
+        assertThat(events)
+                .as("cache eviction events do not depend on the GWC mediator")
+                .extracting(TileLayerEvent::getOldName)
+                .containsExactly("oldWs:foo");
     }
 
     private LayerInfo layerInfoMock(String name) {
         LayerInfo info = mock(LayerInfo.class);
+        when(info.getId()).thenReturn(name + "-id");
         when(info.getName()).thenReturn(name);
         return info;
     }
 
     private LayerGroupInfo layerGroupInfoMock(String name) {
         LayerGroupInfo info = mock(LayerGroupInfo.class);
+        when(info.getId()).thenReturn(name + "-id");
         when(info.getName()).thenReturn(name);
         return info;
     }
@@ -205,6 +296,13 @@ class PgconfigGwcCatalogRenameListenerTest {
         when(event.getPropertyNames()).thenReturn(props);
         when(event.getOldValues()).thenReturn(oldValues);
         when(event.getNewValues()).thenReturn(newValues);
+        return event;
+    }
+
+    private org.geoserver.catalog.event.CatalogRemoveEvent removeEvent(Object source) {
+        org.geoserver.catalog.event.CatalogRemoveEvent event =
+                mock(org.geoserver.catalog.event.CatalogRemoveEvent.class);
+        when(event.getSource()).thenReturn((org.geoserver.catalog.CatalogInfo) source);
         return event;
     }
 

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/repository/CloudCatalogConfiguration.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/repository/CloudCatalogConfiguration.java
@@ -10,7 +10,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.cache.LoadingCache;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.reflect.FieldUtils;
@@ -38,10 +40,13 @@ public class CloudCatalogConfiguration extends CatalogConfiguration {
 
     private LoadingCache<String, GeoServerTileLayer> spiedLayerCache;
 
+    private final TileLayerCatalog tileLayerCatalog;
+
     @SuppressWarnings("unchecked")
     public CloudCatalogConfiguration(Catalog catalog, TileLayerCatalog tileLayerCatalog, GridSetBroker gridSetBroker) {
 
         super(catalog, tileLayerCatalog, gridSetBroker);
+        this.tileLayerCatalog = tileLayerCatalog;
 
         try {
             spiedLayerCache = (LoadingCache<String, GeoServerTileLayer>) FieldUtils.readField(this, "layerCache", true);
@@ -64,9 +69,67 @@ public class CloudCatalogConfiguration extends CatalogConfiguration {
         spiedLayerCache.getIfPresent(publishedId);
     }
 
+    /**
+     * In a cluster, a tile layer configuration can be visible through the shared storage or a {@link TileLayerEvent}
+     * before this node's catalog replicated the {@link PublishedInfo} it refers to. Upstream assumes both are updated
+     * atomically and {@link GeoServerTileLayer#getPublishedInfo()} throws {@link IllegalStateException}, which would
+     * break whole responses like WMTS GetCapabilities. Hide such tile layers until the local catalog catches up.
+     */
+    @Override
+    public Optional<TileLayer> getLayer(final String layerName) {
+        return super.getLayer(layerName).filter(this::publishedInfoResolves);
+    }
+
+    /** Keeps the name listing consistent with {@link #getLayer}, excluding hidden tile layers. */
+    @Override
+    public Set<String> getLayerNames() {
+        return super.getLayerNames().stream()
+                .filter(name -> getLayer(name).isPresent())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    /** Keeps the count consistent with {@link #getLayerNames}, excluding hidden tile layers. */
+    @Override
+    public int getLayerCount() {
+        return getLayerNames().size();
+    }
+
+    /** Keeps the containment check consistent with {@link #getLayer}, excluding hidden tile layers. */
+    @Override
+    public boolean containsLayer(String layerName) {
+        return getLayer(layerName).isPresent();
+    }
+
+    private boolean publishedInfoResolves(TileLayer tileLayer) {
+        if (tileLayer instanceof GeoServerTileLayer geoserverTileLayer) {
+            try {
+                return null != geoserverTileLayer.getPublishedInfo();
+            } catch (IllegalStateException catalogNotYetInSync) {
+                log.debug(
+                        "tile layer {} does not resolve against the local catalog yet, hiding it until the catalog catches up ({})",
+                        tileLayer.getName(),
+                        catalogNotYetInSync.getMessage());
+                return false;
+            }
+        }
+        return true;
+    }
+
     @Override
     public synchronized void addLayer(final @NonNull TileLayer tl) {
         GeoServerTileLayer tileLayer = checkAddPreconditions(tl);
+        // In a cluster the configuration may already be stored when an add arrives: automatic tile layer
+        // creation on another service, or a client told the layer does not exist while this node was
+        // catching up (catalog replication, a configuration reload in progress). Honor the add as a save,
+        // inheriting whatever the request leaves unset from the stored configuration, instead of failing
+        // the upstream already-exists precondition.
+        GeoServerTileLayerInfo stored =
+                tileLayerCatalog.getLayerById(tileLayer.getInfo().getId());
+        if (stored != null) {
+            setMissingConfig(tileLayer.getInfo(), stored);
+            super.modifyLayer(tl);
+            return;
+        }
         completeWithDefaults(tileLayer);
         super.addLayer(tl);
     }

--- a/src/gwc/core/src/test/java/org/geoserver/cloud/gwc/repository/CloudCatalogConfigurationTest.java
+++ b/src/gwc/core/src/test/java/org/geoserver/cloud/gwc/repository/CloudCatalogConfigurationTest.java
@@ -1,0 +1,119 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.gwc.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.gwc.GWC;
+import org.geoserver.gwc.GWCSynchEnv;
+import org.geoserver.gwc.layer.GeoServerTileLayer;
+import org.geoserver.gwc.layer.GeoServerTileLayerInfo;
+import org.geoserver.gwc.layer.GeoServerTileLayerInfoImpl;
+import org.geoserver.gwc.layer.TileLayerCatalog;
+import org.geowebcache.config.DefaultGridsets;
+import org.geowebcache.grid.GridSetBroker;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * In a cluster, a tile layer configuration can be visible through the shared storage or a
+ * {@link org.geoserver.cloud.gwc.event.TileLayerEvent} before this node's catalog replicated the {@link LayerInfo} it
+ * refers to. {@link CloudCatalogConfiguration} must hide such tile layers until the catalog catches up instead of
+ * letting {@link org.geoserver.gwc.layer.GeoServerTileLayer#getPublishedInfo()} throw {@link IllegalStateException} and
+ * break whole responses like WMTS GetCapabilities.
+ */
+class CloudCatalogConfigurationTest {
+
+    private static final String LAYER_ID = "LayerInfo-123";
+    private static final String LAYER_NAME = "test:roads";
+
+    private Catalog catalog;
+    private TileLayerCatalog tileLayerCatalog;
+    private CloudCatalogConfiguration config;
+
+    @BeforeEach
+    void setUp() {
+        catalog = mock(Catalog.class);
+        tileLayerCatalog = mock(TileLayerCatalog.class);
+
+        GeoServerTileLayerInfo info = new GeoServerTileLayerInfoImpl();
+        info.setId(LAYER_ID);
+        info.setName(LAYER_NAME);
+        info.getMimeFormats().add("image/png");
+        info.setMetaTilingX(4);
+        info.setMetaTilingY(4);
+
+        when(tileLayerCatalog.getLayerNames()).thenReturn(Set.of(LAYER_NAME));
+        when(tileLayerCatalog.getLayerIds()).thenReturn(Set.of(LAYER_ID));
+        when(tileLayerCatalog.getLayerId(LAYER_NAME)).thenReturn(LAYER_ID);
+        when(tileLayerCatalog.getLayerById(LAYER_ID)).thenReturn(info);
+        when(tileLayerCatalog.exists(LAYER_ID)).thenReturn(true);
+        when(tileLayerCatalog.getLayerName(LAYER_ID)).thenReturn(LAYER_NAME);
+
+        GridSetBroker gridSetBroker = new GridSetBroker(List.of(new DefaultGridsets(true, true)));
+        config = new CloudCatalogConfiguration(catalog, tileLayerCatalog, gridSetBroker);
+        GWC.set(mock(GWC.class), mock(GWCSynchEnv.class));
+    }
+
+    @AfterEach
+    void tearDown() {
+        GWC.set(null, null);
+    }
+
+    @Test
+    void getLayerHidesTileLayersNotYetInTheLocalCatalog() {
+        when(catalog.getLayer(LAYER_ID)).thenReturn(null);
+        when(catalog.getLayerGroup(LAYER_ID)).thenReturn(null);
+
+        assertThat(config.getLayer(LAYER_NAME)).isEmpty();
+        assertThat(config.getLayers()).isEmpty();
+        assertThat(config.getLayerNames()).isEmpty();
+        assertThat(config.getLayerCount()).isZero();
+        assertThat(config.containsLayer(LAYER_NAME)).isFalse();
+    }
+
+    @Test
+    void addLayerForStoredTileLayerBehavesAsSave() {
+        when(catalog.getLayer(LAYER_ID)).thenReturn(null);
+        when(catalog.getLayerGroup(LAYER_ID)).thenReturn(null);
+
+        GeoServerTileLayerInfo info = new GeoServerTileLayerInfoImpl();
+        info.setId(LAYER_ID);
+        info.setName(LAYER_NAME);
+        GeoServerTileLayer tileLayer = new GeoServerTileLayer(
+                catalog, LAYER_ID, new GridSetBroker(List.of(new DefaultGridsets(true, true))), info);
+
+        assertThatCode(() -> config.addLayer(tileLayer))
+                .as("adding over a tile layer hidden until the catalog catches up must not fail")
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void getLayerReturnsTileLayersResolvableAgainstTheLocalCatalog() {
+        LayerInfo layer = mock(LayerInfo.class);
+        when(layer.getId()).thenReturn(LAYER_ID);
+        when(layer.getName()).thenReturn("roads");
+        when(layer.prefixedName()).thenReturn(LAYER_NAME);
+        when(layer.getStyles()).thenReturn(new HashSet<>());
+        when(catalog.getLayer(LAYER_ID)).thenReturn(layer);
+
+        assertThat(config.getLayer(LAYER_NAME)).isPresent();
+        assertThat(config.getLayers()).hasSize(1);
+        assertThat(config.getLayerNames()).containsExactly(LAYER_NAME);
+        assertThat(config.getLayerCount()).isOne();
+        assertThat(config.containsLayer(LAYER_NAME)).isTrue();
+        assertThatCode(() -> config.getLayers().forEach(tl -> tl.getName())).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
Fixes #519: creating, renaming, moving, and deleting layers through the REST API now creates, renames, and deletes the corresponding GWC tile layers.

The restconfig service runs the GWC core components like wms and webui do, running the standard GWC catalog listeners in the service where the REST catalog changes originate. The existing `TileLayerEvent` bus and the shared tile-layer storage propagate the changes to the other services.

Supersedes #906, adopting its cross-service acceptance-test idea.

The new tests exposed cluster-consistency defects, fixed in the first commit:

- Tile layers whose published info the local catalog has not yet resolved are hidden until replication catches up, instead of breaking whole responses like WMTS GetCapabilities.
- On pgconfig, renames (layer, workspace, store move) and layer removals now publish `TileLayerEvent`s: derived tile-layer names and the shared `publishedinfo` row kept the regular event flow from firing, leaving stale entries in the tile-layer name caches of the other services.
- Tile layer adds over an already stored configuration behave as saves instead of failing the already-exists precondition during replication or reload windows.

Adds restconfig integration tests, on both datadir and pgconfig backends: tile layer lifecycle, workspace rename, and store move to another workspace.

Acceptance tests added in camptocamp/python-geoservercloud#208, released in `0.8.10` (pin updated here): automatic tile layer lifecycle and rename propagation between services, verified against the datadir and pgconfig compositions and against a vanilla GeoServer.
