### PR TITLE
Build GeoServer from a shallow submodule instead of GitHub Packages

### DIFF
--- a/.github/actions/geoserver-artifacts/action.yml
+++ b/.github/actions/geoserver-artifacts/action.yml
@@ -1,0 +1,49 @@
+name: GeoServer submodule artifacts
+description: >
+  Makes the customized GeoServer Maven artifacts available in the local Maven
+  repository. Restores them from a cache keyed on the geoserver_submodule/geoserver
+  commit, building the submodule with `make deps` on a cache miss. Requires the
+  repository checked out with submodules and a JDK already set up.
+
+inputs:
+  lookup-only:
+    description: >
+      Check whether the cache entry exists instead of downloading it. The
+      priming job publishes the artifacts for the jobs that depend on it and
+      has no use for the download itself.
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve geoserver submodule revision
+      id: revision
+      shell: bash
+      run: echo "sha=$(git rev-parse HEAD:geoserver_submodule/geoserver)" >> "$GITHUB_OUTPUT"
+
+    - name: Restore GeoServer artifacts
+      id: restore
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ~/.m2/repository/org/geoserver
+          !~/.m2/repository/org/geoserver/cloud
+        key: geoserver-artifacts-${{ steps.revision.outputs.sha }}
+        lookup-only: ${{ inputs.lookup-only }}
+
+    - name: Build customized GeoServer
+      if: steps.restore.outputs.cache-hit != 'true'
+      shell: bash
+      run: make deps
+
+    # Save right away rather than through a post-job hook: the jobs using this
+    # action purge SNAPSHOT artifacts from ~/.m2 before finishing, which would
+    # otherwise leave nothing to save.
+    - name: Cache GeoServer artifacts
+      if: steps.restore.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          ~/.m2/repository/org/geoserver
+          !~/.m2/repository/org/geoserver/cloud
+        key: geoserver-artifacts-${{ steps.revision.outputs.sha }}

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -12,8 +12,12 @@ on:
       - "Makefile"
       - "pom.xml"
       - ".github/workflows/build-and-push.yaml"
+      - ".github/workflows/geoserver-artifacts.yaml"
+      - ".github/actions/**"
+      - ".gitmodules"
       - "docker-build/**"
       - "config"
+      - "geoserver_submodule/**"
       - "src/**"
     tags:
       - '*'
@@ -27,7 +31,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  geoserver-artifacts:
+    name: GeoServer artifacts
+    if: github.repository == 'geoserver/geoserver-cloud'
+    uses: ./.github/workflows/geoserver-artifacts.yaml
+
   build-base-images:
+    needs: geoserver-artifacts
     if: github.repository == 'geoserver/geoserver-cloud'
     name: Base images (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
@@ -58,6 +68,9 @@ jobs:
         distribution: 'temurin'
         java-version: '25'
         cache: 'maven'
+
+    - name: Build GeoServer submodule artifacts
+      uses: ./.github/actions/geoserver-artifacts
 
     - name: Set version
       run: echo "VERSION=$(make -s show-version)" >> "$GITHUB_ENV"
@@ -218,7 +231,7 @@ jobs:
         find ~/.m2/repository -name "*SNAPSHOT*" -type d -exec rm -rf {} + 2>/dev/null || true
 
   build-geoserver-images:
-    needs: stitch-base-manifests
+    needs: [stitch-base-manifests, geoserver-artifacts]
     if: github.repository == 'geoserver/geoserver-cloud'
     name: GeoServer ${{ matrix.app }} (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
@@ -252,6 +265,9 @@ jobs:
         distribution: 'temurin'
         java-version: '25'
         cache: 'maven'
+
+    - name: Build GeoServer submodule artifacts
+      uses: ./.github/actions/geoserver-artifacts
 
     - name: Set version
       run: echo "VERSION=$(make -s show-version)" >> "$GITHUB_ENV"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -14,6 +14,9 @@ on:
       - "**/pom.xml"
       - "acceptance_tests/**"
       - ".github/workflows/codeql.yaml"
+      - ".github/actions/**"
+      - ".gitmodules"
+      - "geoserver_submodule/**"
   schedule:
     - cron: '0 0 * * 1'  # Weekly on Monday
 
@@ -39,6 +42,10 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        # only the java build needs the geoserver submodule; spare python the
+        # heavyweight checkout
+        submodules: ${{ matrix.language == 'java-kotlin' && 'recursive' || 'false' }}
 
     - name: Set up Java
       if: matrix.language == 'java-kotlin'
@@ -47,6 +54,12 @@ jobs:
         distribution: 'temurin'
         java-version: '25'
         cache: 'maven'
+
+    # Runs before CodeQL init on purpose: the GeoServer submodule compilation
+    # must not be traced into the CodeQL database, only this project's code.
+    - name: Build GeoServer submodule artifacts
+      if: matrix.language == 'java-kotlin'
+      uses: ./.github/actions/geoserver-artifacts
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
@@ -61,3 +74,9 @@ jobs:
       uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"
+
+    - name: Remove project jars from cached repository
+      if: always() && matrix.language == 'java-kotlin'
+      run: |
+        rm -rf ~/.m2/repository/org/geoserver/cloud
+        find ~/.m2/repository -name "*SNAPSHOT*" -type d -exec rm -rf {} + 2>/dev/null || true

--- a/.github/workflows/geoserver-artifacts.yaml
+++ b/.github/workflows/geoserver-artifacts.yaml
@@ -1,0 +1,43 @@
+# Populates the Actions cache with the customized GeoServer Maven artifacts,
+# letting the jobs that need them restore one shared build instead of each
+# running `make deps` concurrently.
+#
+# Called through `needs:` by the workflows whose jobs fan out. Workflows with a
+# single such job build the artifacts inline instead: serializing a priming job
+# in front of one consumer only adds latency without saving a build.
+name: GeoServer artifacts
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build or restore
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Set up java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '25'
+        cache: 'maven'
+
+    - name: Build GeoServer submodule artifacts
+      uses: ./.github/actions/geoserver-artifacts
+      with:
+        lookup-only: 'true'
+
+    - name: Remove project jars from cached repository
+      if: always()
+      run: |
+        rm -rf ~/.m2/repository/org/geoserver/cloud
+        find ~/.m2/repository -name "*SNAPSHOT*" -type d -exec rm -rf {} + 2>/dev/null || true

--- a/.github/workflows/pr-acceptance.yaml
+++ b/.github/workflows/pr-acceptance.yaml
@@ -8,9 +8,13 @@ on:
     paths:
       - ".github/workflows/pr-acceptance.yaml"
       - ".github/workflows/build-and-push.yaml"
+      - ".github/workflows/geoserver-artifacts.yaml"
+      - ".github/actions/**"
+      - ".gitmodules"
       - "pom.xml"
       - "Makefile"
       - "config"
+      - "geoserver_submodule/**"
       - "src/**"
       - "acceptance_tests/**"
       - "ci/**"
@@ -25,8 +29,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  geoserver-artifacts:
+    name: GeoServer artifacts
+    if: github.repository == 'geoserver/geoserver-cloud'
+    uses: ./.github/workflows/geoserver-artifacts.yaml
+
   acceptance:
     name: Acceptance
+    needs: geoserver-artifacts
     if: github.repository == 'geoserver/geoserver-cloud'
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -46,6 +56,9 @@ jobs:
         distribution: 'temurin'
         java-version: '25'
         cache: 'maven'
+
+    - name: Build GeoServer submodule artifacts
+      uses: ./.github/actions/geoserver-artifacts
 
     - name: Install packages
       run: make install

--- a/.github/workflows/pr-build-and-test.yaml
+++ b/.github/workflows/pr-build-and-test.yaml
@@ -8,9 +8,12 @@ on:
     paths:
       - ".github/workflows/pr-build-and-test.yaml"
       - ".github/workflows/build-and-push.yaml"
+      - ".github/actions/**"
+      - ".gitmodules"
       - "pom.xml"
       - "Makefile"
       - "config"
+      - "geoserver_submodule/**"
       - "src/**"
       - "acceptance_tests/**"
       - "ci/**"
@@ -41,6 +44,9 @@ jobs:
         distribution: 'temurin'
         java-version: '25'
         cache: 'maven'
+
+    - name: Build GeoServer submodule artifacts
+      uses: ./.github/actions/geoserver-artifacts
 
     - name: Validate pom formatting
       run: make build-tools lint-pom

--- a/.github/workflows/pr-pgconfig.yaml
+++ b/.github/workflows/pr-pgconfig.yaml
@@ -8,9 +8,13 @@ on:
     paths:
       - ".github/workflows/pr-pgconfig.yaml"
       - ".github/workflows/build-and-push.yaml"
+      - ".github/workflows/geoserver-artifacts.yaml"
+      - ".github/actions/**"
+      - ".gitmodules"
       - "pom.xml"
       - "Makefile"
       - "config"
+      - "geoserver_submodule/**"
       - "src/**"
       - "acceptance_tests/**"
       - "ci/**"
@@ -25,8 +29,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  geoserver-artifacts:
+    name: GeoServer artifacts
+    if: github.repository == 'geoserver/geoserver-cloud'
+    uses: ./.github/workflows/geoserver-artifacts.yaml
+
   pgconfig-pg-compat:
     name: pgconfig (postgres:${{ matrix.pg_version }})
+    needs: geoserver-artifacts
     if: github.repository == 'geoserver/geoserver-cloud'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -45,6 +55,8 @@ jobs:
         distribution: 'temurin'
         java-version: '25'
         cache: 'maven'
+    - name: Build GeoServer submodule artifacts
+      uses: ./.github/actions/geoserver-artifacts
     - name: Build dependencies
       run: |
         ./mvnw clean install -pl :gs-cloud-catalog-backend-pgconfig -ntp -U -am -DskipTests -T1C

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -23,9 +23,12 @@ on:
       - "release/**"
     paths:
       - ".github/workflows/sonarcloud.yaml"
+      - ".github/actions/**"
+      - ".gitmodules"
       - "pom.xml"
       - "src/**"
       - "config"
+      - "geoserver_submodule/**"
   workflow_run:
     workflows: ["PR Build and Test"]
     types: [completed]
@@ -58,6 +61,9 @@ jobs:
           distribution: 'temurin'
           java-version: '25'
           cache: 'maven'
+
+      - name: Build GeoServer submodule artifacts
+        uses: ./.github/actions/geoserver-artifacts
 
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
@@ -182,6 +188,12 @@ jobs:
           distribution: 'temurin'
           java-version: '25'
           cache: 'maven'
+
+      # The Sonar analyzer resolves each module's dependency jars; the
+      # customized GeoServer artifacts are only available by building the
+      # submodule since they are not published to any Maven repository.
+      - name: Build GeoServer submodule artifacts
+        uses: ./.github/actions/geoserver-artifacts
 
       - name: Cache SonarCloud packages
         uses: actions/cache@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,8 @@
 	path = config
 	url = https://github.com/geoserver/geoserver-cloud-config
 	branch = master
+[submodule "geoserver"]
+	path = geoserver_submodule/geoserver
+	url = https://github.com/camptocamp/geoserver.git
+	branch = gscloud/3.1.x/integration
+	shallow = true

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: install test build-image
+all: deps install test build-image
 
 TAG?=$(shell ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
 
@@ -15,6 +15,28 @@ REPACKAGE ?= true
 .PHONY: clean
 clean:
 	./mvnw clean
+
+# Build the customized GeoServer from the geoserver_submodule/geoserver
+# submodule and install its artifacts into the local Maven repository.
+# Run `git submodule update --init` first if the submodule is not checked out.
+GEOSERVER_SUBMODULE = geoserver_submodule/geoserver
+GEOSERVER_BUILD_FLAGS = --batch-mode -DskipTests -ntp -fae -Dsort.skip=true -Dspotless.apply.skip=true -T1C
+GEOSERVER_COMMUNITY_PROFILES = pending,cog,acl,flatgeobuf,geoparquet,graticule,gwc-azure-blob,gwc-gcs-blob,pmtiles-store,oseo,features-templating
+
+.PHONY: deps
+deps: deps-core deps-extensions deps-community
+
+.PHONY: deps-core
+deps-core:
+	./mvnw install -f $(GEOSERVER_SUBMODULE)/src/pom.xml $(GEOSERVER_BUILD_FLAGS)
+
+.PHONY: deps-extensions
+deps-extensions:
+	./mvnw install -f $(GEOSERVER_SUBMODULE)/src/extension/pom.xml -Prelease $(GEOSERVER_BUILD_FLAGS)
+
+.PHONY: deps-community
+deps-community:
+	./mvnw install -f $(GEOSERVER_SUBMODULE)/src/community/pom.xml -P$(GEOSERVER_COMMUNITY_PROFILES) $(GEOSERVER_BUILD_FLAGS)
 
 .PHONY: build-tools
 build-tools:

--- a/docs/src/developer-guide/build_instructions.md
+++ b/docs/src/developer-guide/build_instructions.md
@@ -14,7 +14,10 @@ Clone the repository, including submodules. Alternatively, replace the repositor
 git clone --recurse-submodules git@github.com:geoserver/geoserver-cloud.git
 ```
 
-The `--recurse-submodules` argument is necessary for `clone` to populate the `config/` directory from the [geoserver/geoserver-cloud-config](https://github.com/geoserver/geoserver-cloud-config) repository, which is in turn required to build the Docker images.
+The `--recurse-submodules` argument is necessary for `clone` to populate two submodules:
+
+* `config/`, from the [geoserver/geoserver-cloud-config](https://github.com/geoserver/geoserver-cloud-config) repository, which is in turn required to build the Docker images.
+* `geoserver_submodule/geoserver`, a shallow checkout of the customized GeoServer branch from the [camptocamp/geoserver](https://github.com/camptocamp/geoserver) repository, required to build the upstream GeoServer dependencies (see [below](#note-on-custom-upstream-geoserver-version)).
 
 If you already cloned the repository without it, initialize the submodule with
 
@@ -25,13 +28,21 @@ git submodule update --init --recursive
 
 ## Build
 
-The `make` command from the project root directory will compile, test, and install all the project artifacts, and build the GeoServer-Cloud Docker images. So for a full build just run:
+The `make` command from the project root directory will build the customized GeoServer dependencies, compile, test, and install all the project artifacts, and build the GeoServer-Cloud Docker images. So for a full build just run:
 
 ```bash
 make
 ```
 
-To build without running tests, run
+To build the customized GeoServer dependencies alone, run
+
+```bash
+make deps
+```
+
+This is required once after cloning, and again whenever the `geoserver_submodule/geoserver` submodule is updated. It installs the custom GeoServer Maven artifacts into the local Maven repository, where the rest of the build resolves them from, since they are not published to any public Maven repository.
+
+To build the project without running tests, run
 
 ```bash
 make install
@@ -90,8 +101,8 @@ sufficient for testing.
 
 Additionally, this branch changes the artifact versions (e.g. from `2.28.0` to `2.28.0.0`), to avoid confusing maven if you also work with vanilla GeoServer, and to avoid your IDE downloading the latest `2.28-SNAPSHOT` artifacts from the OsGeo maven repository, overriding your local maven repository ones, and having confusing compilation errors that would require re-building the branch we need.
 
-The `gscloud/gs_version/integration` branch is checked out as a submodule on the [camptocamp/geoserver-cloud-geoserver](https://github.com/camptocamp/geoserver-cloud-geoserver) repository, which publishes the custom geoserver maven artifacts to the Github maven package registry.
+The `gscloud/gs_version/integration` branch of the [camptocamp/geoserver](https://github.com/camptocamp/geoserver) repository is checked out as a shallow submodule under `geoserver_submodule/geoserver`, and each *GeoServer Cloud* branch pins the submodule branch matching its GeoServer version.
 
-The root pom adds this additional maven repository, so no further action is required for the geoserver-cloud build to use those dependencies.
+Run `make deps` to build it and install the custom GeoServer Maven artifacts into the local Maven repository. The CI workflows do the same through the `.github/actions/geoserver-artifacts` composite action, which caches the built artifacts keyed on the submodule commit.
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -314,19 +314,6 @@
     </repository>
     <repository>
       <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>geoserver-github-packages</id>
-      <name>Customized Geoserver Packages</name>
-      <?SORTPOM IGNORE?>
-      <url>https://public:&#103;hp_Mp4UdrZ2GYC4v4UtdzEirXLig4D8t54dKkAf@maven.pkg.github.com/camptocamp/geoserver-cloud-geoserver</url>
-      <?SORTPOM RESUME?>
-    </repository>
-    <repository>
-      <releases>
         <enabled>false</enabled>
       </releases>
       <snapshots>


### PR DESCRIPTION
Remove the hardcoded GitHub PAT embedded in the root pom's geoserver-github-packages repository URL and the repository declaration.

The customized GeoServer artifacts are built locally again from a shallow submodule at geoserver_submodule/geoserver, tracking the gscloud/3.1.x/integration branch of camptocamp/geoserver:

- `make deps` installs the GeoServer core, extension (-Prelease) and community artifacts into the local Maven repository
- CI jobs that need them run the `.github/actions/geoserver-artifacts` composite action, which caches the built artifacts keyed on the submodule commit and rebuilds only when the submodule changes
- the workflows whose jobs fan out prime that cache from a reusable workflow and wait on it through needs:, restoring one shared build instead of repeating it in every job; consumers still build on a miss
- CodeQL builds the submodule before database initialization to keep GeoServer sources out of the analysis scope

on-behalf-of: @camptocamp <info@camptocamp.com>