### PR TITLE
Upgrade to latest GeoServer 3.0.x

### DIFF
--- a/src/config/geoserver-configuration/src/main/java/org/geoserver/configuration/gwc/GwcConfigurationTranspilerAggregator.java
+++ b/src/config/geoserver-configuration/src/main/java/org/geoserver/configuration/gwc/GwcConfigurationTranspilerAggregator.java
@@ -17,6 +17,7 @@ import org.geoserver.spring.config.annotations.TranspileXmlConfig;
  * @see GwcKMLServiceConfiguration
  * @see GwcTMSServiceConfiguration
  * @see GwcWMSServiceConfiguration
+ * @see GwcImageCodecsConfiguration
  * @see GwcWMTSServiceConfiguration
  * @see GwcGeoServerWMTSIntegrationConfiguration
  * @see GwcGeoServerWebUIConfiguration
@@ -88,7 +89,30 @@ import org.geoserver.spring.config.annotations.TranspileXmlConfig;
 @TranspileXmlConfig(
         locations = "jar:gs-gwc-[0-9]+.*!/geowebcache-wmsservice-context.xml",
         targetClass = "GwcWMSServiceConfiguration",
-        publicAccess = true)
+        publicAccess = true,
+        // contributed by GwcImageCodecsConfiguration, which GeoWebCache needs whether or not this service runs
+        excludes = {
+            GwcConfigurationTranspilerAggregator.IMAGE_ENCODERS,
+            GwcConfigurationTranspilerAggregator.IMAGE_DECODERS,
+            GwcConfigurationTranspilerAggregator.IMAGE_ENCODER_CONTAINER,
+            GwcConfigurationTranspilerAggregator.IMAGE_DECODER_CONTAINER
+        })
+@TranspileXmlConfig(
+        locations = "jar:gs-gwc-[0-9]+.*!/geowebcache-wmsservice-context.xml",
+        targetClass = "GwcImageCodecsConfiguration",
+        publicAccess = true,
+        /*
+         * The image codecs upstream declares along with the GWC WMS service. The coalescedRequestSplitter the
+         * gwcFacade is built with decodes the cached member tiles and encodes the assembled multi-layer tile, hence
+         * these beans come with the GeoServer integration instead. The per-format codecs come along with the two
+         * containers, which collect them from the application context and fail to initialize if none is found.
+         */
+        includes = {
+            GwcConfigurationTranspilerAggregator.IMAGE_ENCODERS,
+            GwcConfigurationTranspilerAggregator.IMAGE_DECODERS,
+            GwcConfigurationTranspilerAggregator.IMAGE_ENCODER_CONTAINER,
+            GwcConfigurationTranspilerAggregator.IMAGE_DECODER_CONTAINER
+        })
 @TranspileXmlConfig(
         locations = "jar:gs-gwc-[0-9]+.*!/geowebcache-wmtsservice-context.xml",
         targetClass = "GwcWMTSServiceConfiguration",
@@ -128,4 +152,13 @@ import org.geoserver.spring.config.annotations.TranspileXmlConfig;
             "wfsSqlViewKvpParser",
             "gml2OutputFormat"
         })
-public class GwcConfigurationTranspilerAggregator {}
+public class GwcConfigurationTranspilerAggregator {
+
+    static final String IMAGE_ENCODERS = ".*Encoder";
+
+    static final String IMAGE_DECODERS = ".*Decoder";
+
+    static final String IMAGE_ENCODER_CONTAINER = "encoderContainer";
+
+    static final String IMAGE_DECODER_CONTAINER = "decoderContainer";
+}

--- a/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/GeoServerIntegrationAutoConfiguration.java
+++ b/src/gwc/autoconfigure/src/main/java/org/geoserver/cloud/autoconfigure/gwc/core/GeoServerIntegrationAutoConfiguration.java
@@ -12,6 +12,7 @@ import org.geoserver.cloud.autoconfigure.gwc.backend.DefaultTileLayerCatalogAuto
 import org.geoserver.cloud.gwc.event.ConfigChangeEvent;
 import org.geoserver.config.util.XStreamPersisterFactory;
 import org.geoserver.configuration.gwc.GwcGeoServerContextConfiguration;
+import org.geoserver.configuration.gwc.GwcImageCodecsConfiguration;
 import org.geoserver.gwc.config.CloudGwcConfigPersister;
 import org.geoserver.gwc.config.GWCConfigPersister;
 import org.geoserver.platform.GeoServerResourceLoader;
@@ -27,12 +28,13 @@ import org.springframework.context.annotation.Import;
  *
  * @see ConditionalOnGeoWebCacheEnabled
  * @see GwcGeoServerContextConfiguration
+ * @see GwcImageCodecsConfiguration
  * @see DefaultTileLayerCatalogAutoConfiguration
  * @since 1.0
  */
 @AutoConfiguration
 @ConditionalOnGeoWebCacheEnabled
-@Import(GwcGeoServerContextConfiguration.class)
+@Import({GwcGeoServerContextConfiguration.class, GwcImageCodecsConfiguration.class})
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.gwc.core")
 @SuppressWarnings("java:S1118") // Suppress SonarLint warning, constructor needs to be public
 public class GeoServerIntegrationAutoConfiguration {

--- a/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/GeoWebCacheContextRunner.java
+++ b/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/GeoWebCacheContextRunner.java
@@ -25,6 +25,8 @@ import org.geoserver.platform.resource.MemoryLockProvider;
 import org.geoserver.platform.resource.ResourceStore;
 import org.geoserver.security.GeoServerSecurityManager;
 import org.geoserver.security.impl.LayerGroupContainmentCache;
+import org.geoserver.wms.GetMap;
+import org.geoserver.wms.WMS;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -126,6 +128,17 @@ public class GeoWebCacheContextRunner {
         @ConditionalOnMissingBean
         LayerGroupContainmentCache layerGroupContainmentCache(@Qualifier("rawCatalog") CatalogPlugin rawCatalog) {
             return new LayerGroupContainmentCache(rawCatalog);
+        }
+
+        /**
+         * Stand-in for the bean the WMS service, or GwcWMSMinimalConfiguration, contributes in production, required
+         * since the coalescedRequestSplitter the GWC mediator is built with renders the non-cached members of a
+         * multi-layer tile request through WMS
+         */
+        @Bean(name = "wmsGetMap")
+        @ConditionalOnMissingBean(name = "wmsGetMap")
+        GetMap wmsGetMap(GeoServer geoServer) {
+            return new GetMap(new WMS(geoServer));
         }
     }
 }

--- a/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/core/GeoWebCacheAutoConfigurationTest.java
+++ b/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/core/GeoWebCacheAutoConfigurationTest.java
@@ -96,6 +96,23 @@ class GeoWebCacheAutoConfigurationTest {
         });
     }
 
+    /**
+     * The GWC mediator is built with a {@code coalescedRequestSplitter} that decodes and encodes images, and upstream
+     * declares the codec beans it needs along with the GWC WMS service, which is not enabled here.
+     */
+    @Test
+    void imageCodecsAvailableWithoutTheGwcWmsService() {
+        runner.run(context -> assertThat(context)
+                .hasNotFailed()
+                .hasBean("gwcFacade")
+                .hasBean("coalescedRequestSplitter")
+                .hasBean("decoderContainer")
+                .hasBean("encoderContainer")
+                .hasBean("PNGDecoder")
+                .hasBean("PNGEncoder")
+                .doesNotHaveBean("gwcServiceWMSTarget"));
+    }
+
     @Test
     void contextLoads() {
         runner.run(context -> {

--- a/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/service/GwcWMSServiceAutoConfigurationTest.java
+++ b/src/gwc/autoconfigure/src/test/java/org/geoserver/cloud/autoconfigure/gwc/service/GwcWMSServiceAutoConfigurationTest.java
@@ -1,0 +1,51 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.autoconfigure.gwc.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import org.geoserver.cloud.autoconfigure.gwc.GeoWebCacheContextRunner;
+import org.geowebcache.io.codec.ImageDecoderContainer;
+import org.geowebcache.io.codec.ImageEncoderContainer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+
+/** @since 3.1 */
+class GwcWMSServiceAutoConfigurationTest {
+
+    @TempDir
+    File tmpDir;
+
+    WebApplicationContextRunner runner;
+
+    @BeforeEach
+    void setUp() {
+        runner = GeoWebCacheContextRunner.newMinimalGeoWebCacheContextRunner(tmpDir)
+                .withConfiguration(AutoConfigurations.of(GwcWMSServiceAutoConfiguration.class));
+    }
+
+    @Test
+    void disabledByDefault() {
+        runner.run(context -> assertThat(context).hasNotFailed().doesNotHaveBean("gwcServiceWMSTarget"));
+    }
+
+    /**
+     * The image codec beans upstream declares along with this service come from {@code GwcImageCodecsConfiguration}
+     * instead, since GeoWebCache needs them either way.
+     */
+    @Test
+    void enabledKeepsASingleImageCodecSet() {
+        runner.withPropertyValues("gwc.services.wms=true").run(context -> assertThat(context)
+                .hasNotFailed()
+                .hasBean("gwcServiceWMSTarget")
+                .hasSingleBean(ImageDecoderContainer.class)
+                .hasSingleBean(ImageEncoderContainer.class));
+    }
+}

--- a/src/main/src/main/java/org/geoserver/cloud/autoconfigure/geotools/SpringEnvironmentAwareGeoToolsHttpClient.java
+++ b/src/main/src/main/java/org/geoserver/cloud/autoconfigure/geotools/SpringEnvironmentAwareGeoToolsHttpClient.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import java.util.zip.GZIPInputStream;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hc.client5.http.auth.AuthCache;
@@ -403,16 +402,14 @@ class SpringEnvironmentAwareGeoToolsHttpClient extends org.geotools.http.Abstrac
             return responseHeader == null ? null : responseHeader.getValue();
         }
 
+        /**
+         * Returns the entity content as is, already decoded: Apache HttpClient decompresses it, and since 5.6 it leaves
+         * {@code Content-Encoding} on the response, which would make decompressing here a second pass over plain bytes.
+         */
         @Override
         public InputStream getResponseStream() throws IOException {
             if (responseBodyAsStream == null) {
                 responseBodyAsStream = methodResponse.getEntity().getContent();
-                // commons httpclient does not handle gzip encoding automatically, we have to check
-                // ourselves: https://issues.apache.org/jira/browse/HTTPCLIENT-816
-                Header header = methodResponse.getFirstHeader("Content-Encoding");
-                if (header != null && "gzip".equals(header.getValue())) {
-                    responseBodyAsStream = new GZIPInputStream(responseBodyAsStream);
-                }
             }
             return responseBodyAsStream;
         }

--- a/src/main/src/test/java/org/geoserver/cloud/autoconfigure/geotools/SpringEnvironmentAwareGeoToolsHttpClientTest.java
+++ b/src/main/src/test/java/org/geoserver/cloud/autoconfigure/geotools/SpringEnvironmentAwareGeoToolsHttpClientTest.java
@@ -1,0 +1,98 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.geotools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPOutputStream;
+import org.geotools.http.HTTPResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the response body reaches callers decoded, the way GeoTools' {@code MultithreadedHttpClient} this class is a
+ * copy of delivers it, whether or not the origin compresses it.
+ */
+class SpringEnvironmentAwareGeoToolsHttpClientTest {
+
+    private static final String PAYLOAD = "<WMS_Capabilities version=\"1.3.0\"/>";
+
+    private HttpServer server;
+
+    private SpringEnvironmentAwareGeoToolsHttpClient client;
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        server.createContext("/plain", exchange -> respond(exchange, PAYLOAD.getBytes(StandardCharsets.UTF_8), false));
+        server.createContext("/gzipped", exchange -> respond(exchange, gzip(PAYLOAD), true));
+        server.start();
+        client = new SpringEnvironmentAwareGeoToolsHttpClient(new GeoToolsHttpClientProxyConfigurationProperties());
+    }
+
+    @AfterEach
+    void stopServer() {
+        client.close();
+        server.stop(0);
+    }
+
+    @Test
+    void plainResponseIsReadableAsIs() throws IOException {
+        assertThat(body("/plain")).isEqualTo(PAYLOAD);
+    }
+
+    /**
+     * Apache HttpClient decompresses the entity on its own, and since 5.6 leaves {@code Content-Encoding} on the
+     * response, which used to be the signal to decompress it a second time.
+     */
+    @Test
+    void gzippedResponseIsDecodedOnce() throws IOException {
+        assertThat(body("/gzipped")).isEqualTo(PAYLOAD);
+    }
+
+    private String body(String path) throws IOException {
+        URL url = URI.create("http://%s:%d%s"
+                        .formatted(
+                                server.getAddress().getHostString(),
+                                server.getAddress().getPort(),
+                                path))
+                .toURL();
+        HTTPResponse response = client.get(url);
+        try (InputStream in = response.getResponseStream()) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } finally {
+            response.dispose();
+        }
+    }
+
+    private static void respond(HttpExchange exchange, byte[] body, boolean gzipped) throws IOException {
+        if (gzipped) {
+            exchange.getResponseHeaders().add("Content-Encoding", "gzip");
+        }
+        exchange.getResponseHeaders().add("Content-Type", "text/xml");
+        exchange.sendResponseHeaders(200, body.length);
+        exchange.getResponseBody().write(body);
+        exchange.close();
+    }
+
+    private static byte[] gzip(String content) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(bytes)) {
+            gzip.write(content.getBytes(StandardCharsets.UTF_8));
+        }
+        return bytes.toByteArray();
+    }
+}

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -26,9 +26,9 @@
     <spring-cloud.version>2025.1.2</spring-cloud.version>
     <spring-boot.version>4.0.7</spring-boot.version>
     <!-- match upstream geoserver dependencies -->
-    <spring.version>7.0.8</spring.version>
-    <spring.security.version>7.1.0</spring.security.version>
-    <spring-integration.version>7.1.0</spring-integration.version>
+    <spring.version>7.0.9</spring.version>
+    <spring.security.version>7.1.1</spring.security.version>
+    <spring-integration.version>7.1.1</spring-integration.version>
     <!-- spring-integration 7.1.0 requires spring-amqp 4.1.x (MessageListenerContainer moved to the core
          package); keep it aligned instead of letting spring-boot-dependencies pin the older 4.0.x -->
     <spring-amqp.version>4.1.0</spring-amqp.version>
@@ -39,8 +39,8 @@
     <acl.version>3.0.1</acl.version>
     <cloud-dependencies-bom.version>1.0.2</cloud-dependencies-bom.version>
     <tileverse-geoserver.version>3.0-SNAPSHOT</tileverse-geoserver.version>
-    <jackson.version>3.1.2</jackson.version>
-    <jackson2.version>2.21.0</jackson2.version>
+    <jackson.version>3.2.2</jackson.version>
+    <jackson2.version>2.22.2</jackson2.version>
 
     <!-- default target java version, submodules may override -->
     <java.version>25</java.version>
@@ -48,8 +48,8 @@
     <java.sdk.version>25</java.sdk.version>
 
     <!-- dependency versions -->
-    <postgresql.version>42.7.7</postgresql.version>
-    <httpclient5.version>5.4.4</httpclient5.version>
+    <postgresql.version>42.7.13</postgresql.version>
+    <httpclient5.version>5.6.3</httpclient5.version>
     <lombok.version>1.18.42</lombok.version>
     <mapstruct.version>1.6.3</mapstruct.version>
     <flyway.version>12.1.0</flyway.version>
@@ -1146,49 +1146,66 @@
           </dependency>
           <dependency>
             <!--
-[ERROR] +-org.geoserver.cloud.apps:gs-cloud-webui:jar:3.0.0-SNAPSHOT
-[ERROR]   +-org.geoserver.web:gs-web-core:jar:3.0.0-CLOUD-SNAPSHOT:compile
-[ERROR]     +-joda-time:joda-time:jar:2.8.1:compile
-[ERROR] and
-[ERROR] +-org.geoserver.cloud.apps:gs-cloud-webui:jar:3.0.0-SNAPSHOT
-[ERROR]   +-org.geoserver.cloud.gwc:gwc-cloud-spring-boot-starter:jar:3.0.0-SNAPSHOT:compile
-[ERROR]     +-org.geoserver.cloud.gwc:gwc-cloud-spring-boot-autoconfigure:jar:3.0.0-SNAPSHOT:compile
-[ERROR]       +-org.geoserver.cloud.gwc:gwc-cloud-blobstores:jar:3.0.0-SNAPSHOT:compile
-[ERROR]         +-org.geoserver.extension:gs-gwc-s3:jar:3.0.0-CLOUD-SNAPSHOT:compile
-[ERROR]           +-org.geowebcache:gwc-aws-s3:jar:2.0-SNAPSHOT:compile
+[ERROR] +-org.geoserver.cloud.apps:gs-cloud-wms:jar:3.1.0-SNAPSHOT
+[ERROR]   +-org.geoserver.cloud.gwc:gwc-cloud-spring-boot-starter:jar:3.1.0-SNAPSHOT:compile
+[ERROR]     +-org.geoserver.cloud.gwc:gwc-cloud-spring-boot-autoconfigure:jar:3.1.0-SNAPSHOT:compile
+[ERROR]       +-org.geoserver.cloud.gwc:gwc-cloud-blobstores:jar:3.1.0-SNAPSHOT:compile
+[ERROR]         +-org.geoserver.extension:gs-gwc-s3:jar:3.1.0-CLOUD-SNAPSHOT:compile
+[ERROR]           +-org.geowebcache:gwc-aws-s3:jar:2.1-SNAPSHOT:compile
 [ERROR]             +-com.amazonaws:aws-java-sdk-s3:jar:1.12.797:compile
 [ERROR]               +-com.amazonaws:aws-java-sdk-core:jar:1.12.797:compile
 [ERROR]                 +-joda-time:joda-time:jar:2.12.7:compile
 [ERROR] and
-[ERROR] +-org.geoserver.cloud.apps:gs-cloud-webui:jar:3.0.0-SNAPSHOT
-[ERROR]   +-org.geoserver.cloud:gs-cloud-spring-cloud-starter:jar:3.0.0-SNAPSHOT:compile
+[ERROR] +-org.geoserver.cloud.apps:gs-cloud-wms:jar:3.1.0-SNAPSHOT
+[ERROR]   +-org.geoserver.cloud:gs-cloud-spring-cloud-starter:jar:3.1.0-SNAPSHOT:compile
 [ERROR]     +-org.springframework.cloud:spring-cloud-starter-bus-amqp:jar:5.0.2:compile
 [ERROR]       +-org.springframework.cloud:spring-cloud-starter-stream-rabbit:jar:5.0.2:compile
 [ERROR]         +-org.springframework.cloud:spring-cloud-stream-binder-rabbit:jar:5.0.2:compile
 [ERROR]           +-org.springframework.cloud:spring-cloud-function-context:jar:5.0.3:compile
-[ERROR]             +-tools.jackson.datatype:jackson-datatype-joda:jar:3.1.2:compile
-[ERROR]               +-joda-time:joda-time:jar:2.12.7:compile
+[ERROR]             +-tools.jackson.datatype:jackson-datatype-joda:jar:3.2.2:compile
+[ERROR]               +-joda-time:joda-time:jar:2.14.1:compile
 -->
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.12.7</version>
+            <version>2.14.1</version>
           </dependency>
           <dependency>
             <!--
-[ERROR] +-org.geoserver.cloud:gs-cloud-starter-extensions:jar:3.0.0-SNAPSHOT
-[ERROR]   +-org.geoserver.cloud:gs-cloud-starter-security:jar:3.0.0-SNAPSHOT:compile
-[ERROR]     +-org.geoserver.cloud.extensions:gs-cloud-extension-security-auth-key:jar:3.0.0-SNAPSHOT:compile
-[ERROR]       +-org.geoserver.extension:gs-authkey:jar:3.0.0-CLOUD-SNAPSHOT:compile
+[ERROR] +-org.geoserver.cloud:gs-cloud-starter-extensions:jar:3.1.0-SNAPSHOT
+[ERROR]   +-org.geoserver.cloud:gs-cloud-starter-security:jar:3.1.0-SNAPSHOT:compile
+[ERROR]     +-org.geoserver.cloud.extensions:gs-cloud-extension-security-auth-key:jar:3.1.0-SNAPSHOT:compile
+[ERROR]       +-org.geoserver.extension:gs-authkey:jar:3.1.0-CLOUD-SNAPSHOT:compile
 [ERROR]         +-net.minidev:json-smart:jar:2.6.0:compile
 [ERROR]           +-net.minidev:accessors-smart:jar:2.6.0:compile
 [ERROR]             +-org.ow2.asm:asm:jar:9.7.1:compile
 [ERROR] and
-[ERROR] +-org.geoserver.cloud:gs-cloud-starter-extensions:jar:3.0.0-SNAPSHOT
-[ERROR]   +-org.geoserver.cloud.extensions:gs-cloud-extension-css-styling:jar:3.0.0-SNAPSHOT:compile
-[ERROR]     +-org.geoserver.extension:gs-css:jar:3.0.0-CLOUD-SNAPSHOT:compile
-[ERROR]       +-org.geotools:gt-css:jar:35-SNAPSHOT:compile
+[ERROR] +-org.geoserver.cloud:gs-cloud-starter-extensions:jar:3.1.0-SNAPSHOT
+[ERROR]   +-org.geoserver.cloud.extensions:gs-cloud-extension-css-styling:jar:3.1.0-SNAPSHOT:compile
+[ERROR]     +-org.geoserver.extension:gs-css:jar:3.1.0-CLOUD-SNAPSHOT:compile
+[ERROR]       +-org.geotools:gt-css:jar:36-SNAPSHOT:compile
 [ERROR]         +-org.parboiled:parboiled-java:jar:1.4.1:compile
 [ERROR]           +-org.ow2.asm:asm:jar:9.2:compile
+[ERROR] and
+[ERROR] +-org.geoserver.cloud:gs-cloud-starter-extensions:jar:3.1.0-SNAPSHOT
+[ERROR]   +-org.geoserver.cloud.extensions:gs-cloud-extension-css-styling:jar:3.1.0-SNAPSHOT:compile
+[ERROR]     +-org.geoserver.extension:gs-css:jar:3.1.0-CLOUD-SNAPSHOT:compile
+[ERROR]       +-org.geotools:gt-css:jar:36-SNAPSHOT:compile
+[ERROR]         +-org.parboiled:parboiled-java:jar:1.4.1:compile
+[ERROR]           +-org.ow2.asm:asm-tree:jar:9.2:compile
+[ERROR]             +-org.ow2.asm:asm:jar:9.2:compile
+[ERROR] and
+[ERROR] +-org.geoserver.cloud:gs-cloud-starter-extensions:jar:3.1.0-SNAPSHOT
+[ERROR]   +-org.geoserver.cloud.extensions:gs-cloud-extension-css-styling:jar:3.1.0-SNAPSHOT:compile
+[ERROR]     +-org.geoserver.extension:gs-css:jar:3.1.0-CLOUD-SNAPSHOT:compile
+[ERROR]       +-org.geotools:gt-css:jar:36-SNAPSHOT:compile
+[ERROR]         +-org.parboiled:parboiled-java:jar:1.4.1:compile
+[ERROR]           +-org.ow2.asm:asm-util:jar:9.2:compile
+[ERROR]             +-org.ow2.asm:asm:jar:9.2:compile
+[ERROR] and
+[ERROR] +-org.geoserver.cloud:gs-cloud-starter-extensions:jar:3.1.0-SNAPSHOT
+[ERROR]   +-org.geoserver.cloud.extensions:gs-cloud-extension-css-styling:jar:3.1.0-SNAPSHOT:compile
+[ERROR]     +-org.geoserver.extension:gs-css:jar:3.1.0-CLOUD-SNAPSHOT:compile
+[ERROR]       +-org.ow2.asm:asm:jar:9.2:compile
 -->
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
@@ -1196,37 +1213,70 @@
           </dependency>
           <dependency>
             <!--
-[ERROR] +-org.geoserver.cloud.gwc:gwc-cloud-blobstores:jar:3.0.0-SNAPSHOT
-[ERROR]   +-org.geoserver.cloud.gwc:gwc-cloud-core:jar:3.0.0-SNAPSHOT:compile
-[ERROR]     +-org.geoserver:gs-gwc:jar:3.0.0-SNAPSHOT:compile
-[ERROR]       +-org.geoserver:gs-main:jar:3.0.0-SNAPSHOT:compile
-[ERROR]         +-org.geoserver:gs-ows:jar:3.0.0-SNAPSHOT:compile
-[ERROR]           +-tools.jackson.dataformat:jackson-dataformat-xml:jar:3.1.0:compile
-[ERROR]             +-com.fasterxml.woodstox:woodstox-core:jar:7.1.1:compile
+[ERROR] +-org.geoserver.cloud.extensions:gs-cloud-extension-ogcapi-core:jar:3.1.0-SNAPSHOT
+[ERROR]   +-org.geoserver.extension:gs-ogcapi-core:jar:3.1.0-CLOUD-SNAPSHOT:compile
+[ERROR]     +-tools.jackson.dataformat:jackson-dataformat-xml:jar:3.2.2:compile
+[ERROR]       +-com.fasterxml.woodstox:woodstox-core:jar:7.2.1:compile
 [ERROR] and
-[ERROR] +-org.geoserver.cloud.gwc:gwc-cloud-blobstores:jar:3.0.0-SNAPSHOT
-[ERROR]   +-org.geoserver.community:gs-gwc-gcs-blob:jar:3.0.0-SNAPSHOT:compile
-[ERROR]     +-org.geowebcache:gwc-gcs-blob:jar:2.0-SNAPSHOT:compile
-[ERROR]       +-com.google.cloud:google-cloud-storage:jar:2.63.0:compile
-[ERROR]         +-com.fasterxml.woodstox:woodstox-core:jar:7.0.0:compile
+[ERROR] +-org.geoserver.cloud.extensions:gs-cloud-extension-ogcapi-core:jar:3.1.0-SNAPSHOT
+[ERROR]   +-org.geoserver.extension:gs-ogcapi-core:jar:3.1.0-CLOUD-SNAPSHOT:compile
+[ERROR]     +-com.fasterxml.woodstox:woodstox-core:jar:7.2.2:compile
 -->
             <groupId>com.fasterxml.woodstox</groupId>
             <artifactId>woodstox-core</artifactId>
-            <version>7.1.1</version>
+            <version>7.2.2</version>
           </dependency>
           <dependency>
             <!--
-[ERROR] +-org.geoserver.cloud:gs-cloud-starter-extensions:jar:3.0.0-SNAPSHOT
-[ERROR]   +-org.geoserver.cloud:gs-cloud-starter-input-formats:jar:3.0.0-SNAPSHOT:compile
-[ERROR]     +-org.geoserver.cloud.extensions:gs-cloud-extension-vector-formats:jar:3.0.0-SNAPSHOT:compile
-[ERROR]       +-org.geoserver.community:gs-pmtiles-store:jar:3.0.0-SNAPSHOT:compile
-[ERROR]         +-org.geotools:gt-pmtiles:jar:35-SNAPSHOT:compile
-[ERROR]           +-io.tileverse.pmtiles:tileverse-pmtiles:jar:1.3.3:compile
+[ERROR] +-org.geoserver.cloud.gwc:gwc-cloud-blobstores:jar:3.1.0-SNAPSHOT
+[ERROR]   +-org.geoserver.cloud.gwc:gwc-cloud-core:jar:3.1.0-SNAPSHOT:compile
+[ERROR]     +-org.geoserver:gs-gwc:jar:3.1.0-CLOUD-SNAPSHOT:compile
+[ERROR]       +-org.geoserver:gs-main:jar:3.1.0-CLOUD-SNAPSHOT:compile
+[ERROR]         +-org.geoserver:gs-ows:jar:3.1.0-CLOUD-SNAPSHOT:compile
+[ERROR]           +-tools.jackson.dataformat:jackson-dataformat-xml:jar:3.2.2:compile
+[ERROR]             +-org.codehaus.woodstox:stax2-api:jar:4.3.0:compile
+[ERROR] and
+[ERROR] +-org.geoserver.cloud.gwc:gwc-cloud-blobstores:jar:3.1.0-SNAPSHOT
+[ERROR]   +-org.geoserver.community:gs-gwc-gcs-blob:jar:3.1.0-CLOUD-SNAPSHOT:compile
+[ERROR]     +-org.geowebcache:gwc-gcs-blob:jar:2.1-SNAPSHOT:compile
+[ERROR]       +-com.google.cloud:google-cloud-storage:jar:2.67.0:compile
+[ERROR]         +-org.codehaus.woodstox:stax2-api:jar:4.2.2:compile
+-->
+            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>stax2-api</artifactId>
+            <version>4.3.0</version>
+          </dependency>
+          <dependency>
+            <!--
+[ERROR] +-org.geoserver.cloud:gs-cloud-starter-extensions:jar:3.1.0-SNAPSHOT
+[ERROR]   +-org.geoserver.cloud:gs-cloud-starter-input-formats:jar:3.1.0-SNAPSHOT:compile
+[ERROR]     +-org.geoserver.cloud.extensions:gs-cloud-extension-vector-formats:jar:3.1.0-SNAPSHOT:compile
+[ERROR]       +-org.geoserver.community:gs-pmtiles-store:jar:3.1.0-CLOUD-SNAPSHOT:compile
+[ERROR]         +-org.geotools:gt-pmtiles:jar:36-SNAPSHOT:compile
+[ERROR]           +-io.tileverse.pmtiles:tileverse-pmtiles:jar:2.1-M1:compile
 [ERROR]             +-org.apache.commons:commons-compress:jar:1.28.0:compile
 [ERROR] and
-[ERROR] +-org.geoserver.cloud:gs-cloud-starter-extensions:jar:3.0.0-SNAPSHOT
-[ERROR]   +-org.geoserver.cloud.extensions:gs-cloud-extension-importer:jar:3.0.0-SNAPSHOT:compile
-[ERROR]     +-org.geoserver.importer:gs-importer-core:jar:3.0.0-SNAPSHOT:compile
+[ERROR] +-org.geoserver.cloud:gs-cloud-starter-extensions:jar:3.1.0-SNAPSHOT
+[ERROR]   +-org.geoserver.cloud.extensions:gs-cloud-extension-parquetry:jar:3.1.0-SNAPSHOT:compile
+[ERROR]     +-io.tileverse.geoserver:tileverse-geoserver-parquetry:jar:3.1-SNAPSHOT:compile
+[ERROR]       +-io.tileverse.parquetry:parquetry-geotools:jar:1.0-RC3:compile
+[ERROR]         +-io.tileverse.parquetry:parquetry-core:jar:1.0-RC3:compile
+[ERROR]           +-io.tileverse.parquetry:parquetry-compression:jar:1.0-RC3:compile
+[ERROR]             +-org.apache.commons:commons-compress:jar:1.27.1:compile
+[ERROR] and
+[ERROR] +-org.geoserver.cloud:gs-cloud-starter-extensions:jar:3.1.0-SNAPSHOT
+[ERROR]   +-org.geoserver.cloud.extensions:gs-cloud-extension-importer:jar:3.1.0-SNAPSHOT:compile
+[ERROR]     +-org.geoserver.importer:gs-importer-core:jar:3.1.0-CLOUD-SNAPSHOT:compile
+[ERROR]       +-org.apache.commons:commons-compress:jar:1.26.1:compile
+[ERROR] and
+[ERROR] +-org.geoserver.cloud:gs-cloud-starter-extensions:jar:3.1.0-SNAPSHOT
+[ERROR]   +-org.geoserver.cloud.extensions:gs-cloud-extension-importer:jar:3.1.0-SNAPSHOT:compile
+[ERROR]     +-org.geoserver.importer:gs-importer-web:jar:3.1.0-CLOUD-SNAPSHOT:compile
+[ERROR]       +-org.apache.commons:commons-compress:jar:1.26.1:compile
+[ERROR] and
+[ERROR] +-org.geoserver.cloud:gs-cloud-starter-extensions:jar:3.1.0-SNAPSHOT
+[ERROR]   +-org.geoserver.cloud.extensions:gs-cloud-extension-importer:jar:3.1.0-SNAPSHOT:compile
+[ERROR]     +-org.geoserver.importer:gs-importer-rest:jar:3.1.0-CLOUD-SNAPSHOT:compile
 [ERROR]       +-org.apache.commons:commons-compress:jar:1.26.1:compile
             -->
             <groupId>org.apache.commons</groupId>
@@ -1235,16 +1285,25 @@
           </dependency>
           <dependency>
             <!--
-[ERROR] +-org.geoserver.cloud.extensions:gs-cloud-extension-raster-formats:jar:3.0.0-SNAPSHOT
-[ERROR]   +-org.geoserver.web:gs-web-core:jar:3.0.0-CLOUD-SNAPSHOT:provided
-[ERROR]     +-org.wicketstuff:wicketstuff-select2:jar:10.9.2:provided
+[ERROR] +-org.geoserver.cloud.extensions:gs-cloud-extension-raster-formats:jar:3.1.0-SNAPSHOT
+[ERROR]   +-org.geoserver.web:gs-web-core:jar:3.1.0-CLOUD-SNAPSHOT:provided
+[ERROR]     +-org.apache.wicket:wicket-core:jar:10.10.0:provided
+[ERROR] and
+[ERROR] +-org.geoserver.cloud.extensions:gs-cloud-extension-raster-formats:jar:3.1.0-SNAPSHOT
+[ERROR]   +-org.geoserver.web:gs-web-core:jar:3.1.0-CLOUD-SNAPSHOT:provided
+[ERROR]     +-org.apache.wicket:wicket-extensions:jar:10.10.0:provided
+[ERROR]       +-org.apache.wicket:wicket-core:jar:10.10.0:provided
+[ERROR] and
+[ERROR] +-org.geoserver.cloud.extensions:gs-cloud-extension-raster-formats:jar:3.1.0-SNAPSHOT
+[ERROR]   +-org.geoserver.web:gs-web-core:jar:3.1.0-CLOUD-SNAPSHOT:provided
+[ERROR]     +-org.wicketstuff:wicketstuff-select2:jar:10.10.0:provided
 [ERROR]       +-de.agilecoders.wicket.webjars:wicket-webjars:jar:4.0.14:provided
 [ERROR]         +-org.apache.wicket:wicket-core:jar:10.8.0:provided
 [ERROR] and
-[ERROR] +-org.geoserver.cloud.extensions:gs-cloud-extension-raster-formats:jar:3.0.0-SNAPSHOT
-[ERROR]   +-org.geoserver.web:gs-web-core:jar:3.0.0-CLOUD-SNAPSHOT:provided
-[ERROR]     +-org.wicketstuff:wicketstuff-select2:jar:10.9.2:provided
-[ERROR]       +-org.apache.wicket:wicket-core:jar:10.9.1:provided
+[ERROR] +-org.geoserver.cloud.extensions:gs-cloud-extension-raster-formats:jar:3.1.0-SNAPSHOT
+[ERROR]   +-org.geoserver.web:gs-web-core:jar:3.1.0-CLOUD-SNAPSHOT:provided
+[ERROR]     +-org.wicketstuff:wicketstuff-select2:jar:10.10.0:provided
+[ERROR]       +-org.apache.wicket:wicket-core:jar:10.10.0:provided
 -->
             <groupId>org.apache.wicket</groupId>
             <artifactId>wicket-core</artifactId>


### PR DESCRIPTION
Upgrade geoserver submodule to latest GeoServer 3.0.x

Align dependency versions with the 3.0.x upstream and update the geoserver submodule pointer.

The GWC mediator is now built with a coalesced request splitter that needs the image codec beans upstream declares along with the GWC WMS service. Contribute them from the always-on GeoServer integration configuration instead, and exclude them from the WMS service import to keep a single definition site.

on-behalf-of: @camptocamp <info@camptocamp.com>