### PR TITLE
[Backport release/2.28.x] fix: Bus events dropped for layer group changes with default styles

### DIFF
--- a/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/mapper/InfoReferenceMapper.java
+++ b/src/catalog/jackson-bindings/geoserver/src/main/java/org/geoserver/jackson/databind/mapper/InfoReferenceMapper.java
@@ -25,6 +25,7 @@ import org.geoserver.catalog.WMTSStoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.ClassMappings;
 import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.catalog.impl.ProxyUtils;
 import org.geoserver.catalog.impl.ResolvingProxy;
 import org.geoserver.catalog.impl.StyleInfoImpl;
 import org.geoserver.jackson.databind.catalog.dto.InfoReference;
@@ -104,7 +105,7 @@ public abstract class InfoReferenceMapper {
     }
 
     public <T extends Info> InfoReference infoToReference(final T info) {
-        if (info == null) {
+        if (info == null || isProxyWithoutReference(info)) {
             return null;
         }
         final String id = info.getId();
@@ -124,6 +125,16 @@ public abstract class InfoReferenceMapper {
         Objects.requireNonNull(id, () -> "Object has no id: " + info);
         Objects.requireNonNull(type, () -> "Bad info class: " + info.getClass());
         return new InfoReference(type, id);
+    }
+
+    /**
+     * XStream builds a {@link ResolvingProxy} with an empty reference for an empty {@code <style/>} element, the
+     * placeholder for a layer group's default style, and the catalog resolves it to {@code null}. Encode it as
+     * {@code null} too, since a reference without id cannot be read at the receiving end.
+     */
+    private boolean isProxyWithoutReference(Info info) {
+        ResolvingProxy proxy = ProxyUtils.handler(info, ResolvingProxy.class);
+        return proxy != null && ResolvingProxy.getRef(info) == null;
     }
 
     private ClassMappings resolveType(@NonNull Info value) {

--- a/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/PatchSerializationTest.java
+++ b/src/catalog/jackson-bindings/geoserver/src/test/java/org/geoserver/jackson/databind/catalog/PatchSerializationTest.java
@@ -48,6 +48,7 @@ import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.faker.CatalogFaker;
 import org.geoserver.catalog.impl.CoverageStoreInfoImpl;
 import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.catalog.impl.ResolvingProxy;
 import org.geoserver.catalog.plugin.CatalogPlugin;
 import org.geoserver.catalog.plugin.Patch;
 import org.geoserver.catalog.plugin.resolving.ProxyUtils;
@@ -545,6 +546,25 @@ public abstract class PatchSerializationTest {
         // List.of(data.wmsService, data.wfsService));
         // REVISIT: WCSInfoImpl.equals is broken, can't do testPatch("serviceInfos",
         // List.of(data.wcsService));
+    }
+
+    /**
+     * A layer group modified through the REST API with an empty {@code <style/>} element holds a default style
+     * placeholder in its styles list: a {@link ResolvingProxy} with an empty reference. The patch must encode it as a
+     * null style for the receiving side to be able to read the event.
+     */
+    @Test
+    void testPatchWithDefaultStylePlaceholderInList() throws Exception {
+        StyleInfo defaultStylePlaceholder = ResolvingProxy.create("", StyleInfo.class);
+        List<StyleInfo> styles = Arrays.asList(data.style1, defaultStylePlaceholder);
+
+        Patch decoded = roundtrip(new Patch().with("styles", styles));
+
+        List<StyleInfo> decodedStyles = decoded.get("styles").orElseThrow().value();
+        assertThat(decodedStyles).hasSize(2);
+        assertResolvingProxy(decodedStyles.get(0));
+        assertThat(decodedStyles.get(0).getId()).isEqualTo(data.style1.getId());
+        assertThat(decodedStyles.get(1)).isNull();
     }
 
     @Test


### PR DESCRIPTION
Backport https://github.com/geoserver/geoserver-cloud/pull/989
Authored by: @groldan