### PR TITLE
Extract layered jars with the tools jarmode in the image builds

### DIFF
--- a/src/apps/base-images/geoserver/Dockerfile
+++ b/src/apps/base-images/geoserver/Dockerfile
@@ -6,7 +6,9 @@ ARG JAR_FILE=target/gs-cloud-*-bin.jar
 WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
-RUN java -Djarmode=layertools -jar application.jar extract
+# --layers takes one comma-separated list, and the destination must be an empty directory of its own
+RUN java -Djarmode=tools -jar application.jar extract --launcher --destination extracted \
+ --layers dependencies,spring-boot-loader,snapshot-dependencies,application
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-spring-boot:$TAG
@@ -59,12 +61,12 @@ RUN cat > /etc/fonts/conf.d/05-additional-fonts.conf <<'EOF'
 EOF
 
 WORKDIR /opt/app/bin
-COPY --from=builder /builder/dependencies/ ./
-COPY --from=builder /builder/snapshot-dependencies/ ./
-COPY --from=builder /builder/spring-boot-loader/ ./
+COPY --from=builder /builder/extracted/dependencies/ ./
+COPY --from=builder /builder/extracted/snapshot-dependencies/ ./
+COPY --from=builder /builder/extracted/spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder /builder/application/ ./
+COPY --from=builder /builder/extracted/application/ ./
 
 # -----------------------------------------------------
 # Pre-install DuckDB extensions in the base image to create a shared layer for all GeoServer microservices

--- a/src/apps/base-images/spring-boot/Dockerfile
+++ b/src/apps/base-images/spring-boot/Dockerfile
@@ -9,7 +9,9 @@ WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
 
-RUN java -Djarmode=layertools -jar application.jar extract
+# --layers takes one comma-separated list, and the destination must be an empty directory of its own
+RUN java -Djarmode=tools -jar application.jar extract --launcher --destination extracted \
+ --layers dependencies,spring-boot-loader,snapshot-dependencies,application
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-jre:$TAG
@@ -40,13 +42,13 @@ WORKDIR /opt/app/bin
 EXPOSE 8080
 EXPOSE 8081
 
-COPY --from=builder /builder/dependencies/ ./
+COPY --from=builder /builder/extracted/dependencies/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder /builder/snapshot-dependencies/ ./
+COPY --from=builder /builder/extracted/snapshot-dependencies/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder /builder/spring-boot-loader/ ./
+COPY --from=builder /builder/extracted/spring-boot-loader/ ./
 
 HEALTHCHECK \
 --interval=10s \

--- a/src/apps/geoserver/gwc/Dockerfile
+++ b/src/apps/geoserver/gwc/Dockerfile
@@ -9,19 +9,21 @@ WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
 
-RUN java -Djarmode=layertools -jar application.jar extract
+# --layers takes one comma-separated list, and the destination must be an empty directory of its own
+RUN java -Djarmode=tools -jar application.jar extract --launcher --destination extracted \
+ --layers dependencies,spring-boot-loader,snapshot-dependencies,application
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-geoserver-image:$TAG
 
 # WORKDIR already set to /opt/app/bin
 
-COPY --from=builder /builder/dependencies/ ./
-COPY --from=builder /builder/snapshot-dependencies/ ./
-COPY --from=builder /builder/spring-boot-loader/ ./
+COPY --from=builder /builder/extracted/dependencies/ ./
+COPY --from=builder /builder/extracted/snapshot-dependencies/ ./
+COPY --from=builder /builder/extracted/spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder /builder/application/ ./
+COPY --from=builder /builder/extracted/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
 RUN export GEOSERVER_DATA_DIR=/tmp/datadir && \

--- a/src/apps/geoserver/restconfig/Dockerfile
+++ b/src/apps/geoserver/restconfig/Dockerfile
@@ -9,19 +9,21 @@ WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
 
-RUN java -Djarmode=layertools -jar application.jar extract
+# --layers takes one comma-separated list, and the destination must be an empty directory of its own
+RUN java -Djarmode=tools -jar application.jar extract --launcher --destination extracted \
+ --layers dependencies,spring-boot-loader,snapshot-dependencies,application
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-geoserver-image:$TAG
 
 # WORKDIR already set to /opt/app/bin
 
-COPY --from=builder /builder/dependencies/ ./
-COPY --from=builder /builder/snapshot-dependencies/ ./
-COPY --from=builder /builder/spring-boot-loader/ ./
+COPY --from=builder /builder/extracted/dependencies/ ./
+COPY --from=builder /builder/extracted/snapshot-dependencies/ ./
+COPY --from=builder /builder/extracted/spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder /builder/application/ ./
+COPY --from=builder /builder/extracted/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
 RUN export GEOSERVER_DATA_DIR=/tmp/datadir && \

--- a/src/apps/geoserver/wcs/Dockerfile
+++ b/src/apps/geoserver/wcs/Dockerfile
@@ -9,19 +9,21 @@ WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
 
-RUN java -Djarmode=layertools -jar application.jar extract
+# --layers takes one comma-separated list, and the destination must be an empty directory of its own
+RUN java -Djarmode=tools -jar application.jar extract --launcher --destination extracted \
+ --layers dependencies,spring-boot-loader,snapshot-dependencies,application
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-geoserver-image:$TAG
 
 # WORKDIR already set to /opt/app/bin
 
-COPY --from=builder /builder/dependencies/ ./
-COPY --from=builder /builder/snapshot-dependencies/ ./
-COPY --from=builder /builder/spring-boot-loader/ ./
+COPY --from=builder /builder/extracted/dependencies/ ./
+COPY --from=builder /builder/extracted/snapshot-dependencies/ ./
+COPY --from=builder /builder/extracted/spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder /builder/application/ ./
+COPY --from=builder /builder/extracted/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
 RUN export GEOSERVER_DATA_DIR=/tmp/datadir && \

--- a/src/apps/geoserver/webui/Dockerfile
+++ b/src/apps/geoserver/webui/Dockerfile
@@ -9,19 +9,21 @@ WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
 
-RUN java -Djarmode=layertools -jar application.jar extract
+# --layers takes one comma-separated list, and the destination must be an empty directory of its own
+RUN java -Djarmode=tools -jar application.jar extract --launcher --destination extracted \
+ --layers dependencies,spring-boot-loader,snapshot-dependencies,application
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-geoserver-image:$TAG
 
 # WORKDIR already set to /opt/app/bin
 
-COPY --from=builder /builder/dependencies/ ./
-COPY --from=builder /builder/snapshot-dependencies/ ./
-COPY --from=builder /builder/spring-boot-loader/ ./
+COPY --from=builder /builder/extracted/dependencies/ ./
+COPY --from=builder /builder/extracted/snapshot-dependencies/ ./
+COPY --from=builder /builder/extracted/spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder /builder/application/ ./
+COPY --from=builder /builder/extracted/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
 RUN export GEOSERVER_DATA_DIR=/tmp/datadir && \

--- a/src/apps/geoserver/wfs/Dockerfile
+++ b/src/apps/geoserver/wfs/Dockerfile
@@ -9,19 +9,21 @@ WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
 
-RUN java -Djarmode=layertools -jar application.jar extract
+# --layers takes one comma-separated list, and the destination must be an empty directory of its own
+RUN java -Djarmode=tools -jar application.jar extract --launcher --destination extracted \
+ --layers dependencies,spring-boot-loader,snapshot-dependencies,application
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-geoserver-image:$TAG
 
 # WORKDIR already set to /opt/app/bin
 
-COPY --from=builder /builder/dependencies/ ./
-COPY --from=builder /builder/snapshot-dependencies/ ./
-COPY --from=builder /builder/spring-boot-loader/ ./
+COPY --from=builder /builder/extracted/dependencies/ ./
+COPY --from=builder /builder/extracted/snapshot-dependencies/ ./
+COPY --from=builder /builder/extracted/spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder /builder/application/ ./
+COPY --from=builder /builder/extracted/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
 RUN export GEOSERVER_DATA_DIR=/tmp/datadir && \

--- a/src/apps/geoserver/wms/Dockerfile
+++ b/src/apps/geoserver/wms/Dockerfile
@@ -9,19 +9,21 @@ WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
 
-RUN java -Djarmode=layertools -jar application.jar extract
+# --layers takes one comma-separated list, and the destination must be an empty directory of its own
+RUN java -Djarmode=tools -jar application.jar extract --launcher --destination extracted \
+ --layers dependencies,spring-boot-loader,snapshot-dependencies,application
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-geoserver-image:$TAG
 
 # WORKDIR already set to /opt/app/bin
 
-COPY --from=builder /builder/dependencies/ ./
-COPY --from=builder /builder/snapshot-dependencies/ ./
-COPY --from=builder /builder/spring-boot-loader/ ./
+COPY --from=builder /builder/extracted/dependencies/ ./
+COPY --from=builder /builder/extracted/snapshot-dependencies/ ./
+COPY --from=builder /builder/extracted/spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder /builder/application/ ./
+COPY --from=builder /builder/extracted/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
 RUN export GEOSERVER_DATA_DIR=/tmp/datadir && \

--- a/src/apps/geoserver/wps/Dockerfile
+++ b/src/apps/geoserver/wps/Dockerfile
@@ -9,19 +9,21 @@ WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
 
-RUN java -Djarmode=layertools -jar application.jar extract
+# --layers takes one comma-separated list, and the destination must be an empty directory of its own
+RUN java -Djarmode=tools -jar application.jar extract --launcher --destination extracted \
+ --layers dependencies,spring-boot-loader,snapshot-dependencies,application
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-geoserver-image:$TAG
 
 # WORKDIR already set to /opt/app/bin
 
-COPY --from=builder /builder/dependencies/ ./
-COPY --from=builder /builder/snapshot-dependencies/ ./
-COPY --from=builder /builder/spring-boot-loader/ ./
+COPY --from=builder /builder/extracted/dependencies/ ./
+COPY --from=builder /builder/extracted/snapshot-dependencies/ ./
+COPY --from=builder /builder/extracted/spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder /builder/application/ ./
+COPY --from=builder /builder/extracted/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
 RUN export GEOSERVER_DATA_DIR=/tmp/datadir && \

--- a/src/apps/infrastructure/config/Dockerfile
+++ b/src/apps/infrastructure/config/Dockerfile
@@ -8,19 +8,21 @@ WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
 
-RUN java -Djarmode=layertools -jar application.jar extract
+# --layers takes one comma-separated list, and the destination must be an empty directory of its own
+RUN java -Djarmode=tools -jar application.jar extract --launcher --destination extracted \
+ --layers dependencies,spring-boot-loader,snapshot-dependencies,application
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-spring-boot:$TAG
 
 # WORKDIR already set to /opt/app/bin
 
-COPY --from=builder /builder/dependencies/ ./
-COPY --from=builder /builder/snapshot-dependencies/ ./
-COPY --from=builder /builder/spring-boot-loader/ ./
+COPY --from=builder /builder/extracted/dependencies/ ./
+COPY --from=builder /builder/extracted/snapshot-dependencies/ ./
+COPY --from=builder /builder/extracted/spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder /builder/application/ ./
+COPY --from=builder /builder/extracted/application/ ./
 
 # Either 'git' or 'native'.
 ENV SPRING_PROFILES_ACTIVE=native,standalone

--- a/src/apps/infrastructure/gateway-webmvc/Dockerfile
+++ b/src/apps/infrastructure/gateway-webmvc/Dockerfile
@@ -8,18 +8,20 @@ WORKDIR /builder
 
 COPY ${JAR_FILE} application.jar
 
-RUN java -Djarmode=layertools -jar application.jar extract
+# --layers takes one comma-separated list, and the destination must be an empty directory of its own
+RUN java -Djarmode=tools -jar application.jar extract --launcher --destination extracted \
+ --layers dependencies,spring-boot-loader,snapshot-dependencies,application
 
 ##########
 FROM $REPOSITORY/gs-cloud-base-spring-boot:$TAG
 # WORKDIR already set to /opt/app/bin
 
-COPY --from=builder /builder/dependencies/ ./
-COPY --from=builder /builder/snapshot-dependencies/ ./
-COPY --from=builder /builder/spring-boot-loader/ ./
+COPY --from=builder /builder/extracted/dependencies/ ./
+COPY --from=builder /builder/extracted/snapshot-dependencies/ ./
+COPY --from=builder /builder/extracted/spring-boot-loader/ ./
 #see https://github.com/moby/moby/issues/37965
 RUN true
-COPY --from=builder /builder/application/ ./
+COPY --from=builder /builder/extracted/application/ ./
 
 # AOT training run for faster startup (each arch builds natively, no QEMU)
 RUN java -XX:AOTCacheOutput=app.aot \


### PR DESCRIPTION
In anticipation to upgrading to Spring Boot 4.1, where layertools is gone and every image build fails with "Unsupported jarmode 'layertools'".

The replacement accounts for three things the deprecation notice leaves out, each failing in its own way:

- the layer names come from the jar's `layers.idx` and are listed by `java -Djarmode=tools -jar application.jar list-layers`
- `--layers` as ONE comma-separated list. A space-separated one extracts the first layer and ignores the rest, producing an image with no dependencies
- an explicit destination directory. It defaults to a directory named after the jar, which nests everything under application/, and refuses to write into a non-empty directory such as the builder WORKDIR holding application.jar

`--launcher` keeps the `BOOT-INF` layout.

on-behalf-of: @camptocamp <info@camptocamp.com>

---

Fixes #791, supersedes pull requests #816 and #898, neither worked. 