### PR TITLE
Declare jakarta.servlet-api once in the root pom

### DIFF
--- a/src/apps/geoserver/gwc/pom.xml
+++ b/src/apps/geoserver/gwc/pom.xml
@@ -15,10 +15,6 @@
   <dependencies>
     <!-- Inherit common starters from parent pom -->
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver.cloud.gwc</groupId>
       <artifactId>gwc-cloud-spring-boot-starter</artifactId>
     </dependency>

--- a/src/apps/geoserver/restconfig/pom.xml
+++ b/src/apps/geoserver/restconfig/pom.xml
@@ -15,10 +15,6 @@
   <dependencies>
     <!-- Inherit common starters from parent pom -->
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-restconfig</artifactId>
     </dependency>

--- a/src/apps/geoserver/wcs/pom.xml
+++ b/src/apps/geoserver/wcs/pom.xml
@@ -15,10 +15,6 @@
   <dependencies>
     <!-- Inherit common starters from parent pom -->
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wcs</artifactId>
     </dependency>

--- a/src/apps/geoserver/webui/pom.xml
+++ b/src/apps/geoserver/webui/pom.xml
@@ -15,10 +15,6 @@
   <dependencies>
     <!-- Inherit common starters from parent pom -->
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-cloud-starter-output-formats</artifactId>
     </dependency>

--- a/src/apps/geoserver/wfs/pom.xml
+++ b/src/apps/geoserver/wfs/pom.xml
@@ -15,10 +15,6 @@
   <dependencies>
     <!-- Inherit common starters from parent pom -->
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-cloud-starter-output-formats</artifactId>
     </dependency>

--- a/src/apps/geoserver/wms/pom.xml
+++ b/src/apps/geoserver/wms/pom.xml
@@ -15,10 +15,6 @@
   <dependencies>
     <!-- Inherit common starters from parent pom -->
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-cloud-starter-webmvc</artifactId>
       <exclusions>

--- a/src/apps/geoserver/wps/pom.xml
+++ b/src/apps/geoserver/wps/pom.xml
@@ -15,10 +15,6 @@
   <dependencies>
     <!-- Inherit common starters from parent pom -->
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-wps-core</artifactId>
     </dependency>

--- a/src/apps/pom.xml
+++ b/src/apps/pom.xml
@@ -40,6 +40,11 @@
                     <groupId>org.projectlombok</groupId>
                     <artifactId>lombok</artifactId>
                   </exclude>
+                  <!-- tomcat-embed-core supplies the jakarta.servlet classes at runtime -->
+                  <exclude>
+                    <groupId>jakarta.servlet</groupId>
+                    <artifactId>jakarta.servlet-api</artifactId>
+                  </exclude>
                 </excludes>
               </configuration>
             </execution>

--- a/src/build-tools/spring-config-transpiler/pom.xml
+++ b/src/build-tools/spring-config-transpiler/pom.xml
@@ -46,11 +46,6 @@
 
     <!-- Test dependencies -->
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
       <scope>test</scope>

--- a/src/catalog/backends/common/pom.xml
+++ b/src/catalog/backends/common/pom.xml
@@ -11,10 +11,6 @@
   <description>Base Autoconfigurations to set up the Catalog and Config backend</description>
   <dependencies>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-cloud-main</artifactId>
     </dependency>

--- a/src/catalog/backends/datadir/pom.xml
+++ b/src/catalog/backends/datadir/pom.xml
@@ -11,11 +11,6 @@
   <description>Autoconfigurations for using a shared data-directory as Catalog and config backend</description>
   <dependencies>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver.cloud.catalog.backend</groupId>
       <artifactId>gs-cloud-catalog-backend-common</artifactId>
     </dependency>

--- a/src/catalog/backends/pgconfig/pom.xml
+++ b/src/catalog/backends/pgconfig/pom.xml
@@ -11,11 +11,6 @@
   <description>PostgreSQL catalog backend</description>
   <dependencies>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver.cloud.catalog.backend</groupId>
       <artifactId>gs-cloud-catalog-backend-common</artifactId>
     </dependency>

--- a/src/catalog/backends/pom.xml
+++ b/src/catalog/backends/pom.xml
@@ -17,11 +17,6 @@
   </modules>
   <dependencies>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-webmvc</artifactId>
       <scope>test</scope>

--- a/src/catalog/cache/pom.xml
+++ b/src/catalog/cache/pom.xml
@@ -11,11 +11,6 @@
   <description>Caching catalog decorator</description>
   <dependencies>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver.cloud.catalog</groupId>
       <artifactId>gs-cloud-catalog-plugin</artifactId>
     </dependency>

--- a/src/catalog/events/pom.xml
+++ b/src/catalog/events/pom.xml
@@ -11,11 +11,6 @@
   <description>Adapts the legacy catalog event listener approach as spring ApplicationEvents</description>
   <dependencies>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-bus</artifactId>
       <optional>true</optional>

--- a/src/catalog/jackson-bindings/geoserver/pom.xml
+++ b/src/catalog/jackson-bindings/geoserver/pom.xml
@@ -11,11 +11,6 @@
   <description>GeoServer Catalog/Config Jackson databind bindings</description>
   <dependencies>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver.cloud.jackson</groupId>
       <artifactId>gt-jackson-bindings</artifactId>
     </dependency>

--- a/src/catalog/plugin/pom.xml
+++ b/src/catalog/plugin/pom.xml
@@ -22,15 +22,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <!-- for CatalogImplConformanceTest, this dep is excluded from gs-main in the root pom -->
-      <!-- during the upgrade to GeoServer 2.22.x, GeoServerInfoImpl has the following field: -->
-      <!-- protected Integer xmlPostRequestLogBufferSize = LoggingFilter.REQUEST_LOG_BUFFER_SIZE_DEFAULT -->
-      <!-- which creates a direct dependency against the servlet API (javax.servlet.Filter) -->
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
       <version>${gs.version}</version>

--- a/src/config/geoserver-configuration/pom.xml
+++ b/src/config/geoserver-configuration/pom.xml
@@ -20,11 +20,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver.cloud.build</groupId>
       <artifactId>gs-spring-config-transpiler</artifactId>
       <version>${project.version}</version>

--- a/src/extensions/app-schema/pom.xml
+++ b/src/extensions/app-schema/pom.xml
@@ -38,11 +38,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>

--- a/src/extensions/control-flow/pom.xml
+++ b/src/extensions/control-flow/pom.xml
@@ -29,11 +29,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
       <version>${gs.version}</version>

--- a/src/extensions/core/pom.xml
+++ b/src/extensions/core/pom.xml
@@ -62,11 +62,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure-processor</artifactId>
       <optional>true</optional>

--- a/src/extensions/css-styling/pom.xml
+++ b/src/extensions/css-styling/pom.xml
@@ -30,11 +30,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>

--- a/src/extensions/importer/pom.xml
+++ b/src/extensions/importer/pom.xml
@@ -58,11 +58,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>

--- a/src/extensions/input-formats/raster-formats/pom.xml
+++ b/src/extensions/input-formats/raster-formats/pom.xml
@@ -69,11 +69,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>

--- a/src/extensions/inspire/pom.xml
+++ b/src/extensions/inspire/pom.xml
@@ -30,11 +30,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>

--- a/src/extensions/mapbox-styling/pom.xml
+++ b/src/extensions/mapbox-styling/pom.xml
@@ -24,11 +24,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>

--- a/src/extensions/ogcapi/core/pom.xml
+++ b/src/extensions/ogcapi/core/pom.xml
@@ -41,11 +41,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>

--- a/src/extensions/ogcapi/features/pom.xml
+++ b/src/extensions/ogcapi/features/pom.xml
@@ -41,11 +41,6 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>

--- a/src/extensions/output-formats/dxf/pom.xml
+++ b/src/extensions/output-formats/dxf/pom.xml
@@ -46,11 +46,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>

--- a/src/extensions/output-formats/flatgeobuf/pom.xml
+++ b/src/extensions/output-formats/flatgeobuf/pom.xml
@@ -37,12 +37,6 @@
     </dependency>
 
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>

--- a/src/extensions/output-formats/vector-tiles/pom.xml
+++ b/src/extensions/output-formats/vector-tiles/pom.xml
@@ -34,11 +34,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>

--- a/src/extensions/security/auth-key/pom.xml
+++ b/src/extensions/security/auth-key/pom.xml
@@ -34,11 +34,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>

--- a/src/extensions/security/environment-admin-auth/pom.xml
+++ b/src/extensions/security/environment-admin-auth/pom.xml
@@ -20,11 +20,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
     </dependency>

--- a/src/extensions/security/gateway-shared-auth/pom.xml
+++ b/src/extensions/security/gateway-shared-auth/pom.xml
@@ -31,11 +31,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
     </dependency>

--- a/src/extensions/security/geoserver-acl/pom.xml
+++ b/src/extensions/security/geoserver-acl/pom.xml
@@ -46,11 +46,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
       <scope>provided</scope>

--- a/src/extensions/security/jdbc/pom.xml
+++ b/src/extensions/security/jdbc/pom.xml
@@ -24,11 +24,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>

--- a/src/extensions/security/ldap/pom.xml
+++ b/src/extensions/security/ldap/pom.xml
@@ -24,11 +24,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>

--- a/src/gwc/autoconfigure/pom.xml
+++ b/src/gwc/autoconfigure/pom.xml
@@ -10,10 +10,6 @@
   <packaging>jar</packaging>
   <dependencies>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver.cloud.gwc</groupId>
       <artifactId>gwc-cloud-core</artifactId>
     </dependency>

--- a/src/gwc/core/pom.xml
+++ b/src/gwc/core/pom.xml
@@ -47,10 +47,6 @@
       <artifactId>caffeine</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-    </dependency>
-    <dependency>
       <!-- if available, the wicket ui contributions autoconfiguration will engage -->
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-gwc</artifactId>

--- a/src/gwc/pom.xml
+++ b/src/gwc/pom.xml
@@ -20,11 +20,6 @@
   </modules>
   <dependencies>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <!-- provide IDE auto-completion and documentation for the @ConfigurationProperties when editing application.yml -->
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>

--- a/src/main/pom.xml
+++ b/src/main/pom.xml
@@ -14,10 +14,6 @@
       <artifactId>gs-main</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver.cloud</groupId>
       <artifactId>gs-spring-configuration</artifactId>
     </dependency>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -842,6 +842,17 @@
       <artifactId>lombok</artifactId>
       <scope>provided</scope>
     </dependency>
+    <!--
+      Upstream GeoServer declares jakarta.servlet-api as provided. Provided scope is not
+      transitive: every module compiling against the GeoServer API has to declare it itself,
+      for instance GeoServerInfoImpl.xmlPostRequestLogBufferSize references LoggingFilter.
+      At runtime the servlet classes come from tomcat-embed-core.
+    -->
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>net.datafaker</groupId>
       <artifactId>datafaker</artifactId>

--- a/src/starters/observability/pom.xml
+++ b/src/starters/observability/pom.xml
@@ -26,12 +26,6 @@
       <artifactId>ulid-creator</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>net.logstash.logback</groupId>
       <artifactId>logstash-logback-encoder</artifactId>
     </dependency>

--- a/src/starters/spring-boot/pom.xml
+++ b/src/starters/spring-boot/pom.xml
@@ -23,12 +23,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <!-- for ServiceIdFilterAutoConfiguration to engage if present at runtime -->
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>

--- a/src/starters/webmvc/pom.xml
+++ b/src/starters/webmvc/pom.xml
@@ -33,10 +33,6 @@
       <artifactId>micrometer-registry-prometheus</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>


### PR DESCRIPTION
Upstream moved `jakarta.servlet-api` to provided scope. The 43 resulting declarations had drifted apart: 28 provided, 14 compile and one test.

Replace them with a single provided declaration inherited from the root pom, and excluded from the applications classpaths through `spring-boot-maven-plugin:repackage`


<!--Include a few sentences describing the overall goals for this Pull Request-->

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver-cloud/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] I have read and applied the [AI policy](https://geoserver.org/ai)
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For source code changes:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver-cloud/tree/main/docs/src) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoServer Cloud](https://github.com/geoserver/geoserver-cloud/issues) Github issues (except for changes that do not affect administrators or end users in any way).
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate Github issue describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green, there is a core committer review, and the checklist has been fulfilled.
