### PR TITLE
Upgrade the parquetry plugin to tileverse-geoserver:3.1-SNAPSHOT

### DIFF
--- a/src/extensions/parquetry/pom.xml
+++ b/src/extensions/parquetry/pom.xml
@@ -15,8 +15,8 @@
       <artifactId>gs-cloud-extensions-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.tileverse.parquetry.geoserver</groupId>
-      <artifactId>parquetry-geoserver-plugin</artifactId>
+      <groupId>io.tileverse.geoserver</groupId>
+      <artifactId>tileverse-geoserver-parquetry</artifactId>
     </dependency>
     <dependency>
       <groupId>org.geoserver.web</groupId>

--- a/src/extensions/parquetry/src/main/java/org/geoserver/cloud/autoconfigure/extensions/parquetry/ParquetryWebComponentsAutoConfiguration.java
+++ b/src/extensions/parquetry/src/main/java/org/geoserver/cloud/autoconfigure/extensions/parquetry/ParquetryWebComponentsAutoConfiguration.java
@@ -4,7 +4,7 @@
  */
 package org.geoserver.cloud.autoconfigure.extensions.parquetry;
 
-import io.tileverse.parquetry.geoserver.config.GeoParquetConfiguration;
+import io.tileverse.geoserver.parquetry.config.GeoParquetConfiguration;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.geoserver.cloud.autoconfigure.extensions.ConditionalOnGeoServerWebUI;

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -38,7 +38,7 @@
     <wicket.version>10.10.0</wicket.version>
     <acl.version>3.0.1</acl.version>
     <cloud-dependencies-bom.version>1.0.2</cloud-dependencies-bom.version>
-    <parquetry-geoserver.version>1.0-SNAPSHOT</parquetry-geoserver.version>
+    <tileverse-geoserver.version>3.1-SNAPSHOT</tileverse-geoserver.version>
     <jackson.version>3.1.2</jackson.version>
     <jackson2.version>2.21.0</jackson2.version>
 
@@ -672,9 +672,9 @@
         <version>${gs.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.tileverse.parquetry.geoserver</groupId>
-        <artifactId>parquetry-geoserver-plugin</artifactId>
-        <version>${parquetry-geoserver.version}</version>
+        <groupId>io.tileverse.geoserver</groupId>
+        <artifactId>tileverse-geoserver-parquetry</artifactId>
+        <version>${tileverse-geoserver.version}</version>
       </dependency>
       <!-- GeoServer Cloud Extensions -->
       <!-- GeoServer Cloud Starters -->


### PR DESCRIPTION
Adopt the renamed tileverse-geoserver parquetry plugin which now follows geoserver's series-based versioning.

on-behalf-of: @camptocamp <info@camptocamp.com>