### PR TITLE
Pin 3.0.1.2 images and drop the volume ownership init containers

### DIFF
--- a/docs/src/deploy/docker-compose/dev/datadir/compose.yml
+++ b/docs/src/deploy/docker-compose/dev/datadir/compose.yml
@@ -17,9 +17,6 @@ x-gs-dependencies: &gs-dependencies
   config:
     condition: service_healthy
     required: true
-  init-volumes:
-    condition: service_completed_successfully
-    required: true
 
 volumes:
   shared_data_directory:
@@ -47,7 +44,7 @@ services:
   # Spring Cloud Config service, provides centralized configuration to all
   # microservices. It registers itself with the Consul discovery service and can be scaled
   config:
-    image: geoservercloud/geoserver-cloud-config:3.1.0-SNAPSHOT
+    image: geoservercloud/geoserver-cloud-config:3.0.1.2
     user: 1000:1000 # set the userid:groupid the container runs as
     environment:
       # default to `native` loading the config embedded in /etc/geoserver
@@ -55,7 +52,7 @@ services:
       # the default repository https://github.com/geoserver/geoserver-cloud-config.git
       SPRING_PROFILES_ACTIVE: native
       # If using the `git` profile, get the config from this tag
-      SPRING_CLOUD_CONFIG_SERVER_GIT_DEFAULT_LABEL: v3.1.0-SNAPSHOT
+      SPRING_CLOUD_CONFIG_SERVER_GIT_DEFAULT_LABEL: v3.0.1.2
     # Uncomment to bind to a local filesystem directory if using the 'native' profile
     #volumes:
     #  - ./config:/etc/geoserver
@@ -89,7 +86,7 @@ services:
   # Application facade, provides a single entry point routing to all
   # microservices (e.g. http://localhost:9090/geoserver/cloud/wms, http://localhost:9090/geoserver/cloud/wfs, etc)
   gateway:
-    image: geoservercloud/geoserver-cloud-gateway:3.1.0-SNAPSHOT
+    image: geoservercloud/geoserver-cloud-gateway:3.0.1.2
     user: 1000:1000 # set the userid:groupid the container runs as
     depends_on:
       config:
@@ -106,18 +103,9 @@ services:
           cpus: '4.0'
           memory: 1G
 
-  # Initializes shared volume ownership so GeoServer services (running as 1000:1000) can write to them
-  init-volumes:
-    image: alpine:3.24.0
-    user: root
-    command: chown 1000:1000 /opt/app/data_directory /data/geowebcache
-    volumes:
-      - shared_data_directory:/opt/app/data_directory
-      - geowebcache_data:/data/geowebcache
-
   # GeoServer template service configuration
   geoserver_template:
-    image: geoservercloud/geoserver-cloud-webui:3.1.0-SNAPSHOT
+    image: geoservercloud/geoserver-cloud-webui:3.0.1.2
     user: "1000:1000"
     environment:
       <<: *common_env
@@ -134,7 +122,7 @@ services:
 
   # GeoServer microservices
   wfs:
-    image: geoservercloud/geoserver-cloud-wfs:3.1.0-SNAPSHOT
+    image: geoservercloud/geoserver-cloud-wfs:3.0.1.2
     extends:
       service: geoserver_template
     depends_on: *gs-dependencies
@@ -142,7 +130,7 @@ services:
       replicas: 1
 
   wms:
-    image: geoservercloud/geoserver-cloud-wms:3.1.0-SNAPSHOT
+    image: geoservercloud/geoserver-cloud-wms:3.0.1.2
     extends:
       service: geoserver_template
     depends_on: *gs-dependencies
@@ -150,7 +138,7 @@ services:
       replicas: 1
 
   wcs:
-    image: geoservercloud/geoserver-cloud-wcs:3.1.0-SNAPSHOT
+    image: geoservercloud/geoserver-cloud-wcs:3.0.1.2
     extends:
       service: geoserver_template
     depends_on: *gs-dependencies
@@ -158,7 +146,7 @@ services:
       replicas: 1
 
   wps:
-    image: geoservercloud/geoserver-cloud-wps:3.1.0-SNAPSHOT
+    image: geoservercloud/geoserver-cloud-wps:3.0.1.2
     extends:
       service: geoserver_template
     depends_on: *gs-dependencies
@@ -166,7 +154,7 @@ services:
       replicas: 1
 
   restconfig:
-    image: geoservercloud/geoserver-cloud-rest:3.1.0-SNAPSHOT
+    image: geoservercloud/geoserver-cloud-rest:3.0.1.2
     extends:
       service: geoserver_template
     depends_on: *gs-dependencies
@@ -174,7 +162,7 @@ services:
       replicas: 1
 
   webui:
-    image: geoservercloud/geoserver-cloud-webui:3.1.0-SNAPSHOT
+    image: geoservercloud/geoserver-cloud-webui:3.0.1.2
     extends:
       service: geoserver_template
     depends_on: *gs-dependencies
@@ -182,7 +170,7 @@ services:
       replicas: 1
 
   gwc:
-    image: geoservercloud/geoserver-cloud-gwc:3.1.0-SNAPSHOT
+    image: geoservercloud/geoserver-cloud-gwc:3.0.1.2
     extends:
       service: geoserver_template
     depends_on: *gs-dependencies

--- a/docs/src/deploy/docker-compose/dev/pgconfig/compose.yml
+++ b/docs/src/deploy/docker-compose/dev/pgconfig/compose.yml
@@ -85,9 +85,6 @@ x-gs-dependencies: &gs-dependencies
     condition: service_healthy
   acl:
     condition: service_healthy
-  init-volumes:
-    condition: service_completed_successfully
-    required: true
 
 volumes:
   geowebcache_data: # Stores GeoWebCache tile data
@@ -166,7 +163,7 @@ services:
   # Spring Cloud Config service, provides centralized configuration to all
   # microservices. It registers itself with the Consul discovery service and can be scaled
   config:
-    image: geoservercloud/geoserver-cloud-config:3.1.0-SNAPSHOT
+    image: geoservercloud/geoserver-cloud-config:3.0.1.2
     user: 1000:1000 # set the userid:groupid the container runs as
     environment:
       <<: *config-server-overrides
@@ -175,7 +172,7 @@ services:
       # the default repository https://github.com/geoserver/geoserver-cloud-config.git
       SPRING_PROFILES_ACTIVE: native
       # If using the `git` profile, get the config from this tag
-      SPRING_CLOUD_CONFIG_SERVER_GIT_DEFAULT_LABEL: v3.1.0-SNAPSHOT
+      SPRING_CLOUD_CONFIG_SERVER_GIT_DEFAULT_LABEL: v3.0.1.2
     # Uncomment to bind to a local filesystem directory if using the 'native' profile
     #volumes:
     #  - ./config:/etc/geoserver
@@ -209,7 +206,7 @@ services:
   # Application facade, provides a single entry point routing to all
   # microservices (e.g. http://localhost:9090/geoserver/cloud/wms, http://localhost:9090/geoserver/cloud/wfs, etc)
   gateway:
-    image: geoservercloud/geoserver-cloud-gateway:3.1.0-SNAPSHOT
+    image: geoservercloud/geoserver-cloud-gateway:3.0.1.2
     user: 1000:1000 # set the userid:groupid the container runs as
     depends_on:
       config:
@@ -226,17 +223,9 @@ services:
           cpus: '4.0'
           memory: 1G
 
-  # Initializes shared volume ownership so GeoServer services (running as 1000:1000) can write to them
-  init-volumes:
-    image: alpine:3.24.0
-    user: root
-    command: chown 1000:1000 /data/geowebcache
-    volumes:
-      - geowebcache_data:/data/geowebcache
-
   # GeoServer template service configuration
   geoserver_template:
-    image: geoservercloud/geoserver-cloud-webui:3.1.0-SNAPSHOT
+    image: geoservercloud/geoserver-cloud-webui:3.0.1.2
     user: "1000:1000"
     environment:
       <<: *common_env
@@ -252,7 +241,7 @@ services:
 
   # GeoServer microservices
   wfs:
-    image: geoservercloud/geoserver-cloud-wfs:3.1.0-SNAPSHOT
+    image: geoservercloud/geoserver-cloud-wfs:3.0.1.2
     extends:
       service: geoserver_template
     depends_on: *gs-dependencies
@@ -260,7 +249,7 @@ services:
       replicas: 1
 
   wms:
-    image: geoservercloud/geoserver-cloud-wms:3.1.0-SNAPSHOT
+    image: geoservercloud/geoserver-cloud-wms:3.0.1.2
     extends:
       service: geoserver_template
     depends_on: *gs-dependencies
@@ -268,7 +257,7 @@ services:
       replicas: 1
 
   wcs:
-    image: geoservercloud/geoserver-cloud-wcs:3.1.0-SNAPSHOT
+    image: geoservercloud/geoserver-cloud-wcs:3.0.1.2
     extends:
       service: geoserver_template
     depends_on: *gs-dependencies
@@ -276,7 +265,7 @@ services:
       replicas: 1
 
   wps:
-    image: geoservercloud/geoserver-cloud-wps:3.1.0-SNAPSHOT
+    image: geoservercloud/geoserver-cloud-wps:3.0.1.2
     extends:
       service: geoserver_template
     depends_on: *gs-dependencies
@@ -284,7 +273,7 @@ services:
       replicas: 1
 
   restconfig:
-    image: geoservercloud/geoserver-cloud-rest:3.1.0-SNAPSHOT
+    image: geoservercloud/geoserver-cloud-rest:3.0.1.2
     extends:
       service: geoserver_template
     depends_on: *gs-dependencies
@@ -292,7 +281,7 @@ services:
       replicas: 1
 
   webui:
-    image: geoservercloud/geoserver-cloud-webui:3.1.0-SNAPSHOT
+    image: geoservercloud/geoserver-cloud-webui:3.0.1.2
     extends:
       service: geoserver_template
     depends_on: *gs-dependencies
@@ -300,7 +289,7 @@ services:
       replicas: 1
 
   gwc:
-    image: geoservercloud/geoserver-cloud-gwc:3.1.0-SNAPSHOT
+    image: geoservercloud/geoserver-cloud-gwc:3.0.1.2
     extends:
       service: geoserver_template
     depends_on: *gs-dependencies

--- a/examples/cog-imagemosaic-pgconfig/compose.yml
+++ b/examples/cog-imagemosaic-pgconfig/compose.yml
@@ -1,4 +1,4 @@
-# GeoServer Cloud images default to the 3.1.0 release, which includes the
+# GeoServer Cloud images default to the 3.0.1.2 release, which includes the
 # COG ImageMosaic fix for the pgconfig catalog backend. To use a locally
 # built image instead, run with GSCLOUD_VERSION=3.1.0-SNAPSHOT.
 x-variables:
@@ -89,9 +89,6 @@ x-gs-dependencies: &gs-dependencies
     condition: service_healthy
   acl:
     condition: service_healthy
-  init-volumes:
-    condition: service_completed_successfully
-    required: true
 
 volumes:
   geowebcache_data: # Stores GeoWebCache tile data
@@ -174,7 +171,7 @@ services:
   # Spring Cloud Config service, provides centralized configuration to all
   # microservices. It registers itself with the Consul discovery service and can be scaled
   config:
-    image: geoservercloud/geoserver-cloud-config:${GSCLOUD_VERSION:-3.1.0-SNAPSHOT}
+    image: geoservercloud/geoserver-cloud-config:${GSCLOUD_VERSION:-3.0.1.2}
     user: 1000:1000 # set the userid:groupid the container runs as
     environment:
       <<: *config-server-overrides
@@ -217,7 +214,7 @@ services:
   # Application facade, provides a single entry point routing to all
   # microservices (e.g. http://localhost:9090/geoserver/cloud/wms, http://localhost:9090/geoserver/cloud/wfs, etc)
   gateway:
-    image: geoservercloud/geoserver-cloud-gateway:${GSCLOUD_VERSION:-3.1.0-SNAPSHOT}
+    image: geoservercloud/geoserver-cloud-gateway:${GSCLOUD_VERSION:-3.0.1.2}
     user: 1000:1000 # set the userid:groupid the container runs as
     depends_on:
       config:
@@ -234,17 +231,9 @@ services:
           cpus: '4.0'
           memory: 1G
 
-  # Initializes shared volume ownership so GeoServer services (running as 1000:1000) can write to them
-  init-volumes:
-    image: alpine:3.24.0
-    user: root
-    command: chown 1000:1000 /data/geowebcache
-    volumes:
-      - geowebcache_data:/data/geowebcache
-
   # GeoServer template service configuration
   geoserver_template:
-    image: geoservercloud/geoserver-cloud-webui:${GSCLOUD_VERSION:-3.1.0-SNAPSHOT}
+    image: geoservercloud/geoserver-cloud-webui:${GSCLOUD_VERSION:-3.0.1.2}
     user: "1000:1000"
     environment:
       <<: *common_env
@@ -266,7 +255,7 @@ services:
 
   # GeoServer microservices
   wfs:
-    image: geoservercloud/geoserver-cloud-wfs:${GSCLOUD_VERSION:-3.1.0-SNAPSHOT}
+    image: geoservercloud/geoserver-cloud-wfs:${GSCLOUD_VERSION:-3.0.1.2}
     extends:
       service: geoserver_template
     depends_on: *gs-dependencies
@@ -274,7 +263,7 @@ services:
       replicas: 1
 
   wms:
-    image: geoservercloud/geoserver-cloud-wms:${GSCLOUD_VERSION:-3.1.0-SNAPSHOT}
+    image: geoservercloud/geoserver-cloud-wms:${GSCLOUD_VERSION:-3.0.1.2}
     extends:
       service: geoserver_template
     depends_on: *gs-dependencies
@@ -282,7 +271,7 @@ services:
       replicas: 1
 
   wcs:
-    image: geoservercloud/geoserver-cloud-wcs:${GSCLOUD_VERSION:-3.1.0-SNAPSHOT}
+    image: geoservercloud/geoserver-cloud-wcs:${GSCLOUD_VERSION:-3.0.1.2}
     extends:
       service: geoserver_template
     depends_on: *gs-dependencies
@@ -290,7 +279,7 @@ services:
       replicas: 1
 
   wps:
-    image: geoservercloud/geoserver-cloud-wps:${GSCLOUD_VERSION:-3.1.0-SNAPSHOT}
+    image: geoservercloud/geoserver-cloud-wps:${GSCLOUD_VERSION:-3.0.1.2}
     extends:
       service: geoserver_template
     depends_on: *gs-dependencies
@@ -298,7 +287,7 @@ services:
       replicas: 1
 
   restconfig:
-    image: geoservercloud/geoserver-cloud-rest:${GSCLOUD_VERSION:-3.1.0-SNAPSHOT}
+    image: geoservercloud/geoserver-cloud-rest:${GSCLOUD_VERSION:-3.0.1.2}
     extends:
       service: geoserver_template
     depends_on: *gs-dependencies
@@ -306,7 +295,7 @@ services:
       replicas: 1
 
   webui:
-    image: geoservercloud/geoserver-cloud-webui:${GSCLOUD_VERSION:-3.1.0-SNAPSHOT}
+    image: geoservercloud/geoserver-cloud-webui:${GSCLOUD_VERSION:-3.0.1.2}
     extends:
       service: geoserver_template
     depends_on: *gs-dependencies
@@ -314,7 +303,7 @@ services:
       replicas: 1
 
   gwc:
-    image: geoservercloud/geoserver-cloud-gwc:${GSCLOUD_VERSION:-3.1.0-SNAPSHOT}
+    image: geoservercloud/geoserver-cloud-gwc:${GSCLOUD_VERSION:-3.0.1.2}
     extends:
       service: geoserver_template
     depends_on: *gs-dependencies


### PR DESCRIPTION
Draft until #923 is merged and `3.0.1.2` released

The 3.0.1.2 images ship world-writable data directories again, making the chown init containers unnecessary for fresh volumes.