### PR TITLE
[Backport release/3.0.x] fix: Gateway returns 500 when query values contain a bare equals sign

### DIFF
--- a/src/apps/infrastructure/gateway-webmvc/src/main/java/org/geoserver/cloud/gateway/filter/StripBasePath.java
+++ b/src/apps/infrastructure/gateway-webmvc/src/main/java/org/geoserver/cloud/gateway/filter/StripBasePath.java
@@ -5,7 +5,8 @@
 
 package org.geoserver.cloud.gateway.filter;
 
-import org.springframework.cloud.gateway.server.mvc.filter.BeforeFilterFunctions;
+import java.net.URI;
+import org.springframework.cloud.gateway.server.mvc.common.MvcUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.function.HandlerFilterFunction;
 import org.springframework.web.servlet.function.HandlerFunction;
@@ -18,6 +19,11 @@ import org.springframework.web.servlet.function.ServerResponse;
  *
  * <p>Works around the fact that Spring Cloud Gateway does not natively support a configurable base path for all routes.
  * The filter dynamically determines how many path segments to strip based on the configured prefix.
+ *
+ * <p>The stripped URI keeps the raw query string verbatim. Spring Cloud Gateway's own {@code stripPrefix} rebuilds the
+ * URI through {@code UriComponentsBuilder.build(true)}, whose validation rejects a bare {@code =} inside a query value
+ * ({@code CQL_FILTER=a=1}, {@code viewparams=a:b=c}) and turned such requests into a 500 response, although the
+ * services accept them as sent.
  *
  * <p>Example usage in YAML config:
  *
@@ -45,9 +51,7 @@ class StripBasePath implements HandlerFilterFunction<ServerResponse, ServerRespo
         if (partsToRemove == 0) {
             return next.handle(request);
         }
-        // Delegate to the built-in stripPrefix before-filter
-        ServerRequest strippedRequest =
-                BeforeFilterFunctions.stripPrefix(partsToRemove).apply(request);
+        ServerRequest strippedRequest = stripRequestPath(request, partsToRemove);
         return next.handle(strippedRequest);
     }
 
@@ -59,6 +63,53 @@ class StripBasePath implements HandlerFilterFunction<ServerResponse, ServerRespo
         int basePathSteps = StringUtils.countOccurrencesOf(basePath, "/");
         boolean isRoot = basePath.equals(requestPath);
         return isRoot ? basePathSteps - 1 : basePathSteps;
+    }
+
+    /**
+     * Same outcome as Spring Cloud Gateway's {@code BeforeFilterFunctions.stripPrefix(parts)}, the original URL
+     * recorded for the {@code X-Forwarded-Prefix} header included, except that the query string is copied as received
+     * instead of being parsed and validated again.
+     */
+    private static ServerRequest stripRequestPath(ServerRequest request, int parts) {
+        URI uri = request.uri();
+        MvcUtils.addOriginalRequestUrl(request, uri);
+        String strippedPath = stripLeadingSegments(uri.getRawPath(), parts);
+        URI strippedUri = withPath(uri, strippedPath);
+        return ServerRequest.from(request).uri(strippedUri).build();
+    }
+
+    private static String stripLeadingSegments(String rawPath, int parts) {
+        String[] segments = StringUtils.tokenizeToStringArray(rawPath, "/");
+        StringBuilder stripped = new StringBuilder("/");
+        for (int i = parts; i < segments.length; i++) {
+            if (stripped.length() > 1) {
+                stripped.append('/');
+            }
+            stripped.append(segments[i]);
+        }
+        if (stripped.length() > 1 && rawPath.endsWith("/")) {
+            stripped.append('/');
+        }
+        return stripped.toString();
+    }
+
+    /** Replaces the path, keeping scheme, authority, query and fragment exactly as they were received. */
+    private static URI withPath(URI uri, String rawPath) {
+        StringBuilder rebuilt = new StringBuilder();
+        if (uri.getScheme() != null) {
+            rebuilt.append(uri.getScheme()).append(':');
+        }
+        if (uri.getRawAuthority() != null) {
+            rebuilt.append("//").append(uri.getRawAuthority());
+        }
+        rebuilt.append(rawPath);
+        if (uri.getRawQuery() != null) {
+            rebuilt.append('?').append(uri.getRawQuery());
+        }
+        if (uri.getRawFragment() != null) {
+            rebuilt.append('#').append(uri.getRawFragment());
+        }
+        return URI.create(rebuilt.toString());
     }
 
     private static void checkPreconditions(String prefix) {

--- a/src/apps/infrastructure/gateway-webmvc/src/test/java/org/geoserver/cloud/gateway/app/GatewayMvcApplicationIT.java
+++ b/src/apps/infrastructure/gateway-webmvc/src/test/java/org/geoserver/cloud/gateway/app/GatewayMvcApplicationIT.java
@@ -7,6 +7,9 @@ package org.geoserver.cloud.gateway.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.resttestclient.TestRestTemplate;
@@ -104,6 +107,42 @@ class GatewayMvcApplicationIT {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         String body = response.getBody();
         assertThat(body).contains("GET /wms/reflect").doesNotContain("/geoserver/cloud/wms");
+    }
+
+    // Regression tests for #693: a bare '=' inside a query value (CQL_FILTER=a=1, viewparams=a:b=c) made the
+    // upstream stripPrefix rebuild of the URI throw, and the gateway answered 500 to a request the service accepts.
+
+    @Test
+    void stripBasePath_keepsBareEqualsSignInQuery() {
+        ResponseEntity<String> response = getVerbatim("/geoserver/cloud/ows?CQL_FILTER=1=1");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(decodedRequestLine(response.getBody())).isEqualTo("GET /ows?CQL_FILTER=1=1 HTTP/1.1");
+        assertThat(response.getBody()).contains("X-Forwarded-Prefix: /geoserver/cloud");
+    }
+
+    @Test
+    void stripBasePath_keepsPercentEncodedQuery() {
+        ResponseEntity<String> response = getVerbatim("/geoserver/cloud/ows?layers=a%3Db%20c");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(decodedRequestLine(response.getBody())).isEqualTo("GET /ows?layers=a=b c HTTP/1.1");
+    }
+
+    /** Sends the path and query exactly as given, bypassing the URI template encoding of the String overloads. */
+    private ResponseEntity<String> getVerbatim(String pathAndQuery) {
+        URI uri = URI.create(testRestTemplate.getRootUri() + pathAndQuery);
+        return testRestTemplate.getForEntity(uri, String.class);
+    }
+
+    /** The request line as echoed by the backend, percent-decoded. */
+    private static String decodedRequestLine(String echoedRequest) {
+        String requestLine = echoedRequest
+                .lines()
+                .filter(line -> line.startsWith("GET ") || line.startsWith("POST "))
+                .findFirst()
+                .orElseThrow();
+        return URLDecoder.decode(requestLine, StandardCharsets.UTF_8);
     }
 
     // --- SecureHeaders tests ---

--- a/src/apps/infrastructure/gateway-webmvc/src/test/java/org/geoserver/cloud/gateway/filter/StripBasePathTest.java
+++ b/src/apps/infrastructure/gateway-webmvc/src/test/java/org/geoserver/cloud/gateway/filter/StripBasePathTest.java
@@ -9,9 +9,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
+import java.net.URI;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
+import org.springframework.cloud.gateway.server.mvc.common.MvcUtils;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.servlet.function.HandlerFilterFunction;
 import org.springframework.web.servlet.function.ServerRequest;
@@ -79,6 +82,42 @@ class StripBasePathTest {
     @Test
     void deepPath_stripsCorrectly() throws Exception {
         assertThat(filterPath("/a/b/c", "/a/b/c/d/e")).isEqualTo("/d/e");
+    }
+
+    @Test
+    void queryWithBareEqualsSign_isKeptVerbatim() throws Exception {
+        ServerRequest stripped = filterRequest("/geoserver/cloud", "/geoserver/cloud/ows", "CQL_FILTER=1=1");
+
+        assertThat(stripped.uri().getRawPath()).isEqualTo("/ows");
+        assertThat(stripped.uri().getRawQuery()).isEqualTo("CQL_FILTER=1=1");
+    }
+
+    @Test
+    void percentEncodedQuery_isKeptVerbatim() throws Exception {
+        ServerRequest stripped = filterRequest("/geoserver/cloud", "/geoserver/cloud/ows", "layers=a%3Db%20c");
+
+        assertThat(stripped.uri().getRawQuery()).isEqualTo("layers=a%3Db%20c");
+    }
+
+    /** The X-Forwarded-Prefix header is derived from the original URL recorded by the filter. */
+    @Test
+    void originalRequestUrl_isRecorded() throws Exception {
+        ServerRequest stripped = filterRequest("/geoserver/cloud", "/geoserver/cloud/ows", "service=WMS");
+
+        LinkedHashSet<URI> originalUrls = MvcUtils.getAttribute(stripped, MvcUtils.GATEWAY_ORIGINAL_REQUEST_URL_ATTR);
+        assertThat(originalUrls).containsExactly(URI.create("http://localhost/geoserver/cloud/ows?service=WMS"));
+    }
+
+    private ServerRequest filterRequest(String prefix, String requestPath, String queryString) throws Exception {
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest("GET", requestPath);
+        mockRequest.setQueryString(queryString);
+        ServerRequest request = ServerRequest.create(mockRequest, List.of());
+        AtomicReference<ServerRequest> captured = new AtomicReference<>();
+        GeoServerGatewayFilterFunctions.stripBasePath(prefix).filter(request, req -> {
+            captured.set(req);
+            return ServerResponse.ok().build();
+        });
+        return captured.get();
     }
 
     private String filterPath(String prefix, String requestPath) throws Exception {


### PR DESCRIPTION
Backport #992
 **Authored by:** @groldan