### PR TITLE
fix: User creation via WebUI not propagated to REST API

### DIFF
--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/GeoServerEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/GeoServerEvent.java
@@ -17,12 +17,21 @@ import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.Info;
 import org.geoserver.cloud.event.info.ConfigInfoType;
 import org.geoserver.cloud.event.lifecycle.LifecycleEvent;
+import org.geoserver.cloud.event.security.RolesChanged;
+import org.geoserver.cloud.event.security.UsersAndGroupsChanged;
 import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.LoggingInfo;
 import org.springframework.core.style.ToStringCreator;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
-@JsonSubTypes({@JsonSubTypes.Type(value = UpdateSequenceEvent.class), @JsonSubTypes.Type(value = LifecycleEvent.class)})
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = UpdateSequenceEvent.class),
+    @JsonSubTypes.Type(value = LifecycleEvent.class),
+    @JsonSubTypes.Type(value = UsersAndGroupsChanged.class),
+    @JsonSubTypes.Type(value = RolesChanged.class)
+})
 @SuppressWarnings("serial")
 public abstract class GeoServerEvent implements Serializable {
 
@@ -44,6 +53,12 @@ public abstract class GeoServerEvent implements Serializable {
     protected GeoServerEvent(long timestamp, String author) {
         this.timestamp = timestamp;
         this.author = author;
+    }
+
+    /** The name of the user authenticated on the current thread, if any, as the author of an event created now */
+    protected static String resolveAuthor() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return null == authentication ? null : authentication.getName();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/UpdateSequenceEvent.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/UpdateSequenceEvent.java
@@ -13,8 +13,6 @@ import org.geoserver.cloud.event.info.InfoEvent;
 import org.geoserver.cloud.event.security.SecurityConfigChanged;
 import org.geoserver.config.GeoServerInfo;
 import org.springframework.core.style.ToStringCreator;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 @JsonSubTypes({@JsonSubTypes.Type(value = InfoEvent.class), @JsonSubTypes.Type(value = SecurityConfigChanged.class)})
@@ -39,11 +37,6 @@ public class UpdateSequenceEvent extends GeoServerEvent implements Comparable<Up
 
     protected @Override ToStringCreator toStringBuilder() {
         return super.toStringBuilder().append("updateSequence", updateSequence);
-    }
-
-    private static String resolveAuthor() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        return null == authentication ? null : authentication.getName();
     }
 
     public static UpdateSequenceEvent createLocal(long value) {

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/security/RolesChanged.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/security/RolesChanged.java
@@ -1,0 +1,52 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.event.security;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.Getter;
+import lombok.NonNull;
+import org.geoserver.cloud.event.GeoServerEvent;
+import org.geoserver.security.GeoServerRoleService;
+import org.geoserver.security.GeoServerRoleStore;
+import org.springframework.core.style.ToStringCreator;
+
+/**
+ * Notifies the other service instances that the roles held by a {@link GeoServerRoleService} changed.
+ *
+ * <p>Fired once a {@link GeoServerRoleStore} is saved. Receivers reload the service named by {@code serviceName} to
+ * refresh their in-memory copy of its contents. Changes to the configuration of the security services themselves are
+ * notified through {@link SecurityConfigChanged} instead.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
+@JsonTypeName("RolesChanged")
+@SuppressWarnings("serial")
+public class RolesChanged extends GeoServerEvent {
+
+    private @Getter String serviceName;
+
+    protected RolesChanged() {
+        // no-op default constructor for deserialization
+    }
+
+    protected RolesChanged(@NonNull String serviceName) {
+        super(System.currentTimeMillis(), resolveAuthor());
+        this.serviceName = serviceName;
+    }
+
+    public static RolesChanged createLocal(@NonNull String serviceName) {
+        return new RolesChanged(serviceName);
+    }
+
+    protected @Override ToStringCreator toStringBuilder() {
+        return super.toStringBuilder().append("serviceName", serviceName);
+    }
+
+    @Override
+    public String toShortString() {
+        return "%s[origin: %s, serviceName: %s]".formatted(getClass().getSimpleName(), getOrigin(), serviceName);
+    }
+}

--- a/src/catalog/events/src/main/java/org/geoserver/cloud/event/security/UsersAndGroupsChanged.java
+++ b/src/catalog/events/src/main/java/org/geoserver/cloud/event/security/UsersAndGroupsChanged.java
@@ -1,0 +1,52 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.event.security;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.Getter;
+import lombok.NonNull;
+import org.geoserver.cloud.event.GeoServerEvent;
+import org.geoserver.security.GeoServerUserGroupService;
+import org.geoserver.security.GeoServerUserGroupStore;
+import org.springframework.core.style.ToStringCreator;
+
+/**
+ * Notifies the other service instances that the users and groups held by a {@link GeoServerUserGroupService} changed.
+ *
+ * <p>Fired once a {@link GeoServerUserGroupStore} is saved. Receivers reload the service named by {@code serviceName}
+ * to refresh their in-memory copy of its contents. Changes to the configuration of the security services themselves are
+ * notified through {@link SecurityConfigChanged} instead.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
+@JsonTypeName("UsersAndGroupsChanged")
+@SuppressWarnings("serial")
+public class UsersAndGroupsChanged extends GeoServerEvent {
+
+    private @Getter String serviceName;
+
+    protected UsersAndGroupsChanged() {
+        // no-op default constructor for deserialization
+    }
+
+    protected UsersAndGroupsChanged(@NonNull String serviceName) {
+        super(System.currentTimeMillis(), resolveAuthor());
+        this.serviceName = serviceName;
+    }
+
+    public static UsersAndGroupsChanged createLocal(@NonNull String serviceName) {
+        return new UsersAndGroupsChanged(serviceName);
+    }
+
+    protected @Override ToStringCreator toStringBuilder() {
+        return super.toStringBuilder().append("serviceName", serviceName);
+    }
+
+    @Override
+    public String toShortString() {
+        return "%s[origin: %s, serviceName: %s]".formatted(getClass().getSimpleName(), getOrigin(), serviceName);
+    }
+}

--- a/src/catalog/events/src/test/java/org/geoserver/cloud/event/bus/BusAmqpIntegrationTests.java
+++ b/src/catalog/events/src/test/java/org/geoserver/cloud/event/bus/BusAmqpIntegrationTests.java
@@ -424,7 +424,7 @@ public abstract class BusAmqpIntegrationTests {
         final @Getter BusEventCollector local;
         final @Getter BusEventCollector remote;
 
-        public <E extends InfoEvent> EventsCaptor captureEventsOf(Class<E> type) {
+        public <E extends GeoServerEvent> EventsCaptor captureEventsOf(Class<E> type) {
             local.capture(type);
             remote.capture(type);
             return this;

--- a/src/catalog/events/src/test/java/org/geoserver/cloud/event/bus/BusEventCollector.java
+++ b/src/catalog/events/src/test/java/org/geoserver/cloud/event/bus/BusEventCollector.java
@@ -57,7 +57,7 @@ public class BusEventCollector {
         }
     }
 
-    public void capture(@NonNull Class<? extends InfoEvent> type) {
+    public void capture(@NonNull Class<? extends GeoServerEvent> type) {
         this.eventType = type;
     }
 
@@ -65,7 +65,7 @@ public class BusEventCollector {
         this.eventType = type;
     }
 
-    public <T extends InfoEvent> RemoteGeoServerEvent expectOne(Class<T> payloadType) {
+    public <T extends GeoServerEvent> RemoteGeoServerEvent expectOne(Class<T> payloadType) {
 
         return expectOne(payloadType, x -> true);
     }
@@ -74,7 +74,7 @@ public class BusEventCollector {
         return expectOne(payloadType, c -> infoType.equals(c.getObjectType()));
     }
 
-    public <T extends InfoEvent> RemoteGeoServerEvent expectOne(Class<T> payloadType, Predicate<T> filter) {
+    public <T extends GeoServerEvent> RemoteGeoServerEvent expectOne(Class<T> payloadType, Predicate<T> filter) {
 
         List<RemoteGeoServerEvent> matches = await().atMost(Duration.ofSeconds(10)) //
                 .until(() -> allOf(payloadType, filter), not(List::isEmpty));

--- a/src/catalog/events/src/test/java/org/geoserver/cloud/event/bus/SecurityRemoteApplicationEventsIT.java
+++ b/src/catalog/events/src/test/java/org/geoserver/cloud/event/bus/SecurityRemoteApplicationEventsIT.java
@@ -1,0 +1,81 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.event.bus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.geoserver.cloud.event.GeoServerEvent;
+import org.geoserver.cloud.event.security.RolesChanged;
+import org.geoserver.cloud.event.security.SecurityConfigChanged;
+import org.geoserver.cloud.event.security.UsersAndGroupsChanged;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+
+/**
+ * Verifies the security events published by one service instance reach the other instances through the event bus with
+ * their payload intact.
+ */
+class SecurityRemoteApplicationEventsIT extends BusAmqpIntegrationTests {
+
+    private @Autowired ApplicationEventPublisher localEventPublisher;
+
+    @Test
+    void usersAndGroupsChangedReachesTheRemoteService() {
+        eventsCaptor.stop().clear().captureEventsOf(UsersAndGroupsChanged.class).start();
+
+        localEventPublisher.publishEvent(UsersAndGroupsChanged.createLocal("default"));
+
+        UsersAndGroupsChanged sent = expectSent(UsersAndGroupsChanged.class);
+        assertThat(sent.getServiceName()).isEqualTo("default");
+
+        UsersAndGroupsChanged received = expectReceived(UsersAndGroupsChanged.class);
+        assertThat(received.getServiceName()).isEqualTo("default");
+    }
+
+    @Test
+    void rolesChangedReachesTheRemoteService() {
+        eventsCaptor.stop().clear().captureEventsOf(RolesChanged.class).start();
+
+        localEventPublisher.publishEvent(RolesChanged.createLocal("default"));
+
+        RolesChanged sent = expectSent(RolesChanged.class);
+        assertThat(sent.getServiceName()).isEqualTo("default");
+
+        RolesChanged received = expectReceived(RolesChanged.class);
+        assertThat(received.getServiceName()).isEqualTo("default");
+    }
+
+    @Test
+    void securityConfigChangedReachesTheRemoteService() {
+        eventsCaptor.stop().clear().captureEventsOf(SecurityConfigChanged.class).start();
+
+        localEventPublisher.publishEvent(SecurityConfigChanged.createLocal(1002L, "SecurityManagerConfig changed"));
+
+        SecurityConfigChanged sent = expectSent(SecurityConfigChanged.class);
+        assertThat(sent.getReason()).isEqualTo("SecurityManagerConfig changed");
+
+        SecurityConfigChanged received = expectReceived(SecurityConfigChanged.class);
+        assertThat(received.getReason()).isEqualTo("SecurityManagerConfig changed");
+        assertThat(received.getUpdateSequence()).isEqualTo(1002L);
+    }
+
+    /** The event as broadcast by the local service instance */
+    private <E extends GeoServerEvent> E expectSent(Class<E> type) {
+        RemoteGeoServerEvent busEvent = eventsCaptor.local().expectOne(type);
+        E event = type.cast(busEvent.getEvent());
+        assertThat(event.isLocal()).isTrue();
+        return event;
+    }
+
+    /** The event as received by the remote service instance, after a round trip through the message broker */
+    private <E extends GeoServerEvent> E expectReceived(Class<E> type) {
+        RemoteGeoServerEvent busEvent = eventsCaptor.remote().expectOne(type);
+        E event = type.cast(busEvent.getEvent());
+        assertThat(event.isRemote()).isTrue();
+        return event;
+    }
+}

--- a/src/main/src/main/java/org/geoserver/cloud/autoconfigure/main/GeoServerMainSecurityAutoConfiguration.java
+++ b/src/main/src/main/java/org/geoserver/cloud/autoconfigure/main/GeoServerMainSecurityAutoConfiguration.java
@@ -11,7 +11,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.geoserver.GeoServerConfigurationLock;
-import org.geoserver.cloud.event.security.SecurityConfigChanged;
+import org.geoserver.cloud.event.GeoServerEvent;
 import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.config.util.XStreamPersisterFactory;
 import org.geoserver.configuration.core.main.GeoServerMainSecurityConfiguration;
@@ -82,7 +82,7 @@ public class GeoServerMainSecurityAutoConfiguration {
                             .map(Class::getCanonicalName)
                             .collect(Collectors.joining(", ")));
         }
-        Consumer<SecurityConfigChanged> publisher = localContextPublisher::publishEvent;
+        Consumer<GeoServerEvent> publisher = localContextPublisher::publishEvent;
         Supplier<Long> updateSequenceIncrementor = updateSequence::nextValue;
 
         return new CloudGeoServerSecurityManager(

--- a/src/main/src/main/java/org/geoserver/security/ChangeNotifyingRoleService.java
+++ b/src/main/src/main/java/org/geoserver/security/ChangeNotifyingRoleService.java
@@ -1,0 +1,43 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.security;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Delegate;
+
+/**
+ * Decorates a {@link GeoServerRoleService} to have every store created through it announce the changes saved through
+ * that store.
+ *
+ * <p>Every other method is delegated as-is; only {@link #createStore()} is intercepted, to wrap the returned store in a
+ * {@link ChangeNotifyingRoleStore}.
+ */
+@RequiredArgsConstructor
+class ChangeNotifyingRoleService implements GeoServerRoleService {
+
+    @Delegate(excludes = StoreFactory.class)
+    private final @NonNull GeoServerRoleService delegate;
+
+    /** Called with the service name once a store created by this service saved its changes */
+    private final @NonNull Consumer<String> onStored;
+
+    @Override
+    public GeoServerRoleStore createStore() throws IOException {
+        GeoServerRoleStore store = delegate.createStore();
+        if (store == null) {
+            return null;
+        }
+        return new ChangeNotifyingRoleStore(store, () -> onStored.accept(delegate.getName()));
+    }
+
+    /** Methods implemented by this decorator itself rather than delegated */
+    private interface StoreFactory {
+        GeoServerRoleStore createStore() throws IOException;
+    }
+}

--- a/src/main/src/main/java/org/geoserver/security/ChangeNotifyingRoleStore.java
+++ b/src/main/src/main/java/org/geoserver/security/ChangeNotifyingRoleStore.java
@@ -1,0 +1,39 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.security;
+
+import java.io.IOException;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Delegate;
+
+/**
+ * Decorates a {@link GeoServerRoleStore} to run a callback once {@link #store()} saved pending changes.
+ *
+ * <p>Storing an unmodified store is a no-op upstream and stays silent here too.
+ */
+@RequiredArgsConstructor
+class ChangeNotifyingRoleStore implements GeoServerRoleStore {
+
+    @Delegate(excludes = Store.class)
+    private final @NonNull GeoServerRoleStore delegate;
+
+    private final @NonNull Runnable onStored;
+
+    @Override
+    public void store() throws IOException {
+        boolean modified = delegate.isModified();
+        delegate.store();
+        if (modified) {
+            onStored.run();
+        }
+    }
+
+    /** Methods implemented by this decorator itself rather than delegated */
+    private interface Store {
+        void store() throws IOException;
+    }
+}

--- a/src/main/src/main/java/org/geoserver/security/ChangeNotifyingUserGroupService.java
+++ b/src/main/src/main/java/org/geoserver/security/ChangeNotifyingUserGroupService.java
@@ -1,0 +1,43 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.security;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Delegate;
+
+/**
+ * Decorates a {@link GeoServerUserGroupService} to have every store created through it announce the changes saved
+ * through that store.
+ *
+ * <p>Every other method is delegated as-is; only {@link #createStore()} is intercepted, to wrap the returned store in a
+ * {@link ChangeNotifyingUserGroupStore}.
+ */
+@RequiredArgsConstructor
+class ChangeNotifyingUserGroupService implements GeoServerUserGroupService {
+
+    @Delegate(excludes = StoreFactory.class)
+    private final @NonNull GeoServerUserGroupService delegate;
+
+    /** Called with the service name once a store created by this service saved its changes */
+    private final @NonNull Consumer<String> onStored;
+
+    @Override
+    public GeoServerUserGroupStore createStore() throws IOException {
+        GeoServerUserGroupStore store = delegate.createStore();
+        if (store == null) {
+            return null;
+        }
+        return new ChangeNotifyingUserGroupStore(store, () -> onStored.accept(delegate.getName()));
+    }
+
+    /** Methods implemented by this decorator itself rather than delegated */
+    private interface StoreFactory {
+        GeoServerUserGroupStore createStore() throws IOException;
+    }
+}

--- a/src/main/src/main/java/org/geoserver/security/ChangeNotifyingUserGroupStore.java
+++ b/src/main/src/main/java/org/geoserver/security/ChangeNotifyingUserGroupStore.java
@@ -1,0 +1,39 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.security;
+
+import java.io.IOException;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Delegate;
+
+/**
+ * Decorates a {@link GeoServerUserGroupStore} to run a callback once {@link #store()} saved pending changes.
+ *
+ * <p>Storing an unmodified store is a no-op upstream and stays silent here too.
+ */
+@RequiredArgsConstructor
+class ChangeNotifyingUserGroupStore implements GeoServerUserGroupStore {
+
+    @Delegate(excludes = Store.class)
+    private final @NonNull GeoServerUserGroupStore delegate;
+
+    private final @NonNull Runnable onStored;
+
+    @Override
+    public void store() throws IOException {
+        boolean modified = delegate.isModified();
+        delegate.store();
+        if (modified) {
+            onStored.run();
+        }
+    }
+
+    /** Methods implemented by this decorator itself rather than delegated */
+    private interface Store {
+        void store() throws IOException;
+    }
+}

--- a/src/main/src/main/java/org/geoserver/security/CloudGeoServerSecurityManager.java
+++ b/src/main/src/main/java/org/geoserver/security/CloudGeoServerSecurityManager.java
@@ -15,8 +15,11 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.geoserver.GeoServerConfigurationLock;
 import org.geoserver.GeoServerConfigurationLock.LockType;
+import org.geoserver.cloud.event.GeoServerEvent;
+import org.geoserver.cloud.event.security.RolesChanged;
 import org.geoserver.cloud.event.security.SecurityConfigChanged;
 import org.geoserver.cloud.event.security.SecurityManagerReloaded;
+import org.geoserver.cloud.event.security.UsersAndGroupsChanged;
 import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.security.config.PasswordPolicyConfig;
 import org.geoserver.security.config.SecurityAuthProviderConfig;
@@ -36,11 +39,17 @@ import org.springframework.security.authentication.AuthenticationProvider;
  * to the security configuration happened on the currently running service, and to
  * {@link #onRemoteSecurityConfigChangeEvent listen to} those events to {@link GeoServerSecurityManager#reload() reload}
  * the security config when other service made a change.
+ *
+ * <p>Changes to the contents of user/group and role services (users, groups, roles and their associations) are notified
+ * separately, through {@link UsersAndGroupsChanged} and {@link RolesChanged}: the services returned by
+ * {@link #loadUserGroupService(String)} and {@link #loadRoleService(String)} create stores that fire those events once
+ * saved, and {@link #onRemoteUsersAndGroupsChanged} and {@link #onRemoteRolesChanged} reload just the named service,
+ * instead of the whole security configuration, when another service instance saved such a store.
  */
 @Slf4j(topic = "org.geoserver.cloud.security")
 public class CloudGeoServerSecurityManager extends GeoServerSecurityManager {
 
-    private final Consumer<SecurityConfigChanged> eventPublisher;
+    private final Consumer<GeoServerEvent> eventPublisher;
     private final Supplier<Long> updateSequenceIncrementor;
 
     // Store applicationContext from setApplicationContext method
@@ -53,7 +62,7 @@ public class CloudGeoServerSecurityManager extends GeoServerSecurityManager {
     public CloudGeoServerSecurityManager(
             GeoServerConfigurationLock configLock,
             GeoServerDataDirectory dataDir,
-            @NonNull Consumer<SecurityConfigChanged> eventPublisher,
+            @NonNull Consumer<GeoServerEvent> eventPublisher,
             @NonNull Supplier<Long> updateSequenceIncrementor,
             @NonNull List<AuthenticationProvider> additionalAuthenticationProviders)
             throws Exception {
@@ -131,16 +140,115 @@ public class CloudGeoServerSecurityManager extends GeoServerSecurityManager {
         log.debug("Security configuration reloaded due to change event:", event);
     }
 
+    /** Listens to {@link UsersAndGroupsChanged} sent by other services and reloads the named user group service */
+    @EventListener(UsersAndGroupsChanged.class)
+    public void onRemoteUsersAndGroupsChanged(UsersAndGroupsChanged event) {
+        if (shallHandle(event)) {
+            reloadUserGroupService(event.getServiceName());
+        }
+    }
+
+    /** Listens to {@link RolesChanged} sent by other services and reloads the named role service */
+    @EventListener(RolesChanged.class)
+    public void onRemoteRolesChanged(RolesChanged event) {
+        if (shallHandle(event)) {
+            reloadRoleService(event.getServiceName());
+        }
+    }
+
+    private boolean shallHandle(GeoServerEvent event) {
+        if (event.isLocal()) {
+            return false;
+        }
+        if (!isInitialized()) {
+            log.info("Ignoring event, security subsystem not yet initialized: {}", event);
+            return false;
+        }
+        return true;
+    }
+
+    private void reloadUserGroupService(String serviceName) {
+        try {
+            GeoServerUserGroupService service = loadUserGroupService(serviceName);
+            if (service == null) {
+                log.info("Ignoring users and groups change, no user group service named {}", serviceName);
+            } else {
+                log.info("Reloading users and groups of service {}", serviceName);
+                service.load();
+            }
+        } catch (IOException e) {
+            log.error("Error reloading users and groups of service {}", serviceName, e);
+        }
+    }
+
+    private void reloadRoleService(String serviceName) {
+        try {
+            GeoServerRoleService service = loadRoleService(serviceName);
+            if (service == null) {
+                log.info("Ignoring roles change, no role service named {}", serviceName);
+            } else {
+                log.info("Reloading roles of service {}", serviceName);
+                service.load();
+            }
+        } catch (IOException e) {
+            log.error("Error reloading roles of service {}", serviceName, e);
+        }
+    }
+
+    /**
+     * Override to make the stores created by the returned service {@link #fireUsersAndGroupsChanged fire} a remote
+     * {@link UsersAndGroupsChanged} once saved
+     */
+    @Override
+    public GeoServerUserGroupService loadUserGroupService(String name) throws IOException {
+        GeoServerUserGroupService service = super.loadUserGroupService(name);
+        if (service == null) {
+            return null;
+        }
+        return new ChangeNotifyingUserGroupService(service, this::fireUsersAndGroupsChanged);
+    }
+
+    /**
+     * Override to make the stores created by the returned service {@link #fireRolesChanged fire} a remote
+     * {@link RolesChanged} once saved
+     */
+    @Override
+    public GeoServerRoleService loadRoleService(String name) throws IOException {
+        GeoServerRoleService service = super.loadRoleService(name);
+        if (service == null) {
+            return null;
+        }
+        return new ChangeNotifyingRoleService(service, this::fireRolesChanged);
+    }
+
     /**
      * Fires a {@link SecurityConfigChanged} for other services to react accordingly, unless it is {@link #reload()
      * reloading} .
      */
     public void fireRemoteChangedEvent(@NonNull String reason) {
+        publishUnlessReloading(reason, () -> event(reason));
+    }
+
+    /**
+     * Fires a {@link UsersAndGroupsChanged} for the named user group service, unless it is {@link #reload() reloading}
+     */
+    void fireUsersAndGroupsChanged(@NonNull String serviceName) {
+        String reason = "users and groups of service %s changed".formatted(serviceName);
+        publishUnlessReloading(reason, () -> UsersAndGroupsChanged.createLocal(serviceName));
+    }
+
+    /** Fires a {@link RolesChanged} for the named role service, unless it is {@link #reload() reloading} */
+    void fireRolesChanged(@NonNull String serviceName) {
+        String reason = "roles of service %s changed".formatted(serviceName);
+        publishUnlessReloading(reason, () -> RolesChanged.createLocal(serviceName));
+    }
+
+    private void publishUnlessReloading(String reason, Supplier<GeoServerEvent> event) {
         if (reloading.get()) {
             log.info("{}: won't send security change event, config is reloading", reason);
         } else {
             log.debug("Publishing remote security event due to {}", reason);
-            eventPublisher.accept(event(reason));
+            eventPublisher.accept(event.get());
         }
     }
 

--- a/src/main/src/test/java/org/geoserver/security/CloudGeoServerSecurityManagerTest.java
+++ b/src/main/src/test/java/org/geoserver/security/CloudGeoServerSecurityManagerTest.java
@@ -1,0 +1,297 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import lombok.SneakyThrows;
+import org.geoserver.GeoServerConfigurationLock;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.impl.CatalogImpl;
+import org.geoserver.cloud.autoconfigure.main.GeoServerMainSecurityAutoConfiguration;
+import org.geoserver.cloud.event.GeoServerEvent;
+import org.geoserver.cloud.event.security.RolesChanged;
+import org.geoserver.cloud.event.security.UsersAndGroupsChanged;
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.GeoServerDataDirectory;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.platform.GeoServerResourceLoader;
+import org.geoserver.platform.config.UpdateSequence;
+import org.geoserver.platform.resource.FileSystemResourceStore;
+import org.geoserver.platform.resource.FileSystemWatcher;
+import org.geoserver.platform.resource.ResourceStore;
+import org.geoserver.security.impl.GeoServerRole;
+import org.geoserver.security.impl.GeoServerUser;
+import org.geoserver.security.xml.XMLRoleService;
+import org.geoserver.security.xml.XMLUserGroupService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.runner.ContextConsumer;
+import org.springframework.context.event.EventListener;
+
+/**
+ * Verifies {@link CloudGeoServerSecurityManager} broadcasts changes to the contents of user/group and role services to
+ * the other service instances, and refreshes the named service when such a change arrives from another instance.
+ */
+class CloudGeoServerSecurityManagerTest {
+
+    private static final String USER_GROUP_SERVICE = XMLUserGroupService.DEFAULT_NAME;
+    private static final String ROLE_SERVICE = XMLRoleService.DEFAULT_NAME;
+
+    @TempDir
+    File dataDirectory;
+
+    private ApplicationContextRunner runner;
+
+    @BeforeEach
+    void setUp() {
+        runner = createContextRunner(dataDirectory);
+    }
+
+    @Test
+    void addingAUserBroadcastsUsersAndGroupsChanged() {
+        runInitialized(context -> {
+            addUser(securityManager(context), "newuser");
+
+            UsersAndGroupsChanged event = publishedEvents(context).expectOne(UsersAndGroupsChanged.class);
+            assertThat(event.getServiceName()).isEqualTo(USER_GROUP_SERVICE);
+            assertThat(event.isLocal()).isTrue();
+        });
+    }
+
+    @Test
+    void addingARoleBroadcastsRolesChanged() {
+        runInitialized(context -> {
+            addRole(securityManager(context), "ROLE_NEW");
+
+            RolesChanged event = publishedEvents(context).expectOne(RolesChanged.class);
+            assertThat(event.getServiceName()).isEqualTo(ROLE_SERVICE);
+            assertThat(event.isLocal()).isTrue();
+        });
+    }
+
+    @Test
+    void storingWithoutChangesBroadcastsNothing() {
+        runInitialized(context -> {
+            CloudGeoServerSecurityManager manager = securityManager(context);
+            manager.loadUserGroupService(USER_GROUP_SERVICE).createStore().store();
+            manager.loadRoleService(ROLE_SERVICE).createStore().store();
+
+            assertThat(publishedEvents(context).all()).isEmpty();
+        });
+    }
+
+    @Test
+    void remoteUsersAndGroupsChangedRefreshesTheNamedService() {
+        runInitialized(context -> {
+            CloudGeoServerSecurityManager manager = securityManager(context);
+            assertThat(userNames(manager)).doesNotContain("newuser");
+
+            addUserFromAnotherInstance(manager, "newuser");
+            assertThat(userNames(manager))
+                    .as("the cached service is stale until the event arrives")
+                    .doesNotContain("newuser");
+
+            context.publishEvent(remote(UsersAndGroupsChanged.createLocal(USER_GROUP_SERVICE)));
+
+            assertThat(userNames(manager)).contains("newuser");
+        });
+    }
+
+    @Test
+    void remoteRolesChangedRefreshesTheNamedService() {
+        runInitialized(context -> {
+            CloudGeoServerSecurityManager manager = securityManager(context);
+            assertThat(roleNames(manager)).doesNotContain("ROLE_NEW");
+
+            addRoleFromAnotherInstance(manager, "ROLE_NEW");
+            assertThat(roleNames(manager))
+                    .as("the cached service is stale until the event arrives")
+                    .doesNotContain("ROLE_NEW");
+
+            context.publishEvent(remote(RolesChanged.createLocal(ROLE_SERVICE)));
+
+            assertThat(roleNames(manager)).contains("ROLE_NEW");
+        });
+    }
+
+    @Test
+    void localEventsDoNotRefreshServices() {
+        runInitialized(context -> {
+            CloudGeoServerSecurityManager manager = securityManager(context);
+            addUserFromAnotherInstance(manager, "newuser");
+            addRoleFromAnotherInstance(manager, "ROLE_NEW");
+
+            context.publishEvent(UsersAndGroupsChanged.createLocal(USER_GROUP_SERVICE));
+            context.publishEvent(RolesChanged.createLocal(ROLE_SERVICE));
+
+            assertThat(userNames(manager)).doesNotContain("newuser");
+            assertThat(roleNames(manager)).doesNotContain("ROLE_NEW");
+        });
+    }
+
+    @Test
+    void remoteEventsForUnknownServicesAreIgnored() {
+        runInitialized(context -> assertThatCode(() -> {
+                    context.publishEvent(remote(UsersAndGroupsChanged.createLocal("no-such-service")));
+                    context.publishEvent(remote(RolesChanged.createLocal("no-such-service")));
+                })
+                .doesNotThrowAnyException());
+    }
+
+    private void runInitialized(ContextConsumer<AssertableApplicationContext> test) {
+        runner.run(context -> {
+            assertThat(context).hasNotFailed();
+            securityManager(context).reload();
+            publishedEvents(context).clear();
+            test.accept(context);
+        });
+    }
+
+    private CloudGeoServerSecurityManager securityManager(AssertableApplicationContext context) {
+        return context.getBean(CloudGeoServerSecurityManager.class);
+    }
+
+    private PublishedEvents publishedEvents(AssertableApplicationContext context) {
+        return context.getBean(PublishedEvents.class);
+    }
+
+    private void addUser(GeoServerSecurityManager manager, String username) throws Exception {
+        addUser(manager.loadUserGroupService(USER_GROUP_SERVICE), username);
+    }
+
+    /**
+     * Mimics another service instance writing to the shared storage:
+     * {@link GeoServerSecurityManager#loadUserGroupServices()} creates fresh, uncached service instances over the same
+     * files, and storing through them leaves the service cached by the manager untouched.
+     */
+    private void addUserFromAnotherInstance(GeoServerSecurityManager manager, String username) throws Exception {
+        GeoServerUserGroupService detached = manager.loadUserGroupServices().stream()
+                .filter(service -> USER_GROUP_SERVICE.equals(service.getName()))
+                .findFirst()
+                .orElseThrow();
+        addUser(detached, username);
+    }
+
+    private void addUser(GeoServerUserGroupService service, String username) throws Exception {
+        GeoServerUserGroupStore store = service.createStore();
+        GeoServerUser user = store.createUserObject(username, "s3cret", true);
+        store.addUser(user);
+        store.store();
+    }
+
+    private void addRole(GeoServerSecurityManager manager, String roleName) throws IOException {
+        addRole(manager.loadRoleService(ROLE_SERVICE), roleName);
+    }
+
+    /**
+     * Mimics another service instance writing to the shared storage: the helper creates a fresh, uncached role service
+     * over the same files, and storing through it leaves the service cached by the manager untouched.
+     */
+    private void addRoleFromAnotherInstance(GeoServerSecurityManager manager, String roleName) throws IOException {
+        GeoServerRoleService detached = manager.roleServiceHelper.load(ROLE_SERVICE);
+        addRole(detached, roleName);
+    }
+
+    private void addRole(GeoServerRoleService service, String roleName) throws IOException {
+        GeoServerRoleStore store = service.createStore();
+        store.addRole(store.createRoleObject(roleName));
+        store.store();
+    }
+
+    private List<String> userNames(GeoServerSecurityManager manager) throws IOException {
+        SortedSet<GeoServerUser> users =
+                manager.loadUserGroupService(USER_GROUP_SERVICE).getUsers();
+        return users.stream().map(GeoServerUser::getUsername).toList();
+    }
+
+    private List<String> roleNames(GeoServerSecurityManager manager) throws IOException {
+        SortedSet<GeoServerRole> roles = manager.loadRoleService(ROLE_SERVICE).getRoles();
+        return roles.stream().map(GeoServerRole::getAuthority).toList();
+    }
+
+    private <E extends GeoServerEvent> E remote(E event) {
+        event.setRemote(true);
+        event.setOrigin("another-instance");
+        return event;
+    }
+
+    @SneakyThrows(Exception.class)
+    private static ApplicationContextRunner createContextRunner(File dataDirectory) {
+        Catalog rawCatalog = new CatalogImpl();
+        SecureCatalogImpl secureCatalog = new SecureCatalogImpl(rawCatalog, new TestResourceAccessManager());
+        GeoServer geoserver = mock(GeoServer.class);
+        FileSystemResourceStore resourceStore = new FileSystemResourceStore(dataDirectory);
+        disableFilePolling(resourceStore);
+        GeoServerResourceLoader resourceLoader = new GeoServerResourceLoader(resourceStore);
+        GeoServerDataDirectory datadir = new GeoServerDataDirectory(resourceLoader);
+        UpdateSequence updateSequence = mock(UpdateSequence.class);
+
+        return new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(GeoServerMainSecurityAutoConfiguration.class))
+                .withBean("extensions", GeoServerExtensions.class)
+                .withBean(GeoServerConfigurationLock.class)
+                .withBean(ResourceStore.class, () -> resourceStore)
+                .withBean(GeoServerResourceLoader.class, () -> resourceLoader)
+                .withBean("dataDirectory", GeoServerDataDirectory.class, () -> datadir)
+                .withBean("rawCatalog", Catalog.class, () -> rawCatalog)
+                .withBean("catalog", Catalog.class, () -> secureCatalog)
+                .withBean("secureCatalog", Catalog.class, () -> secureCatalog)
+                .withBean("geoServer", GeoServer.class, () -> geoserver)
+                .withBean("updateSequence", UpdateSequence.class, () -> updateSequence)
+                .withBean(PublishedEvents.class)
+                .withPropertyValues("logging.level.org.geoserver.platform: off");
+    }
+
+    /**
+     * The XML services poll their files for external changes. A long polling delay keeps that out of the way: the
+     * refresh under test is the one triggered by the events.
+     */
+    private static void disableFilePolling(FileSystemResourceStore resourceStore) {
+        FileSystemWatcher watcher = (FileSystemWatcher) resourceStore.getResourceNotificationDispatcher();
+        watcher.schedule(1, TimeUnit.HOURS);
+    }
+
+    /** Collects the events published by the security manager into the application context */
+    static class PublishedEvents {
+
+        private final List<GeoServerEvent> events = new CopyOnWriteArrayList<>();
+
+        @EventListener(GeoServerEvent.class)
+        void onEvent(GeoServerEvent event) {
+            events.add(event);
+        }
+
+        List<GeoServerEvent> all() {
+            return List.copyOf(events);
+        }
+
+        void clear() {
+            events.clear();
+        }
+
+        <E extends GeoServerEvent> E expectOne(Class<E> type) {
+            List<E> matches =
+                    events.stream().filter(type::isInstance).map(type::cast).toList();
+            assertThat(matches)
+                    .as("expected one %s, got %s", type.getSimpleName(), events)
+                    .hasSize(1);
+            return matches.getFirst();
+        }
+    }
+}


### PR DESCRIPTION
Broadcast user, group and role changes over the event bus.

The security manager only published SecurityConfigChanged when a security service configuration was saved, saving a user group or role store go through a different path.

Add the UsersAndGroupsChanged and RolesChanged events, and decorate the user group and role services loaded through the security manager with event firing and handling stores. On the receiving side reload only the named service instead of the whole security configuration.

The new events extend GeoServerEvent directly: a user or role change alters nothing described by a capabilities document, and must neither bump the update sequence nor evict the configuration caches.

Fixes #702

on-behalf-of: @multiversio <info@multivers.io>


<!--Include a few sentences describing the overall goals for this Pull Request-->

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver-cloud/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] I have read and applied the [AI policy](https://geoserver.org/ai)
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For source code changes:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver-cloud/tree/main/docs/src) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoServer Cloud](https://github.com/geoserver/geoserver-cloud/issues) Github issues (except for changes that do not affect administrators or end users in any way).
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate Github issue describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green, there is a core committer review, and the checklist has been fulfilled.
