### PR TITLE
Prevent "IllegalStateException: Recursive update" errors in pgconfig cache

### DIFF
--- a/src/catalog/cache/src/main/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeContainmentSupport.java
+++ b/src/catalog/cache/src/main/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeContainmentSupport.java
@@ -155,11 +155,31 @@ class CachingCatalogFacadeContainmentSupport {
         cache.put(key, value);
     }
 
+    /**
+     * The loader runs outside the cache's compute function: loading a {@link LayerGroupInfo} resolves its child groups
+     * and hence re-enters this method, which {@link Cache#get(Object, Callable)} does not allow.
+     */
+    @SuppressWarnings("unchecked")
     public <T> T get(Object key, Callable<T> loader) {
-        T value = cache.get(key, loader);
+        ValueWrapper cached = cache.get(key);
+        T value = null == cached ? load(loader) : (T) cached.get();
         if (null == value || (value instanceof Collection<?> c && c.isEmpty())) {
             cache.evict(key);
+        } else if (null == cached) {
+            put(key, value);
         }
+        return value;
+    }
+
+    /** As {@link #get get}, but caches null, meaning there is no such default. */
+    @SuppressWarnings("unchecked")
+    private <T> T getAllowingNull(Object key, Callable<T> loader) {
+        ValueWrapper cached = cache.get(key);
+        if (null != cached) {
+            return (T) cached.get();
+        }
+        T value = load(loader);
+        put(key, value);
         return value;
     }
 
@@ -214,7 +234,7 @@ class CachingCatalogFacadeContainmentSupport {
     }
 
     public WorkspaceInfo getDefaultWorkspace(Callable<WorkspaceInfo> loader) {
-        return cache.get(DEFAULT_WORKSPACE_CACHE_KEY, loader);
+        return getAllowingNull(DEFAULT_WORKSPACE_CACHE_KEY, loader);
     }
 
     public void evictDefaultWorkspace() {
@@ -224,7 +244,7 @@ class CachingCatalogFacadeContainmentSupport {
     }
 
     public NamespaceInfo getDefaultNamespace(Callable<NamespaceInfo> loader) {
-        return cache.get(DEFAULT_NAMESPACE_CACHE_KEY, loader);
+        return getAllowingNull(DEFAULT_NAMESPACE_CACHE_KEY, loader);
     }
 
     public void evictDefaultNamespace() {
@@ -234,7 +254,7 @@ class CachingCatalogFacadeContainmentSupport {
     }
 
     public DataStoreInfo getDefaultDataStore(WorkspaceInfo workspace, Callable<DataStoreInfo> loader) {
-        return cache.get(generateDefaultDataStoreKey(workspace.getId()), loader);
+        return getAllowingNull(generateDefaultDataStoreKey(workspace.getId()), loader);
     }
 
     public void evictDefaultDataStore(WorkspaceInfo ws) {

--- a/src/catalog/cache/src/main/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeContainmentSupport.java
+++ b/src/catalog/cache/src/main/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeContainmentSupport.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicLong;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;
@@ -55,6 +56,13 @@ class CachingCatalogFacadeContainmentSupport {
     private final @NonNull Cache cache;
 
     /**
+     * Loaders run outside the cache's atomic computation, so an eviction arriving while a load is in flight, as remote
+     * events do, finds nothing to remove. The epoch changes on every eviction, and a loaded value is only cached when
+     * the epoch is unchanged since the load started.
+     */
+    private final AtomicLong evictionEpoch = new AtomicLong();
+
+    /**
      * Cascade evicts cached {@link CatalogInfo} objects that directly or indirectly reference an object called to be
      * evicted
      */
@@ -76,6 +84,7 @@ class CachingCatalogFacadeContainmentSupport {
     }
 
     public void evictAll() {
+        evictionEpoch.incrementAndGet();
         cache.clear();
     }
 
@@ -118,10 +127,12 @@ class CachingCatalogFacadeContainmentSupport {
         }
         // regardless of the object being evicted or not, cascade evict any entry referencing it
         referenceCleaner.cascadeEvict(idKey);
+        evictionEpoch.incrementAndGet();
         return evicted;
     }
 
     boolean evict(Object key) {
+        evictionEpoch.incrementAndGet();
         boolean evicted = cache.evictIfPresent(key);
         if (evicted) {
             log.trace("evicted {}", key);
@@ -162,10 +173,13 @@ class CachingCatalogFacadeContainmentSupport {
     @SuppressWarnings("unchecked")
     public <T> T get(Object key, Callable<T> loader) {
         ValueWrapper cached = cache.get(key);
-        T value = null == cached ? load(loader) : (T) cached.get();
-        if (null == value || (value instanceof Collection<?> c && c.isEmpty())) {
-            cache.evict(key);
-        } else if (null == cached) {
+        if (null != cached) {
+            return (T) cached.get();
+        }
+        long epoch = evictionEpoch.get();
+        T value = load(loader);
+        boolean empty = null == value || (value instanceof Collection<?> c && c.isEmpty());
+        if (!empty && epoch == evictionEpoch.get()) {
             put(key, value);
         }
         return value;
@@ -178,8 +192,11 @@ class CachingCatalogFacadeContainmentSupport {
         if (null != cached) {
             return (T) cached.get();
         }
+        long epoch = evictionEpoch.get();
         T value = load(loader);
-        put(key, value);
+        if (epoch == evictionEpoch.get()) {
+            put(key, value);
+        }
         return value;
     }
 
@@ -204,8 +221,9 @@ class CachingCatalogFacadeContainmentSupport {
             T value = (T) cachedValue;
             return value;
         }
+        long epoch = evictionEpoch.get();
         T value = load(loader);
-        if (value != null && key.equals(InfoNameKey.valueOf(value))) {
+        if (value != null && key.equals(InfoNameKey.valueOf(value)) && epoch == evictionEpoch.get()) {
             put(key, value);
         }
         return value;
@@ -263,6 +281,7 @@ class CachingCatalogFacadeContainmentSupport {
 
     public void evictDefaultDataStore(String workspaceId, String name) {
         Object key = generateDefaultDataStoreKey(workspaceId);
+        evictionEpoch.incrementAndGet();
         if (cache.evictIfPresent(key)) {
             log.trace("evicted default datastore for workspace {}", name);
         }

--- a/src/catalog/cache/src/test/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeContainmentSupportTest.java
+++ b/src/catalog/cache/src/test/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeContainmentSupportTest.java
@@ -146,6 +146,28 @@ class CachingCatalogFacadeContainmentSupportTest {
     }
 
     @Test
+    @DisplayName("get() supports a loader that loads another entry, as nested layer groups do")
+    void testGetLoaderCanReenterTheCache() {
+        LayerGroupInfo group = stub(LayerGroupInfo.class, "Aa", "group");
+        LayerGroupInfo nested = stub(LayerGroupInfo.class, "BB", "nested");
+        InfoIdKey groupKey = InfoIdKey.valueOf(group);
+        InfoIdKey nestedKey = InfoIdKey.valueOf(nested);
+
+        // the ids collide, so both keys land in the same ConcurrentHashMap bin, where a nested load is
+        // rejected rather than merely being likely to be
+        assertThat(groupKey).hasSameHashCodeAs(nestedKey);
+
+        assertThat(support.get(groupKey, () -> {
+                    support.get(nestedKey, () -> nested);
+                    return group;
+                }))
+                .isSameAs(group);
+
+        assertCached(groupKey, group);
+        assertCached(nestedKey, nested);
+    }
+
+    @Test
     @DisplayName("getByName() caches when the requested key is the object's canonical name key")
     void testGetByNameCanonicalKeyIsCached() throws Exception {
         LayerInfo layer = stubReal(LayerInfo.class, "l1", "roads");

--- a/src/catalog/cache/src/test/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeContainmentSupportTest.java
+++ b/src/catalog/cache/src/test/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeContainmentSupportTest.java
@@ -168,6 +168,51 @@ class CachingCatalogFacadeContainmentSupportTest {
     }
 
     @Test
+    @DisplayName("get() does not cache a value loaded before a concurrent eviction of its key")
+    void testGetDoesNotCacheValueLoadedBeforeConcurrentEviction() {
+        WorkspaceInfo ws = stub(WorkspaceInfo.class);
+        InfoIdKey key = InfoIdKey.valueOf(ws);
+
+        // the loader stands for a load in flight when a remote event evicts the same key
+        WorkspaceInfo loaded = support.get(key, () -> {
+            support.evict(key.id(), "ws", key.type());
+            return ws;
+        });
+
+        assertThat(loaded).isSameAs(ws);
+        assertNotCached(key);
+    }
+
+    @Test
+    @DisplayName("getByName() does not cache a value loaded before a concurrent eviction of its key")
+    void testGetByNameDoesNotCacheValueLoadedBeforeConcurrentEviction() {
+        WorkspaceInfo ws = stubReal(WorkspaceInfo.class, "ws1", "ws");
+        InfoNameKey key = InfoNameKey.valueOf(ws);
+
+        WorkspaceInfo loaded = support.getByName(key, () -> {
+            support.evict(ws.getId(), key.prefixedName(), key.type());
+            return ws;
+        });
+
+        assertThat(loaded).isSameAs(ws);
+        assertNotCached(key);
+    }
+
+    @Test
+    @DisplayName("getDefaultWorkspace() does not cache a value loaded before a concurrent eviction")
+    void testGetDefaultWorkspaceDoesNotCacheValueLoadedBeforeConcurrentEviction() {
+        WorkspaceInfo ws = stub(WorkspaceInfo.class);
+
+        WorkspaceInfo loaded = support.getDefaultWorkspace(() -> {
+            support.evictDefaultWorkspace();
+            return ws;
+        });
+
+        assertThat(loaded).isSameAs(ws);
+        assertNotCached(DEFAULT_WORKSPACE_CACHE_KEY);
+    }
+
+    @Test
     @DisplayName("getByName() caches when the requested key is the object's canonical name key")
     void testGetByNameCanonicalKeyIsCached() throws Exception {
         LayerInfo layer = stubReal(LayerInfo.class, "l1", "roads");


### PR DESCRIPTION
Loading a nested `LayerGroupInfo` re-enters `CachingCatalogFacadeContainmentSupport.get()`, which `Cache.get(Object, Callable)` forbids: the backing `ConcurrentHashMap` throws 'IllegalStateException: Recursive update' when the nested key falls in the bin the outer load reserved, failing cascade layer deletes and layer group queries.

This is fixed if we run the loader outside the cache's compute function, as `getByName()` already does.