### PR TITLE
Upgrade to latest GeoServer 2.28.x

### DIFF
--- a/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/GeoWebCacheContextRunner.java
+++ b/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/GeoWebCacheContextRunner.java
@@ -22,6 +22,8 @@ import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.platform.resource.FileSystemResourceStore;
 import org.geoserver.platform.resource.ResourceStore;
 import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.wms.GetMap;
+import org.geoserver.wms.WMS;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -110,6 +112,18 @@ public class GeoWebCacheContextRunner {
         @ConditionalOnMissingBean
         GeoServerSecurityManager geoServerSecurityManager(GeoServerDataDirectory datadir) throws Exception {
             return new GeoServerSecurityManager(datadir);
+        }
+
+        /**
+         * The {@code coalescedRequestSplitter} the GWC mediator is built with renders the non-cached
+         * members of a multi-layer tile request through WMS. Applications get this bean from the WMS
+         * service, or from {@code WebMapServiceMinimalConfiguration} when they don't run it; a bare
+         * {@link GetMap} serves the same purpose here without pulling the WMS context in.
+         */
+        @Bean(name = "wmsGetMap")
+        @ConditionalOnMissingBean(name = "wmsGetMap")
+        GetMap wmsGetMap(GeoServer geoServer) {
+            return new GetMap(new WMS(geoServer));
         }
     }
 }

--- a/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/core/GeoWebCacheAutoConfigurationTest.java
+++ b/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/core/GeoWebCacheAutoConfigurationTest.java
@@ -100,6 +100,24 @@ class GeoWebCacheAutoConfigurationTest {
         });
     }
 
+    /**
+     * The GWC mediator is built with a {@code coalescedRequestSplitter} that decodes and encodes
+     * images, and upstream declares the codec beans it needs along with the GWC WMS service, which
+     * is not enabled here.
+     */
+    @Test
+    void imageCodecsAvailableWithoutTheGwcWmsService() {
+        runner.run(context -> assertThat(context)
+                .hasNotFailed()
+                .hasBean("gwcFacade")
+                .hasBean("coalescedRequestSplitter")
+                .hasBean("decoderContainer")
+                .hasBean("encoderContainer")
+                .hasBean("PNGDecoder")
+                .hasBean("PNGEncoder")
+                .doesNotHaveBean("gwcServiceWMS"));
+    }
+
     @Test
     void contextLoads() {
         runner.run(context -> {

--- a/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/service/WebMapServiceAutoConfigurationTest.java
+++ b/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/service/WebMapServiceAutoConfigurationTest.java
@@ -1,0 +1,54 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.autoconfigure.gwc.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheContextRunner;
+import org.geowebcache.io.codec.ImageDecoderContainer;
+import org.geowebcache.io.codec.ImageEncoderContainer;
+import org.geowebcache.service.wms.WMSService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+
+/**
+ * @since 2.28.5
+ */
+class WebMapServiceAutoConfigurationTest {
+
+    @TempDir
+    File tmpDir;
+
+    WebApplicationContextRunner runner;
+
+    @BeforeEach
+    void setUp() {
+        runner = GeoWebCacheContextRunner.newMinimalGeoWebCacheContextRunner(tmpDir)
+                .withConfiguration(AutoConfigurations.of(WebMapServiceAutoConfiguration.class));
+    }
+
+    @Test
+    void disabledByDefault() {
+        runner.run(context -> assertThat(context).hasNotFailed().doesNotHaveBean(WMSService.class));
+    }
+
+    /**
+     * The image codec beans upstream declares along with this service come from {@code
+     * ImageCodecsConfiguration} instead, since GeoWebCache needs them either way.
+     */
+    @Test
+    void enabledKeepsASingleImageCodecSet() {
+        runner.withPropertyValues("gwc.services.wms=true").run(context -> assertThat(context)
+                .hasNotFailed()
+                .hasBean("gwcServiceWMSTarget")
+                .hasSingleBean(ImageDecoderContainer.class)
+                .hasSingleBean(ImageEncoderContainer.class));
+    }
+}

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/GeoServerIntegrationConfiguration.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/GeoServerIntegrationConfiguration.java
@@ -16,13 +16,16 @@ import org.geoserver.platform.GeoServerResourceLoader;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 /**
  * @since 1.0
  * @see DefaultTileLayerCatalogConfiguration
+ * @see ImageCodecsConfiguration
  */
 @Configuration(proxyBeanMethods = true)
 @ImportFilteredResource(GeoServerIntegrationConfiguration.GS_INTEGRATION_INCLUDES)
+@Import(ImageCodecsConfiguration.class)
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.core")
 public class GeoServerIntegrationConfiguration {
 

--- a/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/ImageCodecsConfiguration.java
+++ b/src/gwc/core/src/main/java/org/geoserver/cloud/gwc/config/core/ImageCodecsConfiguration.java
@@ -1,0 +1,39 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.gwc.config.core;
+
+import org.geoserver.cloud.config.factory.ImportFilteredResource;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Contributes the GeoWebCache image codec beans, which upstream declares in {@literal
+ * geowebcache-wmsservice-context.xml} but are needed regardless of whether the GWC WMS service is
+ * enabled: the {@code coalescedRequestSplitter} the {@code gwcFacade} is built with decodes the
+ * cached member tiles and encodes the assembled multi-layer tile.
+ *
+ * <p>The codecs come as a set: {@code ImageDecoderContainer} and {@code ImageEncoderContainer}
+ * collect the per-format codec beans from the application context and fail to initialize if none is
+ * found.
+ *
+ * <p>{@code WebMapServiceConfiguration} imports the rest of {@literal
+ * geowebcache-wmsservice-context.xml} and excludes these beans, keeping a single definition site.
+ *
+ * @since 2.28.5
+ */
+@Configuration(proxyBeanMethods = false)
+@ImportFilteredResource(ImageCodecsConfiguration.CODEC_BEANS_INCLUDES)
+public class ImageCodecsConfiguration {
+
+    /**
+     * Bean name pattern matching the per-format {@code ImageEncoder} and {@code ImageDecoder} beans
+     * plus the two containers collecting them, and nothing else in {@literal
+     * geowebcache-wmsservice-context.xml}.
+     */
+    public static final String CODEC_BEAN_NAMES = "(.*Encoder|.*Decoder|encoderContainer|decoderContainer)";
+
+    static final String CODEC_BEANS_INCLUDES =
+            "jar:gs-gwc-[0-9]+.*!/geowebcache-wmsservice-context.xml#name=^" + CODEC_BEAN_NAMES + "$";
+}

--- a/src/gwc/services/src/main/java/org/geoserver/cloud/gwc/config/services/WebMapServiceConfiguration.java
+++ b/src/gwc/services/src/main/java/org/geoserver/cloud/gwc/config/services/WebMapServiceConfiguration.java
@@ -6,6 +6,7 @@
 package org.geoserver.cloud.gwc.config.services;
 
 import org.geoserver.cloud.config.factory.ImportFilteredResource;
+import org.geoserver.cloud.gwc.config.core.ImageCodecsConfiguration;
 import org.geowebcache.service.wms.WMSService;
 import org.gwc.web.wms.WMSController;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -14,9 +15,19 @@ import org.springframework.context.annotation.Configuration;
 
 /**
  * @since 1.0
+ * @see ImageCodecsConfiguration
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(WMSService.class)
 @ComponentScan(basePackageClasses = WMSController.class)
-@ImportFilteredResource("jar:gs-gwc-[0-9]+.*!/geowebcache-wmsservice-context.xml")
-public class WebMapServiceConfiguration {}
+@ImportFilteredResource(WebMapServiceConfiguration.WMS_SERVICE_INCLUDES)
+public class WebMapServiceConfiguration {
+
+    /**
+     * The image codec beans declared alongside the WMS service are contributed by {@link
+     * ImageCodecsConfiguration} instead, since GeoWebCache needs them whether or not this service
+     * is enabled.
+     */
+    static final String WMS_SERVICE_INCLUDES = "jar:gs-gwc-[0-9]+.*!/geowebcache-wmsservice-context.xml#name=^(?!"
+            + ImageCodecsConfiguration.CODEC_BEAN_NAMES + "$).*$";
+}

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -29,16 +29,16 @@
     <spring.version>5.3.39</spring.version>
     <spring.security.version>5.8.16</spring.security.version>
     <tomcat.version>9.0.113</tomcat.version>
-    <jackson.version>2.19.4</jackson.version>
-    <jackson.version.annotations>2.21</jackson.version.annotations>
+    <jackson.version>2.22.2</jackson.version>
+    <jackson.version.annotations>2.22</jackson.version.annotations>
     <gs.version>2.28.5-SNAPSHOT</gs.version>
     <gt.version>34-SNAPSHOT</gt.version>
     <wicket.version>9.23.0</wicket.version>
     <acl.version>2.4.0</acl.version>
-    <postgresql.version>42.7.7</postgresql.version>
+    <postgresql.version>42.7.13</postgresql.version>
     <lombok.version>1.18.42</lombok.version>
     <mapstruct.version>1.6.3</mapstruct.version>
-    <flyway.version>11.16.0</flyway.version>
+    <flyway.version>11.4.0</flyway.version>
     <cloud-dependencies-bom.version>1.0.2</cloud-dependencies-bom.version>
     <testcontainers.version>1.21.4</testcontainers.version>
     <fork.javac>false</fork.javac>
@@ -1325,14 +1325,9 @@
       <dependencyManagement>
         <dependencies>
           <dependency>
-            <groupId>com.azure</groupId>
-            <artifactId>azure-core</artifactId>
-            <version>1.57.0</version>
-          </dependency>
-          <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.25.8</version>
+            <version>4.33.2</version>
           </dependency>
           <dependency>
             <groupId>commons-jxpath</groupId>
@@ -1373,34 +1368,19 @@
             <version>1.0.3</version>
           </dependency>
           <dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-            <version>1.11.0</version>
-          </dependency>
-          <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-            <version>3.2.2</version>
-          </dependency>
-          <dependency>
-            <groupId>commons-digester</groupId>
-            <artifactId>commons-digester</artifactId>
-            <version>1.7</version>
-          </dependency>
-          <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
-          </dependency>
-          <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.18.0</version>
+            <version>3.20.0</version>
           </dependency>
           <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.3.5</version>
+            <version>1.3.6</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.26.1</version>
           </dependency>
           <dependency>
             <groupId>commons-io</groupId>
@@ -1410,12 +1390,12 @@
           <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.12.0</version>
+            <version>1.15.0</version>
           </dependency>
           <dependency>
             <groupId>org.codehaus.jettison</groupId>
             <artifactId>jettison</artifactId>
-            <version>1.5.4</version>
+            <version>1.5.7</version>
           </dependency>
           <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -1426,21 +1406,6 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <version>3.0.2</version>
-          </dependency>
-          <dependency>
-            <groupId>org.checkerframework</groupId>
-            <artifactId>checker-qual</artifactId>
-            <version>3.33.0</version>
-          </dependency>
-          <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-            <version>2.18.0</version>
-          </dependency>
-          <dependency>
-            <groupId>com.google.j2objc</groupId>
-            <artifactId>j2objc-annotations</artifactId>
-            <version>2.8</version>
           </dependency>
           <dependency>
             <groupId>org.apache.wicket</groupId>
@@ -1456,6 +1421,11 @@
             <groupId>com.fasterxml.woodstox</groupId>
             <artifactId>woodstox-core</artifactId>
             <version>6.6.2</version>
+          </dependency>
+          <dependency>
+            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>stax2-api</artifactId>
+            <version>4.3.0</version>
           </dependency>
           <dependency>
             <groupId>com.netflix.servo</groupId>
@@ -1509,6 +1479,11 @@
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
             <version>2.7.2</version>
+          </dependency>
+          <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
+            <version>4.13.2</version>
           </dependency>
         </dependencies>
       </dependencyManagement>


### PR DESCRIPTION
Upgrade geoserver submodule to latest GeoServer 2.28.x

Align dependency versions with the 2.28.x upstream and update the geoserver submodule pointer.

The GWC mediator is now built with a coalesced request splitter that needs the image codec beans upstream declares along with the GWC WMS service. Contribute them from the always-on GeoServer integration configuration instead, and exclude them from the WMS service import to keep a single definition site.

on-behalf-of: @camptocamp <info@camptocamp.com>
