### PR TITLE
fix: NPE posting a layer group without <style> elements

### DIFF
--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/validation/DefaultPropertyValuesResolver.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/validation/DefaultPropertyValuesResolver.java
@@ -153,11 +153,13 @@ public class DefaultPropertyValuesResolver {
     }
 
     private void resolve(LayerGroupInfo layerGroup) {
+        // XStream bypasses field initializers and leaves the styles list null; resolving the collections first turns
+        // that null into an empty list
+        resolveCollections(layerGroup);
         List<StyleInfo> styles = layerGroup.getStyles();
         if (styles.isEmpty()) {
             layerGroup.getLayers().forEach(l -> styles.add(null));
         }
-        resolveCollections(layerGroup);
     }
 
     private void resolve(StyleInfo style) {

--- a/src/catalog/plugin/src/test/java/org/geoserver/catalog/plugin/CatalogConformanceTest.java
+++ b/src/catalog/plugin/src/test/java/org/geoserver/catalog/plugin/CatalogConformanceTest.java
@@ -2322,6 +2322,24 @@ public abstract class CatalogConformanceTest {
         assertThrows(IllegalArgumentException.class, () -> catalog.add(lg2));
     }
 
+    /**
+     * A layer group posted through the REST API without a {@code <styles>} element reaches the catalog with a
+     * {@code null} styles list, since XStream bypasses field initializers. The catalog must assign the default style to
+     * every layer instead of failing.
+     */
+    @Test
+    void testAddLayerGroupWithNullStylesAssignsDefaultStyles() {
+        LayerInfo layer = addLayer();
+        LayerGroupInfo lg = catalog.getFactory().createLayerGroup();
+        lg.setName("layerGroupWithoutStyles");
+        lg.getLayers().add(layer);
+        OwsUtils.set(lg, "styles", null);
+
+        LayerGroupInfo added = addLayerGroup(lg);
+
+        assertEquals(Collections.singletonList(null), added.getStyles());
+    }
+
     @Test
     void testGetLayerGroupByName() {
         addLayerGroup();

--- a/src/catalog/plugin/src/test/java/org/geoserver/catalog/plugin/validation/DefaultPropertyValuesResolverTest.java
+++ b/src/catalog/plugin/src/test/java/org/geoserver/catalog/plugin/validation/DefaultPropertyValuesResolverTest.java
@@ -1,0 +1,80 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.catalog.plugin.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.CatalogTestData;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.impl.LayerGroupInfoImpl;
+import org.geoserver.catalog.plugin.CatalogPlugin;
+import org.geoserver.config.plugin.GeoServerImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DefaultPropertyValuesResolverTest {
+
+    Catalog catalog;
+    DefaultPropertyValuesResolver resolver;
+    CatalogTestData testData;
+
+    @BeforeEach
+    void setUp() {
+        catalog = new CatalogPlugin();
+        GeoServerImpl geoServer = new GeoServerImpl();
+        geoServer.setCatalog(catalog);
+        resolver = new DefaultPropertyValuesResolver(catalog);
+        testData = CatalogTestData.initialized(() -> catalog, () -> geoServer).initCatalog();
+    }
+
+    /**
+     * A layer group deserialized from a REST payload without a {@code <styles>} element has a {@code null} styles list,
+     * since XStream bypasses field initializers. The resolver must treat it like an empty list and assign the default
+     * style to every layer.
+     */
+    @Test
+    void resolveLayerGroupWithNullStylesAssignsOneDefaultStylePerLayer() {
+        LayerGroupInfoImpl layerGroup = layerGroupWithTwoLayers();
+        layerGroup.setStyles(null);
+
+        resolver.resolve((CatalogInfo) layerGroup);
+
+        assertEquals(Arrays.asList(null, null), layerGroup.getStyles());
+    }
+
+    @Test
+    void resolveLayerGroupWithEmptyStylesAssignsOneDefaultStylePerLayer() {
+        LayerGroupInfoImpl layerGroup = layerGroupWithTwoLayers();
+        layerGroup.getStyles().clear();
+
+        resolver.resolve((CatalogInfo) layerGroup);
+
+        assertEquals(Arrays.asList(null, null), layerGroup.getStyles());
+    }
+
+    @Test
+    void resolveLayerGroupWithAssignedStylesLeavesThemUntouched() {
+        LayerGroupInfoImpl layerGroup = layerGroupWithTwoLayers();
+        List<StyleInfo> assigned = Arrays.asList(testData.style1, testData.style2);
+        layerGroup.setStyles(assigned);
+
+        resolver.resolve((CatalogInfo) layerGroup);
+
+        assertEquals(assigned, layerGroup.getStyles());
+    }
+
+    private LayerGroupInfoImpl layerGroupWithTwoLayers() {
+        LayerGroupInfoImpl layerGroup = new LayerGroupInfoImpl();
+        layerGroup.setName("layerGroup");
+        layerGroup.getLayers().add(testData.layerFeatureTypeA);
+        layerGroup.getLayers().add(testData.layerFeatureTypeA);
+        return layerGroup;
+    }
+}


### PR DESCRIPTION
Resolve the collections first, assign default styles to layer groups added without styles, otherwise it reaches the catalog with a null styles list since XStream bypasses field initializers.

on-behalf-of: @multiversio <info@multivers.io>


<!--Include a few sentences describing the overall goals for this Pull Request-->

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver-cloud/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] I have read and applied the [AI policy](https://geoserver.org/ai)
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For source code changes:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver-cloud/tree/main/docs/src) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoServer Cloud](https://github.com/geoserver/geoserver-cloud/issues) Github issues (except for changes that do not affect administrators or end users in any way).
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate Github issue describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green, there is a core committer review, and the checklist has been fulfilled.
