### PR TITLE
fix: Gateway double-encodes non-ASCII characters in browser form posts

### DIFF
--- a/src/apps/infrastructure/gateway-webmvc/src/main/java/org/geoserver/cloud/autoconfigure/gateway/GatewayApplicationAutoconfiguration.java
+++ b/src/apps/infrastructure/gateway-webmvc/src/main/java/org/geoserver/cloud/autoconfigure/gateway/GatewayApplicationAutoconfiguration.java
@@ -5,6 +5,7 @@
 
 package org.geoserver.cloud.autoconfigure.gateway;
 
+import org.geoserver.cloud.gateway.filter.FormPostCharacterEncodingFilter;
 import org.geoserver.cloud.gateway.filter.GeoServerGatewayFilterFunctions;
 import org.geoserver.cloud.gateway.filter.ProxyExceptionFilter;
 import org.geoserver.cloud.gateway.predicate.GeoServerGatewayRequestPredicates;
@@ -59,6 +60,18 @@ public class GatewayApplicationAutoconfiguration {
     @Bean
     ProxyExceptionFilter proxyExceptionFilter() {
         return new ProxyExceptionFilter();
+    }
+
+    /**
+     * Servlet filter declaring UTF-8 as the character encoding of form posts that do not specify one, before Spring
+     * Cloud Gateway's {@code FormFilter} rebuilds their body. Without it, browser form submissions containing non-ASCII
+     * characters reach the backend services double-encoded.
+     *
+     * @see FormPostCharacterEncodingFilter
+     */
+    @Bean
+    FormPostCharacterEncodingFilter formPostCharacterEncodingFilter() {
+        return new FormPostCharacterEncodingFilter();
     }
 
     /**

--- a/src/apps/infrastructure/gateway-webmvc/src/main/java/org/geoserver/cloud/gateway/filter/FormPostCharacterEncodingFilter.java
+++ b/src/apps/infrastructure/gateway-webmvc/src/main/java/org/geoserver/cloud/gateway/filter/FormPostCharacterEncodingFilter.java
@@ -1,0 +1,72 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.gateway.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.springframework.cloud.gateway.server.mvc.filter.FormFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Declares UTF-8 as the request character encoding of form posts that do not specify one, before Spring Cloud Gateway's
+ * {@link FormFilter} parses them.
+ *
+ * <p>{@link FormFilter} rebuilds the body of every {@code application/x-www-form-urlencoded} POST from the servlet
+ * parameter map and encodes the result as UTF-8. Tomcat parses that map with the request character encoding, falling
+ * back to ISO-8859-1 when the {@code Content-Type} header has no {@code charset} parameter, which is how browsers
+ * submit HTML forms. Decoding as ISO-8859-1 and re-encoding as UTF-8 double-encodes every non-ASCII character on its
+ * way to the backend service: a contact title with non-ASCII letters saved from the web UI reached the catalog garbled,
+ * while the same value sent by a Wicket Ajax request, which declares its charset, arrived intact.
+ *
+ * <p>The gateway keeps Spring Boot's {@code CharacterEncodingFilter} disabled because it would declare a charset on
+ * every proxied request, altering {@code Content-Type} headers such as {@code application/zip} that backend services
+ * match exactly. This filter limits the declaration to the form posts re-encoded by {@link FormFilter}; the forwarded
+ * {@code Content-Type} of those requests gains {@code charset=UTF-8}, which describes the rebuilt body accurately.
+ *
+ * <p>Registered as a bean in {@link org.geoserver.cloud.autoconfigure.gateway.GatewayApplicationAutoconfiguration
+ * GatewayApplicationAutoconfiguration}.
+ *
+ * @see <a href="https://github.com/geoserver/geoserver-cloud/issues/981">Issue #981</a>
+ * @since 3.1.0
+ */
+public class FormPostCharacterEncodingFilter extends OncePerRequestFilter implements Ordered {
+
+    /** Runs right before {@link FormFilter}, which must see the encoding before it reads the parameter map. */
+    public static final int ORDER = FormFilter.FORM_FILTER_ORDER - 1;
+
+    @Override
+    public int getOrder() {
+        return ORDER;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        if (isFormPostWithoutCharset(request)) {
+            request.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        }
+        chain.doFilter(request, response);
+    }
+
+    private static boolean isFormPostWithoutCharset(HttpServletRequest request) {
+        return isFormPost(request) && request.getCharacterEncoding() == null;
+    }
+
+    /** The same criteria used by {@link FormFilter} to decide which requests it rebuilds. */
+    private static boolean isFormPost(HttpServletRequest request) {
+        String contentType = request.getContentType();
+        boolean formUrlEncoded =
+                contentType != null && contentType.contains(MediaType.APPLICATION_FORM_URLENCODED_VALUE);
+        return formUrlEncoded && HttpMethod.POST.matches(request.getMethod());
+    }
+}

--- a/src/apps/infrastructure/gateway-webmvc/src/main/resources/application.yml
+++ b/src/apps/infrastructure/gateway-webmvc/src/main/resources/application.yml
@@ -13,6 +13,8 @@ spring:
       # Disable CharacterEncodingFilter. It appends ';charset=UTF-8' to Content-Type headers
       # (e.g. 'application/zip' becomes 'application/zip;charset=UTF-8'), which breaks
       # downstream services that rely on exact media type matching.
+      # Form posts are the exception: FormPostCharacterEncodingFilter declares UTF-8 on those lacking
+      # a charset, otherwise the gateway's FormFilter double-encodes their non-ASCII characters.
       enabled: false
     multipart:
       # Disable multipart request parsing so multipart/form-data bodies are streamed through

--- a/src/apps/infrastructure/gateway-webmvc/src/test/java/org/geoserver/cloud/autoconfigure/gateway/GatewayApplicationAutoconfigurationTest.java
+++ b/src/apps/infrastructure/gateway-webmvc/src/test/java/org/geoserver/cloud/autoconfigure/gateway/GatewayApplicationAutoconfigurationTest.java
@@ -8,6 +8,7 @@ package org.geoserver.cloud.autoconfigure.gateway;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
+import org.geoserver.cloud.gateway.filter.FormPostCharacterEncodingFilter;
 import org.geoserver.cloud.gateway.filter.GeoServerGatewayFilterFunctions;
 import org.geoserver.cloud.gateway.predicate.GeoServerGatewayRequestPredicates;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ class GatewayApplicationAutoconfigurationTest {
                 .hasNotFailed()
                 .hasSingleBean(GeoServerGatewayRequestPredicates.GeoServerGatewayPredicateSupplier.class)
                 .hasSingleBean(GeoServerGatewayFilterFunctions.GeoServerGatewayFilterSupplier.class)
+                .hasSingleBean(FormPostCharacterEncodingFilter.class)
                 .hasSingleBean(CorsFilter.class));
     }
 

--- a/src/apps/infrastructure/gateway-webmvc/src/test/java/org/geoserver/cloud/gateway/app/GatewayMvcApplicationIT.java
+++ b/src/apps/infrastructure/gateway-webmvc/src/test/java/org/geoserver/cloud/gateway/app/GatewayMvcApplicationIT.java
@@ -260,6 +260,39 @@ class GatewayMvcApplicationIT {
         assertThat(echoedRequest).contains("Content-Type: application/json").doesNotContain("charset");
     }
 
+    // --- Form post body preservation tests ---
+    // Regression tests for #981: the gateway's FormFilter rebuilds form bodies from the servlet parameter map and
+    // encodes them as UTF-8. Browsers omit the charset parameter on form submissions, and without it Tomcat parses the
+    // body as ISO-8859-1, double-encoding every non-ASCII character on the way to the backend.
+
+    @Test
+    void formPost_withoutCharset_preservesUtf8Body() {
+        String echoedRequest = postForm("application/x-www-form-urlencoded");
+
+        assertThat(echoedRequest).contains("title=%C3%85%C3%84%C3%96");
+    }
+
+    @Test
+    void formPost_withCharset_preservesUtf8Body() {
+        String echoedRequest = postForm("application/x-www-form-urlencoded; charset=UTF-8");
+
+        assertThat(echoedRequest).contains("title=%C3%85%C3%84%C3%96");
+    }
+
+    /** Posts a {@code title} of three non-ASCII letters, percent-encoded as UTF-8, and returns the echoed request. */
+    private String postForm(String contentType) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.parseMediaType(contentType));
+        byte[] body = "title=%C3%85%C3%84%C3%96".getBytes(StandardCharsets.US_ASCII);
+        HttpEntity<byte[]> entity = new HttpEntity<>(body, headers);
+
+        ResponseEntity<String> response =
+                testRestTemplate.exchange("/echo/form", HttpMethod.POST, entity, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        return response.getBody();
+    }
+
     // --- ProxyExceptionFilter tests ---
     // Verify the gateway returns 502 instead of hanging or dumping a stack trace
     // when a backend service is unreachable.

--- a/src/apps/infrastructure/gateway-webmvc/src/test/java/org/geoserver/cloud/gateway/filter/FormPostCharacterEncodingFilterTest.java
+++ b/src/apps/infrastructure/gateway-webmvc/src/test/java/org/geoserver/cloud/gateway/filter/FormPostCharacterEncodingFilterTest.java
@@ -1,0 +1,72 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cloud.gateway.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.gateway.server.mvc.filter.FormFilter;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/** @since 3.1.0 */
+class FormPostCharacterEncodingFilterTest {
+
+    private final FormPostCharacterEncodingFilter filter = new FormPostCharacterEncodingFilter();
+
+    @Test
+    void runsBeforeFormFilter() {
+        FormFilter formFilter = new FormFilter();
+
+        assertThat(filter.getOrder()).isLessThan(formFilter.getOrder());
+    }
+
+    @Test
+    void formPostWithoutCharset_declaresUtf8() throws ServletException, IOException {
+        MockHttpServletRequest request = request("POST", "application/x-www-form-urlencoded");
+        assertThat(request.getCharacterEncoding()).isNull();
+
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        assertThat(request.getCharacterEncoding()).isEqualTo("UTF-8");
+    }
+
+    @Test
+    void formPostWithCharset_keepsDeclaredCharset() throws ServletException, IOException {
+        MockHttpServletRequest request = request("POST", "application/x-www-form-urlencoded; charset=ISO-8859-1");
+
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        assertThat(request.getCharacterEncoding()).isEqualTo("ISO-8859-1");
+    }
+
+    @Test
+    void nonFormPost_leavesEncodingUndeclared() throws ServletException, IOException {
+        MockHttpServletRequest request = request("POST", "application/zip");
+
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        assertThat(request.getCharacterEncoding()).isNull();
+    }
+
+    @Test
+    void formContentTypeOnGet_leavesEncodingUndeclared() throws ServletException, IOException {
+        MockHttpServletRequest request = request("GET", "application/x-www-form-urlencoded");
+
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        assertThat(request.getCharacterEncoding()).isNull();
+    }
+
+    private static MockHttpServletRequest request(String method, String contentType) {
+        MockHttpServletRequest request = new MockHttpServletRequest(method, "/web/wicket/page");
+        request.setContentType(contentType);
+        return request;
+    }
+}


### PR DESCRIPTION
Declare UTF-8 as the request encoding of form posts that do not specify a charset, right before Spring Cloud Gateway's FormFilter rebuilds their body.

FormFilter parses the body through Tomcat, which falls back to ISO-8859-1 without a charset, and re-encodes it as UTF-8, mangling non-ASCII characters on the way to the backend services.

Browser form submissions never declare a charset, while Wicket Ajax requests do, hence Save corrupted a title that Apply kept intact.

Fixes #981

on-behalf-of: @multiversio <info@multivers.io>


<!--Include a few sentences describing the overall goals for this Pull Request-->

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver-cloud/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] I have read and applied the [AI policy](https://geoserver.org/ai)
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For source code changes:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver-cloud/tree/main/docs/src) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoServer Cloud](https://github.com/geoserver/geoserver-cloud/issues) Github issues (except for changes that do not affect administrators or end users in any way).
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate Github issue describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green, there is a core committer review, and the checklist has been fulfilled.
