### PR TITLE
[Backport release/2.28.x] Fix REST API requests failing on paths containing /gwc

### DIFF
--- a/acceptance_tests/requirements.txt
+++ b/acceptance_tests/requirements.txt
@@ -1,4 +1,4 @@
-geoservercloud==0.8.10
+geoservercloud==0.8.11
 # To debug a local version of python-geoservercloud:
 # git clone git@github.com:camptocamp/python-geoservercloud
 # and then uncomment the following line and adjust the path accordingly

--- a/src/apps/geoserver/restconfig/src/main/java/org/geoserver/cloud/restconfig/RestConfigApplicationConfiguration.java
+++ b/src/apps/geoserver/restconfig/src/main/java/org/geoserver/cloud/restconfig/RestConfigApplicationConfiguration.java
@@ -6,6 +6,7 @@
 package org.geoserver.cloud.restconfig;
 
 import java.io.IOException;
+import java.util.List;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -23,7 +24,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.support.FormattingConversionService;
+import org.springframework.http.MediaType;
 import org.springframework.web.accept.ContentNegotiationManager;
+import org.springframework.web.accept.ContentNegotiationStrategy;
+import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 import org.springframework.web.servlet.resource.ResourceUrlProvider;
@@ -63,6 +67,62 @@ public class RestConfigApplicationConfiguration extends RestConfiguration {
         handlerMapping.setUseRegisteredSuffixPatternMatch(true);
 
         return handlerMapping;
+    }
+
+    /**
+     * Restores the {@code format} query parameter as the authority over the response representation for
+     * {@code /rest/resource/**} requests.
+     *
+     * <p>Upstream ships this as {@code ResourceController$ResourceControllerConfiguration}, but its patterns
+     * ({@code /resource}, {@code /resource/**}) lack the {@code /rest} prefix and never match the request lookup
+     * path, leaving format resolution to the path-extension and Accept-header strategies. A metadata request for
+     * {@code probe.txt} then negotiates {@code text/plain} from the file extension, and a directory listing follows
+     * the Accept header; neither type has a message converter for the REST wrapper and both fail with a 500.
+     *
+     * <p>{@link RestConfiguration}'s delegating strategy finds this bean through {@code GeoServerExtensions} and
+     * consults it before the extension and header strategies. File content downloads are unaffected: their content
+     * type is preset on the {@code ResponseEntity} the controller returns, bypassing negotiation.
+     */
+    @Bean
+    ContentNegotiationStrategy resourceApiFormatContentNegotiationStrategy() {
+        return new ResourceApiFormatContentNegotiationStrategy();
+    }
+
+    static class ResourceApiFormatContentNegotiationStrategy implements ContentNegotiationStrategy {
+
+        @SuppressWarnings("java:S1075") // base path is fixed
+        static final String RESOURCE_API_BASE_PATH = "/rest/resource";
+
+        @Override
+        public List<MediaType> resolveMediaTypes(NativeWebRequest webRequest) {
+            HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+            if (request == null || !isResourceApiRequest(request)) {
+                return List.of();
+            }
+            return List.of(requestedFormat(request));
+        }
+
+        private boolean isResourceApiRequest(HttpServletRequest request) {
+            String path =
+                    request.getRequestURI().substring(request.getContextPath().length());
+            if (!path.startsWith(RESOURCE_API_BASE_PATH)) {
+                return false;
+            }
+            int basePathEnd = RESOURCE_API_BASE_PATH.length();
+            return path.length() == basePathEnd || path.charAt(basePathEnd) == '/';
+        }
+
+        /** Mirrors {@code ResourceController.getFormat}: xml and json are honored, anything else means html */
+        private MediaType requestedFormat(HttpServletRequest request) {
+            String format = request.getParameter("format");
+            if ("xml".equals(format)) {
+                return MediaType.APPLICATION_XML;
+            }
+            if ("json".equals(format)) {
+                return MediaType.APPLICATION_JSON;
+            }
+            return MediaType.TEXT_HTML;
+        }
     }
 
     /**

--- a/src/apps/geoserver/restconfig/src/main/java/org/geoserver/cloud/restconfig/RestConfigApplicationConfiguration.java
+++ b/src/apps/geoserver/restconfig/src/main/java/org/geoserver/cloud/restconfig/RestConfigApplicationConfiguration.java
@@ -65,8 +65,13 @@ public class RestConfigApplicationConfiguration extends RestConfiguration {
         return handlerMapping;
     }
 
+    /**
+     * Named {@code restRequestPathInfoFilter} because the GWC starter's {@code GeoWebCacheCoreConfiguration}
+     * contributes a {@code setRequestPathInfoFilter} bean; with bean definition overriding enabled, reusing that
+     * name would replace this filter and leave REST API requests without servlet path and path info (issue #913).
+     */
     @Bean
-    SetRequestPathInfoFilter setRequestPathInfoFilter() {
+    SetRequestPathInfoFilter restRequestPathInfoFilter() {
         return new SetRequestPathInfoFilter();
     }
 

--- a/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationTest.java
+++ b/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationTest.java
@@ -6,8 +6,12 @@
 package org.geoserver.cloud.restconfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.APPLICATION_XML;
@@ -27,6 +31,7 @@ import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.SLDHandler;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.cloud.autoconfigure.extensions.test.ConditionalTestAutoConfiguration;
+import org.geoserver.cloud.gwc.config.core.GwcRequestPathInfoFilter;
 import org.geoserver.gwc.GWC;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
@@ -286,6 +291,84 @@ abstract class RestConfigApplicationTest {
         testPathExtensionContentType("/rest/workspaces.html", TEXT_HTML);
         testPathExtensionContentType("/rest/workspaces.xml", APPLICATION_XML);
         testPathExtensionContentType("/rest/workspaces.json", APPLICATION_JSON);
+    }
+
+    /**
+     * The REST and GWC path info filters must both be registered: they used to share the {@code
+     * setRequestPathInfoFilter} bean name, and with bean definition overriding enabled the GWC one replaced the REST
+     * one, breaking every {@code /rest/resource/**} request (issue #913).
+     */
+    @Test
+    void restAndGwcPathInfoFiltersBothRegistered() {
+        assertThat(context.getBean("restRequestPathInfoFilter"))
+                .isInstanceOf(RestConfigApplicationConfiguration.SetRequestPathInfoFilter.class);
+        assertThat(context.getBean("setRequestPathInfoFilter")).isInstanceOf(GwcRequestPathInfoFilter.class);
+    }
+
+    /**
+     * Any {@code /rest/resource/**} path containing the {@code /gwc} character sequence failed, because the servlet
+     * filters that rebuild {@code getPathInfo()} mistook such URIs for GeoWebCache requests. See issue #913.
+     */
+    @Test
+    void testResourceEndpointPathContainingGwc() {
+        ResponseEntity<String> response = restTemplate.getForEntity("/rest/resource/gwc-gs.xml", String.class);
+        assertThat(response.getStatusCode()).isEqualTo(OK);
+        assertThat(response.getBody()).contains("GeoServerGWCConfig");
+
+        response = restTemplate.getForEntity("/rest/resource/gwcfoo", String.class);
+        assertThat(response.getStatusCode()).isEqualTo(NOT_FOUND);
+    }
+
+    /** Directory variant of issue #913: listing a directory whose name starts with {@code gwc} */
+    @Test
+    void testResourceEndpointDirectoryNameContainingGwc() {
+        try {
+            putTextResource("/rest/resource/gwc913dir/child.txt", "issue #913 directory probe");
+
+            ResponseEntity<String> listing =
+                    restTemplate.getForEntity("/rest/resource/gwc913dir?format=json", String.class);
+            assertThat(listing.getStatusCode()).isEqualTo(OK);
+            assertThat(listing.getBody()).contains("child.txt");
+        } finally {
+            deleteResourceQuietly("/rest/resource/gwc913dir");
+        }
+    }
+
+    /** Round trip through the resource REST API on a file path containing {@code /gwc}, see issue #913 */
+    @Test
+    void testResourceEndpointRoundTripOnGwcPrefixedFileName() {
+        String file = "/rest/resource/styles/gwc-913-probe.txt";
+        String contents = "issue #913 round trip probe";
+        try {
+            putTextResource(file, contents);
+
+            ResponseEntity<String> get = restTemplate.getForEntity(file, String.class);
+            assertThat(get.getStatusCode()).isEqualTo(OK);
+            assertThat(get.getBody()).isEqualTo(contents);
+
+            ResponseEntity<Void> delete = restTemplate.exchange(file, DELETE, null, Void.class);
+            assertThat(delete.getStatusCode()).isEqualTo(OK);
+
+            ResponseEntity<String> afterDelete = restTemplate.getForEntity(file, String.class);
+            assertThat(afterDelete.getStatusCode()).isEqualTo(NOT_FOUND);
+        } finally {
+            deleteResourceQuietly(file);
+        }
+    }
+
+    private void putTextResource(String path, String contents) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.TEXT_PLAIN);
+        ResponseEntity<Void> put = restTemplate.exchange(path, PUT, new HttpEntity<>(contents, headers), Void.class);
+        assertThat(put.getStatusCode()).isIn(OK, CREATED);
+    }
+
+    private void deleteResourceQuietly(String path) {
+        try {
+            restTemplate.exchange(path, DELETE, null, Void.class);
+        } catch (RuntimeException e) {
+            // ignore, the assertion failure is the interesting outcome
+        }
     }
 
     protected void testPathExtensionContentType(String uri, MediaType expected) {

--- a/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationTest.java
+++ b/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationTest.java
@@ -356,6 +356,49 @@ abstract class RestConfigApplicationTest {
         }
     }
 
+    /**
+     * The {@code format} parameter must decide the metadata representation even when the resource name has a
+     * well-known file extension: the path-extension negotiation strategy used to win, asking for a
+     * {@code text/plain} response no message converter can produce for the REST wrapper.
+     */
+    @Test
+    void testResourceEndpointMetadataHonorsFormatParameter() {
+        String file = "/rest/resource/resource_api_meta/probe.txt";
+        try {
+            putTextResource(file, "metadata probe");
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Accept", "*/*");
+            ResponseEntity<String> metadata = restTemplate.exchange(
+                    file + "?operation=metadata&format=json", GET, new HttpEntity<>(headers), String.class);
+            assertThat(metadata.getStatusCode()).isEqualTo(OK);
+            assertThat(metadata.getHeaders().getContentType()).isEqualTo(APPLICATION_JSON);
+            assertThat(metadata.getBody()).contains("probe.txt");
+        } finally {
+            deleteResourceQuietly("/rest/resource/resource_api_meta");
+        }
+    }
+
+    /**
+     * Directory listings default to the html representation for any Accept header: without the {@code format}
+     * parameter the Accept header used to decide, and clients preferring a type without a converter for the REST
+     * wrapper, such as this test's {@code text/plain}, got a 500.
+     */
+    @Test
+    void testResourceEndpointDirectoryHtmlListing() {
+        try {
+            putTextResource("/rest/resource/resource_api_html/child.txt", "html listing probe");
+
+            ResponseEntity<String> listing =
+                    restTemplate.getForEntity("/rest/resource/resource_api_html", String.class);
+            assertThat(listing.getStatusCode()).isEqualTo(OK);
+            assertThat(listing.getHeaders().getContentType()).asString().contains("text/html");
+            assertThat(listing.getBody()).contains("child.txt");
+        } finally {
+            deleteResourceQuietly("/rest/resource/resource_api_html");
+        }
+    }
+
     private void putTextResource(String path, String contents) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.TEXT_PLAIN);

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/GwcRequestPathInfoFilter.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/GwcRequestPathInfoFilter.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.gwc.config.core;
 
 import java.io.IOException;
+import java.util.Set;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -20,6 +21,13 @@ import javax.servlet.http.HttpServletRequestWrapper;
  *
  * <p>GWC makes heavy use of {@link HttpServletRequestWrapper#getPathInfo()}, but it returns
  * {@code null} in a spring-boot application.
+ *
+ * <p>Only genuine GWC dispatch paths are adapted: those where {@code /gwc} is a whole path segment
+ * placed either right after the context path or after a virtual service prefix
+ * ({@code /{workspace}} or {@code /{workspace}/{layer}}). Requests under another dispatcher's URL
+ * space that merely contain {@code /gwc} in their data, such as the REST API's
+ * {@code /rest/resource/gwc-gs.xml} or {@code /rest/resource/gwc/...}, are left untouched (issue
+ * #913).
  *
  * <p>For virtual service URLs (workspace-prefixed), the behavior depends on the path type:
  *
@@ -39,6 +47,16 @@ import javax.servlet.http.HttpServletRequestWrapper;
  */
 public class GwcRequestPathInfoFilter implements Filter {
 
+    @SuppressWarnings("java:S1075") // base path is fixed
+    static final String GWC_BASE_PATH = "/gwc";
+
+    /**
+     * First path segments claimed by other GeoServer dispatchers: {@code rest} is the REST API and
+     * {@code web} the wicket UI. A workspace with one of these names cannot be addressed through
+     * virtual service URLs anyway, the gateway routes those base paths to their own services.
+     */
+    private static final Set<String> RESERVED_DISPATCH_PREFIXES = Set.of("rest", "web");
+
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
@@ -47,15 +65,13 @@ public class GwcRequestPathInfoFilter implements Filter {
         chain.doFilter(request, response);
     }
 
-    @SuppressWarnings("java:S1075")
     public static HttpServletRequest adaptRequest(HttpServletRequest request) {
         final String requestURI = request.getRequestURI();
-        final String gwcBasePath = "/gwc";
-        final int gwcIdx = requestURI.indexOf(gwcBasePath);
+        final String contextPath = request.getContextPath();
+        final int gwcIdx = indexOfGwcBasePath(requestURI, contextPath);
         if (gwcIdx > -1) {
-            final String contextPath = request.getContextPath();
             final String prefix = requestURI.substring(0, gwcIdx);
-            final String afterGwc = requestURI.substring(gwcIdx + gwcBasePath.length());
+            final String afterGwc = requestURI.substring(gwcIdx + GWC_BASE_PATH.length());
             final String servletPath;
             final String adjustedRequestURI;
             if (prefix.length() > contextPath.length()) {
@@ -66,11 +82,11 @@ public class GwcRequestPathInfoFilter implements Filter {
                     adjustedRequestURI = contextPath + requestURI.substring(prefix.length());
                 }
             } else {
-                servletPath = gwcBasePath;
+                servletPath = GWC_BASE_PATH;
                 adjustedRequestURI = requestURI;
             }
 
-            final String pathToGwc = requestURI.substring(0, gwcIdx + gwcBasePath.length());
+            final String pathToGwc = requestURI.substring(0, gwcIdx + GWC_BASE_PATH.length());
             final String pathInfo = requestURI.substring(pathToGwc.length());
 
             return new HttpServletRequestWrapper(request) {
@@ -91,5 +107,44 @@ public class GwcRequestPathInfoFilter implements Filter {
             };
         }
         return request;
+    }
+
+    /**
+     * Locates {@code /gwc} where it acts as the GWC servlet base path, returning its index within
+     * {@code requestURI}, or {@code -1} when the request is not a GWC one. Occurrences inside
+     * longer segments ({@code /gwc-gs.xml}) or deeper in the path than a virtual service prefix
+     * allows ({@code /rest/resource/gwc/...}) do not qualify.
+     */
+    private static int indexOfGwcBasePath(String requestURI, String contextPath) {
+        final String path = requestURI.substring(contextPath.length());
+        int idx = path.indexOf(GWC_BASE_PATH);
+        while (idx > -1) {
+            if (isWholeSegment(path, idx) && isVirtualServicePrefix(path.substring(0, idx))) {
+                return contextPath.length() + idx;
+            }
+            idx = path.indexOf(GWC_BASE_PATH, idx + 1);
+        }
+        return -1;
+    }
+
+    private static boolean isWholeSegment(String path, int idx) {
+        final int end = idx + GWC_BASE_PATH.length();
+        return end == path.length() || path.charAt(end) == '/';
+    }
+
+    /**
+     * The path before {@code /gwc} may only be empty or a virtual service prefix:
+     * {@code /{workspace}} or {@code /{workspace}/{layer}}, with the workspace not being a base
+     * path reserved by another dispatcher.
+     */
+    private static boolean isVirtualServicePrefix(String prefix) {
+        if (prefix.isEmpty()) {
+            return true;
+        }
+        String[] segments = prefix.substring(1).split("/");
+        if (segments.length > 2) {
+            return false;
+        }
+        return !RESERVED_DISPATCH_PREFIXES.contains(segments[0]);
     }
 }

--- a/src/gwc/core/src/test/java/org/geoserver/cloud/gwc/config/core/GwcRequestPathInfoFilterTest.java
+++ b/src/gwc/core/src/test/java/org/geoserver/cloud/gwc/config/core/GwcRequestPathInfoFilterTest.java
@@ -98,6 +98,58 @@ class GwcRequestPathInfoFilterTest {
     }
 
     @Test
+    void virtual_workspaceNameStartingWithGwc() {
+        MockHttpServletRequest request = mockRequest("/gwcws/gwc/demo/layer:name", "");
+        HttpServletRequest result = GwcRequestPathInfoFilter.adaptRequest(request);
+        assertThat(result.getServletPath()).isEqualTo("/gwcws");
+        assertThat(result.getPathInfo()).isEqualTo("/demo/layer:name");
+        assertThat(result.getRequestURI()).isEqualTo("/gwc/demo/layer:name");
+    }
+
+    /** {@code GET /rest/resource/gwc-gs.xml} failed on any path containing "/gwc", see issue #913 */
+    @Test
+    void restResourceFileNameContainingGwc_returnsOriginalRequest() {
+        MockHttpServletRequest request = mockRequest("/rest/resource/gwc-gs.xml", "");
+        HttpServletRequest result = GwcRequestPathInfoFilter.adaptRequest(request);
+        assertThat(result).isSameAs(request);
+    }
+
+    @Test
+    void restResourceGwcDirectory_returnsOriginalRequest() {
+        MockHttpServletRequest request = mockRequest("/rest/resource/gwc/geowebcache.xml", "");
+        HttpServletRequest result = GwcRequestPathInfoFilter.adaptRequest(request);
+        assertThat(result).isSameAs(request);
+    }
+
+    @Test
+    void restResourceNonExistentGwcPrefixedPath_returnsOriginalRequest() {
+        MockHttpServletRequest request = mockRequest("/rest/resource/gwcfoo", "");
+        HttpServletRequest result = GwcRequestPathInfoFilter.adaptRequest(request);
+        assertThat(result).isSameAs(request);
+    }
+
+    @Test
+    void webUiPathWithGwcSegment_returnsOriginalRequest() {
+        MockHttpServletRequest request = mockRequest("/web/images/gwc/tile.png", "");
+        HttpServletRequest result = GwcRequestPathInfoFilter.adaptRequest(request);
+        assertThat(result).isSameAs(request);
+    }
+
+    @Test
+    void gwcNotAtSegmentBoundary_returnsOriginalRequest() {
+        MockHttpServletRequest request = mockRequest("/gwcstore/styles.json", "");
+        HttpServletRequest result = GwcRequestPathInfoFilter.adaptRequest(request);
+        assertThat(result).isSameAs(request);
+    }
+
+    @Test
+    void gwcSegmentDeeperThanVirtualServicePrefix_returnsOriginalRequest() {
+        MockHttpServletRequest request = mockRequest("/a/b/c/gwc/tile.png", "");
+        HttpServletRequest result = GwcRequestPathInfoFilter.adaptRequest(request);
+        assertThat(result).isSameAs(request);
+    }
+
+    @Test
     void doFilter_delegatesToAdaptRequestAndChain() throws Exception {
         MockHttpServletRequest request = mockRequest("/gwc/demo/layer:name", "");
         HttpServletResponse response = mock(HttpServletResponse.class);


### PR DESCRIPTION
Backport #934 to 2.28.x