### PR TITLE
Simplify GeoServer submodule updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
 .PHONY: all
-all: deps install test build-image
+all: deps install test build-image ## Full build: GeoServer dependencies, artifacts, tests and local images
+
+.PHONY: help
+help: ## Show this help
+	@awk 'BEGIN {FS = ":.*## "; printf "Targets:\n"} /^[a-zA-Z0-9_-]+:.*## / {printf "  \033[36m%-32s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 TAG?=$(shell ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
 
 .PHONY: show-version
-show-version:
+show-version: ## Print the project version
 	@echo $(TAG)
 
 COSIGN_PASSWORD := $(COSIGN_PASSWORD)
@@ -13,18 +17,33 @@ COSIGN_PASSWORD := $(COSIGN_PASSWORD)
 REPACKAGE ?= true
 
 .PHONY: clean
-clean:
+clean: ## Remove build output (mvnw clean)
 	./mvnw clean
 
 # Build the customized GeoServer from the geoserver_submodule/geoserver
 # submodule and install its artifacts into the local Maven repository.
-# Run `git submodule update --init` first if the submodule is not checked out.
+# `make deps` builds the submodule as checked out, `make deps-sync` moves it to
+# the head of the GeoServer branch this branch tracks.
 GEOSERVER_SUBMODULE = geoserver_submodule/geoserver
+GEOSERVER_SUBMODULE_BRANCH = $(shell git config -f .gitmodules submodule.geoserver.branch)
 GEOSERVER_BUILD_FLAGS = --batch-mode -DskipTests -ntp -fae -Dsort.skip=true -Dspotless.apply.skip=true -T1C
 GEOSERVER_COMMUNITY_PROFILES = pending,cog,acl,flatgeobuf,geoparquet,graticule,gwc-azure-blob,gwc-gcs-blob,pmtiles-store,oseo,features-templating
 
 .PHONY: deps
-deps: deps-core deps-extensions deps-community
+deps: deps-core deps-extensions deps-community ## Build the customized GeoServer from the submodule into the local repo
+
+# Moves the submodule to the current head of the GeoServer branch declared in
+# .gitmodules, which differs per release line, and leaves the resulting commit
+# for the superproject to record. That branch is force-pushed upstream, hence
+# fetching it by name at depth 1: the new head needs no ancestry with the old
+# one, and no remote-tracking ref has to exist for it. Build the result with
+# `make deps` and commit the submodule to pin it.
+.PHONY: deps-sync
+deps-sync: ## Move the submodule to the head of the GeoServer branch it tracks
+	@test -e $(GEOSERVER_SUBMODULE)/.git || git submodule update --init $(GEOSERVER_SUBMODULE)
+	git -C $(GEOSERVER_SUBMODULE) fetch --depth 1 origin $(GEOSERVER_SUBMODULE_BRANCH)
+	git -C $(GEOSERVER_SUBMODULE) checkout --detach FETCH_HEAD
+	@git status --short $(GEOSERVER_SUBMODULE)
 
 .PHONY: deps-core
 deps-core:
@@ -43,7 +62,7 @@ build-tools:
 	./mvnw clean install -pl src/build-tools/build-config/ -ntp
 
 .PHONY: lint
-lint: build-tools
+lint: build-tools ## Run static analysis (checkstyle, spotless, sortpom)
 	./mvnw validate -Dqa -fae -ntp -T1C
 
 .PHONY: lint-pom
@@ -55,7 +74,7 @@ lint-java: build-tools
 	./mvnw validate -Dqa -fae -Dsortpom.skip=true -ntp -T1C
 
 .PHONY: format
-format: format-pom format-java
+format: format-pom format-java ## Apply Java and POM formatting
 
 .PHONY: format-pom
 format-pom:
@@ -66,19 +85,19 @@ format-java:
 	./mvnw spotless:apply -ntp -T1C
 
 .PHONY: install
-install: build-tools
+install: build-tools ## Compile and install all modules, skipping tests
 	./mvnw clean install -DskipTests -ntp -U -T1C
 
 .PHONY: package
-package:
+package: ## Package all modules, skipping tests
 	./mvnw clean package -Dfmt.skip -DskipTests -ntp -U -T1C
 
 .PHONY: test
-test:
+test: ## Run unit and integration tests
 	./mvnw verify -Dfmt.skip -ntp -T1C
 
 .PHONY: build-image
-build-image: build-base-images build-image-infrastructure build-image-geoserver
+build-image: build-base-images build-image-infrastructure build-image-geoserver ## Build the Docker images for this platform
 
 .PHONY: build-base-images
 build-base-images: package-base-images
@@ -123,7 +142,7 @@ else
 endif
 
 .PHONY: pull-images
-pull-images:
+pull-images: ## Pull the published images for the current version
 	TAG=$$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout) \
 	docker compose \
      -f docker-build/geoserver.yml \
@@ -131,7 +150,7 @@ pull-images:
      pull --quiet
 
 .PHONY: sign-image
-sign-image:
+sign-image: ## Sign the release images with cosign
 	@bash -c '\
 	TAG=$$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout); \
 	images=$$(TAG=$$TAG docker compose -f docker-build/geoserver.yml -f docker-build/infrastructure.yml config --images); \
@@ -147,7 +166,7 @@ sign-image:
 	done'
 
 .PHONY: verify-image
-verify-image:
+verify-image: ## Verify the release image signatures with cosign
 	@bash -c '\
 	TAG=$$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout); \
 	images=$$(TAG=$$TAG docker compose -f docker-build/geoserver.yml -f docker-build/infrastructure.yml config --images); \
@@ -167,7 +186,7 @@ build-acceptance:
 	docker build --tag=geoservercloud/acceptance:latest acceptance_tests
 
 .PHONY: acceptance-tests-datadir
-acceptance-tests-datadir: build-acceptance start-acceptance-tests-datadir run-acceptance-tests-datadir
+acceptance-tests-datadir: build-acceptance start-acceptance-tests-datadir run-acceptance-tests-datadir ## Run the acceptance tests on the data directory backend
 
 .PHONY: start-acceptance-tests-datadir
 start-acceptance-tests-datadir:
@@ -178,11 +197,11 @@ run-acceptance-tests-datadir:
 	(cd compose/ && TAG=$(TAG) ./acceptance_datadir run --rm -T acceptance bash -c 'until [ -f /tmp/healthcheck ]; do echo "Waiting for /tmp/healthcheck to be available..."; sleep 5; done && COLUMNS=120 pytest -v --color=yes --pyargs geoserver_acceptance_tests.tests  -k "not test_i18n_layers_default_locale"')
 
 .PHONY: clean-acceptance-tests-datadir
-clean-acceptance-tests-datadir:
+clean-acceptance-tests-datadir: ## Tear down the data directory acceptance composition
 	(cd compose/ && TAG=$(TAG) ./acceptance_datadir down -v --remove-orphans)
 
 .PHONY: acceptance-tests-pgconfig
-acceptance-tests-pgconfig: build-acceptance start-acceptance-tests-pgconfig run-acceptance-tests-pgconfig
+acceptance-tests-pgconfig: build-acceptance start-acceptance-tests-pgconfig run-acceptance-tests-pgconfig ## Run the acceptance tests on the pgconfig backend
 
 .PHONY: start-acceptance-tests-pgconfig
 start-acceptance-tests-pgconfig:
@@ -193,7 +212,7 @@ run-acceptance-tests-pgconfig:
 	(cd compose/ && TAG=$(TAG) ./acceptance_pgconfig run --rm -T acceptance bash -c 'until [ -f /tmp/healthcheck ]; do echo "Waiting for /tmp/healthcheck to be available..."; sleep 5; done && COLUMNS=120 pytest -v --color=yes --pyargs geoserver_acceptance_tests.tests  -k "not test_i18n_layers_default_locale"')
 
 .PHONY: clean-acceptance-tests-pgconfig
-clean-acceptance-tests-pgconfig:
+clean-acceptance-tests-pgconfig: ## Tear down the pgconfig acceptance composition
 	(cd compose/ && TAG=$(TAG) ./acceptance_pgconfig down -v --remove-orphans)
 
 # Prevent make from treating service names as targets when using $(MAKECMDGOALS) in build-image-geoserver

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Check out the full [Release Notes](https://github.com/geoserver/geoserver-cloud/
 
 Please read [the contribution guidelines](CONTRIBUTING.md) before contributing pull requests to the GeoServer Cloud project.
 
-Follow the [developer's guide](docs/develop/index.md) to know more about the project's technical details.
+Follow the [developer's guide](docs/src/developer-guide/index.md) to know more about the project's technical details.
 
 ## Bugs
 
@@ -143,13 +143,25 @@ Requirements:
  * [GNU Make](https://www.gnu.org/software/make/) (optional, recommended).
 
 
-This is a super quick-start guide to make your first build. For more detailed information on the build process and options, follow the [Build Instructions](./docs/develop/build_instructions.md) guide.
+This is a super quick-start guide to make your first build. For more detailed information on the build process and options, follow the [Build Instructions](./docs/src/developer-guide/build_instructions.md) guide.
 
 Clone the repository, including submodules. Alternatively, replace the repository URL by your own fork's:
 
 ```shell
 git clone --recurse-submodules git@github.com:geoserver/geoserver-cloud.git
 ```
+
+The `geoserver_submodule/geoserver` submodule holds the customized GeoServer sources, which `make` builds and installs through its `deps` target. Whenever the pinned submodule commit changes, for instance after pulling or switching branches, check it out and rebuild those artifacts:
+
+```shell
+git submodule update --init
+make deps
+```
+
+`make deps` never changes what the submodule has checked out. Moving the pin to the head of the tracked GeoServer branch is `make deps-sync`, described in the guide above.
+
+See [Note on custom upstream GeoServer version](docs/src/developer-guide/build_instructions.md#note-on-custom-upstream-geoserver-version) for why this dependency is built locally and how to move the pin to a newer commit.
+
 Build with:
 
 ```shell

--- a/docs/src/developer-guide/build_instructions.md
+++ b/docs/src/developer-guide/build_instructions.md
@@ -42,6 +42,8 @@ make deps
 
 This is required once after cloning, and again whenever the `geoserver_submodule/geoserver` submodule is updated. It installs the custom GeoServer Maven artifacts into the local Maven repository, where the rest of the build resolves them from, since they are not published to any public Maven repository.
 
+`make deps` builds the submodule exactly as checked out, and never changes what is checked out, see [Updating the GeoServer submodule](#updating-the-geoserver-submodule).
+
 To build the project without running tests, run
 
 ```bash
@@ -105,4 +107,38 @@ The `gscloud/gs_version/integration` branch of the [camptocamp/geoserver](https:
 
 Run `make deps` to build it and install the custom GeoServer Maven artifacts into the local Maven repository. The CI workflows do the same through the `.github/actions/geoserver-artifacts` composite action, which caches the built artifacts keyed on the submodule commit.
 
+#### Updating the GeoServer submodule
 
+Two distinct operations.
+
+*Check out the commit the current branch pins*, needed after cloning, pulling, or switching *GeoServer Cloud* branches:
+
+```shell
+git submodule update --init
+make deps
+```
+
+*Move the pin to the current head of the tracked GeoServer branch*, which is how a change made in the [camptocamp/geoserver](https://github.com/camptocamp/geoserver) repository reaches *GeoServer Cloud*:
+
+```shell
+make deps-sync
+make deps
+git add geoserver_submodule/geoserver
+```
+
+`make deps-sync` fetches the branch `.gitmodules` declares for the current *GeoServer Cloud* branch, `gscloud/3.1.x/integration` here and a different one per release line, and checks its head out. That leaves the submodule pointing at a commit the superproject does not record yet. Staging and committing it is what pins the new GeoServer revision; until then the next `git submodule update` puts the old one back.
+
+The `gscloud` branches are force-pushed, and their heads need no ancestry with the commit currently pinned. `deps-sync` therefore fetches the branch by name at depth 1 rather than going through `git submodule update --remote`, which resolves a remote-tracking ref and would pull the rewritten history into the shallow clone. Repeated rounds of this leave unreachable objects behind in `geoserver_submodule/geoserver/.git`; `git -C geoserver_submodule/geoserver gc --prune=now` reclaims them.
+
+Never pass `--depth` to `git submodule update`. It reaches the underlying `git clone`, where it implies `--single-branch`, leaving a clone that tracks only the GeoServer repository's default branch, `main`, and never fetches the branch `.gitmodules` declares. The pinned commit still arrives through a follow-up fetch by object id, which hides the problem until the day a command needs the branch:
+
+```
+fatal: Unable to find refs/remotes/origin/gscloud/3.1.x/integration revision in submodule path 'geoserver_submodule/geoserver'
+```
+
+The `shallow = true` flag in `.gitmodules` keeps the clone at depth 1 without that side effect, and is honored by both `git clone --recurse-submodules` and a plain `git submodule update --init`. `make deps-sync` works either way, fetching by branch name instead of relying on the refspec. To give an already narrowed clone its branch back, without recloning:
+
+```shell
+git -C geoserver_submodule/geoserver config remote.origin.fetch \
+  '+refs/heads/gscloud/3.1.x/integration:refs/remotes/origin/gscloud/3.1.x/integration'
+```


### PR DESCRIPTION
Add `make deps-sync`. Ffetches the head of the GeoServer branch in .gitmodules and checks it out, leaving the new commit for the superproject to record. `make deps` keeps building the submodule as checked out.

on-behalf-of: @camptocamp <info@camptocamp.com>