### PR TITLE
fix: Export GEOSERVER_DATA_DIR in the AOT training runs

### DIFF
--- a/src/apps/geoserver/gwc/Dockerfile
+++ b/src/apps/geoserver/gwc/Dockerfile
@@ -24,7 +24,7 @@ RUN true
 COPY --from=builder /builder/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
-RUN GEOSERVER_DATA_DIR=/tmp/datadir && \
+RUN export GEOSERVER_DATA_DIR=/tmp/datadir && \
  mkdir $GEOSERVER_DATA_DIR && \
  java -XX:AOTCacheOutput=app.aot -Dspring.context.exit=onRefresh \
   -Dgeoserver.acl.client.startupCheck=false \

--- a/src/apps/geoserver/restconfig/Dockerfile
+++ b/src/apps/geoserver/restconfig/Dockerfile
@@ -24,7 +24,7 @@ RUN true
 COPY --from=builder /builder/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
-RUN GEOSERVER_DATA_DIR=/tmp/datadir && \
+RUN export GEOSERVER_DATA_DIR=/tmp/datadir && \
  mkdir $GEOSERVER_DATA_DIR && \
  java -XX:AOTCacheOutput=app.aot -Dspring.context.exit=onRefresh \
   -Dgeoserver.acl.client.startupCheck=false \

--- a/src/apps/geoserver/wcs/Dockerfile
+++ b/src/apps/geoserver/wcs/Dockerfile
@@ -24,7 +24,7 @@ RUN true
 COPY --from=builder /builder/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
-RUN GEOSERVER_DATA_DIR=/tmp/datadir && \
+RUN export GEOSERVER_DATA_DIR=/tmp/datadir && \
  mkdir $GEOSERVER_DATA_DIR && \
  java -XX:AOTCacheOutput=app.aot -Dspring.context.exit=onRefresh \
   -Dgeoserver.acl.client.startupCheck=false \

--- a/src/apps/geoserver/webui/Dockerfile
+++ b/src/apps/geoserver/webui/Dockerfile
@@ -24,7 +24,7 @@ RUN true
 COPY --from=builder /builder/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
-RUN GEOSERVER_DATA_DIR=/tmp/datadir && \
+RUN export GEOSERVER_DATA_DIR=/tmp/datadir && \
  mkdir $GEOSERVER_DATA_DIR && \
  java -XX:AOTCacheOutput=app.aot -Dspring.context.exit=onRefresh \
   -Dgeoserver.acl.client.startupCheck=false \

--- a/src/apps/geoserver/wfs/Dockerfile
+++ b/src/apps/geoserver/wfs/Dockerfile
@@ -24,7 +24,7 @@ RUN true
 COPY --from=builder /builder/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
-RUN GEOSERVER_DATA_DIR=/tmp/datadir && \
+RUN export GEOSERVER_DATA_DIR=/tmp/datadir && \
  mkdir $GEOSERVER_DATA_DIR && \
  java -XX:AOTCacheOutput=app.aot -Dspring.context.exit=onRefresh \
   -Dgeoserver.acl.client.startupCheck=false \

--- a/src/apps/geoserver/wms/Dockerfile
+++ b/src/apps/geoserver/wms/Dockerfile
@@ -24,7 +24,7 @@ RUN true
 COPY --from=builder /builder/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
-RUN GEOSERVER_DATA_DIR=/tmp/datadir && \
+RUN export GEOSERVER_DATA_DIR=/tmp/datadir && \
  mkdir $GEOSERVER_DATA_DIR && \
  java -XX:AOTCacheOutput=app.aot -Dspring.context.exit=onRefresh \
   -Dgeoserver.acl.client.startupCheck=false \

--- a/src/apps/geoserver/wps/Dockerfile
+++ b/src/apps/geoserver/wps/Dockerfile
@@ -24,7 +24,7 @@ RUN true
 COPY --from=builder /builder/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
-RUN GEOSERVER_DATA_DIR=/tmp/datadir && \
+RUN export GEOSERVER_DATA_DIR=/tmp/datadir && \
  mkdir $GEOSERVER_DATA_DIR && \
  java -XX:AOTCacheOutput=app.aot -Dspring.context.exit=onRefresh \
   -Dgeoserver.acl.client.startupCheck=false \


### PR DESCRIPTION
The training step sets `GEOSERVER_DATA_DIR=/tmp/datadir` as a shell variable without exporting it: the java process never sees it and boots against the default /opt/app/data_directory. Since 4da64b99c every image ships a root-owned, initialized data directory baked in at build time. Containers without a data directory volume fail under a non-root uid on the root-owned .filelocks, and named volumes mounted at `/opt/app/data_directory` get seeded with the training files through docker's copy-up, which fc882f0c7 and b792c0cde worked around at the compose level.

Exporting the variable makes the training run write to /tmp/datadir, cleaned right after, restoring the empty world-writable data directory the base image prepares.