### PR TITLE
Fix REST API requests failing on paths containing /gwc

### DIFF
--- a/acceptance_tests/requirements.txt
+++ b/acceptance_tests/requirements.txt
@@ -1,4 +1,4 @@
-geoservercloud==0.8.10
+geoservercloud==0.8.11
 # To debug a local version of python-geoservercloud:
 # git clone git@github.com:camptocamp/python-geoservercloud
 # and then uncomment the following line and adjust the path accordingly

--- a/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationTest.java
+++ b/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationTest.java
@@ -7,9 +7,12 @@ package org.geoserver.cloud.restconfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.APPLICATION_XML;
@@ -288,6 +291,78 @@ abstract class RestConfigApplicationTest {
         testPathExtensionContentType("/rest/workspaces.html", TEXT_HTML);
         testPathExtensionContentType("/rest/workspaces.xml", APPLICATION_XML);
         testPathExtensionContentType("/rest/workspaces.json", APPLICATION_JSON);
+    }
+
+    /**
+     * Any {@code /rest/resource/**} path containing the {@code /gwc} character sequence returned a 500 NPE ("Cannot
+     * invoke String.substring(int) because path is null"), because the servlet filters that rebuild
+     * {@code getPathInfo()} mistook such URIs for GeoWebCache requests. See issue #913.
+     */
+    @Test
+    void testResourceEndpointPathContainingGwc() {
+        restTemplate = restTemplate.withBasicAuth("admin", "geoserver");
+
+        ResponseEntity<String> response = restTemplate.getForEntity("/rest/resource/gwc-gs.xml", String.class);
+        assertThat(response.getStatusCode()).isEqualTo(OK);
+        assertThat(response.getBody()).contains("GeoServerGWCConfig");
+
+        response = restTemplate.getForEntity("/rest/resource/gwcfoo", String.class);
+        assertThat(response.getStatusCode()).isEqualTo(NOT_FOUND);
+    }
+
+    /** Directory variant of issue #913: listing a directory whose name starts with {@code gwc} */
+    @Test
+    void testResourceEndpointDirectoryNameContainingGwc() {
+        restTemplate = restTemplate.withBasicAuth("admin", "geoserver");
+
+        try {
+            putTextResource("/rest/resource/gwc913dir/child.txt", "issue #913 directory probe");
+
+            ResponseEntity<String> listing = restTemplate.getForEntity("/rest/resource/gwc913dir", String.class);
+            assertThat(listing.getStatusCode()).isEqualTo(OK);
+            assertThat(listing.getBody()).contains("child.txt");
+        } finally {
+            deleteResourceQuietly("/rest/resource/gwc913dir");
+        }
+    }
+
+    /** Round trip through the resource REST API on a file path containing {@code /gwc}, see issue #913 */
+    @Test
+    void testResourceEndpointRoundTripOnGwcPrefixedFileName() {
+        restTemplate = restTemplate.withBasicAuth("admin", "geoserver");
+
+        String file = "/rest/resource/styles/gwc-913-probe.txt";
+        String contents = "issue #913 round trip probe";
+        try {
+            putTextResource(file, contents);
+
+            ResponseEntity<String> get = restTemplate.getForEntity(file, String.class);
+            assertThat(get.getStatusCode()).isEqualTo(OK);
+            assertThat(get.getBody()).isEqualTo(contents);
+
+            ResponseEntity<Void> delete = restTemplate.exchange(file, DELETE, null, Void.class);
+            assertThat(delete.getStatusCode()).isEqualTo(OK);
+
+            ResponseEntity<String> afterDelete = restTemplate.getForEntity(file, String.class);
+            assertThat(afterDelete.getStatusCode()).isEqualTo(NOT_FOUND);
+        } finally {
+            deleteResourceQuietly(file);
+        }
+    }
+
+    private void putTextResource(String path, String contents) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.TEXT_PLAIN);
+        ResponseEntity<Void> put = restTemplate.exchange(path, PUT, new HttpEntity<>(contents, headers), Void.class);
+        assertThat(put.getStatusCode()).isIn(OK, CREATED);
+    }
+
+    private void deleteResourceQuietly(String path) {
+        try {
+            restTemplate.exchange(path, DELETE, null, Void.class);
+        } catch (RuntimeException e) {
+            // ignore, the assertion failure is the interesting outcome
+        }
     }
 
     protected void testPathExtensionContentType(String uri, MediaType expected) {

--- a/src/config/geoserver-configuration/src/main/java/org/geoserver/configuration/core/rest/RestRequestPathInfoFilter.java
+++ b/src/config/geoserver-configuration/src/main/java/org/geoserver/configuration/core/rest/RestRequestPathInfoFilter.java
@@ -28,8 +28,17 @@ import org.springframework.http.MediaType;
  * <p>Standard GeoServer REST expects specific servlet path and path info structures. This filter, along with its
  * associated {@link SuffixStripFilterAwareHttpServletRequest}, ensures that even when running behind a gateway or in a
  * microservice context, the REST controllers receive requests in the expected format.
+ *
+ * <p>A request is adapted when {@code /rest} is the first path segment after the context path. Matching the whole first
+ * segment keeps REST API requests whose path contains another base path as data, such as
+ * {@code /rest/resource/gwc-gs.xml}, from being mistaken for GeoWebCache requests (issue #913), while GWC-dispatched
+ * URLs such as {@code /gwc/rest/**} and {@code /{workspace}/gwc/rest/**} are left alone because their first segment is
+ * not {@code rest}.
  */
 public class RestRequestPathInfoFilter implements Filter {
+
+    @SuppressWarnings("java:S1075") // base path is fixed
+    static final String REST_BASE_PATH = "/rest";
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
@@ -40,19 +49,25 @@ public class RestRequestPathInfoFilter implements Filter {
     }
 
     public static HttpServletRequest adaptRequest(HttpServletRequest request) {
-        final String requestURI = request.getRequestURI();
-        @SuppressWarnings("java:S1075") // base path is fixed
-        final String basePath = "/rest";
-        final int basePathIdx = requestURI.indexOf(basePath);
-        if (basePathIdx > -1 && !requestURI.contains("/gwc")) {
-            return new SuffixStripFilterAwareHttpServletRequest(request, basePath);
+        if (isRestApiRequest(request)) {
+            return new SuffixStripFilterAwareHttpServletRequest(request, REST_BASE_PATH);
         }
         return request;
     }
 
+    private static boolean isRestApiRequest(HttpServletRequest request) {
+        String pathAfterContext =
+                request.getRequestURI().substring(request.getContextPath().length());
+        if (!pathAfterContext.startsWith(REST_BASE_PATH)) {
+            return false;
+        }
+        int basePathEnd = REST_BASE_PATH.length();
+        return pathAfterContext.length() == basePathEnd || pathAfterContext.charAt(basePathEnd) == '/';
+    }
+
     /**
-     * An {@link HttpServletRequestWrapper} that adjusts the request URI, servlet path, and path info to match what the
-     * GeoServer REST API expects.
+     * An {@link HttpServletRequestWrapper} that adjusts the servlet path and path info to match what the GeoServer REST
+     * API expects: the servlet path is the {@code /rest} base path and the path info is whatever follows it.
      *
      * <p>It also overrides content-type resolution to support path extensions (e.g., .sld) when the original request's
      * Content-Type is generic or missing.
@@ -62,7 +77,6 @@ public class RestRequestPathInfoFilter implements Filter {
         private HttpServletRequest request;
 
         final String servletPath;
-        final String adjustedRequestURI;
         final String pathInfo;
 
         public SuffixStripFilterAwareHttpServletRequest(HttpServletRequest request, String basePath) {
@@ -70,26 +84,10 @@ public class RestRequestPathInfoFilter implements Filter {
             this.request = request;
 
             final String requestURI = request.getRequestURI();
-            final int basePathIdx = requestURI.indexOf(basePath);
-
             final String contextPath = request.getContextPath();
-            final String prefix = requestURI.substring(0, basePathIdx);
-            if (prefix.length() > contextPath.length()) {
-                // virtual service URL: strip the workspace prefix from the URI
-                servletPath = prefix.substring(contextPath.length());
-                adjustedRequestURI = contextPath + requestURI.substring(prefix.length());
-            } else {
-                servletPath = basePath;
-                adjustedRequestURI = requestURI;
-            }
 
-            final String pathToBase = requestURI.substring(0, basePathIdx + basePath.length());
-            pathInfo = requestURI.substring(pathToBase.length());
-        }
-
-        @Override
-        public String getRequestURI() {
-            return adjustedRequestURI;
+            servletPath = basePath;
+            pathInfo = requestURI.substring(contextPath.length() + basePath.length());
         }
 
         @Override
@@ -126,10 +124,11 @@ public class RestRequestPathInfoFilter implements Filter {
                     || contentType.startsWith(MediaType.APPLICATION_OCTET_STREAM_VALUE)) {
                 String ext = (String) request.getAttribute(SuffixStripFilter.EXTENSION_ATTRIBUTE);
                 if (ext == null) {
-                    int lastDot = adjustedRequestURI.lastIndexOf('.');
-                    int lastSlash = adjustedRequestURI.lastIndexOf('/');
+                    String requestURI = request.getRequestURI();
+                    int lastDot = requestURI.lastIndexOf('.');
+                    int lastSlash = requestURI.lastIndexOf('/');
                     if (lastDot > lastSlash) {
-                        ext = adjustedRequestURI.substring(lastDot + 1);
+                        ext = requestURI.substring(lastDot + 1);
                     }
                 }
                 if (ext != null) {

--- a/src/config/geoserver-configuration/src/test/java/org/geoserver/configuration/core/rest/RestRequestPathInfoFilterTest.java
+++ b/src/config/geoserver-configuration/src/test/java/org/geoserver/configuration/core/rest/RestRequestPathInfoFilterTest.java
@@ -1,0 +1,99 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.configuration.core.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * Tests {@link RestRequestPathInfoFilter#adaptRequest}: every request under the {@code /rest} base path must be
+ * adapted, including paths that merely contain {@code /gwc} in a resource name (issue #913), while GWC-dispatched URLs
+ * such as {@code /gwc/rest/**} are left alone.
+ */
+class RestRequestPathInfoFilterTest {
+
+    @Test
+    void plainRestPath_adapted() {
+        HttpServletRequest result = adapt("/rest/workspaces.json", "");
+        assertThat(result.getServletPath()).isEqualTo("/rest");
+        assertThat(result.getPathInfo()).isEqualTo("/workspaces.json");
+        assertThat(result.getRequestURI()).isEqualTo("/rest/workspaces.json");
+    }
+
+    /** {@code GET /rest/resource/gwc-gs.xml} returned a 500 NPE, see issue #913 */
+    @Test
+    void restResourceFileNameContainingGwc_adapted() {
+        HttpServletRequest result = adapt("/rest/resource/gwc-gs.xml", "");
+        assertThat(result.getServletPath()).isEqualTo("/rest");
+        assertThat(result.getPathInfo()).isEqualTo("/resource/gwc-gs.xml");
+        assertThat(result.getRequestURI()).isEqualTo("/rest/resource/gwc-gs.xml");
+    }
+
+    @Test
+    void restResourceGwcDirectory_adapted() {
+        HttpServletRequest result = adapt("/rest/resource/gwc/geowebcache.xml", "");
+        assertThat(result.getServletPath()).isEqualTo("/rest");
+        assertThat(result.getPathInfo()).isEqualTo("/resource/gwc/geowebcache.xml");
+    }
+
+    @Test
+    void restResourceNonExistentGwcPrefixedPath_adapted() {
+        HttpServletRequest result = adapt("/rest/resource/gwcfoo", "");
+        assertThat(result.getServletPath()).isEqualTo("/rest");
+        assertThat(result.getPathInfo()).isEqualTo("/resource/gwcfoo");
+    }
+
+    @Test
+    void restWithContextPath_adapted() {
+        HttpServletRequest result = adapt("/ctx/rest/resource/gwc-gs.xml", "/ctx");
+        assertThat(result.getServletPath()).isEqualTo("/rest");
+        assertThat(result.getPathInfo()).isEqualTo("/resource/gwc-gs.xml");
+        assertThat(result.getRequestURI()).isEqualTo("/ctx/rest/resource/gwc-gs.xml");
+    }
+
+    @Test
+    void restBasePathAlone_adapted() {
+        HttpServletRequest result = adapt("/rest", "");
+        assertThat(result.getServletPath()).isEqualTo("/rest");
+        assertThat(result.getPathInfo()).isEmpty();
+    }
+
+    @Test
+    void gwcRestApi_notAdapted() {
+        MockHttpServletRequest request = mockRequest("/gwc/rest/layers.json", "");
+        assertThat(RestRequestPathInfoFilter.adaptRequest(request)).isSameAs(request);
+    }
+
+    @Test
+    void virtualServiceGwcRestApi_notAdapted() {
+        MockHttpServletRequest request = mockRequest("/ws/gwc/rest/layers.json", "");
+        assertThat(RestRequestPathInfoFilter.adaptRequest(request)).isSameAs(request);
+    }
+
+    @Test
+    void nonRestPath_notAdapted() {
+        MockHttpServletRequest request = mockRequest("/actuator/health", "");
+        assertThat(RestRequestPathInfoFilter.adaptRequest(request)).isSameAs(request);
+    }
+
+    @Test
+    void restNotAtSegmentBoundary_notAdapted() {
+        MockHttpServletRequest request = mockRequest("/restful/thing", "");
+        assertThat(RestRequestPathInfoFilter.adaptRequest(request)).isSameAs(request);
+    }
+
+    private HttpServletRequest adapt(String requestURI, String contextPath) {
+        return RestRequestPathInfoFilter.adaptRequest(mockRequest(requestURI, contextPath));
+    }
+
+    private MockHttpServletRequest mockRequest(String requestURI, String contextPath) {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", requestURI);
+        request.setContextPath(contextPath);
+        return request;
+    }
+}

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/GwcRequestPathInfoFilter.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/GwcRequestPathInfoFilter.java
@@ -12,6 +12,7 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 import java.io.IOException;
+import java.util.Set;
 
 /**
  * Servlet filter that proceeds with an {@link HttpServletRequestWrapper} decorator to return
@@ -21,9 +22,24 @@ import java.io.IOException;
  * <p>GWC makes heavy use of {@link HttpServletRequestWrapper#getPathInfo()}, but it returns {@code null} in a
  * spring-boot application.
  *
+ * <p>Only genuine GWC dispatch paths are adapted: those where {@code /gwc} is a whole path segment placed either right
+ * after the context path or after a virtual service prefix ({@code /{workspace}} or {@code /{workspace}/{layer}}).
+ * Requests under another dispatcher's URL space that merely contain {@code /gwc} in their data, such as the REST API's
+ * {@code /rest/resource/gwc-gs.xml} or {@code /rest/resource/gwc/...}, are left untouched (issue #913).
+ *
  * @since 1.0
  */
 public class GwcRequestPathInfoFilter implements Filter {
+
+    @SuppressWarnings("java:S1075") // base path is fixed
+    static final String GWC_BASE_PATH = "/gwc";
+
+    /**
+     * First path segments claimed by other GeoServer dispatchers: {@code rest} is the REST API and {@code web} the
+     * wicket UI. A workspace with one of these names cannot be addressed through virtual service URLs anyway, the
+     * gateway routes those base paths to their own services.
+     */
+    private static final Set<String> RESERVED_DISPATCH_PREFIXES = Set.of("rest", "web");
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
@@ -35,11 +51,9 @@ public class GwcRequestPathInfoFilter implements Filter {
 
     public static HttpServletRequest adaptRequest(HttpServletRequest request) {
         final String requestURI = request.getRequestURI();
-        @SuppressWarnings("java:S1075") // base path is fixed
-        final String gwcBasePath = "/gwc";
-        final int gwcIdx = requestURI.indexOf(gwcBasePath);
+        final String contextPath = request.getContextPath();
+        final int gwcIdx = indexOfGwcBasePath(requestURI, contextPath);
         if (gwcIdx > -1) {
-            final String contextPath = request.getContextPath();
             final String prefix = requestURI.substring(0, gwcIdx);
             final String servletPath;
             final String adjustedRequestURI;
@@ -49,11 +63,11 @@ public class GwcRequestPathInfoFilter implements Filter {
                 servletPath = prefix.substring(contextPath.length());
                 adjustedRequestURI = contextPath + requestURI.substring(prefix.length());
             } else {
-                servletPath = gwcBasePath;
+                servletPath = GWC_BASE_PATH;
                 adjustedRequestURI = requestURI;
             }
 
-            final String pathToGwc = requestURI.substring(0, gwcIdx + gwcBasePath.length());
+            final String pathToGwc = requestURI.substring(0, gwcIdx + GWC_BASE_PATH.length());
             final String pathInfo = requestURI.substring(pathToGwc.length());
 
             return new HttpServletRequestWrapper(request) {
@@ -74,5 +88,42 @@ public class GwcRequestPathInfoFilter implements Filter {
             };
         }
         return request;
+    }
+
+    /**
+     * Locates {@code /gwc} where it acts as the GWC servlet base path, returning its index within {@code requestURI},
+     * or {@code -1} when the request is not a GWC one. Occurrences inside longer segments ({@code /gwc-gs.xml}) or
+     * deeper in the path than a virtual service prefix allows ({@code /rest/resource/gwc/...}) do not qualify.
+     */
+    private static int indexOfGwcBasePath(String requestURI, String contextPath) {
+        final String path = requestURI.substring(contextPath.length());
+        int idx = path.indexOf(GWC_BASE_PATH);
+        while (idx > -1) {
+            if (isWholeSegment(path, idx) && isVirtualServicePrefix(path.substring(0, idx))) {
+                return contextPath.length() + idx;
+            }
+            idx = path.indexOf(GWC_BASE_PATH, idx + 1);
+        }
+        return -1;
+    }
+
+    private static boolean isWholeSegment(String path, int idx) {
+        final int end = idx + GWC_BASE_PATH.length();
+        return end == path.length() || path.charAt(end) == '/';
+    }
+
+    /**
+     * The path before {@code /gwc} may only be empty or a virtual service prefix: {@code /{workspace}} or
+     * {@code /{workspace}/{layer}}, with the workspace not being a base path reserved by another dispatcher.
+     */
+    private static boolean isVirtualServicePrefix(String prefix) {
+        if (prefix.isEmpty()) {
+            return true;
+        }
+        String[] segments = prefix.substring(1).split("/");
+        if (segments.length > 2) {
+            return false;
+        }
+        return !RESERVED_DISPATCH_PREFIXES.contains(segments[0]);
     }
 }

--- a/src/gwc/core/src/test/java/org/geoserver/cloud/gwc/config/core/GwcRequestPathInfoFilterTest.java
+++ b/src/gwc/core/src/test/java/org/geoserver/cloud/gwc/config/core/GwcRequestPathInfoFilterTest.java
@@ -73,6 +73,67 @@ class GwcRequestPathInfoFilterTest {
         assertThat(result.getRequestURI()).isEqualTo("/gwc/rest/web/blobstores");
     }
 
+    @Test
+    void virtual_workspaceAndLayer() {
+        MockHttpServletRequest request = mockRequest("/ws/layer/gwc/service/wmts", "");
+        HttpServletRequest result = GwcRequestPathInfoFilter.adaptRequest(request);
+        assertThat(result.getServletPath()).isEqualTo("/ws/layer");
+        assertThat(result.getPathInfo()).isEqualTo("/service/wmts");
+        assertThat(result.getRequestURI()).isEqualTo("/gwc/service/wmts");
+    }
+
+    @Test
+    void virtual_workspaceNameStartingWithGwc() {
+        MockHttpServletRequest request = mockRequest("/gwcws/gwc/demo/layer:name", "");
+        HttpServletRequest result = GwcRequestPathInfoFilter.adaptRequest(request);
+        assertThat(result.getServletPath()).isEqualTo("/gwcws");
+        assertThat(result.getPathInfo()).isEqualTo("/demo/layer:name");
+        assertThat(result.getRequestURI()).isEqualTo("/gwc/demo/layer:name");
+    }
+
+    /** {@code GET /rest/resource/gwc-gs.xml} returned a 500 NPE, see issue #913 */
+    @Test
+    void restResourceFileNameContainingGwc_returnsOriginalRequest() {
+        MockHttpServletRequest request = mockRequest("/rest/resource/gwc-gs.xml", "");
+        HttpServletRequest result = GwcRequestPathInfoFilter.adaptRequest(request);
+        assertThat(result).isSameAs(request);
+    }
+
+    @Test
+    void restResourceGwcDirectory_returnsOriginalRequest() {
+        MockHttpServletRequest request = mockRequest("/rest/resource/gwc/geowebcache.xml", "");
+        HttpServletRequest result = GwcRequestPathInfoFilter.adaptRequest(request);
+        assertThat(result).isSameAs(request);
+    }
+
+    @Test
+    void restResourceNonExistentGwcPrefixedPath_returnsOriginalRequest() {
+        MockHttpServletRequest request = mockRequest("/rest/resource/gwcfoo", "");
+        HttpServletRequest result = GwcRequestPathInfoFilter.adaptRequest(request);
+        assertThat(result).isSameAs(request);
+    }
+
+    @Test
+    void webUiPathWithGwcSegment_returnsOriginalRequest() {
+        MockHttpServletRequest request = mockRequest("/web/images/gwc/tile.png", "");
+        HttpServletRequest result = GwcRequestPathInfoFilter.adaptRequest(request);
+        assertThat(result).isSameAs(request);
+    }
+
+    @Test
+    void gwcNotAtSegmentBoundary_returnsOriginalRequest() {
+        MockHttpServletRequest request = mockRequest("/gwcstore/styles.json", "");
+        HttpServletRequest result = GwcRequestPathInfoFilter.adaptRequest(request);
+        assertThat(result).isSameAs(request);
+    }
+
+    @Test
+    void gwcSegmentDeeperThanVirtualServicePrefix_returnsOriginalRequest() {
+        MockHttpServletRequest request = mockRequest("/a/b/c/gwc/tile.png", "");
+        HttpServletRequest result = GwcRequestPathInfoFilter.adaptRequest(request);
+        assertThat(result).isSameAs(request);
+    }
+
     private MockHttpServletRequest mockRequest(String requestURI, String contextPath) {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", requestURI);
         request.setContextPath(contextPath);


### PR DESCRIPTION
As a side effect of #914, `RestRequestPathInfoFilter` skipped any request whose URI contains "/gwc" anywhere, leaving `getPathInfo()` `null` and making the upstream `ResourceController` fail with a 500 NPE on e.g. `GET /rest/resource/gwc-gs.xml`. With the GWC starter in the restconfig service, `GwcRequestPathInfoFilter` also claimed those URIs and rewrote them to GWC dispatch paths, turning them into 404s for existing resources.

Anchor the REST filter on /rest as the first path segment, and make the GWC filter claim only genuine GWC dispatch paths: `/gwc` as a whole segment, alone or after a `/{workspace}` or `/{workspace}/{layer}` virtual service prefix, never under another dispatcher's base path.

* Pins the acceptance tests to 8.0.11 as per https://github.com/camptocamp/python-geoservercloud/releases/tag/0.8.11

Fixes #913

on-behalf-of: @camptocamp <info@camptocamp.com>