### PR TITLE
Stop bundling the Oracle JDBC driver

### DIFF
--- a/docs/src/user-guide/additional-libs-and-fonts.md
+++ b/docs/src/user-guide/additional-libs-and-fonts.md
@@ -8,7 +8,7 @@ mount points, without rebuilding the images:
 
 Typical uses:
 
-- JDBC drivers that cannot be redistributed, like the Oracle `ojdbc` driver.
+- JDBC drivers the images do not bundle, like the Oracle `ojdbc` driver.
 - GeoServer extensions not bundled in the official images.
 - Corporate or symbol fonts for map labeling with SLD styles.
 
@@ -72,6 +72,23 @@ Jars in `/opt/additional_libs` come before the bundled libraries on the
 classpath. This allows replacing the version of a bundled library, but also
 means a mounted jar can unintentionally shadow classes the services depend
 on. Mount only what you need.
+
+### Oracle JDBC driver
+
+The official images do not include the Oracle JDBC driver. Its license,
+the Oracle Free Use Terms and Conditions, permits redistribution only
+under conditions like shipping the license text with every distribution;
+not bundling the driver avoids taking on those conditions and keeps
+GeoServer Cloud a GPL-only distribution. The Oracle extension is
+included; to use Oracle datastores, provide the driver:
+
+1. Download `ojdbc17.jar` from the
+   [Oracle JDBC downloads page](https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html)
+   or from Maven Central (`com.oracle.database.jdbc:ojdbc17`).
+2. Place it in the directory mounted at `/opt/additional_libs` on every
+   GeoServer container, including the services that do not access Oracle
+   datastores: all of them load the catalog, and the catalog fails to load
+   datastores whose classes are missing.
 
 ### File permissions
 

--- a/src/extensions/input-formats/vector-formats/pom.xml
+++ b/src/extensions/input-formats/vector-formats/pom.xml
@@ -53,8 +53,17 @@
       <artifactId>gt-geopkg</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.geotools.jdbc</groupId>
-      <artifactId>gt-jdbc-oracle</artifactId>
+      <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-oracle</artifactId>
+    </dependency>
+    <dependency>
+      <!--
+        Test scope: the images do not bundle the driver (see the ojdbc17 exclusions in dependencyManagement); the
+        tests need it for the Oracle NG factory to report itself as available.
+      -->
+      <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>ojdbc17</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geotools.jdbc</groupId>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -574,9 +574,20 @@
         <version>${gs.version}</version>
       </dependency>
       <dependency>
+        <!--
+          ojdbc17 is not bundled: its FUTC license requires shipping the license text along (the gs-oracle plugin zip
+          includes OracleFUTC.html, the bare maven artifact does not) and excluding it keeps the distribution GPL-only.
+          Provide the driver through /opt/additional_libs, see the "Additional libraries and fonts" user guide page.
+        -->
         <groupId>org.geoserver.importer</groupId>
         <artifactId>gs-importer-core</artifactId>
         <version>${gs.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc17</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.geoserver.importer</groupId>
@@ -597,6 +608,22 @@
         <groupId>org.geoserver.extension</groupId>
         <artifactId>gs-feature-pregeneralized</artifactId>
         <version>${gs.version}</version>
+      </dependency>
+      <dependency>
+        <!--
+          ojdbc17 is not bundled: its FUTC license requires shipping the license text along (the gs-oracle plugin zip
+          includes OracleFUTC.html, the bare maven artifact does not) and excluding it keeps the distribution GPL-only.
+          Provide the driver through /opt/additional_libs, see the "Additional libraries and fonts" user guide page.
+        -->
+        <groupId>org.geoserver.extension</groupId>
+        <artifactId>gs-oracle</artifactId>
+        <version>${gs.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc17</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.geoserver.extension</groupId>


### PR DESCRIPTION
The `ojdbc17` driver ships under Oracle's proprietary Free Use Terms and Conditions, and every service image included it as a transitive dependency. This PR keeps it out of the images, avoiding attaching those terms to the GeoServer Cloud distribution, keeping it GPL-only, and documents providing it at runtime through the `/opt/additional_libs` mount point introduced in #920.