### PR TITLE
Support mounting additional jar libraries and fonts in the containers

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -111,6 +111,7 @@ nav:
         - Example — pgconfig: deploy/kubernetes/helm/example-pgconfig.md
   - User Guide:
     - Overview: user-guide/index.md
+    - Additional libraries and fonts: user-guide/additional-libs-and-fonts.md
     - ImageMosaics through the REST API: user-guide/imagemosaic-rest-api.md
     - GeoParquet through the REST API: user-guide/geoparquet-rest-api.md
     - Monitoring control-flow: user-guide/controlflow-monitoring.md

--- a/docs/src/user-guide/additional-libs-and-fonts.md
+++ b/docs/src/user-guide/additional-libs-and-fonts.md
@@ -1,0 +1,124 @@
+# Additional libraries and fonts
+
+GeoServer Cloud containers load user-provided jar files and fonts from two
+mount points, without rebuilding the images:
+
+- `/opt/additional_libs`: jar files added to the application classpath.
+- `/opt/additional_fonts`: font files registered with the operating system.
+
+Typical uses:
+
+- JDBC drivers that cannot be redistributed, like the Oracle `ojdbc` driver.
+- GeoServer extensions not bundled in the official images.
+- Corporate or symbol fonts for map labeling with SLD styles.
+
+## Provide additional jar libraries
+
+Mount a directory with the jar files at `/opt/additional_libs` on every
+service that needs them.
+
+With `docker run`:
+
+```shell
+docker run -v ./my-libs:/opt/additional_libs geoservercloud/geoserver-cloud-wms
+```
+
+With Docker Compose:
+
+```yaml
+services:
+  wms:
+    image: geoservercloud/geoserver-cloud-wms
+    volumes:
+      - ./my-libs:/opt/additional_libs
+```
+
+With Kubernetes, use any volume type and mount it at `/opt/additional_libs`:
+
+```yaml
+        volumeMounts:
+          - name: additional-libs
+            mountPath: /opt/additional_libs
+```
+
+The jars become part of the application classpath at startup, as peers of the
+bundled libraries. They can both provide self-contained libraries like JDBC
+drivers and GeoServer extensions that depend on GeoServer and GeoTools
+classes.
+
+Note that GeoServer Cloud activates extensions through Spring Boot
+autoconfigurations, not through the traditional GeoServer mechanism of
+scanning every jar for an `applicationContext.xml` bean definitions file. A
+vanilla GeoServer extension jar dropped in `/opt/additional_libs` will not
+activate by itself: extensions must be packaged as described in
+[Adding Extensions to GeoServer Cloud](../developer-guide/extensions/adding_extensions.md).
+
+### How it works
+
+The containers start the application through Spring Boot's
+`PropertiesLauncher`, which reads the `LOADER_PATH` environment variable. The
+images set `LOADER_PATH=/opt/additional_libs` by default. To load jars from
+several directories, override it with a comma-separated list that includes
+the default:
+
+```yaml
+    environment:
+      LOADER_PATH: /opt/additional_libs,/opt/my-other-libs
+```
+
+### Classpath precedence
+
+Jars in `/opt/additional_libs` come before the bundled libraries on the
+classpath. This allows replacing the version of a bundled library, but also
+means a mounted jar can unintentionally shadow classes the services depend
+on. Mount only what you need.
+
+### File permissions
+
+The services run with the user id given by the deployment (for example
+`user: ${GS_USER}` in the Docker Compose files). Read access is all the
+services need: make sure the mounted files are readable by that uid, or
+world-readable. The directory baked into the image is world-writable with the
+sticky bit set (`1777`), meaning init containers or `docker cp` can populate
+a named volume under any uid.
+
+## Provide additional fonts
+
+Mount a directory with font files (`.ttf`, `.otf`, and any other
+fontconfig-supported format) at `/opt/additional_fonts` on the GeoServer
+services that render maps or list fonts (at least `wms` and `webui`):
+
+```yaml
+services:
+  wms:
+    image: geoservercloud/geoserver-cloud-wms
+    volumes:
+      - ./my-fonts:/opt/additional_fonts
+```
+
+The directory is registered with fontconfig inside the image, meaning the JVM
+finds the fonts like any other system font: they are available to SLD
+`<Font>` elements in the `wms` service and listed in the web UI under
+*About & Status > Server Status > Fonts*. No startup script copies files
+around and no font cache needs rebuilding: fontconfig scans the directory
+when the JVM first enumerates fonts.
+
+Fonts referenced by styles must be mounted on every service that renders with
+those styles. Subdirectories are scanned recursively, and the same read
+access rules as for `/opt/additional_libs` apply.
+
+## Verify
+
+To check a mounted jar is on the classpath, start the service with
+`JAVA_OPTS=-Dloader.debug=true`: the launcher prints the resolved classpath
+URLs, including the jars found in `/opt/additional_libs`, before the
+application starts.
+
+To check the fonts are registered, list them with fontconfig from inside the
+container:
+
+```shell
+docker compose exec wms fc-list | grep -i myfont
+```
+
+or open *About & Status > Server Status > Fonts* in the web UI.

--- a/docs/src/user-guide/index.md
+++ b/docs/src/user-guide/index.md
@@ -5,6 +5,10 @@ complete, real-world workflow against a running deployment.
 
 Available guides:
 
+- [Additional libraries and fonts](additional-libs-and-fonts.md): mount
+  user-provided jar files and fonts into the containers, like JDBC drivers,
+  GeoServer extensions, and fonts for map labeling, without rebuilding the
+  images.
 - [ImageMosaics through the REST API](imagemosaic-rest-api.md): publish an
   ImageMosaic of Cloud Optimized GeoTIFFs stored on object storage, using the
   same REST API calls that work against vanilla GeoServer.

--- a/src/apps/base-images/geoserver/Dockerfile
+++ b/src/apps/base-images/geoserver/Dockerfile
@@ -45,6 +45,19 @@ fonts-noto-core \
 RUN mkdir -p /opt/app/data_directory /data/geowebcache \
 && chmod 0777 /opt/app/data_directory /data/geowebcache
 
+# Mount point for user-provided fonts, registered with fontconfig, which makes the
+# JVM pick them up and list them in the GeoServer web UI's available fonts without
+# any startup script. Fontconfig scans the directory lazily at runtime; its per-user
+# cache goes to $HOME/.cache, writable by any runtime uid.
+RUN mkdir -p /opt/additional_fonts && chmod 1777 /opt/additional_fonts
+RUN cat > /etc/fonts/conf.d/05-additional-fonts.conf <<'EOF'
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <dir>/opt/additional_fonts</dir>
+</fontconfig>
+EOF
+
 WORKDIR /opt/app/bin
 COPY --from=builder /builder/dependencies/ ./
 COPY --from=builder /builder/snapshot-dependencies/ ./

--- a/src/apps/base-images/spring-boot/Dockerfile
+++ b/src/apps/base-images/spring-boot/Dockerfile
@@ -28,6 +28,13 @@ COPY target/config/ /etc/geoserver/
 
 RUN mkdir -p /opt/app/bin
 
+# Mount point for user-provided jar files (e.g. JDBC drivers, GeoServer extensions).
+# PropertiesLauncher prepends the jars in LOADER_PATH to the application classpath.
+# Sticky bit (1777) allows any runtime uid to populate it (e.g. from an init container)
+# while only owners can delete their own files.
+RUN mkdir -p /opt/additional_libs && chmod 1777 /opt/additional_libs
+ENV LOADER_PATH=/opt/additional_libs
+
 WORKDIR /opt/app/bin
 
 EXPOSE 8080
@@ -53,4 +60,6 @@ CMD curl -f -s -o /dev/null localhost:8081/actuator/health || exit 1
 # the cache if present, or silently continue without it.
 # Override at runtime with -e AOT_MODE=off to disable AOT for a specific container.
 ENV AOT_MODE=auto
-CMD exec java $JAVA_OPTS -XX:AOTMode=$AOT_MODE -XX:AOTCache=app.aot org.springframework.boot.loader.launch.JarLauncher
+# PropertiesLauncher instead of JarLauncher: builds the same BOOT-INF classpath and
+# additionally prepends the jars found in LOADER_PATH (/opt/additional_libs)
+CMD exec java $JAVA_OPTS -XX:AOTMode=$AOT_MODE -XX:AOTCache=app.aot org.springframework.boot.loader.launch.PropertiesLauncher

--- a/src/apps/geoserver/gwc/Dockerfile
+++ b/src/apps/geoserver/gwc/Dockerfile
@@ -30,5 +30,5 @@ RUN GEOSERVER_DATA_DIR=/tmp/datadir && \
   -Dgeoserver.acl.client.startupCheck=false \
   -Dgeoserver.bus.enabled=true \
   -Dspring.profiles.active=standalone,datadir,acl \
-  org.springframework.boot.loader.launch.JarLauncher && \
+  org.springframework.boot.loader.launch.PropertiesLauncher && \
  rm -rf /tmp/*

--- a/src/apps/geoserver/restconfig/Dockerfile
+++ b/src/apps/geoserver/restconfig/Dockerfile
@@ -30,5 +30,5 @@ RUN GEOSERVER_DATA_DIR=/tmp/datadir && \
   -Dgeoserver.acl.client.startupCheck=false \
   -Dgeoserver.bus.enabled=true \
   -Dspring.profiles.active=standalone,datadir,acl \
-  org.springframework.boot.loader.launch.JarLauncher && \
+  org.springframework.boot.loader.launch.PropertiesLauncher && \
  rm -rf /tmp/*

--- a/src/apps/geoserver/wcs/Dockerfile
+++ b/src/apps/geoserver/wcs/Dockerfile
@@ -30,5 +30,5 @@ RUN GEOSERVER_DATA_DIR=/tmp/datadir && \
   -Dgeoserver.acl.client.startupCheck=false \
   -Dgeoserver.bus.enabled=true \
   -Dspring.profiles.active=standalone,datadir,acl \
-  org.springframework.boot.loader.launch.JarLauncher && \
+  org.springframework.boot.loader.launch.PropertiesLauncher && \
  rm -rf /tmp/*

--- a/src/apps/geoserver/webui/Dockerfile
+++ b/src/apps/geoserver/webui/Dockerfile
@@ -30,5 +30,5 @@ RUN GEOSERVER_DATA_DIR=/tmp/datadir && \
   -Dgeoserver.acl.client.startupCheck=false \
   -Dgeoserver.bus.enabled=true \
   -Dspring.profiles.active=standalone,datadir,acl \
-  org.springframework.boot.loader.launch.JarLauncher && \
+  org.springframework.boot.loader.launch.PropertiesLauncher && \
  rm -rf /tmp/*

--- a/src/apps/geoserver/wfs/Dockerfile
+++ b/src/apps/geoserver/wfs/Dockerfile
@@ -30,5 +30,5 @@ RUN GEOSERVER_DATA_DIR=/tmp/datadir && \
   -Dgeoserver.acl.client.startupCheck=false \
   -Dgeoserver.bus.enabled=true \
   -Dspring.profiles.active=standalone,datadir,acl \
-  org.springframework.boot.loader.launch.JarLauncher && \
+  org.springframework.boot.loader.launch.PropertiesLauncher && \
  rm -rf /tmp/*

--- a/src/apps/geoserver/wms/Dockerfile
+++ b/src/apps/geoserver/wms/Dockerfile
@@ -30,5 +30,5 @@ RUN GEOSERVER_DATA_DIR=/tmp/datadir && \
   -Dgeoserver.acl.client.startupCheck=false \
   -Dgeoserver.bus.enabled=true \
   -Dspring.profiles.active=standalone,datadir,acl \
-  org.springframework.boot.loader.launch.JarLauncher && \
+  org.springframework.boot.loader.launch.PropertiesLauncher && \
  rm -rf /tmp/*

--- a/src/apps/geoserver/wps/Dockerfile
+++ b/src/apps/geoserver/wps/Dockerfile
@@ -30,5 +30,5 @@ RUN GEOSERVER_DATA_DIR=/tmp/datadir && \
   -Dgeoserver.acl.client.startupCheck=false \
   -Dgeoserver.bus.enabled=true \
   -Dspring.profiles.active=standalone,datadir,acl \
-  org.springframework.boot.loader.launch.JarLauncher && \
+  org.springframework.boot.loader.launch.PropertiesLauncher && \
  rm -rf /tmp/*

--- a/src/apps/infrastructure/config/Dockerfile
+++ b/src/apps/infrastructure/config/Dockerfile
@@ -41,6 +41,6 @@ ENV XDG_CONFIG_HOME: /tmp
 # AOT training run for faster startup (each arch builds natively, no QEMU)
 RUN java -XX:AOTCacheOutput=app.aot -Dspring.context.exit=onRefresh \
   -Dspring.profiles.active=native \
-  org.springframework.boot.loader.launch.JarLauncher; \
+  org.springframework.boot.loader.launch.PropertiesLauncher; \
   rm -rf /tmp/*
 

--- a/src/apps/infrastructure/gateway-webmvc/Dockerfile
+++ b/src/apps/infrastructure/gateway-webmvc/Dockerfile
@@ -25,5 +25,5 @@ COPY --from=builder /builder/application/ ./
 RUN java -XX:AOTCacheOutput=app.aot \
 -Dspring.context.exit=onRefresh \
 -Dspring.profiles.active=standalone \
-org.springframework.boot.loader.launch.JarLauncher; \
+org.springframework.boot.loader.launch.PropertiesLauncher; \
 rm -rf /tmp/*


### PR DESCRIPTION
Adds two mount points to all container images, usable without rebuilding them:

- `/opt/additional_libs`: user-provided jar files added to the application classpath, e.g. proprietary JDBC drivers like Oracle `ojdbc`, or GeoServer extensions not bundled in the official images.
- `/opt/additional_fonts`: user-provided fonts, registered with fontconfig and available to the JVM, e.g. for SLD map labeling. They show up in the web UI's *Server Status > Fonts* listing.
