### PR TITLE
fix: Default style change ignored by pods on warm catalog cache

### DIFF
--- a/src/catalog/cache/src/main/java/org/geoserver/cloud/catalog/cache/CachedReferenceCleaner.java
+++ b/src/catalog/cache/src/main/java/org/geoserver/cloud/catalog/cache/CachedReferenceCleaner.java
@@ -130,8 +130,9 @@ class CachedReferenceCleaner {
             case COVERAGESTORE, DATASTORE, WMSSTORE, WMTSSTORE -> canReferenceStore(cached, evicted);
             case COVERAGE, FEATURETYPE, WMSLAYER, WMTSLAYER -> canReferenceResource(cached, evicted);
 
-            // evicted a LayerInfo, only LayerGroupInfos may reference it
-            case LAYER -> cached instanceof LayerGroupInfo;
+            // evicted a LayerInfo, held by the cached layers-by-resource lists and referenced by LayerGroupInfos
+            case LAYER ->
+                (cached instanceof LayerInfo l && evicted.id().equals(l.getId())) || cached instanceof LayerGroupInfo;
 
             // evicted a LayerGroupInfo, only other LayerGroupInfos may reference it
             case LAYERGROUP -> cached instanceof LayerGroupInfo;

--- a/src/catalog/cache/src/test/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeContainmentSupportTest.java
+++ b/src/catalog/cache/src/test/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeContainmentSupportTest.java
@@ -314,6 +314,27 @@ class CachingCatalogFacadeContainmentSupportTest {
         assertNotCached(key);
     }
 
+    /**
+     * Remote events only provide the id, name and type of the modified object, hence
+     * {@code Catalog.getLayerByName(prefixedName)}, which resolves the resource and then calls
+     * {@code getLayers(resource)}, kept returning the stale cached layer.
+     */
+    @Test
+    @DisplayName("when a LayerInfo is evicted by id and name, the layers by resource list holding it is evicted")
+    void testEvictByIdAndNameLayerInfoEvictsLayersByResource() {
+        LayerInfo layer = stub(LayerInfo.class);
+        FeatureTypeInfo resource = stub(FeatureTypeInfo.class);
+        when(layer.getResource()).thenReturn(resource);
+
+        InfoIdKey key = support.generateLayersByResourceKey(resource);
+        List<LayerInfo> value = List.of(layer);
+        support.getCache().put(key, value);
+
+        assertCached(key, value);
+        support.evict(layer.getId(), InfoEvent.prefixedName(layer), ConfigInfoType.LAYER);
+        assertNotCached(key);
+    }
+
     @Test
     @DisplayName("when a StoreInfo is evicted, the keys for StoreInfo and its concrete type are evicted")
     void testEvictStoreInfoEvictsTheGenericAndConcreteTypeKeys() {

--- a/src/catalog/cache/src/test/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeTest.java
+++ b/src/catalog/cache/src/test/java/org/geoserver/cloud/catalog/cache/CachingCatalogFacadeTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.geoserver.catalog.CatalogFacade.ANY_WORKSPACE;
 import static org.geoserver.catalog.CatalogFacade.NO_WORKSPACE;
 import static org.geoserver.cloud.event.info.ConfigInfoType.FEATURETYPE;
+import static org.geoserver.cloud.event.info.ConfigInfoType.LAYER;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -58,6 +59,7 @@ import org.geoserver.cloud.event.catalog.DefaultDataStoreSet;
 import org.geoserver.cloud.event.info.ConfigInfoType;
 import org.geoserver.cloud.event.info.InfoEvent;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -439,6 +441,25 @@ class CachingCatalogFacadeTest {
         facade.getLayers(resource);
         facade.getLayers(resource);
 
+        verify(subject, times(2)).getLayers(resource);
+    }
+
+    @Test
+    @DisplayName("a remote LayerInfo modified event evicts the cached layers by resource list holding the layer")
+    void testOnCatalogInfoModifiedLayerEvictsLayersByResource() {
+        facade = new CachingCatalogFacade(subject);
+        FeatureTypeInfo resource = stub(FeatureTypeInfo.class);
+        LayerInfo layer = stub(LayerInfo.class);
+        when(subject.getLayers(resource)).thenReturn(List.of(layer));
+        assertThat(facade.getLayers(resource)).containsExactly(layer);
+
+        String layerName = layer.getName();
+        CatalogInfoModified event = event(CatalogInfoModified.class, layer.getId(), LAYER);
+        when(event.getObjectName()).thenReturn(layerName);
+        when(event.getOldName()).thenReturn(layerName);
+        facade.onCatalogInfoModified(event);
+
+        facade.getLayers(resource);
         verify(subject, times(2)).getLayers(resource);
     }
 


### PR DESCRIPTION
Make the cascade match the modified layer itself, and cover the id-and-name eviction path and the remote event in the cache tests.

`Catalog.getLayerByName(prefixedName)` resolves the resource and then calls `getLayers(resource)`, and the caching facade keeps that list under a per-resource key. The eviction caused by a remote `CatalogInfoModified` event only cascades to cached objects that can reference the modified layer, and the predicate admitted layer groups alone. A pod that had already served a layer kept rendering it with the previous default style, unless an unrelated change evicted the list.

Fixes #781

on-behalf-of: @multiversio <info@multivers.io>


<!--Include a few sentences describing the overall goals for this Pull Request-->

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver-cloud/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] I have read and applied the [AI policy](https://geoserver.org/ai)
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For source code changes:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver-cloud/tree/main/docs/src) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoServer Cloud](https://github.com/geoserver/geoserver-cloud/issues) Github issues (except for changes that do not affect administrators or end users in any way).
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate Github issue describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green, there is a core committer review, and the checklist has been fulfilled.
