### PR TITLE
fix: restore log4j-core dependency for the Importer extension (#912)

### DIFF
--- a/src/extensions/importer/pom.xml
+++ b/src/extensions/importer/pom.xml
@@ -79,6 +79,17 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <!-- Importer.onApplicationEvent() calls LoggingUtils.checkBuiltInLoggingConfiguration(),
+           whose bytecode references org.apache.logging.log4j.core.config.Configuration.
+           RELINQUISH_LOG4J_CONTROL (set by GeoServerContextInitializer) makes it a no-op at
+           runtime, but the JVM still resolves that type during class verification, so it must
+           be present at runtime or the class loading fails with NoClassDefFoundError as soon as
+           the Importer extension is enabled. See https://github.com/geoserver/geoserver-cloud/issues/912
+           and the equivalent fix previously applied to gs-cloud-webui for GlobalSettingsPage. -->
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
Fixes #912

## Problem

`webui` and `rest` (3.0.0 and 3.0.1) crash on startup with a `NoClassDefFoundError` as soon as the
Importer extension is enabled:

```
java.lang.NoClassDefFoundError: org/apache/logging/log4j/core/config/Configuration
    at org.geoserver.logging.LoggingUtils.checkBuiltInLoggingConfiguration(LoggingUtils.java:183)
    at org.geoserver.importer.Importer.onApplicationEvent(Importer.java:282)
```

Confirmed identical on both `webui` and `restconfig`, since the `Importer` bean that triggers the
call is shared by both (`ImporterAutoConfiguration` imports `ImporterWebUIAutoConfiguration` and
`ImporterRestAutoConfiguration`, both importing `ImporterCoreConfiguration`).

## Root cause

geoserver-cloud excludes `log4j-core` from the classpath (logging is fully delegated to Spring
Boot/Logback) and sets `RELINQUISH_LOG4J_CONTROL=true` via `GeoServerContextInitializer` so that
`LoggingUtils.checkBuiltInLoggingConfiguration()` becomes a no-op at runtime.

That flag avoids *executing* the log4j-dependent code path, but it does **not** avoid the class
being resolved: the JVM resolves the types referenced in a method's bytecode (StackMapTable) during
verification, on first invocation, independently of which branch actually runs. So the class must
be present on the classpath or the method throws `NoClassDefFoundError` as soon as it's called —
regardless of `RELINQUISH_LOG4J_CONTROL`.

The exact same issue existed in 2.27.2.0 for a different code path (`GlobalSettingsPage`), and was
fixed by adding an explicit `log4j-core` dependency to `src/apps/geoserver/webui/pom.xml`:

```xml
<dependency>
  <groupId>org.apache.logging.log4j</groupId>
  <!-- to avoid ClassNotFoundException(org/apache/logging/log4j/core/config/Configuration) at GlobalSettingsPage -->
  <artifactId>log4j-core</artifactId>
</dependency>
```

That dependency was lost during the 3.0.0 dependency rework ("Align dependencies with upstream
3.0.0") and was never present on `restconfig` either, even though it hits the exact same code path
through the shared `Importer` bean.

## Fix

Re-add `log4j-core` as a direct dependency, this time on `src/extensions/importer/pom.xml`
(`gs-cloud-extension-importer`) rather than on each individual app. This is the most targeted fix:
the `Importer` bean that triggers the problematic call lives in this module, which is imported by
both `ImporterWebUIAutoConfiguration` and `ImporterRestAutoConfiguration` — so any app that enables
the extension gets the dependency transitively, without duplicating it per app or risking it being
missed by a future consumer of the extension. The version is resolved from the `log4j-bom` (2.21.1)
already imported in `dependencyManagement` in the root `src/pom.xml`, so no explicit version is set.

This dependency is not affected by the wildcard `org.apache.logging.log4j:*` exclusions present in
`src/pom.xml`, since those only apply to transitive dependencies of `gs-platform`/`gs-main` declared
in `dependencyManagement`, not to a direct dependency declared in a module.

## Testing

Reproduced and verified end-to-end locally, against a build of the `v3.0.1` tag:

- **Before the fix**: built `webui:3.0.1` and `rest:3.0.1` unmodified, ran with
  `geoserver.extension.importer.enabled=true` — both containers crash immediately at startup with
  the exact stacktrace above.
- **After the fix**: targeted rebuild of `gs-cloud-extension-importer`, `restconfig-service` and
  `web-ui-service`, images rebuilt and restarted with the same configuration — both services start
  successfully (`Started WebUIApplication`/`Started RestConfigApplication`, healthy), and
  `GET /rest/imports.json` (authenticated) returns `200 {"imports":[]}`.

I did not add an automated test, since covering a `NoClassDefFoundError` caused by bytecode
verification realistically requires the actual runtime classpath (a unit/slice test wouldn't
reproduce the failure mode). Happy to extend the existing `ImporterAutoConfigurationTest` — which
already documents this exact issue in a comment around `relinquishLog4jControl` — with an explicit
assertion that `log4j-core` is present on the module's dependency tree, if that's preferred over the
manual validation described above.

## Note on backport

The bug is present identically on both `main` and `release/3.0.x` (verified). This PR targets
`main` per the project's contribution guidelines; happy to open a second PR against `release/3.0.x`
if a direct 3.0.1.x patch release is wanted rather than waiting for 3.1.0.