### PR TITLE
fix: Bus events dropped for layer group changes with default styles

### DIFF
--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/mapper/ResolvingProxyMapper.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/mapper/ResolvingProxyMapper.java
@@ -25,6 +25,7 @@ import org.geoserver.catalog.WMTSStoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.ClassMappings;
 import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.catalog.impl.ProxyUtils;
 import org.geoserver.catalog.impl.ResolvingProxy;
 import org.geoserver.catalog.impl.StyleInfoImpl;
 import org.geoserver.jackson.databind.catalog.dto.ResolvingProxyDto;
@@ -104,7 +105,7 @@ public abstract class ResolvingProxyMapper {
     }
 
     public <T extends Info> ResolvingProxyDto infoToReference(final T info) {
-        if (info == null) {
+        if (info == null || isProxyWithoutReference(info)) {
             return null;
         }
         final String id = info.getId();
@@ -124,6 +125,16 @@ public abstract class ResolvingProxyMapper {
         Objects.requireNonNull(id, () -> "Object has no id: " + info);
         Objects.requireNonNull(type, () -> "Bad info class: " + info.getClass());
         return new ResolvingProxyDto(type, id);
+    }
+
+    /**
+     * XStream builds a {@link ResolvingProxy} with an empty reference for an empty {@code <style/>} element, the
+     * placeholder for a layer group's default style, and the catalog resolves it to {@code null}. Encode it as
+     * {@code null} too, since a reference without id cannot be read at the receiving end.
+     */
+    private boolean isProxyWithoutReference(Info info) {
+        ResolvingProxy proxy = ProxyUtils.handler(info, ResolvingProxy.class);
+        return proxy != null && ResolvingProxy.getRef(info) == null;
     }
 
     private ClassMappings resolveType(@NonNull Info value) {

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/PatchSerializationTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/PatchSerializationTest.java
@@ -45,6 +45,7 @@ import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.faker.CatalogFaker;
 import org.geoserver.catalog.impl.CoverageStoreInfoImpl;
 import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.catalog.impl.ResolvingProxy;
 import org.geoserver.catalog.plugin.CatalogPlugin;
 import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.catalog.plugin.resolving.ProxyUtils;
@@ -544,6 +545,25 @@ public abstract class PatchSerializationTest {
         // List.of(data.wmsService, data.wfsService));
         // REVISIT: WCSInfoImpl.equals is broken, can't do testPatch("serviceInfos",
         // List.of(data.wcsService));
+    }
+
+    /**
+     * A layer group modified through the REST API with an empty {@code <style/>} element holds a default style
+     * placeholder in its styles list: a {@link ResolvingProxy} with an empty reference. The patch must encode it as a
+     * null style for the receiving side to be able to read the event.
+     */
+    @Test
+    void testPatchWithDefaultStylePlaceholderInList() throws Exception {
+        StyleInfo defaultStylePlaceholder = ResolvingProxy.create("", StyleInfo.class);
+        List<StyleInfo> styles = Arrays.asList(data.style1, defaultStylePlaceholder);
+
+        Patch decoded = roundtrip(new Patch().with("styles", styles));
+
+        List<StyleInfo> decodedStyles = decoded.get("styles").orElseThrow().value();
+        assertThat(decodedStyles).hasSize(2);
+        assertResolvingProxy(decodedStyles.get(0));
+        assertThat(decodedStyles.get(0).getId()).isEqualTo(data.style1.getId());
+        assertThat(decodedStyles.get(1)).isNull();
     }
 
     @Test


### PR DESCRIPTION
Encode a resolving proxy without reference as null, like done by the creation event, and cover the patch round trip.

XStream builds a ResolvingProxy with an empty reference for an empty `<style/>` element as the placeholder for a layer group's default style, and the modification patch is built before the catalog resolves it to `null`.

The reference mapper accepted the empty id, the bus mapper's non-empty inclusion stripped it from the JSON, and the receiving pods could not construct a reference without id and dropped the whole event, leaving their caches, GWC and datadir replicas stale.

Fixes #986

on-behalf-of: @multiversio <info@multivers.io>


<!--Include a few sentences describing the overall goals for this Pull Request-->

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver-cloud/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] I have read and applied the [AI policy](https://geoserver.org/ai)
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For source code changes:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver-cloud/tree/main/docs/src) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoServer Cloud](https://github.com/geoserver/geoserver-cloud/issues) Github issues (except for changes that do not affect administrators or end users in any way).
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate Github issue describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green, there is a core committer review, and the checklist has been fulfilled.
