### PR TITLE
Import the AWS SDK 1.12.797 BOM to drop ion-java

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1325,6 +1325,16 @@
       <dependencyManagement>
         <dependencies>
           <dependency>
+            <!-- gwc-aws-s3 pins 1.12.261, whose aws-java-sdk-core still depends on
+                 software.amazon.ion:ion-java 1.0.2, a groupId that no longer receives releases
+                 (the project moved to com.amazon.ion). Later 1.12.x releases dropped ion-java -->
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-bom</artifactId>
+            <version>1.12.797</version>
+            <type>pom</type>
+            <scope>import</scope>
+          </dependency>
+          <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>4.33.2</version>


### PR DESCRIPTION
gwc-aws-s3 pins the AWS SDK at 1.12.261, whose core module still depends on software.amazon.ion:ion-java 1.0.2, which no longer receives releases. Manage the SDK modules from the 1.12.797 BOM in the dependencyConvergence profile; later 1.12.x releases dropped ion-java altogether.


<!--Include a few sentences describing the overall goals for this Pull Request-->

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver-cloud/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] I have read and applied the [AI policy](https://geoserver.org/ai)
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For source code changes:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver-cloud/tree/main/docs/src) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoServer Cloud](https://github.com/geoserver/geoserver-cloud/issues) Github issues (except for changes that do not affect administrators or end users in any way).
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate Github issue describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green, there is a core committer review, and the checklist has been fulfilled.
