### PR TITLE
Fix SonarCloud issues

### DIFF
--- a/src/apps/base-images/geoserver/src/main/java/org/geoserver/cloud/InstallDuckDBExtensions.java
+++ b/src/apps/base-images/geoserver/src/main/java/org/geoserver/cloud/InstallDuckDBExtensions.java
@@ -30,7 +30,7 @@ public class InstallDuckDBExtensions {
      *
      * @param args Command line arguments (not used)
      */
-    @SuppressWarnings({"java:S4507", "java:S106"}) // printStackTrace() and System.out.println() are ok in this class
+    @SuppressWarnings({"java:S4507", "java:S106"}) // stack traces and stdout are fine in this build-time installer
     void main() {
         try {
             Class.forName("org.duckdb.DuckDBDriver");

--- a/src/apps/geoserver/gwc/src/test/java/org/geoserver/cloud/gwc/app/DiskQuotaControllerPgconfigIT.java
+++ b/src/apps/geoserver/gwc/src/test/java/org/geoserver/cloud/gwc/app/DiskQuotaControllerPgconfigIT.java
@@ -89,9 +89,10 @@ class DiskQuotaControllerPgconfigIT {
         ResponseEntity<String> resp = authed.getForEntity("/gwc/rest/diskquota", String.class);
         assertThat(resp.getStatusCode()).as("body: %s", resp.getBody()).isEqualTo(OK);
         String body = resp.getBody();
-        assertThat(body).contains("<org.geowebcache.diskquota.DiskQuotaConfig>");
-        assertThat(body).contains("<enabled>");
-        assertThat(body).contains("<globalQuota>");
+        assertThat(body)
+                .contains("<org.geowebcache.diskquota.DiskQuotaConfig>")
+                .contains("<enabled>")
+                .contains("<globalQuota>");
     }
 
     /**
@@ -126,11 +127,12 @@ class DiskQuotaControllerPgconfigIT {
         ResponseEntity<String> getResp = authed.getForEntity("/gwc/rest/diskquota", String.class);
         assertThat(getResp.getStatusCode()).isEqualTo(OK);
         String body = getResp.getBody();
-        assertThat(body).contains("<enabled>true</enabled>");
-        assertThat(body).contains("<cacheCleanUpFrequency>5</cacheCleanUpFrequency>");
-        assertThat(body).contains("<cacheCleanUpUnits>SECONDS</cacheCleanUpUnits>");
-        assertThat(body).contains("<maxConcurrentCleanUps>4</maxConcurrentCleanUps>");
-        assertThat(body).contains("<globalExpirationPolicyName>LFU</globalExpirationPolicyName>");
+        assertThat(body)
+                .contains("<enabled>true</enabled>")
+                .contains("<cacheCleanUpFrequency>5</cacheCleanUpFrequency>")
+                .contains("<cacheCleanUpUnits>SECONDS</cacheCleanUpUnits>")
+                .contains("<maxConcurrentCleanUps>4</maxConcurrentCleanUps>")
+                .contains("<globalExpirationPolicyName>LFU</globalExpirationPolicyName>");
     }
 
     @Test

--- a/src/apps/geoserver/wfs/src/test/java/org/geoserver/cloud/wfs/app/WfsApplicationTest.java
+++ b/src/apps/geoserver/wfs/src/test/java/org/geoserver/cloud/wfs/app/WfsApplicationTest.java
@@ -105,8 +105,7 @@ abstract class WfsApplicationTest {
         String wsa = getFeatureAsJson(port, "wsa");
         assertThat(wsa)
                 .as("the wsa virtual service should not crash on the unqualified typeName")
-                .doesNotContain("ClassCastException", "cannot be cast");
-        assertThat(wsa)
+                .doesNotContain("ClassCastException", "cannot be cast")
                 .as("the wsa virtual service should return wsa's own 'roads' feature")
                 .contains("FeatureCollection")
                 .contains("wsa road")

--- a/src/apps/infrastructure/gateway-webmvc/src/main/java/org/geoserver/cloud/autoconfigure/gateway/NormalizedBasePathPropertySource.java
+++ b/src/apps/infrastructure/gateway-webmvc/src/main/java/org/geoserver/cloud/autoconfigure/gateway/NormalizedBasePathPropertySource.java
@@ -27,7 +27,7 @@ import org.springframework.core.env.PropertySource;
  */
 class NormalizedBasePathPropertySource extends PropertySource<Object> {
 
-    static final String NAME = "geoserverNormalizedBasePath";
+    static final String SOURCE_NAME = "geoserverNormalizedBasePath";
 
     static final String BASE_PATH_PROPERTY = "basepath";
 
@@ -45,14 +45,14 @@ class NormalizedBasePathPropertySource extends PropertySource<Object> {
     private final ConfigurableEnvironment environment;
 
     private NormalizedBasePathPropertySource(ConfigurableEnvironment environment) {
-        super(NAME);
+        super(SOURCE_NAME);
         this.environment = environment;
     }
 
     /** Puts a normalizing source at the top of the environment's property sources; a no-op if already registered. */
     static void register(ConfigurableEnvironment environment) {
         MutablePropertySources sources = environment.getPropertySources();
-        if (!sources.contains(NAME)) {
+        if (!sources.contains(SOURCE_NAME)) {
             sources.addFirst(new NormalizedBasePathPropertySource(environment));
         }
     }
@@ -66,7 +66,7 @@ class NormalizedBasePathPropertySource extends PropertySource<Object> {
         try {
             return resolveNormalizedBasePath();
         } finally {
-            resolving.set(Boolean.FALSE);
+            resolving.remove();
         }
     }
 
@@ -113,5 +113,19 @@ class NormalizedBasePathPropertySource extends PropertySource<Object> {
             value = "/" + value;
         }
         return value;
+    }
+
+    /**
+     * Property sources are identified by name alone, per the {@link PropertySource} equality contract; the environment
+     * and reentrancy guard are collaborators, not identity.
+     */
+    @Override
+    public boolean equals(Object other) {
+        return super.equals(other);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
     }
 }

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/resource/DbBackedFileSynchronizer.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/resource/DbBackedFileSynchronizer.java
@@ -157,10 +157,9 @@ public class DbBackedFileSynchronizer {
             }
             long localMtime = file.lastModified();
             maxSeen = Math.max(maxSeen, localMtime);
-            if (localMtime <= newestSynced) {
-                continue;
+            if (localMtime > newestSynced) {
+                push(resourcePath, file, localMtime);
             }
-            push(resourcePath, file, localMtime);
         }
         newestSyncedMtime.put(path, maxSeen);
         lastSynced.put(path, System.currentTimeMillis());

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceStore.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceStore.java
@@ -219,7 +219,7 @@ public class PgconfigResourceStore implements ResourceStore {
         Resource from = get(path);
         Resource to = get(target);
         if (from instanceof PgconfigResource pgFrom && to instanceof PgconfigResource pgTo) {
-            return PgconfigResourceStore.this.move(pgFrom, pgTo);
+            return moveDbResource(pgFrom, pgTo);
         }
         if (from instanceof PgconfigResource) {
             throw new UnsupportedOperationException(
@@ -244,7 +244,7 @@ public class PgconfigResourceStore implements ResourceStore {
         Optional<PgconfigResource> dbBacked = findByPath(normalize(path));
         if (dbBacked.isPresent()) {
             PgconfigResource pgTarget = findByPathOrUndefined(normalize(target));
-            return move(dbBacked.get(), pgTarget);
+            return moveDbResource(dbBacked.get(), pgTarget);
         }
         return cache.getLocalOnlyStore().move(path, target);
     }
@@ -394,6 +394,15 @@ public class PgconfigResourceStore implements ResourceStore {
 
     @Transactional(transactionManager = "pgconfigTransactionManager", propagation = REQUIRED)
     public boolean move(@NonNull final PgconfigResource source, @NonNull final PgconfigResource target) {
+        return moveDbResource(source, target);
+    }
+
+    /**
+     * Move implementation shared by the transactional entry points. In-class callers already run within the transaction
+     * begun by {@link #move(String, String)} and use this method directly: self-invoking the {@code @Transactional}
+     * overload through {@code this} would bypass the transactional proxy.
+     */
+    private boolean moveDbResource(final PgconfigResource source, final PgconfigResource target) {
         if (source.isUndefined()) {
             return true;
         }

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceIT.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/backend/pgconfig/resource/PgconfigResourceIT.java
@@ -410,7 +410,7 @@ class PgconfigResourceIT {
     }
 
     @Test
-    void testMoveUpdatesParentDirectoryMtimes() throws Exception {
+    void testMoveUpdatesParentDirectoryMtimes() {
         store.get("workspaces").dir();
         store.get("workspaces/mvsrc").dir();
         store.get("workspaces/mvdst").dir();

--- a/src/catalog/cache/src/main/java/org/geoserver/cloud/catalog/cache/CachedReferenceCleaner.java
+++ b/src/catalog/cache/src/main/java/org/geoserver/cloud/catalog/cache/CachedReferenceCleaner.java
@@ -104,21 +104,16 @@ class CachedReferenceCleaner {
     private int evictReferencingLayerLists(InfoIdKey idKey, ConcurrentMap<?, ?> cache, AtomicInteger visited) {
         int evicted = 0;
         for (var entry : cache.entrySet()) {
-            Object value = entry.getValue();
-            if (!(value instanceof List<?> list) || list.isEmpty()) {
-                continue;
-            }
-            if (!(list.get(0) instanceof LayerInfo)) {
-                continue;
-            }
-            visited.incrementAndGet();
-            boolean anyReferences = list.stream()
-                    .filter(LayerInfo.class::isInstance)
-                    .map(LayerInfo.class::cast)
-                    .anyMatch(layer -> canReference(layer, idKey));
-            if (anyReferences && cache.remove(entry.getKey()) != null) {
-                evicted++;
-                log.trace("cascade evicted layer list {} referencing {}", entry.getKey(), idKey.id());
+            if (entry.getValue() instanceof List<?> list && !list.isEmpty() && list.get(0) instanceof LayerInfo) {
+                visited.incrementAndGet();
+                boolean anyReferences = list.stream()
+                        .filter(LayerInfo.class::isInstance)
+                        .map(LayerInfo.class::cast)
+                        .anyMatch(layer -> canReference(layer, idKey));
+                if (anyReferences && cache.remove(entry.getKey()) != null) {
+                    evicted++;
+                    log.trace("cascade evicted layer list {} referencing {}", entry.getKey(), idKey.id());
+                }
             }
         }
         return evicted;

--- a/src/catalog/cache/src/test/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeContainmentSupportTest.java
+++ b/src/catalog/cache/src/test/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeContainmentSupportTest.java
@@ -178,7 +178,7 @@ class CachingCatalogFacadeContainmentSupportTest {
     }
 
     @Test
-    void testGetByNameDoesNotCacheNullValues() throws Exception {
+    void testGetByNameDoesNotCacheNullValues() {
         InfoNameKey key = InfoNameKey.valueOf("roads", ConfigInfoType.LAYER);
         Callable<LayerInfo> loader = loader();
 

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/rules/DefaultNamespaceInfoRules.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/rules/DefaultNamespaceInfoRules.java
@@ -40,7 +40,7 @@ public class DefaultNamespaceInfoRules implements CatalogInfoBusinessRules<Names
     protected void setAsDefaultIfThereWasNoDefaultNamespace(CatalogOpContext<NamespaceInfo> context) {
         if (context.isSuccess()) {
             Boolean needsSetDefault = context.getContextOption(SET_DEFAULT);
-            if (needsSetDefault.booleanValue()) {
+            if (Boolean.TRUE.equals(needsSetDefault)) {
                 context.getCatalog().setDefaultNamespace(context.getObject());
             }
         }

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/rules/DefaultWorkspaceInfoRules.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/rules/DefaultWorkspaceInfoRules.java
@@ -52,7 +52,7 @@ public class DefaultWorkspaceInfoRules implements CatalogInfoBusinessRules<Works
     private void setAsDefaultIfThereWasNoDefaultWorkspace(CatalogOpContext<WorkspaceInfo> context) {
         if (context.isSuccess()) {
             Boolean needsSetDefault = context.getContextOption(SET_DEFAULT);
-            if (needsSetDefault.booleanValue()) {
+            if (Boolean.TRUE.equals(needsSetDefault)) {
                 context.getCatalog().setDefaultWorkspace(context.getObject());
             }
         }

--- a/src/catalog/plugin/src/main/java/org/geoserver/config/plugin/RepositoryGeoServerFacadeImpl.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/config/plugin/RepositoryGeoServerFacadeImpl.java
@@ -81,6 +81,7 @@ public class RepositoryGeoServerFacadeImpl implements RepositoryGeoServerFacade 
 
     @Override
     public void setGlobal(GeoServerInfo global) {
+        requireNonNull(global);
         resolve(global);
         setId(global.getSettings());
         repository.setGlobal(global);

--- a/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowMetrics.java
+++ b/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowMetrics.java
@@ -10,6 +10,7 @@ import io.micrometer.core.instrument.MultiGauge;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.ToDoubleFunction;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -65,7 +66,7 @@ class ControlFlowMetrics implements MeterBinder {
     private MultiGauge ruleActiveQueues;
     private MultiGauge ruleRateLimit;
 
-    private volatile List<FlowController> lastSeenControllers;
+    private final AtomicReference<List<FlowController>> lastSeenControllers = new AtomicReference<>();
     private volatile boolean lastRefreshFailed;
 
     @Override
@@ -147,15 +148,15 @@ class ControlFlowMetrics implements MeterBinder {
             }
             return;
         }
-        if (current == lastSeenControllers) {
+        if (current == lastSeenControllers.get()) {
             return;
         }
         synchronized (this) {
-            if (current == lastSeenControllers) {
+            if (current == lastSeenControllers.get()) {
                 return;
             }
             registerRuleRows(ControlFlowRuleRows.resolve(current));
-            lastSeenControllers = current;
+            lastSeenControllers.set(current);
         }
     }
 

--- a/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowRuleRows.java
+++ b/src/extensions/control-flow/src/main/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowRuleRows.java
@@ -4,11 +4,11 @@
  */
 package org.geoserver.cloud.autoconfigure.extensions.controlflow;
 
-import com.google.common.base.Predicate;
 import io.micrometer.core.instrument.MultiGauge;
 import io.micrometer.core.instrument.Tags;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.function.ToDoubleFunction;
 import lombok.extern.slf4j.Slf4j;
 import org.geoserver.flow.FlowController;
@@ -97,8 +97,8 @@ class ControlFlowRuleRows {
             running.add(row(tags, monitored, MonitoredPriorityThreadBlocker::getAdmittedCount));
             waiting.add(row(tags, monitored, PriorityThreadBlocker::getRunningRequestsCount));
         } else if (blocker instanceof PriorityThreadBlocker priority) {
-            // upstream getRunningRequestsCount() reports the waiting queue here;
-            // the running count is private state with no accessor
+            // upstream's running-requests accessor reports the waiting queue on this
+            // blocker type, and the actual running count is private with no accessor
             waiting.add(row(tags, priority, PriorityThreadBlocker::getRunningRequestsCount));
         } else if (blocker instanceof SimpleThreadBlocker simple) {
             running.add(row(tags, simple, SimpleThreadBlocker::getRunningRequestsCount));
@@ -106,7 +106,7 @@ class ControlFlowRuleRows {
     }
 
     private String singleQueueRuleKey(SingleQueueFlowController controller) {
-        // guava's Predicate, which upstream's OWSRequestMatcher and IpRequestMatcher implement
+        // upstream's matchers implement guava's Predicate, a subtype of java.util.function.Predicate
         Predicate<?> matcher = controller.getMatcher();
         if (matcher instanceof IpRequestMatcher ipMatcher) {
             return "ip." + ipMatcher.getIp();

--- a/src/extensions/control-flow/src/test/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowMetricsTest.java
+++ b/src/extensions/control-flow/src/test/java/org/geoserver/cloud/autoconfigure/extensions/controlflow/ControlFlowMetricsTest.java
@@ -258,9 +258,7 @@ class ControlFlowMetricsTest {
                 .as("rule active queues gauge keeps its documented name")
                 .contains("geoserver_controlflow_rule_queues_active")
                 .as("rule rate limit gauge keeps its documented name")
-                .contains("geoserver_controlflow_rule_rate_limit");
-
-        assertThat(scrape)
+                .contains("geoserver_controlflow_rule_rate_limit")
                 .as("no base-unit suffix on the global running gauge")
                 .doesNotContain("_running_requests")
                 .as("no base-unit suffix on the rule active queues gauge")

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigDiskQuotaAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/backend/PgconfigDiskQuotaAutoConfiguration.java
@@ -75,6 +75,7 @@ public class PgconfigDiskQuotaAutoConfiguration {
     }
 
     @Bean(name = "PostgreSQLQuotaDialect")
+    @SuppressWarnings("java:S6830") // upstream bean-name contract, see class javadoc
     SQLDialect postgreSQLQuotaDialect() {
         return new PostgreSQLDialect();
     }
@@ -84,7 +85,7 @@ public class PgconfigDiskQuotaAutoConfiguration {
             @Qualifier("pgconfigDataSource") DataSource pgconfigDataSource,
             @Qualifier("gwcDefaultStorageFinder") DefaultStorageFinder storageFinder,
             @Qualifier("gwcTilePageCalculator") TilePageCalculator tilePageCalculator,
-            @Qualifier("PostgreSQLQuotaDialect") SQLDialect dialect,
+            @SuppressWarnings("java:S6830") @Qualifier("PostgreSQLQuotaDialect") SQLDialect dialect,
             PgconfigBackendProperties pgconfigProperties) {
 
         DataSource nonClosingDataSource = new DelegatingDataSource(pgconfigDataSource);
@@ -97,6 +98,7 @@ public class PgconfigDiskQuotaAutoConfiguration {
     }
 
     @Bean(name = "DiskQuotaStoreProvider")
+    @SuppressWarnings("java:S6830") // upstream bean-name contract, see class javadoc
     ConfigurableQuotaStoreProvider diskQuotaStoreProvider(
             @Qualifier("DiskQuotaConfigLoader") ConfigLoader loader,
             @Qualifier("gwcTilePageCalculator") TilePageCalculator tilePageCalculator,

--- a/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigGwcCatalogRenameListener.java
+++ b/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigGwcCatalogRenameListener.java
@@ -271,7 +271,7 @@ public class PgconfigGwcCatalogRenameListener implements CatalogListener {
         GWC mediator;
         try {
             mediator = GWC.get();
-        } catch (NullPointerException npe) {
+        } catch (NullPointerException _) {
             log.debug("Skipping {} tile layer rename(s); GWC singleton not available", pairs.size());
             return;
         }

--- a/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigTileLayerCatalog.java
+++ b/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigTileLayerCatalog.java
@@ -189,7 +189,7 @@ public class PgconfigTileLayerCatalog implements TileLayerConfiguration {
         GWC mediator;
         try {
             mediator = GWC.get();
-        } catch (NullPointerException npe) {
+        } catch (NullPointerException _) {
             return;
         }
         if (mediator == null) {

--- a/src/gwc/core/src/test/java/org/geoserver/cloud/gwc/repository/CachingTileLayerCatalogTest.java
+++ b/src/gwc/core/src/test/java/org/geoserver/cloud/gwc/repository/CachingTileLayerCatalogTest.java
@@ -60,7 +60,7 @@ class CachingTileLayerCatalogTest {
     }
 
     @Test
-    public void initialize() {
+    void initialize() {
         caching = new CachingTileLayerCatalog(cacheManager, catalog);
         assertThat(caching.idCache).isNull();
         assertThat(caching.namesById).isNotNull().isEmpty();
@@ -74,7 +74,7 @@ class CachingTileLayerCatalogTest {
     }
 
     @Test
-    public void reset() {
+    void reset() {
 
         assertThat(caching.idCache).isNotNull();
         add(caching, "tl1");
@@ -87,7 +87,7 @@ class CachingTileLayerCatalogTest {
     }
 
     @Test
-    public void onTileLayerEvent() {
+    void onTileLayerEvent() {
         final String origName = "origName";
         final String newName = "newName";
         catalog.addListener(new TileLayerCatalogListener() {
@@ -140,7 +140,7 @@ class CachingTileLayerCatalogTest {
     }
 
     @Test
-    public void getLayerIds() {
+    void getLayerIds() {
         add(catalog, "tl1");
         add(catalog, "tl2");
         assertThat(caching.getLayerIds()).isEmpty();
@@ -151,7 +151,7 @@ class CachingTileLayerCatalogTest {
     }
 
     @Test
-    public void getLayerNames() {
+    void getLayerNames() {
         add(catalog, "tl1");
         add(catalog, "tl2");
         assertThat(caching.getLayerNames()).isEmpty();
@@ -162,7 +162,7 @@ class CachingTileLayerCatalogTest {
     }
 
     @Test
-    public void save() {
+    void save() {
         add(caching, "tl1");
         GeoServerTileLayerInfo tl = add(caching, "tl2");
 
@@ -185,7 +185,7 @@ class CachingTileLayerCatalogTest {
     }
 
     @Test
-    public void delete() {
+    void delete() {
         add(caching, "tl1");
         add(caching, "tl2");
 
@@ -202,7 +202,7 @@ class CachingTileLayerCatalogTest {
     }
 
     @Test
-    public void getLayerId() {
+    void getLayerId() {
         add(caching, "tl1", "name1");
         add(caching, "tl2", "name2");
 
@@ -211,7 +211,7 @@ class CachingTileLayerCatalogTest {
     }
 
     @Test
-    public void getLayerName() {
+    void getLayerName() {
         // bypass cache
         add(catalog, "tl1", "name1");
         add(catalog, "tl2", "name2");
@@ -221,7 +221,7 @@ class CachingTileLayerCatalogTest {
     }
 
     @Test
-    public void getLayerById() {
+    void getLayerById() {
         add(catalog, "tl1", "name1");
         add(catalog, "tl2", "name2");
 
@@ -230,7 +230,7 @@ class CachingTileLayerCatalogTest {
     }
 
     @Test
-    public void getLayerByName() {
+    void getLayerByName() {
         // bypass cache
         add(catalog, "tl1", "name1");
         add(catalog, "tl2", "name2");


### PR DESCRIPTION
- PgconfigResourceStore: give in-class callers a private move implementation instead of self-invoking the `@Transactional` overload (S6809)
- NormalizedBasePathPropertySource: rename NAME to avoid the clash with PropertySource.name (S1845), ThreadLocal.remove() in the reentrancy guard (S5164), explicit name-based equals/hashCode (S2160)
- Null-safety: tolerate an absent SET_DEFAULT context option in the default workspace/namespace rules, require a non-null global config in RepositoryGeoServerFacadeImpl.setGlobal (javabugs:S2259)
- ControlFlowMetrics: AtomicReference instead of a volatile list field (S3077)
- ControlFlowRuleRows: java.util.function.Predicate over guava's (S4738)
- PgconfigDiskQuotaAutoConfiguration: suppress S6830 on upstream-contract bean names
- Unnamed catch patterns (S7467), single-continue loops (S135), comments no longer mistaken for code (S125)
- Tests: joined assertion chains (S5853), no dead throws clauses (S1130), no redundant public modifiers (S5786)
