### PR TITLE
[Backport release/2.28.x] Register XStream persister initializers in every service

### DIFF
--- a/acceptance_tests/requirements.txt
+++ b/acceptance_tests/requirements.txt
@@ -1,4 +1,4 @@
-geoservercloud==0.8.11
+geoservercloud==0.8.12
 # To debug a local version of python-geoservercloud:
 # git clone git@github.com:camptocamp/python-geoservercloud
 # and then uncomment the following line and adjust the path accordingly

--- a/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationTest.java
+++ b/src/apps/geoserver/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationTest.java
@@ -6,6 +6,8 @@
 package org.geoserver.cloud.restconfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.list;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.PUT;
@@ -20,6 +22,7 @@ import static org.springframework.http.MediaType.TEXT_HTML;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.geoserver.catalog.Catalog;
@@ -28,11 +31,23 @@ import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.ProjectionPolicy;
 import org.geoserver.catalog.SLDHandler;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.cloud.autoconfigure.extensions.test.ConditionalTestAutoConfiguration;
 import org.geoserver.cloud.gwc.config.core.GwcRequestPathInfoFilter;
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.util.XStreamPersisterInitializer;
 import org.geoserver.gwc.GWC;
+import org.geoserver.inspire.InspireXStreamPersisterInitializer;
+import org.geoserver.ogcapi.LinkInfo;
+import org.geoserver.ogcapi.OGCAPIXStreamPersisterInitializer;
+import org.geoserver.ogcapi.impl.LinkInfoImpl;
+import org.geoserver.ogcapi.v1.features.FeatureConformance;
+import org.geoserver.ogcapi.v1.features.FeatureServiceXStreamPersisterInitializer;
+import org.geoserver.wfs.WFSInfo;
+import org.geoserver.wfs.WFSXStreamPersisterInitializer;
+import org.geotools.data.wfs.internal.v2_0.storedquery.StoredQueryConfiguration;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,6 +74,9 @@ abstract class RestConfigApplicationTest {
 
     @Autowired
     protected Catalog catalog;
+
+    @Autowired
+    protected GeoServer geoServer;
 
     @BeforeEach
     void before() {
@@ -200,6 +218,7 @@ abstract class RestConfigApplicationTest {
         ft.setName(ftName);
         ft.setNativeName(ftName);
         ft.setSRS("EPSG:4326");
+        ft.setProjectionPolicy(ProjectionPolicy.NONE);
         ReferencedEnvelope world = new ReferencedEnvelope(-180, 180, -90, 90, DefaultGeographicCRS.WGS84);
         ft.setNativeBoundingBox(world);
         ft.setLatLonBoundingBox(world);
@@ -412,6 +431,159 @@ abstract class RestConfigApplicationTest {
         } catch (RuntimeException e) {
             // ignore, the assertion failure is the interesting outcome
         }
+    }
+
+    /**
+     * Serializing a stored configuration object depends on an {@link XStreamPersisterInitializer} that knows its type.
+     * Those beans used to be registered only by the service that consumes them, leaving this one to rewrite complex
+     * metadata map values as their {@code toString()}. See issue #872.
+     */
+    @Test
+    void configSerializationInitializersPresent() {
+        assertThat(context.getBeansOfType(XStreamPersisterInitializer.class).values())
+                .as("every service must be able to serialize stored configuration objects (issue #872)")
+                .hasAtLeastOneElementOfType(WFSXStreamPersisterInitializer.class)
+                .hasAtLeastOneElementOfType(OGCAPIXStreamPersisterInitializer.class)
+                .hasAtLeastOneElementOfType(FeatureServiceXStreamPersisterInitializer.class)
+                .hasAtLeastOneElementOfType(InspireXStreamPersisterInitializer.class);
+    }
+
+    /**
+     * Reading the WFS settings and writing the same document back used to replace the OGC API Features conformance
+     * object with the string returned by its {@code toString()}, breaking the WFS service with a
+     * {@code ClassCastException}. See issue #872.
+     */
+    @Test
+    void wfsSettingsRoundTripPreservesOgcApiFeaturesConformance() {
+        try {
+            storeFeatureConformance();
+
+            String settings = getWfsSettings();
+            putWfsSettings(settings);
+
+            WFSInfo wfs = geoServer.getService(WFSInfo.class);
+            assertThat(wfs.getMetadata().get(FeatureConformance.METADATA_KEY))
+                    .as("a REST settings round trip must preserve the conformance object type (issue #872)")
+                    .isInstanceOf(FeatureConformance.class);
+
+            FeatureConformance conformance = FeatureConformance.configuration(wfs);
+            assertThat(conformance.isCore()).isTrue();
+            assertThat(conformance.isPropertySelection()).isTrue();
+        } finally {
+            removeFeatureConformance();
+        }
+    }
+
+    /**
+     * The {@code ogcApiLinks} metadata entry of a resource used to come back from a REST round trip as the string
+     * returned by {@code ArrayList.toString()}. See issue #872.
+     */
+    @Test
+    void featureTypeRoundTripPreservesOgcApiLinks(@TempDir Path storeDirectory) throws IOException {
+        try {
+            createVectorLayer(storeDirectory, "ogcapilinks", "ogcapilinksstore", "roads");
+            storeOgcApiLinks("ogcapilinks", "roads");
+
+            roundTripFeatureType("ogcapilinks", "ogcapilinksstore", "roads");
+
+            Object links = catalog.getFeatureTypeByName("ogcapilinks", "roads")
+                    .getMetadata()
+                    .get(LinkInfo.LINKS_METADATA_KEY);
+            assertThat(links)
+                    .as("a REST round trip must preserve the OGC API links (issue #872)")
+                    .asInstanceOf(list(LinkInfo.class))
+                    .singleElement()
+                    .extracting(LinkInfo::getHref)
+                    .isEqualTo("http://example.com/roads.gpkg");
+        } finally {
+            dropVectorLayerTree("ogcapilinks", "ogcapilinksstore", "roads");
+        }
+    }
+
+    /**
+     * The {@code storedQueryConfiguration} metadata entry of a cascaded WFS feature type used to come back from a REST
+     * round trip as a string. See issue #872.
+     */
+    @Test
+    void featureTypeRoundTripPreservesStoredQueryConfiguration(@TempDir Path storeDirectory) throws IOException {
+        try {
+            createVectorLayer(storeDirectory, "storedquery", "storedquerystore", "roads");
+            storeStoredQueryConfiguration("storedquery", "roads");
+
+            roundTripFeatureType("storedquery", "storedquerystore", "roads");
+
+            Object configuration = catalog.getFeatureTypeByName("storedquery", "roads")
+                    .getMetadata()
+                    .get(FeatureTypeInfo.STORED_QUERY_CONFIGURATION);
+            assertThat(configuration)
+                    .as("a REST round trip must preserve the cascaded stored query configuration (issue #872)")
+                    .asInstanceOf(type(StoredQueryConfiguration.class))
+                    .extracting(StoredQueryConfiguration::getStoredQueryId)
+                    .isEqualTo("urn:ogc:def:query:OGC-WFS::GetFeatureById");
+        } finally {
+            dropVectorLayerTree("storedquery", "storedquerystore", "roads");
+        }
+    }
+
+    private void storeOgcApiLinks(String workspace, String featureType) {
+        ArrayList<LinkInfo> links = new ArrayList<>();
+        links.add(new LinkInfoImpl("enclosure", "application/geopackage+sqlite3", "http://example.com/roads.gpkg"));
+
+        FeatureTypeInfo info = catalog.getFeatureTypeByName(workspace, featureType);
+        info.getMetadata().put(LinkInfo.LINKS_METADATA_KEY, links);
+        catalog.save(info);
+    }
+
+    private void storeStoredQueryConfiguration(String workspace, String featureType) {
+        StoredQueryConfiguration configuration = new StoredQueryConfiguration();
+        configuration.setStoredQueryId("urn:ogc:def:query:OGC-WFS::GetFeatureById");
+
+        FeatureTypeInfo info = catalog.getFeatureTypeByName(workspace, featureType);
+        info.getMetadata().put(FeatureTypeInfo.STORED_QUERY_CONFIGURATION, configuration);
+        catalog.save(info);
+    }
+
+    private void roundTripFeatureType(String workspace, String store, String featureType) {
+        String uri = "/rest/workspaces/%s/datastores/%s/featuretypes/%s.json".formatted(workspace, store, featureType);
+
+        ResponseEntity<String> get = restTemplate.getForEntity(uri, String.class);
+        assertThat(get.getStatusCode()).isEqualTo(OK);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(APPLICATION_JSON);
+        ResponseEntity<String> put =
+                restTemplate.exchange(uri, PUT, new HttpEntity<>(get.getBody(), headers), String.class);
+        assertThat(put.getStatusCode()).isEqualTo(OK);
+    }
+
+    private void storeFeatureConformance() {
+        FeatureConformance conformance = new FeatureConformance();
+        conformance.setCore(Boolean.TRUE);
+        conformance.setPropertySelection(Boolean.TRUE);
+
+        WFSInfo wfs = geoServer.getService(WFSInfo.class);
+        wfs.getMetadata().put(FeatureConformance.METADATA_KEY, conformance);
+        geoServer.save(wfs);
+    }
+
+    private void removeFeatureConformance() {
+        WFSInfo wfs = geoServer.getService(WFSInfo.class);
+        wfs.getMetadata().remove(FeatureConformance.METADATA_KEY);
+        geoServer.save(wfs);
+    }
+
+    private String getWfsSettings() {
+        ResponseEntity<String> response = restTemplate.getForEntity("/rest/services/wfs/settings.json", String.class);
+        assertThat(response.getStatusCode()).isEqualTo(OK);
+        return response.getBody();
+    }
+
+    private void putWfsSettings(String settings) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(APPLICATION_JSON);
+        ResponseEntity<String> response = restTemplate.exchange(
+                "/rest/services/wfs/settings", PUT, new HttpEntity<>(settings, headers), String.class);
+        assertThat(response.getStatusCode()).isEqualTo(OK);
     }
 
     protected void testPathExtensionContentType(String uri, MediaType expected) {

--- a/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/wfs/WfsConfiguration.java
+++ b/src/apps/geoserver/webui/src/main/java/org/geoserver/cloud/autoconfigure/web/wfs/WfsConfiguration.java
@@ -8,10 +8,19 @@ package org.geoserver.cloud.autoconfigure.web.wfs;
 import org.geoserver.cloud.config.factory.ImportFilteredResource;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * Contributes the WFS administration pages and the WFS service beans they read.
+ * <p>
+ * {@code wfsXStreamPersisterInitializer} is filtered out of the {@code gs-wfs}
+ * import: every service reads and writes the cascaded stored query
+ * configuration it describes, so it is contributed unconditionally by
+ * {@code WfsXStreamPersisterAutoConfiguration} instead of by the services
+ * that happen to run a WFS.
+ */
 @Configuration(proxyBeanMethods = true)
 @ImportFilteredResource({
     "jar:gs-web-wfs-.*!/applicationContext.xml",
-    "jar:gs-wfs-.*!/applicationContext.xml",
+    "jar:gs-wfs-.*!/applicationContext.xml#name=^(?!wfsXStreamPersisterInitializer).*$",
     "jar:gs-dxf-core-.*!/applicationContext.xml#name=.*"
     // FlatGeobuf moved to output-formats/flatgeobuf extension
 })

--- a/src/apps/geoserver/wfs/src/main/java/org/geoserver/cloud/wfs/config/WfsAutoConfiguration.java
+++ b/src/apps/geoserver/wfs/src/main/java/org/geoserver/cloud/wfs/config/WfsAutoConfiguration.java
@@ -13,9 +13,18 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Bean;
 
+/**
+ * Contributes the WFS service beans from {@code gs-wfs}'s {@code applicationContext.xml}.
+ * <p>
+ * {@code wfsXStreamPersisterInitializer} is filtered out of the {@code gs-wfs}
+ * import: every service reads and writes the cascaded stored query
+ * configuration it describes, so it is contributed unconditionally by
+ * {@code WfsXStreamPersisterAutoConfiguration} instead of by the services
+ * that happen to run a WFS.
+ */
 @AutoConfiguration(after = GeoServerWebMvcMainAutoConfiguration.class)
 @SuppressWarnings("java:S1118") // Suppress SonarLint warning, constructor needs to be public
-@ImportFilteredResource({"jar:gs-wfs-.*!/applicationContext.xml#name=.*"})
+@ImportFilteredResource({"jar:gs-wfs-.*!/applicationContext.xml#name=^(?!wfsXStreamPersisterInitializer).*$"})
 public class WfsAutoConfiguration {
 
     @Bean

--- a/src/apps/geoserver/wfs/src/test/java/org/geoserver/cloud/wfs/app/WfsApplicationTest.java
+++ b/src/apps/geoserver/wfs/src/test/java/org/geoserver/cloud/wfs/app/WfsApplicationTest.java
@@ -17,6 +17,10 @@ import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.cloud.autoconfigure.extensions.test.ConditionalTestAutoConfiguration;
+import org.geoserver.config.util.XStreamPersisterInitializer;
+import org.geoserver.ogcapi.OGCAPIXStreamPersisterInitializer;
+import org.geoserver.ogcapi.v1.features.FeatureServiceXStreamPersisterInitializer;
+import org.geoserver.wfs.WFSXStreamPersisterInitializer;
 import org.geotools.feature.NameImpl;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,6 +43,25 @@ abstract class WfsApplicationTest {
     @Autowired
     @Qualifier("rawCatalog")
     private Catalog catalog;
+
+    /**
+     * The initializers that describe stored configuration objects moved out of the service-scoped configurations and
+     * into auto-configurations conditional on class presence alone, so this service, which runs the OGC API, must end
+     * up with exactly one of each rather than a duplicate. See issue #872.
+     */
+    @Test
+    void configSerializationInitializersAreNotDuplicated() {
+        assertThat(context.getBeansOfType(XStreamPersisterInitializer.class).values())
+                .hasAtLeastOneElementOfType(WFSXStreamPersisterInitializer.class)
+                .hasAtLeastOneElementOfType(OGCAPIXStreamPersisterInitializer.class)
+                .hasAtLeastOneElementOfType(FeatureServiceXStreamPersisterInitializer.class);
+
+        assertThat(context.getBeansOfType(WFSXStreamPersisterInitializer.class)).hasSize(1);
+        assertThat(context.getBeansOfType(OGCAPIXStreamPersisterInitializer.class))
+                .hasSize(1);
+        assertThat(context.getBeansOfType(FeatureServiceXStreamPersisterInitializer.class))
+                .hasSize(1);
+    }
 
     @Test
     void owsGetCapabilitiesSmokeTest(@LocalServerPort int servicePort) {

--- a/src/apps/geoserver/wps/src/main/java/org/geoserver/cloud/wps/WpsApplicationConfiguration.java
+++ b/src/apps/geoserver/wps/src/main/java/org/geoserver/cloud/wps/WpsApplicationConfiguration.java
@@ -12,6 +12,15 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * Contributes the WPS service beans and the WCS and WFS beans WPS processes build on.
+ * <p>
+ * {@code wfsXStreamPersisterInitializer} is filtered out of the {@code gs-wfs}
+ * import: every service reads and writes the cascaded stored query
+ * configuration it describes, so it is contributed unconditionally by
+ * {@code WfsXStreamPersisterAutoConfiguration} instead of by the services
+ * that happen to run a WFS.
+ */
 @Configuration
 @ImportFilteredResource({
     "jar:gs-wps-.*!/applicationContext.xml",
@@ -19,7 +28,7 @@ import org.springframework.context.annotation.Configuration;
     "jar:gs-wcs1_0-.*!/applicationContext.xml",
     "jar:gs-wcs1_1-.*!/applicationContext.xml",
     "jar:gs-wcs2_0-.*!/applicationContext.xml",
-    "jar:gs-wfs-.*!/applicationContext.xml#name=^(?!wfsInsertElementHandler|wfsUpdateElementHandler|wfsDeleteElementHandler|wfsReplaceElementHandler).*$",
+    "jar:gs-wfs-.*!/applicationContext.xml#name=^(?!wfsInsertElementHandler|wfsUpdateElementHandler|wfsDeleteElementHandler|wfsReplaceElementHandler|wfsXStreamPersisterInitializer).*$",
     "jar:gs-dxf-core-.*!/applicationContext.xml#name=.*",
     "jar:gs-dxf-wps-.*!/applicationContext.xml#name=.*"
 })

--- a/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/wfs/WfsXStreamPersisterAutoConfiguration.java
+++ b/src/extensions/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/wfs/WfsXStreamPersisterAutoConfiguration.java
@@ -1,0 +1,33 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.wfs;
+
+import org.geoserver.wfs.WFSXStreamPersisterInitializer;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Teaches {@code XStreamPersister} how to read and write the {@code StoredQueryConfiguration} stored under the
+ * {@code storedQueryConfiguration} key of a cascaded WFS feature type's metadata map.
+ *
+ * <p>Without the initializer, {@code XStreamPersister} writes that metadata value as the string returned by its
+ * {@code toString()} and reads it back as a {@code String}, silently losing the stored query the layer cascades to.
+ * Every service reads and writes the catalog, so this is a property of the configuration subsystem rather than of the
+ * WFS service, and {@code geoserver.service.wfs.enabled} must not control it.
+ *
+ * <p>This module hosts the bean because {@code WFSXStreamPersisterInitializer} belongs to core GeoServer rather than to
+ * an extension, and this is the module every service already has on its classpath with {@code gs-wfs} declared
+ * optional.
+ */
+@AutoConfiguration
+@ConditionalOnClass(WFSXStreamPersisterInitializer.class)
+public class WfsXStreamPersisterAutoConfiguration {
+
+    @Bean
+    WFSXStreamPersisterInitializer wfsXStreamPersisterInitializer() {
+        return new WFSXStreamPersisterInitializer();
+    }
+}

--- a/src/extensions/core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/extensions/core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.geoserver.cloud.autoconfigure.extensions.wfs.WfsXStreamPersisterAutoConfiguration

--- a/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/wfs/WfsXStreamPersisterAutoConfigurationTest.java
+++ b/src/extensions/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/wfs/WfsXStreamPersisterAutoConfigurationTest.java
@@ -1,0 +1,39 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.wfs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.geoserver.wfs.WFSXStreamPersisterInitializer;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * A cascaded stored query configuration lives in a feature type's metadata map, which every service reads and writes,
+ * so the initializer that teaches {@code XStreamPersister} about it must not depend on
+ * {@code geoserver.service.wfs.enabled}. See issue #872.
+ */
+class WfsXStreamPersisterAutoConfigurationTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(WfsXStreamPersisterAutoConfiguration.class));
+
+    @Test
+    void contributedWithoutTheWfsServiceEnabled() {
+        runner.run(context -> assertThat(context)
+                .hasNotFailed()
+                .hasSingleBean(WFSXStreamPersisterInitializer.class)
+                .hasBean("wfsXStreamPersisterInitializer"));
+    }
+
+    @Test
+    void absentWithoutTheWfsCoreClasses() {
+        runner.withClassLoader(new FilteredClassLoader(WFSXStreamPersisterInitializer.class))
+                .run(context ->
+                        assertThat(context).hasNotFailed().doesNotHaveBean(WFSXStreamPersisterInitializer.class));
+    }
+}

--- a/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/InspireXStreamPersisterAutoConfiguration.java
+++ b/src/extensions/inspire/src/main/java/org/geoserver/cloud/autoconfigure/extensions/inspire/InspireXStreamPersisterAutoConfiguration.java
@@ -1,0 +1,34 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire;
+
+import org.geoserver.inspire.InspireXStreamPersisterInitializer;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Keeps {@code XStreamPersister} from writing the INSPIRE spatial dataset identifiers as a generic list.
+ *
+ * <p>{@code UniqueResourceIdentifiers} extends {@code ArrayList}, and the OGC API core initializer registers
+ * {@code List} itself as a brief map complex type. This initializer exempts the INSPIRE type from that registration, so
+ * the two are only correct as a pair: both are contributed on class presence alone, so that no service ever sees one
+ * without the other.
+ *
+ * <p>The INSPIRE metadata entries are read and written by every service, so neither the running GeoServer service nor
+ * {@code geoserver.extension.inspire.enabled} controls this bean. Turning the extension off must not let a service
+ * corrupt the configuration the extension wrote while it was on.
+ *
+ * @see InspireAutoConfiguration
+ */
+@AutoConfiguration
+@ConditionalOnClass(InspireXStreamPersisterInitializer.class)
+public class InspireXStreamPersisterAutoConfiguration {
+
+    @Bean
+    InspireXStreamPersisterInitializer inspireXStreamConfigurer() {
+        return new InspireXStreamPersisterInitializer();
+    }
+}

--- a/src/extensions/inspire/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/extensions/inspire/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -4,3 +4,4 @@ org.geoserver.cloud.autoconfigure.extensions.inspire.gwc.InspireAutoConfiguratio
 org.geoserver.cloud.autoconfigure.extensions.inspire.wfs.InspireAutoConfigurationWfs
 org.geoserver.cloud.autoconfigure.extensions.inspire.wms.InspireAutoConfigurationWms
 org.geoserver.cloud.autoconfigure.extensions.inspire.wcs.InspireAutoConfigurationWcs
+org.geoserver.cloud.autoconfigure.extensions.inspire.InspireXStreamPersisterAutoConfiguration

--- a/src/extensions/inspire/src/test/java/org/geoserver/cloud/autoconfigure/extensions/inspire/InspireXStreamPersisterAutoConfigurationTest.java
+++ b/src/extensions/inspire/src/test/java/org/geoserver/cloud/autoconfigure/extensions/inspire/InspireXStreamPersisterAutoConfigurationTest.java
@@ -1,0 +1,39 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.inspire;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.geoserver.inspire.InspireXStreamPersisterInitializer;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * The INSPIRE spatial dataset identifiers live in metadata maps every service reads and writes, so the initializer that
+ * keeps {@code XStreamPersister} from mangling them must not depend on the running service or on the extension being
+ * enabled. See issue #872.
+ */
+class InspireXStreamPersisterAutoConfigurationTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(InspireXStreamPersisterAutoConfiguration.class));
+
+    @Test
+    void contributedWithoutTheExtensionEnabled() {
+        runner.run(context -> assertThat(context)
+                .hasNotFailed()
+                .hasSingleBean(InspireXStreamPersisterInitializer.class)
+                .hasBean("inspireXStreamConfigurer"));
+    }
+
+    @Test
+    void absentWithoutTheInspireClasses() {
+        runner.withClassLoader(new FilteredClassLoader(InspireXStreamPersisterInitializer.class))
+                .run(context ->
+                        assertThat(context).hasNotFailed().doesNotHaveBean(InspireXStreamPersisterInitializer.class));
+    }
+}

--- a/src/extensions/ogcapi/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ogcapi/core/OgcApiCoreXStreamPersisterAutoConfiguration.java
+++ b/src/extensions/ogcapi/core/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ogcapi/core/OgcApiCoreXStreamPersisterAutoConfiguration.java
@@ -1,0 +1,42 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.ogcapi.core;
+
+import org.geoserver.ogcapi.OGCAPIXStreamPersisterInitializer;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Teaches {@code XStreamPersister} how to read and write the {@code LinkInfo} lists stored under the
+ * {@code ogcApiLinks} key of the metadata maps of layers, layer groups, resources and settings.
+ *
+ * <p>Without the initializer, {@code XStreamPersister} writes those metadata values as the string returned by their
+ * {@code toString()} and reads them back as a {@code String}. Every service reads and writes the catalog, so this is a
+ * property of the configuration subsystem rather than of any one GeoServer service: neither the running service nor
+ * {@code geoserver.extension.ogcapi.features.enabled} controls it. Turning the extension off must not let a service
+ * corrupt the configuration the extension wrote while it was on.
+ *
+ * <p>The initializer also registers {@code List} itself as a brief map complex type. That registration is only correct
+ * alongside the INSPIRE initializer, which exempts {@code UniqueResourceIdentifiers} from it; both are contributed on
+ * class presence alone so that no service ever sees one without the other.
+ *
+ * <p>{@code OgcApiCoreConfiguration} contributes the same initializer through the component scan in
+ * {@code gs-ogcapi-core}'s {@code applicationContext.xml}, which the bean name filters of
+ * {@code ImportFilteredResource} cannot reach. Hence {@link ConditionalOnMissingBean} and the ordering after the
+ * services that import that configuration, so the services running an OGC API keep a single initializer.
+ */
+@AutoConfiguration(
+        afterName = "org.geoserver.cloud.autoconfigure.extensions.ogcapi.features.OgcApiFeaturesAutoConfiguration")
+@ConditionalOnClass(OGCAPIXStreamPersisterInitializer.class)
+public class OgcApiCoreXStreamPersisterAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(OGCAPIXStreamPersisterInitializer.class)
+    OGCAPIXStreamPersisterInitializer ogcApiXStreamPersisterInitializer() {
+        return new OGCAPIXStreamPersisterInitializer();
+    }
+}

--- a/src/extensions/ogcapi/core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/extensions/ogcapi/core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.geoserver.cloud.autoconfigure.extensions.ogcapi.core.OgcApiCoreXStreamPersisterAutoConfiguration

--- a/src/extensions/ogcapi/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ogcapi/core/OgcApiCoreXStreamPersisterAutoConfigurationTest.java
+++ b/src/extensions/ogcapi/core/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ogcapi/core/OgcApiCoreXStreamPersisterAutoConfigurationTest.java
@@ -1,0 +1,57 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.ogcapi.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.geoserver.ogcapi.OGCAPIXStreamPersisterInitializer;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * The {@code ogcApiLinks} metadata entries are read and written by every service, so the initializer that teaches
+ * {@code XStreamPersister} about them must not depend on which GeoServer service the application runs. See issue #872.
+ */
+class OgcApiCoreXStreamPersisterAutoConfigurationTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(OgcApiCoreXStreamPersisterAutoConfiguration.class));
+
+    @Test
+    void contributedWithoutAnyServiceEnabled() {
+        runner.run(
+                context -> assertThat(context).hasNotFailed().hasSingleBean(OGCAPIXStreamPersisterInitializer.class));
+    }
+
+    @Test
+    void backsOffWhenTheOgcApiCoreConfigurationAlreadyContributedIt() {
+        runner.withUserConfiguration(ComponentScannedInitializer.class).run(context -> assertThat(context)
+                .as("the services running an OGC API must keep a single initializer")
+                .hasNotFailed()
+                .hasSingleBean(OGCAPIXStreamPersisterInitializer.class)
+                .hasBean("OGCAPIXStreamPersisterInitializer"));
+    }
+
+    @Test
+    void absentWithoutTheOgcApiCoreClasses() {
+        runner.withClassLoader(new FilteredClassLoader(OGCAPIXStreamPersisterInitializer.class))
+                .run(context ->
+                        assertThat(context).hasNotFailed().doesNotHaveBean(OGCAPIXStreamPersisterInitializer.class));
+    }
+
+    /** Stands in for the bean the {@code gs-ogcapi-core} component scan registers. */
+    @Configuration
+    static class ComponentScannedInitializer {
+
+        @Bean(name = "OGCAPIXStreamPersisterInitializer")
+        OGCAPIXStreamPersisterInitializer scanned() {
+            return new OGCAPIXStreamPersisterInitializer();
+        }
+    }
+}

--- a/src/extensions/ogcapi/features/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ogcapi/features/OgcApiFeaturesConfiguration.java
+++ b/src/extensions/ogcapi/features/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ogcapi/features/OgcApiFeaturesConfiguration.java
@@ -14,12 +14,19 @@ import org.springframework.context.annotation.Import;
 
 /**
  * Configuration class for OGC API Features, conditional on WFS service.
+ * <p>
+ * {@code featureServiceXStreamInitializer} is filtered out: every service
+ * reads and writes the conformance objects it describes, so it is contributed
+ * unconditionally by
+ * {@link OgcApiFeaturesXStreamPersisterAutoConfiguration} instead of by this
+ * service-scoped configuration.
  */
 @Configuration
 @ConditionalOnOgcApiFeatures
 @ConditionalOnGeoServerWFS
 @Import(OgcApiCoreConfiguration.class)
-@ImportFilteredResource("jar:gs-ogcapi-features-.*!/applicationContext.xml")
+@ImportFilteredResource(
+        "jar:gs-ogcapi-features-.*!/applicationContext.xml#name=^(?!featureServiceXStreamInitializer).*$")
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.extensions.ogcapi.features")
 class OgcApiFeaturesConfiguration {
 

--- a/src/extensions/ogcapi/features/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ogcapi/features/OgcApiFeaturesWebUIConfiguration.java
+++ b/src/extensions/ogcapi/features/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ogcapi/features/OgcApiFeaturesWebUIConfiguration.java
@@ -13,12 +13,21 @@ import org.geoserver.cloud.configuration.ogcapi.core.OgcApiCoreWebConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+/**
+ * Configuration class for the OGC API Features administration pages, conditional on the web UI service.
+ * <p>
+ * {@code featureServiceXStreamInitializer} is filtered out: every service
+ * reads and writes the conformance objects it describes, so it is contributed
+ * unconditionally by
+ * {@link OgcApiFeaturesXStreamPersisterAutoConfiguration} instead of by this
+ * service-scoped configuration.
+ */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnOgcApiFeatures
 @ConditionalOnGeoServerWebUI
 @Import({OgcApiCoreConfiguration.class, OgcApiCoreWebConfiguration.class})
 @ImportFilteredResource({
-    "jar:gs-ogcapi-features-.*!/applicationContext.xml",
+    "jar:gs-ogcapi-features-.*!/applicationContext.xml#name=^(?!featureServiceXStreamInitializer).*$",
     "jar:gs-web-features-.*!/applicationContext.xml"
 })
 @Slf4j(topic = "org.geoserver.cloud.autoconfigure.extensions.ogcapi.features")

--- a/src/extensions/ogcapi/features/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ogcapi/features/OgcApiFeaturesXStreamPersisterAutoConfiguration.java
+++ b/src/extensions/ogcapi/features/src/main/java/org/geoserver/cloud/autoconfigure/extensions/ogcapi/features/OgcApiFeaturesXStreamPersisterAutoConfiguration.java
@@ -1,0 +1,34 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.ogcapi.features;
+
+import org.geoserver.ogcapi.v1.features.FeatureConformance;
+import org.geoserver.ogcapi.v1.features.FeatureServiceXStreamPersisterInitializer;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Teaches {@code XStreamPersister} how to read and write the OGC API Features conformance objects stored under the
+ * {@code ogcapiFeatures}, {@code cql2} and {@code ecql} keys of {@code WFSInfo}'s metadata map.
+ *
+ * <p>Without the initializer, {@code XStreamPersister} writes those metadata values as the string returned by their
+ * {@code toString()} and reads them back as a {@code String}, which later fails with a {@code ClassCastException} in
+ * the WFS service. Every service reads and writes {@code WFSInfo}, so this is a property of the configuration subsystem
+ * rather than of the OGC API Features service: neither the running GeoServer service nor
+ * {@code geoserver.extension.ogcapi.features.enabled} controls it. Turning the extension off must not let a service
+ * corrupt the configuration the extension wrote while it was on.
+ *
+ * @see OgcApiFeaturesAutoConfiguration
+ */
+@AutoConfiguration
+@ConditionalOnClass(FeatureConformance.class)
+public class OgcApiFeaturesXStreamPersisterAutoConfiguration {
+
+    @Bean
+    FeatureServiceXStreamPersisterInitializer featureServiceXStreamInitializer() {
+        return new FeatureServiceXStreamPersisterInitializer();
+    }
+}

--- a/src/extensions/ogcapi/features/src/main/java/org/geoserver/jackson/databind/ogcapi/features/OgcApiFeaturesConformancesModule.java
+++ b/src/extensions/ogcapi/features/src/main/java/org/geoserver/jackson/databind/ogcapi/features/OgcApiFeaturesConformancesModule.java
@@ -291,6 +291,7 @@ public class OgcApiFeaturesConformancesModule extends SimpleModule {
             writeNullSafe(gen, "queryables", value.isQueryables());
             writeNullSafe(gen, "ids", value.isIDs());
             writeNullSafe(gen, "sortBy", value.isSortBy());
+            writeNullSafe(gen, "propertySelection", value.isPropertySelection());
 
             gen.writeEndObject();
         }
@@ -359,6 +360,7 @@ public class OgcApiFeaturesConformancesModule extends SimpleModule {
                 case "queryables" -> conf.setQueryables(value);
                 case "ids" -> conf.setIDs(value);
                 case "sortBy" -> conf.setSortBy(value);
+                case "propertySelection" -> conf.setPropertySelection(value);
                 default -> throw new IllegalArgumentException("Unknown field in FeatureConformance: " + fieldName);
             }
         }

--- a/src/extensions/ogcapi/features/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/extensions/ogcapi/features/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
 org.geoserver.cloud.autoconfigure.extensions.ogcapi.features.OgcApiFeaturesAutoConfiguration
 org.geoserver.cloud.autoconfigure.extensions.ogcapi.features.OgcApiFeaturesConformancesModuleAutoConfiguration
+org.geoserver.cloud.autoconfigure.extensions.ogcapi.features.OgcApiFeaturesXStreamPersisterAutoConfiguration

--- a/src/extensions/ogcapi/features/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ogcapi/features/OgcApiFeaturesXStreamPersisterAutoConfigurationTest.java
+++ b/src/extensions/ogcapi/features/src/test/java/org/geoserver/cloud/autoconfigure/extensions/ogcapi/features/OgcApiFeaturesXStreamPersisterAutoConfigurationTest.java
@@ -1,0 +1,50 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.autoconfigure.extensions.ogcapi.features;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.geoserver.ogcapi.v1.features.FeatureConformance;
+import org.geoserver.ogcapi.v1.features.FeatureServiceXStreamPersisterInitializer;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * The conformance objects stored in {@code WFSInfo}'s metadata map are read and written by every service, so the
+ * initializer that teaches {@code XStreamPersister} about them must not depend on which GeoServer service the
+ * application runs. See issue #872.
+ */
+class OgcApiFeaturesXStreamPersisterAutoConfigurationTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(OgcApiFeaturesXStreamPersisterAutoConfiguration.class));
+
+    @Test
+    void contributedWithoutAnyServiceEnabled() {
+        runner.run(context -> assertThat(context)
+                .hasNotFailed()
+                .hasSingleBean(FeatureServiceXStreamPersisterInitializer.class)
+                .hasBean("featureServiceXStreamInitializer"));
+    }
+
+    @Test
+    void contributedWhenTheExtensionIsDisabled() {
+        runner.withPropertyValues("geoserver.extension.ogcapi.features.enabled=false")
+                .run(context -> assertThat(context)
+                        .as("disabling the extension must not make the service corrupt configuration it wrote")
+                        .hasNotFailed()
+                        .hasSingleBean(FeatureServiceXStreamPersisterInitializer.class));
+    }
+
+    @Test
+    void absentWithoutTheOgcApiFeaturesClasses() {
+        runner.withClassLoader(new FilteredClassLoader(FeatureConformance.class))
+                .run(context -> assertThat(context)
+                        .hasNotFailed()
+                        .doesNotHaveBean(FeatureServiceXStreamPersisterInitializer.class));
+    }
+}

--- a/src/extensions/ogcapi/features/src/test/java/org/geoserver/jackson/databind/ogcapi/features/OgcApiFeaturesConformancesModuleTest.java
+++ b/src/extensions/ogcapi/features/src/test/java/org/geoserver/jackson/databind/ogcapi/features/OgcApiFeaturesConformancesModuleTest.java
@@ -189,4 +189,25 @@ class OgcApiFeaturesConformancesModuleTest {
         assertEquals(true, deserialized.isQueryables());
         assertEquals(true, deserialized.isFilter());
     }
+
+    /**
+     * {@code propertySelection} used to be missing from both the serializer and the deserializer, so a pgconfig backend
+     * silently dropped it. See issue #872.
+     */
+    @Test
+    void testSerializeDeserializeFeatureConformancePropertySelection() throws JsonProcessingException {
+
+        FeatureConformance original = new FeatureConformance();
+        original.setPropertySelection(true);
+        original.setSortBy(false);
+
+        String json = mapper.writeValueAsString(original);
+
+        assertTrue(json.contains("\"propertySelection\":true"));
+
+        FeatureConformance deserialized = mapper.readValue(json, FeatureConformance.class);
+
+        assertEquals(true, deserialized.isPropertySelection());
+        assertEquals(false, deserialized.isSortBy());
+    }
 }


### PR DESCRIPTION
Backport #964 to 2.28.x.

