### PR TITLE
Add a pull request template adapted from upstream GeoServer

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+
+<!--Include a few sentences describing the overall goals for this Pull Request-->
+
+<!-- Please help our volunteers reviewing this PR by completing the following items. 
+Ask in a comment if you have troubles with any of them. -->
+
+# Checklist
+
+- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver-cloud/blob/main/CONTRIBUTING.md).
+- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
+- [ ] I have read and applied the [AI policy](https://geoserver.org/ai)
+- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
+
+For source code changes:
+
+- [ ] New unit tests have been added covering the changes.
+- [ ] [Documentation](https://github.com/geoserver/geoserver-cloud/tree/main/docs/src) has been updated (if change is visible to end users).
+- [ ] There is an issue in [GeoServer Cloud](https://github.com/geoserver/geoserver-cloud/issues) Github issues (except for changes that do not affect administrators or end users in any way).
+- [ ] Bug fixes and small new features are presented as a single commit.
+- [ ] Each commit has a single objective (if there are multiple commits, each has a separate Github issue describing its goal).
+
+<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
+
+The PR will be merged when all the build checks are green, there is a core committer review, and the checklist has been fulfilled.


### PR DESCRIPTION
Retargets the checklist at this repository: links to its CONTRIBUTING.md and docs/src, GitHub issues in place of Jira, and no [GEOS-XYZWV] commit title rule. The REST API docs item does not apply here and is dropped.

on-behalf-of: @multiversio <info@multivers.io>